### PR TITLE
feat: Phase 16 — Deployment & Infrastructure

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Build artifacts
+target/
+
+# Frontend dependencies
+node_modules/
+frontend/node_modules/
+frontend/dist/
+
+# Version control
+.git/
+.gitignore
+
+# Deployment configs (not needed inside the image)
+docker/
+k8s/
+
+# SDKs and dev docs
+sdks/
+claude_dev/
+
+# GitHub workflows
+.github/
+
+# Environment and secrets — NEVER bake into images
+.env
+.env.*
+.env.local
+
+# Documentation files
+*.md
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS junk
+.DS_Store
+Thumbs.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ frontend/dist/
 
 # Deployment configs (not needed inside the image)
 docker/
+!docker/nginx.conf
 k8s/
 
 # SDKs and dev docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,27 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
 env:
   CARGO_TERM_COLOR: always
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-docker:
-    name: Build Docker Image
+  build-server:
+    name: Build Server Image
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -31,16 +38,139 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/server
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
+          file: docker/Dockerfile.server
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ github.repository }}/server@${{ steps.build.outputs.digest }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/server
+          subject-digest: ${{ steps.build.outputs.digest }}
+
+  build-frontend:
+    name: Build Frontend Image
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/frontend
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.frontend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign
+        run: cosign sign --yes ${{ env.REGISTRY }}/${{ github.repository }}/frontend@${{ steps.build.outputs.digest }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/frontend
+          subject-digest: ${{ steps.build.outputs.digest }}
+
+  build-binary:
+    name: Build Release Binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Build release binary
+        run: cargo build --release -p axiam-server
+
+      - name: Strip binary
+        run: strip target/release/axiam-server
+
+      - name: Create tarball
+        run: tar czf axiam-server-x86_64-linux.tar.gz -C target/release axiam-server
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: axiam-server-x86_64-linux
+          path: axiam-server-x86_64-linux.tar.gz
+
+  release:
+    name: Create GitHub Release
+    needs: [build-server, build-frontend, build-binary]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: axiam-server-x86_64-linux
+
+      - name: Generate changelog
+        id: changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --latest
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: CHANGELOG.md
+          files: axiam-server-x86_64-linux.tar.gz
+          generate_release_notes: false

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,0 +1,45 @@
+# ============================================================================
+# AXIAM Frontend — Multi-stage Docker Build
+# ============================================================================
+# Build:  docker build -f docker/Dockerfile.frontend -t axiam-frontend .
+# Run:    docker run -p 80:80 axiam-frontend
+# ============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build the React frontend
+# ---------------------------------------------------------------------------
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependency manifests first for layer caching
+COPY frontend/package.json frontend/package-lock.json ./
+
+RUN npm ci
+
+# Copy the rest of the frontend source
+COPY frontend/ .
+
+# Build the Vite project (outputs to dist/)
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: Serve with nginx
+# ---------------------------------------------------------------------------
+FROM nginx:1.27-alpine
+
+# Copy built assets from builder
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy custom nginx config
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+LABEL org.opencontainers.image.title="axiam-frontend" \
+      org.opencontainers.image.description="AXIAM IAM admin dashboard" \
+      org.opencontainers.image.vendor="AXIAM Contributors" \
+      org.opencontainers.image.source="https://github.com/emanuele/axiam" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later"
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -2,7 +2,7 @@
 # AXIAM Frontend — Multi-stage Docker Build
 # ============================================================================
 # Build:  docker build -f docker/Dockerfile.frontend -t axiam-frontend .
-# Run:    docker run -p 80:80 axiam-frontend
+# Run:    docker run -p 80:8080 axiam-frontend
 # ============================================================================
 
 # ---------------------------------------------------------------------------
@@ -24,9 +24,9 @@ COPY frontend/ .
 RUN npm run build
 
 # ---------------------------------------------------------------------------
-# Stage 2: Serve with nginx
+# Stage 2: Serve with unprivileged nginx (listens on 8080, runs as uid 101)
 # ---------------------------------------------------------------------------
-FROM nginx:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 # Copy built assets from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
@@ -34,7 +34,7 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Copy custom nginx config
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 LABEL org.opencontainers.image.title="axiam-frontend" \
       org.opencontainers.image.description="AXIAM IAM admin dashboard" \

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,0 +1,110 @@
+# ============================================================================
+# AXIAM Server — Multi-stage Docker Build
+# ============================================================================
+# Build:  docker build -f docker/Dockerfile.server -t axiam-server .
+# Run:    docker run -p 8080:8080 -p 50051:50051 axiam-server
+# ============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build the release binary
+# ---------------------------------------------------------------------------
+FROM rust:1.86-bookworm AS builder
+
+# Install build-time dependencies: protobuf compiler for tonic/prost codegen
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy manifests first for better layer caching.
+# When only source code changes (not dependencies), Docker reuses the
+# dependency-download layer, which is the slowest part of a Rust build.
+COPY Cargo.toml Cargo.lock ./
+
+# Copy every crate's Cargo.toml so cargo can resolve the full dependency graph.
+COPY crates/axiam-core/Cargo.toml         crates/axiam-core/Cargo.toml
+COPY crates/axiam-db/Cargo.toml           crates/axiam-db/Cargo.toml
+COPY crates/axiam-auth/Cargo.toml         crates/axiam-auth/Cargo.toml
+COPY crates/axiam-authz/Cargo.toml        crates/axiam-authz/Cargo.toml
+COPY crates/axiam-api-rest/Cargo.toml     crates/axiam-api-rest/Cargo.toml
+COPY crates/axiam-api-grpc/Cargo.toml     crates/axiam-api-grpc/Cargo.toml
+COPY crates/axiam-amqp/Cargo.toml         crates/axiam-amqp/Cargo.toml
+COPY crates/axiam-oauth2/Cargo.toml       crates/axiam-oauth2/Cargo.toml
+COPY crates/axiam-federation/Cargo.toml   crates/axiam-federation/Cargo.toml
+COPY crates/axiam-audit/Cargo.toml        crates/axiam-audit/Cargo.toml
+COPY crates/axiam-pki/Cargo.toml          crates/axiam-pki/Cargo.toml
+COPY crates/axiam-email/Cargo.toml        crates/axiam-email/Cargo.toml
+COPY crates/axiam-server/Cargo.toml       crates/axiam-server/Cargo.toml
+
+# Create stub lib.rs / main.rs so cargo can compile dependencies without
+# the real source. This is the "skeleton trick" — it lets Docker cache
+# the expensive dependency compilation layer.
+RUN for dir in crates/*/; do \
+        mkdir -p "$dir/src"; \
+        name=$(basename "$dir"); \
+        if [ "$name" = "axiam-server" ]; then \
+            echo 'fn main() {}' > "$dir/src/main.rs"; \
+        else \
+            echo '' > "$dir/src/lib.rs"; \
+        fi; \
+    done
+
+# Pre-build dependencies only. This layer is cached until Cargo.toml/lock change.
+RUN cargo build --release -p axiam-server 2>/dev/null || true
+
+# Now copy the real source code and proto definitions
+COPY crates/ crates/
+COPY proto/  proto/
+
+# Touch all source files so cargo sees them as newer than the stub artifacts
+RUN find crates/ -name "*.rs" -exec touch {} +
+
+# Build the actual server binary and strip debug symbols
+RUN cargo build --release -p axiam-server \
+    && strip target/release/axiam-server
+
+# ---------------------------------------------------------------------------
+# Stage 2: Minimal runtime image
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+LABEL org.opencontainers.image.title="axiam-server" \
+      org.opencontainers.image.description="AXIAM — Access eXtended Identity and Authorization Management" \
+      org.opencontainers.image.vendor="AXIAM Contributors" \
+      org.opencontainers.image.source="https://github.com/emanuele/axiam" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later"
+
+# Install runtime dependencies:
+#   ca-certificates — TLS root CAs for outbound HTTPS
+#   libssl3         — OpenSSL shared libs (transitive deps may need it)
+#   curl            — used by HEALTHCHECK
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libssl3 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd --gid 1000 axiam \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /usr/sbin/nologin axiam
+
+# Copy the release binary from the builder stage
+COPY --from=builder --chown=axiam:axiam \
+    /build/target/release/axiam-server /usr/local/bin/axiam-server
+
+# Switch to non-root user
+USER axiam
+WORKDIR /home/axiam
+
+# Default environment
+ENV RUST_LOG=axiam=info
+
+# REST API + gRPC
+EXPOSE 8080 50051
+
+# Health check: probe the REST health endpoint
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -sf http://localhost:8080/health || exit 1
+
+ENTRYPOINT ["axiam-server"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -51,7 +51,7 @@ RUN for dir in crates/*/; do \
     done
 
 # Pre-build dependencies only. This layer is cached until Cargo.toml/lock change.
-RUN cargo build --release -p axiam-server 2>/dev/null || true
+RUN cargo build --release -p axiam-server || true
 
 # Now copy the real source code and proto definitions
 COPY crates/ crates/

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,0 +1,103 @@
+# Production-like Docker Compose for local testing of the full AXIAM stack.
+# Usage: docker compose -f docker/docker-compose.prod.yml up --build
+#
+# This file is NOT intended for actual production deployment (use Kubernetes
+# manifests in k8s/ for that). It exists so developers can spin up the entire
+# stack locally with a single command and validate end-to-end behaviour.
+
+services:
+  # ---------------------------------------------------------------------------
+  # AXIAM Backend (REST + gRPC)
+  # ---------------------------------------------------------------------------
+  axiam-server:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.server
+    container_name: axiam-server
+    ports:
+      - "8080:8080"   # REST API
+      - "50051:50051" # gRPC
+    environment:
+      AXIAM_DATABASE__URL: "ws://surrealdb:8000"
+      AXIAM_DATABASE__USERNAME: "root"
+      AXIAM_DATABASE__PASSWORD: "root"
+      AXIAM_DATABASE__NAMESPACE: "axiam"
+      AXIAM_DATABASE__DATABASE: "axiam"
+      AXIAM_AMQP__URL: "amqp://axiam:axiam@rabbitmq:5672"
+      RUST_LOG: "axiam=info"
+    depends_on:
+      surrealdb:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - axiam-network
+
+  # ---------------------------------------------------------------------------
+  # AXIAM Frontend (React / Nginx)
+  # ---------------------------------------------------------------------------
+  axiam-frontend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.frontend
+    container_name: axiam-frontend
+    ports:
+      - "80:80"
+    depends_on:
+      - axiam-server
+    restart: unless-stopped
+    networks:
+      - axiam-network
+
+  # ---------------------------------------------------------------------------
+  # SurrealDB — document/graph database
+  # ---------------------------------------------------------------------------
+  surrealdb:
+    image: surrealdb/surrealdb:v2
+    container_name: axiam-surrealdb
+    command: start --user root --pass root --log info
+    volumes:
+      - surrealdb-data:/data
+    healthcheck:
+      test: ["CMD", "/surreal", "isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - axiam-network
+
+  # ---------------------------------------------------------------------------
+  # RabbitMQ — AMQP message broker
+  # ---------------------------------------------------------------------------
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: axiam-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: axiam
+      RABBITMQ_DEFAULT_PASS: axiam
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - axiam-network
+
+volumes:
+  surrealdb-data:
+  rabbitmq-data:
+
+networks:
+  axiam-network:
+    driver: bridge

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -18,12 +18,14 @@ services:
       - "8080:8080"   # REST API
       - "50051:50051" # gRPC
     environment:
-      AXIAM_DATABASE__URL: "ws://surrealdb:8000"
-      AXIAM_DATABASE__USERNAME: "root"
-      AXIAM_DATABASE__PASSWORD: "root"
-      AXIAM_DATABASE__NAMESPACE: "axiam"
-      AXIAM_DATABASE__DATABASE: "axiam"
+      AXIAM_DB__URL: "ws://surrealdb:8000"
+      AXIAM_DB__USERNAME: "root"
+      AXIAM_DB__PASSWORD: "root"
+      AXIAM_DB__NAMESPACE: "axiam"
+      AXIAM_DB__DATABASE: "axiam"
       AXIAM_AMQP__URL: "amqp://axiam:axiam@rabbitmq:5672"
+      AXIAM_SERVER__HOST: "0.0.0.0"
+      AXIAM_GRPC__HOST: "0.0.0.0"
       RUST_LOG: "axiam=info"
     depends_on:
       surrealdb:
@@ -49,7 +51,7 @@ services:
       dockerfile: docker/Dockerfile.frontend
     container_name: axiam-frontend
     ports:
-      - "80:80"
+      - "80:8080"
     depends_on:
       - axiam-server
     restart: unless-stopped

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -51,8 +51,8 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy API requests to the backend
-    location /api/ {
+    # Proxy API requests to the backend (match both /api and /api/*)
+    location /api {
         proxy_pass http://axiam-server:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
 
     root /usr/share/nginx/html;
@@ -54,15 +54,6 @@ server {
     # Proxy API requests to the backend
     location /api/ {
         proxy_pass http://axiam-server:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Proxy gRPC-web requests to the gRPC server
-    location /grpc/ {
-        proxy_pass http://axiam-server:50051;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,71 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_min_length 256;
+    gzip_types
+        text/html
+        text/css
+        application/javascript
+        application/json
+        image/svg+xml;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Cache static assets for 1 year (Vite hashes filenames)
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|webp|avif|woff2?)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+
+        # Re-add security headers (add_header in a location block
+        # replaces headers from the parent context)
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    # index.html must not be cached so deploys are picked up
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
+    # SPA fallback — serve index.html for all unmatched routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API requests to the backend
+    location /api/ {
+        proxy_pass http://axiam-server:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy gRPC-web requests to the gRPC server
+    location /grpc/ {
+        proxy_pass http://axiam-server:50051;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/justfile
+++ b/justfile
@@ -56,3 +56,18 @@ frontend-build:
 # Run frontend E2E tests
 frontend-test:
     cd frontend && npx playwright test
+
+# Start full production-like stack (build images + run all services)
+prod-up:
+    docker compose -f docker/docker-compose.prod.yml up --build -d
+    @echo "AXIAM Frontend: http://localhost"
+    @echo "AXIAM REST API: http://localhost:8080"
+    @echo "AXIAM gRPC:     localhost:50051"
+
+# Stop production-like stack
+prod-down:
+    docker compose -f docker/docker-compose.prod.yml down
+
+# Stop production-like stack and remove volumes
+prod-clean:
+    docker compose -f docker/docker-compose.prod.yml down -v

--- a/k8s/frontend/deployment.yml
+++ b/k8s/frontend/deployment.yml
@@ -20,10 +20,10 @@ spec:
     spec:
       containers:
         - name: axiam-frontend
-          image: ghcr.io/OWNER/axiam-frontend:latest
+          image: ghcr.io/OWNER/frontend:latest
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           resources:
             requests:
@@ -35,14 +35,16 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 10
             periodSeconds: 30
           securityContext:
-            runAsNonRoot: false
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101

--- a/k8s/frontend/deployment.yml
+++ b/k8s/frontend/deployment.yml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: axiam-frontend
+  namespace: axiam
+  labels:
+    app: axiam
+    component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: axiam
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: axiam
+        component: frontend
+    spec:
+      containers:
+        - name: axiam-frontend
+          image: ghcr.io/OWNER/axiam-frontend:latest
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          securityContext:
+            runAsNonRoot: false

--- a/k8s/frontend/service.yml
+++ b/k8s/frontend/service.yml
@@ -14,5 +14,5 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 80
+      targetPort: 8080
       protocol: TCP

--- a/k8s/frontend/service.yml
+++ b/k8s/frontend/service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: axiam-frontend
+  namespace: axiam
+  labels:
+    app: axiam
+    component: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: axiam
+    component: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: axiam-ingress
+  namespace: axiam
+  labels:
+    app: axiam
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - axiam.example.com
+      secretName: axiam-tls
+  rules:
+    - host: axiam.example.com
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: axiam-server
+                port:
+                  number: 8080
+          - path: /grpc
+            pathType: Prefix
+            backend:
+              service:
+                name: axiam-server
+                port:
+                  number: 50051
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: axiam-frontend
+                port:
+                  number: 80

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -25,13 +25,6 @@ spec:
                 name: axiam-server
                 port:
                   number: 8080
-          - path: /grpc
-            pathType: Prefix
-            backend:
-              service:
-                name: axiam-server
-                port:
-                  number: 50051
           - path: /
             pathType: Prefix
             backend:
@@ -39,3 +32,31 @@ spec:
                 name: axiam-frontend
                 port:
                   number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: axiam-grpc-ingress
+  namespace: axiam
+  labels:
+    app: axiam
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - grpc.axiam.example.com
+      secretName: axiam-tls
+  rules:
+    - host: grpc.axiam.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: axiam-server
+                port:
+                  number: 50051

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: axiam
+
+commonLabels:
+  app: axiam
+
+resources:
+  - namespace.yml
+  - server/deployment.yml
+  - server/service.yml
+  - server/hpa.yml
+  - server/configmap.yml
+  - server/secret.yml
+  - frontend/deployment.yml
+  - frontend/service.yml
+  - ingress.yml
+  - surrealdb/statefulset.yml
+  - surrealdb/service.yml
+  - rabbitmq/statefulset.yml
+  - rabbitmq/service.yml

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -18,5 +18,7 @@ resources:
   - ingress.yml
   - surrealdb/statefulset.yml
   - surrealdb/service.yml
+  - surrealdb/secret.yml
   - rabbitmq/statefulset.yml
   - rabbitmq/service.yml
+  - rabbitmq/secret.yml

--- a/k8s/namespace.yml
+++ b/k8s/namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: axiam
+  labels:
+    app: axiam

--- a/k8s/rabbitmq/secret.yml
+++ b/k8s/rabbitmq/secret.yml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: axiam-secrets
+  name: rabbitmq-credentials
   namespace: axiam
   labels:
     app: axiam
-    component: server
+    component: rabbitmq
 type: Opaque
 data:
   # Base64-encoded placeholders — replace before deploying
   # echo -n 'change-me' | base64 → Y2hhbmdlLW1l
-  AXIAM_DB__USERNAME: "Y2hhbmdlLW1l"
-  AXIAM_DB__PASSWORD: "Y2hhbmdlLW1l"
+  username: "Y2hhbmdlLW1l"
+  password: "Y2hhbmdlLW1l"

--- a/k8s/rabbitmq/secret.yml
+++ b/k8s/rabbitmq/secret.yml
@@ -8,7 +8,7 @@ metadata:
     component: rabbitmq
 type: Opaque
 data:
-  # Base64-encoded placeholders — replace before deploying
-  # echo -n 'change-me' | base64 → Y2hhbmdlLW1l
-  username: "Y2hhbmdlLW1l"
-  password: "Y2hhbmdlLW1l"
+  # Intentionally left blank — provide real values at deploy time
+  # (e.g., via CI/CD secrets, sealed-secrets, or external-secrets operator)
+  username: ""
+  password: ""

--- a/k8s/rabbitmq/service.yml
+++ b/k8s/rabbitmq/service.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: axiam
+  labels:
+    app: axiam
+    component: rabbitmq
+spec:
+  clusterIP: None
+  selector:
+    app: axiam
+    component: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+    - name: management
+      port: 15672
+      targetPort: 15672

--- a/k8s/rabbitmq/statefulset.yml
+++ b/k8s/rabbitmq/statefulset.yml
@@ -24,9 +24,15 @@ spec:
           image: rabbitmq:3-management-alpine
           env:
             - name: RABBITMQ_DEFAULT_USER
-              value: "axiam"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: username
             - name: RABBITMQ_DEFAULT_PASS
-              value: "axiam"
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: password
           ports:
             - containerPort: 5672
               name: amqp

--- a/k8s/rabbitmq/statefulset.yml
+++ b/k8s/rabbitmq/statefulset.yml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  namespace: axiam
+  labels:
+    app: axiam
+    component: rabbitmq
+spec:
+  serviceName: rabbitmq
+  replicas: 1
+  selector:
+    matchLabels:
+      app: axiam
+      component: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: axiam
+        component: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3-management-alpine
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: "axiam"
+            - name: RABBITMQ_DEFAULT_PASS
+              value: "axiam"
+          ports:
+            - containerPort: 5672
+              name: amqp
+              protocol: TCP
+            - containerPort: 15672
+              name: management
+              protocol: TCP
+          volumeMounts:
+            - name: rabbitmq-data
+              mountPath: /var/lib/rabbitmq
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "check_running"]
+            initialDelaySeconds: 20
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "check_running"]
+            initialDelaySeconds: 60
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: rabbitmq-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/server/configmap.yml
+++ b/k8s/server/configmap.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: axiam-config
+  namespace: axiam
+  labels:
+    app: axiam
+    component: server
+data:
+  AXIAM_DATABASE__URL: "ws://surrealdb:8000"
+  AXIAM_DATABASE__NAMESPACE: "axiam"
+  AXIAM_DATABASE__DATABASE: "axiam"
+  AXIAM_AMQP__URL: "amqp://rabbitmq:5672"
+  RUST_LOG: "info,axiam=debug"

--- a/k8s/server/configmap.yml
+++ b/k8s/server/configmap.yml
@@ -7,8 +7,10 @@ metadata:
     app: axiam
     component: server
 data:
-  AXIAM_DATABASE__URL: "ws://surrealdb:8000"
-  AXIAM_DATABASE__NAMESPACE: "axiam"
-  AXIAM_DATABASE__DATABASE: "axiam"
+  AXIAM_DB__URL: "ws://surrealdb:8000"
+  AXIAM_DB__NAMESPACE: "axiam"
+  AXIAM_DB__DATABASE: "axiam"
   AXIAM_AMQP__URL: "amqp://rabbitmq:5672"
+  AXIAM_SERVER__HOST: "0.0.0.0"
+  AXIAM_GRPC__HOST: "0.0.0.0"
   RUST_LOG: "info,axiam=debug"

--- a/k8s/server/deployment.yml
+++ b/k8s/server/deployment.yml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: axiam-server
+  namespace: axiam
+  labels:
+    app: axiam
+    component: server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: axiam
+      component: server
+  template:
+    metadata:
+      labels:
+        app: axiam
+        component: server
+    spec:
+      containers:
+        - name: axiam-server
+          image: ghcr.io/OWNER/axiam-server:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 50051
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          envFrom:
+            - configMapRef:
+                name: axiam-config
+            - secretRef:
+                name: axiam-secrets
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: true

--- a/k8s/server/deployment.yml
+++ b/k8s/server/deployment.yml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: axiam-server
-          image: ghcr.io/OWNER/axiam-server:latest
+          image: ghcr.io/OWNER/server:latest
           ports:
             - name: http
               containerPort: 8080
@@ -37,7 +37,7 @@ spec:
               memory: 512Mi
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/k8s/server/hpa.yml
+++ b/k8s/server/hpa.yml
@@ -1,0 +1,28 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: axiam-server
+  namespace: axiam
+  labels:
+    app: axiam
+    component: server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: axiam-server
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/k8s/server/secret.yml
+++ b/k8s/server/secret.yml
@@ -8,7 +8,7 @@ metadata:
     component: server
 type: Opaque
 data:
-  # Base64-encoded placeholders — replace before deploying
-  # echo -n 'change-me' | base64 → Y2hhbmdlLW1l
-  AXIAM_DB__USERNAME: "Y2hhbmdlLW1l"
-  AXIAM_DB__PASSWORD: "Y2hhbmdlLW1l"
+  # Intentionally left blank — provide real values at deploy time
+  # (e.g., via CI/CD secrets, sealed-secrets, or external-secrets operator)
+  AXIAM_DB__USERNAME: ""
+  AXIAM_DB__PASSWORD: ""

--- a/k8s/server/secret.yml
+++ b/k8s/server/secret.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: axiam-secrets
+  namespace: axiam
+  labels:
+    app: axiam
+    component: server
+type: Opaque
+data:
+  # Base64-encoded placeholders — replace before deploying
+  # echo -n 'root' | base64 → cm9vdA==
+  AXIAM_DATABASE__USERNAME: "Y2hhbmdlLW1l"
+  # echo -n 'change-me' | base64 → Y2hhbmdlLW1l
+  AXIAM_DATABASE__PASSWORD: "Y2hhbmdlLW1l"

--- a/k8s/server/service.yml
+++ b/k8s/server/service.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: axiam-server
+  namespace: axiam
+  labels:
+    app: axiam
+    component: server
+spec:
+  type: ClusterIP
+  selector:
+    app: axiam
+    component: server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+      protocol: TCP

--- a/k8s/surrealdb/secret.yml
+++ b/k8s/surrealdb/secret.yml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: axiam-secrets
+  name: surrealdb-credentials
   namespace: axiam
   labels:
     app: axiam
-    component: server
+    component: surrealdb
 type: Opaque
 data:
   # Base64-encoded placeholders — replace before deploying
   # echo -n 'change-me' | base64 → Y2hhbmdlLW1l
-  AXIAM_DB__USERNAME: "Y2hhbmdlLW1l"
-  AXIAM_DB__PASSWORD: "Y2hhbmdlLW1l"
+  username: "Y2hhbmdlLW1l"
+  password: "Y2hhbmdlLW1l"

--- a/k8s/surrealdb/secret.yml
+++ b/k8s/surrealdb/secret.yml
@@ -8,7 +8,7 @@ metadata:
     component: surrealdb
 type: Opaque
 data:
-  # Base64-encoded placeholders — replace before deploying
-  # echo -n 'change-me' | base64 → Y2hhbmdlLW1l
-  username: "Y2hhbmdlLW1l"
-  password: "Y2hhbmdlLW1l"
+  # Intentionally left blank — provide real values at deploy time
+  # (e.g., via CI/CD secrets, sealed-secrets, or external-secrets operator)
+  username: ""
+  password: ""

--- a/k8s/surrealdb/service.yml
+++ b/k8s/surrealdb/service.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: surrealdb
+  namespace: axiam
+  labels:
+    app: axiam
+    component: surrealdb
+spec:
+  clusterIP: None
+  selector:
+    app: axiam
+    component: surrealdb
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+      protocol: TCP

--- a/k8s/surrealdb/statefulset.yml
+++ b/k8s/surrealdb/statefulset.yml
@@ -23,7 +23,25 @@ spec:
         - name: surrealdb
           image: surrealdb/surrealdb:v2
           command: ["surreal"]
-          args: ["start", "--user", "root", "--pass", "root", "--log", "info"]
+          args:
+            - "start"
+            - "--user"
+            - "$(SURREALDB_USER)"
+            - "--pass"
+            - "$(SURREALDB_PASS)"
+            - "--log"
+            - "info"
+          env:
+            - name: SURREALDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: surrealdb-credentials
+                  key: username
+            - name: SURREALDB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: surrealdb-credentials
+                  key: password
           ports:
             - containerPort: 8000
               name: http

--- a/k8s/surrealdb/statefulset.yml
+++ b/k8s/surrealdb/statefulset.yml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: surrealdb
+  namespace: axiam
+  labels:
+    app: axiam
+    component: surrealdb
+spec:
+  serviceName: surrealdb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: axiam
+      component: surrealdb
+  template:
+    metadata:
+      labels:
+        app: axiam
+        component: surrealdb
+    spec:
+      containers:
+        - name: surrealdb
+          image: surrealdb/surrealdb:v2
+          command: ["surreal"]
+          args: ["start", "--user", "root", "--pass", "root", "--log", "info"]
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: surrealdb-data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command: ["/surreal", "isready"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["/surreal", "isready"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+  volumeClaimTemplates:
+    - metadata:
+        name: surrealdb-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/surrealdb/statefulset.yml
+++ b/k8s/surrealdb/statefulset.yml
@@ -31,6 +31,7 @@ spec:
             - "$(SURREALDB_PASS)"
             - "--log"
             - "info"
+            - "file:/data/surreal.db"
           env:
             - name: SURREALDB_USER
               valueFrom:


### PR DESCRIPTION
## Summary

- **T16.1** — Multi-stage Dockerfiles for server (Rust builder → debian-slim runtime) and frontend (Node builder → nginx), with `.dockerignore`, nginx SPA config, production docker-compose, and justfile commands
- **T16.2** — Complete Kubernetes manifests: server/frontend Deployments with health probes, ClusterIP Services, Ingress with TLS, HPA (2-10 replicas), ConfigMap/Secret templates, SurrealDB/RabbitMQ StatefulSets with PVCs, Kustomize base
- **T16.3** — CD pipeline rewrite: parallel build+sign+attest of both Docker images via Sigstore cosign (keyless OIDC), release binary with strip, GitHub Release with git-cliff changelog

Closes #55, closes #56, closes #57

## Test plan

- [ ] Verify `docker build -f docker/Dockerfile.server -t axiam-server .` builds successfully
- [ ] Verify `docker build -f docker/Dockerfile.frontend -t axiam-frontend .` builds successfully
- [ ] Verify `just prod-up` starts the full stack and all services become healthy
- [ ] Verify `kubectl apply -k k8s/` applies all manifests without errors (dry-run)
- [ ] Verify release workflow syntax is valid (`gh workflow view release.yml`)
- [ ] Tag a test release to validate the full CD pipeline (build, sign, attest, release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)