### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Potential fix for [https://github.com/ilpanich/axiam/security/code-scanning/4](https://github.com/ilpanich/axiam/security/code-scanning/4)

In general, the fix is to add a `permissions` block to the workflow (or specifically to the `test` job) that limits the `GITHUB_TOKEN` to only the minimal scopes required. Since none of the jobs appear to push commits, manage issues, or modify repository data, they can safely run with read-only permissions on `contents` (and optionally `packages` if needed).

The best way to fix this without changing existing functionality is to add a top-level `permissions` block (at the same level as `on:` and `env:`) so that it applies uniformly to all jobs: `contents: read`. This documents the workflow’s needs and prevents it from inheriting broader defaults. No imports, additional methods, or other code changes are needed; it is a pure YAML configuration change. Specifically, in `.github/workflows/ci.yml`, insert a `permissions:` section between the `on:` block (lines 3–7) and the `env:` block (line 9). This block will look like:

```yaml
permissions:
  contents: read
```

This is sufficient to address the CodeQL warning and follow least-privilege practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
