### PR TITLE
docs(review): add full code & security review reports

Full-repository review (Rust backend + React frontend) at commit 6f2676d:
- claude_dev/security-review.md — 43 findings (6 critical) with stable
  SEC-NNN IDs, dependency audit results, and a prioritized remediation plan
- claude_dev/code-review.md — 62 findings with stable CQ-Bnn/CQ-Fnn IDs,
  architecture observations, and test-coverage summary

https://claude.ai/code/session_01FPPzeAJ1bZhyc4PWGPDUiV

### DIFF
--- a/claude_dev/code-review.md
+++ b/claude_dev/code-review.md
@@ -1,0 +1,408 @@
+# AXIAM — Full Code Review (Quality & Correctness)
+
+- **Date**: 2026-06-09
+- **Scope**: Entire repository at commit `6f2676d` — all 13 Rust crates (~47k LoC), React/TypeScript frontend (~17k LoC), workspace config, build tooling.
+- **Method**: Manual line-level review split across backend core crates, backend API/protocol crates, and the frontend, verified with `cargo clippy --workspace --all-targets` (**clean — zero warnings**), `tsc -b` (**clean**), `eslint .` (**9 errors**, see CQ-F06), Playwright/e2e inventory, and dependency inspection.
+- **Companion document**: [`security-review.md`](security-review.md). Findings that are primarily security issues live there; overlapping items are cross-referenced as `SEC-NNN`.
+
+Finding IDs: `CQ-Bnn` = backend, `CQ-Fnn` = frontend. IDs are stable — use them to drive and track fixes.
+
+---
+
+## Executive summary
+
+The architecture is sound and consistent: clean crate layering (core traits → db impls → protocol crates → server), thin handlers, complete OpenAPI registration, a real frontend services layer with react-query, strict TypeScript with zero `any`, and genuinely good REST integration tests (~230 test fns against in-memory SurrealDB). Clippy is clean.
+
+The dominant problems are:
+
+1. **Composition bugs in `main.rs`** — services constructed inconsistently produce real defects (the pepper bug CQ-B01 breaks login for REST-created users; the PKI zero-key fallback is SEC-012).
+2. **Blocking CPU work on async executors** (Argon2, RSA-4096/PGP keygen) with zero `spawn_blocking` in the workspace.
+3. **Mechanical duplication with drift** — ~28 near-identical repository files, ~14 near-identical frontend CRUD pages; the copies have already diverged in correctness-relevant ways (tenant guarding, error mapping, debouncing, pagination).
+4. **Reliability gaps** in AMQP (audit events silently dropped), migrations (non-idempotent, non-transactional), and multi-statement graph mutations (no transactions).
+
+| Priority | Backend | Frontend |
+|---|---|---|
+| High | 9 | 8 |
+| Medium | 17 | 10 |
+| Low | 8 | 7 |
+
+### Suggested fix order
+
+1. CQ-B01 (pepper), CQ-B02 (blocking async), CQ-B05 (AMQP audit loss), CQ-B06 (migrations) — production-breaking or data-loss class.
+2. CQ-B03 / CQ-B04 (settings snapshot + double-`Option` clearing) — silent wrong behavior.
+3. CQ-F01–CQ-F08 — user-visible frontend bugs, lint gate.
+4. Structural debt: CQ-B09/CQ-B10 (dup hashing, repo boilerplate), CQ-F15 (CRUD page abstraction) — do these before more handlers/pages land.
+5. Test gaps: axiam-pki (zero tests), gRPC/AMQP/federation (zero tests), webauthn/password-reset/notification handlers (zero REST tests).
+
+---
+
+# Backend findings
+
+## High
+
+### CQ-B01 [HIGH] Users created via REST can never log in when a password pepper is configured
+- **File**: `crates/axiam-server/src/main.rs:96`; `crates/axiam-db/src/repository/user.rs:178-196`; `crates/axiam-auth/src/service.rs:183-187`
+- **Type**: Bug (composition)
+- **Issue**: `SurrealUserRepository::new` hardcodes `pepper: None` (the `with_pepper` constructor exists but is never called), so `POST /api/v1/users` hashes **without** the pepper, while login/gRPC/password-reset verify **with** `config.auth.pepper`. With a pepper configured, every REST-created user fails login until they password-reset.
+- **Fix**: Construct with `with_pepper(db, config.auth.pepper)` in `main.rs` — but the better fix is CQ-B09: a single hashing path in axiam-auth.
+
+### CQ-B02 [HIGH] Blocking CPU-heavy crypto on async executor threads (no `spawn_blocking` anywhere)
+- **File**: Argon2: `crates/axiam-auth/src/service.rs:183`, `crates/axiam-db/src/repository/user.rs:196`, `crates/axiam-auth/src/policy.rs:243-263` (history loop — up to N verifications per password change), `password_reset.rs:178`, `crates/axiam-api-grpc/src/services/user.rs:126-131`. Keygen: `crates/axiam-pki/src/ca.rs:62`, `cert.rs:110`, `pgp.rs:42, 196-228`.
+- **Type**: Bug (async)
+- **Issue**: Argon2id (~20-100 ms CPU + 19 MiB per call) runs inline in `/auth/login` and friends; RSA-4096/PGP generation (seconds of CPU) runs inline in certificate/PGP services. A burst of logins or one cert request stalls Tokio/Actix workers, delaying all requests including health checks.
+- **Fix**: Wrap hash/verify/keygen/sign/encrypt in `tokio::task::spawn_blocking`; consider a semaphore to bound concurrent hashes. Also verify rcgen's backend actually supports RSA generation (ring does not; aws-lc-rs does) — nothing tests the `Rsa4096` path (CQ-B24).
+
+### CQ-B03 [HIGH] Tenant settings store a write-time merged snapshot — org baseline changes never propagate
+- **File**: `crates/axiam-db/src/repository/settings.rs:524-542`; `crates/axiam-api-rest/src/handlers/settings.rs:134-149`; `diff_against_org` in core settings model
+- **Type**: Bug (design)
+- **Issue**: `PUT /settings` persists the fully *merged* row (org baseline + overrides). When the org later changes a baseline value, every field where the stored row still holds the old org value now *differs* from the new baseline, so `diff_against_org` misclassifies it as a tenant override and the stale value wins — the opposite of the code comment's claim. Which fields were "explicitly overridden" is unrecoverable from a merged row. Security implication tracked as SEC-033 (MFA enforcement freezes).
+- **Fix**: Persist the sparse `TenantSettingsOverride` (`Option` fields) and merge against the live org baseline at read time.
+
+### CQ-B04 [HIGH] "Clear field" double-`Option` semantics unreachable from JSON
+- **File**: `crates/axiam-core/src/models/resource.rs:37` (`parent_id: Option<Option<Uuid>>` via `handlers/resources.rs:112-122`); `handlers/federation.rs:50` (`metadata_url: Option<Option<String>>`)
+- **Type**: Bug (serde)
+- **Issue**: With plain serde, JSON `null` deserializes the outer `Option` to `None` ("no change"); `Some(None)` ("clear") is unreachable without `serde_with::double_option` (not used anywhere in the workspace). Consequently `PUT /resources/{id}` can never move a resource to root, and `PUT /federation-configs/{id}` can never clear `metadata_url`. The federation handler even validates the `Some(Some(""))` case clients cannot send. The frontend compounds this by sending `undefined` for "clear" (CQ-F12).
+- **Fix**: `#[serde(default, with = "serde_with::rust::double_option")]` on these fields; add a test asserting `null` clears the parent.
+
+### CQ-B05 [HIGH] AMQP: audit events and authz requests silently dropped on transient failures; no dead-letter queue
+- **File**: `crates/axiam-amqp/src/audit_consumer.rs:140`; `authz_consumer.rs:122, 146, 175-181`; `connection.rs:100-115`
+- **Type**: Bug (reliability / compliance)
+- **Issue**: `BasicNackOptions::default()` is `requeue: false` — a transient DB outage permanently drops audit events (a compliance feature), and failed publishes drop authz requests with no response to the caller. No DLX is declared, so poison messages vanish rather than being quarantined. Conversely, broker-nack handling uses `requeue: true`, which can hot-loop.
+- **Fix**: Declare queues with a dead-letter exchange; requeue on transient errors, dead-letter on parse errors, cap redeliveries.
+
+### CQ-B06 [HIGH] Migration runner is not idempotent, not transactional, and has no concurrency guard
+- **File**: `crates/axiam-db/src/schema.rs:117-440, 787-844`
+- **Type**: Bug
+- **Issue**: The doc comment claims "All DEFINE statements are idempotent", but only the `_migration` DDL uses `IF NOT EXISTS`; V1–V14 use plain `DEFINE`, which errors on re-run in SurrealDB ≥2. Migration apply + record insert are two statements with no transaction — if the record insert fails, the next startup re-runs the migration and fails permanently. Two replicas starting concurrently race the same window.
+- **Fix**: `IF NOT EXISTS`/`OVERWRITE` on all DDL; wrap apply+record in a transaction; serialize startup migration via a lock record.
+
+### CQ-B07 [HIGH] Multi-statement graph deletes run unguarded and without transactions
+- **File**: `crates/axiam-db/src/repository/role.rs:252-270` (same pattern: permission.rs:247-264, resource.rs:257-277, group/service_account deletes)
+- **Type**: Bug
+- **Issue**: `DELETE has_role WHERE out = role:...; DELETE grants ...; DELETE role WHERE tenant_id = $tenant_id;` — only the final record delete is tenant-guarded. A wrong-tenant call leaves the role intact but destroys all its edges (silently revoking assignments — see SEC-007 for the isolation angle). No `BEGIN/COMMIT`, so partial failure leaves the graph inconsistent.
+- **Fix**: Verify tenant ownership first (or guard edge deletes with `out.tenant_id = $tenant_id`); wrap multi-statement mutations in transactions.
+
+### CQ-B08 [HIGH] Resource hierarchy: cycles not prevented; `get_ancestors` silently truncates; orphaned children on delete
+- **File**: `crates/axiam-db/src/repository/resource.rs:86, 172-255, 350-393`
+- **Type**: Bug
+- **Issue**: `update` allows setting `parent_id` to a descendant (or self) — no cycle check. With a cycle, `get_ancestors` loops `MAX_ANCESTOR_DEPTH=50` iterations pushing duplicates and returns garbage **without error**, making authorization decisions depth-dependent. `delete` cleans edges but leaves children's `parent_id` dangling.
+- **Fix**: Reject parent updates creating cycles (walk new parent's ancestors); return an error (not truncation) past MAX depth; null children's `parent_id` on delete. The frontend parent picker has the matching bug (CQ-F12).
+
+### CQ-B09 [HIGH] Password hashing/verification duplicated between axiam-db and axiam-auth — both live in production
+- **File**: `crates/axiam-db/src/repository/user.rs:138-159, 482-503` vs `crates/axiam-auth/src/password.rs:13-66`
+- **Type**: Duplication (correctness-critical)
+- **Issue**: `hash_password`/`verify_password` are copy-pasted with different error types; gRPC uses the db copy, login uses the auth copy. Drift in pepper handling or Argon2 params changes who can log in — CQ-B01 is exactly this class of failure. Partial duplication also in `generate_client_id/secret` (service_account.rs vs oauth2_client.rs).
+- **Fix**: One implementation (axiam-auth or a small shared crypto module); delete the db copy; route gRPC through it.
+
+## Medium
+
+### CQ-B10 [MEDIUM] ~28 repositories duplicate Row/CountRow/UUID-parse/pagination boilerplate, with visible drift
+- **File**: `crates/axiam-db/src/repository/*.rs` (e.g. user.rs:21-132, role.rs:13-95, group.rs:15-118)
+- **Type**: Duplication
+- **Issue**: Every repo re-implements `XxxRow`+`XxxRowWithId`, `CountRow` (20+ copies), the count+select pagination pair, `.check().map_err(...)`, and per-field UUID/status parsing (~80 copies). Drift is already real: some repos `.check()` and some don't; some return `NotFound` on 0-row delete and some return `Ok(())`; one repo lacks `#[derive(Clone)]`.
+- **Fix**: Shared helpers — `parse_uuid(field, s)`, generic `paginate<T>(db, table, where, pagination)`, one `CountRow`, `take_first_or_not_found`. Would roughly halve the crate and eliminate per-repo drift.
+
+### CQ-B11 [MEDIUM] `DbError::Migration` is a catch-all for every non-NotFound failure; conflicts surface as 500s
+- **File**: `crates/axiam-db/src/error.rs:5-17` (used in ~200 places)
+- **Type**: Error handling
+- **Issue**: Constraint violations (duplicate username on the unique index), row-decode failures, even Argon2 errors all become "Migration failed: …". `AxiamError::AlreadyExists` exists but is never produced by the db layer — duplicate-username create returns a misleading 500 instead of 409.
+- **Fix**: Add `DbError::Query`/`Decode`/`Conflict` variants; detect SurrealDB index-violation errors → `AlreadyExists`; remove crypto from the db error space (per CQ-B09).
+
+### CQ-B12 [MEDIUM] `login` swallows database errors from the email lookup
+- **File**: `crates/axiam-auth/src/service.rs:167-171`
+- **Type**: Error handling
+- **Issue**: `.map_err(|_| AuthError::InvalidCredentials)` — a DB outage during the email-fallback lookup reports "invalid credentials" instead of an internal error, hiding incidents.
+- **Fix**: Match `NotFound` only (as the username branch does); propagate other errors.
+
+### CQ-B13 [MEDIUM] AuthZ engine: N+1 queries, sequential ancestor walk, dead generic parameter
+- **File**: `crates/axiam-authz/src/engine.rs:33-35, 121-133`; `crates/axiam-db/src/repository/resource.rs:350-393`
+- **Type**: Performance / Design
+- **Issue**: One query per applicable role plus one per hierarchy level — a single `check_access` (the hot path of an IAM product) can cost 3 + roles + depth round-trips. `group_repo` is `#[allow(dead_code)]` yet forces a fifth generic parameter on every instantiation.
+- **Fix**: Batched `get_permission_grants_for_roles(&[Uuid])`; recursive/graph query for ancestors (the `child_of` edges exist but are unused for traversal); drop the dead generic.
+
+### CQ-B14 [MEDIUM] Ed25519 PEM keys re-parsed on every token issue/validate; four near-identical JWT helpers
+- **File**: `crates/axiam-auth/src/token.rs:68, 106, 183, 196`; `service.rs:659-723`; `webauthn.rs:313-327`
+- **Type**: Performance / Duplication
+- **Issue**: `EncodingKey::from_ed_pem` per call on the hottest path (every request-level validation); key-parse errors surface at request time instead of startup. The issue/decode helpers for access/client-credentials/MFA-challenge/MFA-setup tokens are near-verbatim copies.
+- **Fix**: Parse keys once at construction (fail fast); one parameterized issue/decode helper. (Pairs with SEC-006's `token_use` claim work.)
+
+### CQ-B15 [MEDIUM] `CertService::generate` reconstructs the CA certificate instead of using the stored one
+- **File**: `crates/axiam-pki/src/cert.rs:108-122, 185-192`
+- **Type**: Bug (latent)
+- **Issue**: The issuer handed to rcgen is a fresh self-signed reconstruction (default serial/validity, CN-only DN, no SKI continuity) — not the stored `public_cert_pem`. Signatures verify (same key) but Authority Key Identifier / issuer DN can diverge from the real CA cert, breaking strict chain validation in some verifiers. Also `cert.rs` duplicates `generate_keypair`/`compute_fingerprint`/`to_rcgen_time` verbatim from `ca.rs`.
+- **Fix**: `CertificateParams::from_ca_cert_pem(&ca_cert.public_cert_pem)`; share the helpers.
+
+### CQ-B16 [MEDIUM] Org/tenant delete: no cascade; all deletes report success for missing records
+- **File**: `crates/axiam-db/src/repository/organization.rs:210-218`, `tenant.rs:221-229` (pattern also user.rs:411-428, session.rs)
+- **Type**: Bug / Design
+- **Issue**: Deleting an org leaves its tenants; deleting a tenant orphans users/sessions/roles/settings/tokens/certs. All `delete()`s return `Ok(())` whether or not anything matched, while `update()` returns `NotFound` — an inconsistent contract that hides caller bugs.
+- **Fix**: Cascade in a transaction or refuse to delete non-empty parents; `RETURN BEFORE` to detect 0-row deletes → `NotFound`.
+
+### CQ-B17 [MEDIUM] Duplicate graph edges: `RELATE` without uniqueness, comment claims dedup that doesn't exist
+- **File**: `crates/axiam-db/src/repository/group.rs:385-388`; role.rs:331-343; permission.rs:323-328
+- **Type**: Bug
+- **Issue**: Comment says "IF NOT EXISTS avoids duplicates" but the query has no such clause and no unique index exists on edge tables. Repeated calls create duplicate `member_of`/`has_role`/`grants` edges; `get_members` counts edges for `total` while the item list dedupes — pagination totals drift.
+- **Fix**: Unique indexes on `(in, out[, resource_id])` or upsert semantics; fix the comment.
+
+### CQ-B18 [MEDIUM] OAuth2: repository errors collapsed into `invalid_client`/`invalid_grant`; client-auth block duplicated 3×
+- **File**: `crates/axiam-oauth2/src/token.rs:171-175, 206-214, 339-343, 447-451` (helper exists at 723-747)
+- **Type**: Error handling / Duplication
+- **Issue**: Any DB error becomes 401 `invalid_client`/400 `invalid_grant` — clients are told their credentials are wrong during an outage. The 15-line lookup+`ct_eq` client-auth block is re-implemented inline in three grant handlers although `authenticate_client()` exists — drift risk on a security-critical comparison.
+- **Fix**: `NotFound` → invalid_client, other errors → `server_error`; route all call sites through `authenticate_client`.
+
+### CQ-B19 [MEDIUM] OIDC discovery advertises endpoints that don't work as advertised (`?tenant_id=` required)
+- **File**: `crates/axiam-oauth2/src/oidc.rs:36-41` vs `crates/axiam-api-rest/src/handlers/oauth2.rs:43-46, 172-177`
+- **Type**: API design
+- **Issue**: `/oauth2/token|revoke|introspect` hard-require a non-standard `tenant_id` query param, but discovery advertises bare URLs; standards-compliant clients get a plain-text Actix 400 (not an RFC 6749 error body, since extractor failures bypass `build_oauth2_error_response`).
+- **Fix**: Per-tenant issuer paths (or resolve tenant from `client_id`); RFC-shaped error when `tenant_id` is missing.
+
+### CQ-B20 [MEDIUM] gRPC server: no graceful shutdown, no message-size/time limits, batch all-or-nothing
+- **File**: `crates/axiam-api-grpc/src/server.rs:39-44`; `services/authorization.rs:91-117`
+- **Type**: API design / Bug
+- **Issue**: `serve` (not `serve_with_shutdown`), no `max_decoding_message_size`/`timeout`/`concurrency_limit`/TLS. `BatchCheckAccess` is unbounded, serial, and one malformed UUID fails the whole batch. (Missing auth and lockout accounting are SEC-003/SEC-026.)
+- **Fix**: Graceful shutdown, limits, per-item batch error semantics, max batch size.
+
+### CQ-B21 [MEDIUM] Inconsistent error envelopes and JSON body limits across the REST surface
+- **File**: `crates/axiam-api-rest/src/server.rs:37`; `error.rs`
+- **Type**: Error handling / API design
+- **Issue**: Only `/auth` gets the 64 KiB JSON limit (`/api/v1/*` gets Actix's 2 MiB default — presumably unintentional). Three error shapes coexist: the `{"error","message"}` envelope, Actix plain-text extractor failures (no `JsonConfig::error_handler`/`QueryConfig`/`PathConfig` anywhere), and OAuth2's `{"error","error_description"}`.
+- **Fix**: App-wide `JsonConfig`/`QueryConfig`/`PathConfig` with a standard-envelope error handler; one global body limit.
+
+### CQ-B22 [MEDIUM] Webhook delivery is fire-and-forget, unbounded, unrecorded — and currently dead code
+- **File**: `crates/axiam-api-rest/src/webhook.rs:34-129`; wired at main.rs:274 but no handler calls `.deliver()`
+- **Type**: Reliability / Dead code
+- **Issue**: Deliveries (with up to 10 retries and up-to-1h sleeps) live in detached `tokio::spawn` tasks — lost on restart, no persistence/history, no per-tenant concurrency bound. `UpdateWebhookRequest` cannot rotate the secret.
+- **Fix**: Route deliveries through the existing RabbitMQ infra (durable queue + consumer); add secret rotation; or remove until wired.
+
+### CQ-B23 [MEDIUM] Federation: discovery fetched twice per login, size cap applied after full buffering, IdP 4xx → HTTP 500, `attribute_map` ignored for OIDC
+- **File**: `crates/axiam-federation/src/oidc.rs:131-140, 203, 267, 432-552`; `error.rs:52-56`; contrast saml.rs:425
+- **Type**: Bug / Error handling
+- **Issue**: (a) the 256 KiB cap is checked **after** `bytes()` buffers the whole response; (b) discovery is fetched on both `authorize` and `callback` with no cache; (c) `TokenExchangeFailed`/`DiscoveryFailed` map to `Internal` → 500 even for user-caused invalid codes; (d) `config.attribute_map` is honored for SAML but never read on the OIDC provisioning path despite the DTO documenting it.
+- **Fix**: Stream-limited reads; per-config discovery cache (TTL); 4xx-class mapping for IdP-rejected exchanges; apply the map in OIDC provisioning or document SAML-only.
+
+### CQ-B24 [MEDIUM] Test coverage holes in security-critical crates
+- **Type**: Testing
+- **Inventory**:
+  - **axiam-pki: zero tests** — CA generation, leaf signing, AES round-trips, fingerprints, mTLS, PGP all untested. Most urgent given key material (and the rcgen-RSA backend question in CQ-B02).
+  - **axiam-api-grpc, axiam-amqp, axiam-federation: zero tests** (federation notable given hand-rolled SAML XML and JWT-peek logic).
+  - REST handler groups with no tests: webauthn (4 endpoints), email_verification, password_reset, notification_rules, mfa_methods.
+  - axiam-db: ~half the repos untested (audit, settings, oauth2*, federation*, certificates/CA, pgp, webhook, notification_rule, email_*).
+  - authz engine: missing edge cases — cycles/>50 depth, duplicate assignments, scope on ancestor, concurrent grant changes.
+- **Fix**: Prioritize axiam-pki unit tests and federation tests alongside the SEC-004/005 work; add the missing handler test files following the existing (good) integration-test pattern.
+
+### CQ-B25 [MEDIUM] DTO strategy drift; server-set fields accepted in bodies then silently overwritten
+- **File**: e.g. `handlers/certificates.rs:40-41`, `pgp_keys.rs:34-35`, `ca_certificates.rs:34-35`, `groups.rs:130`, `organizations.rs:27`
+- **Type**: API design
+- **Issue**: Half the API binds core domain structs straight to the wire (organizations/tenants/groups/roles/permissions/resources/scopes/service-accounts/certificates), half defines request DTOs. `CreateCertificate.tenant_id`/`CreateCaCertificate.organization_id` appear in OpenAPI yet are overwritten from JWT/path — confusing for SDK generators. (Mass-assignment angle: SEC-035.)
+- **Fix**: Standardize on request DTOs, or `#[serde(skip_deserializing)]` + `#[schema(ignore)]` for server-set fields.
+
+### CQ-B26 [MEDIUM] Validation inconsistency; admin user creation bypasses the tenant password policy
+- **File**: `handlers/users.rs:80-95` vs `password_reset.rs:147-166`; `notification_rules.rs:258-273`
+- **Type**: Bug / API design
+- **Issue**: `users::create` does no validation (no email format, no username constraints, **no password policy**) while the same tenant's reset flow enforces policy; notification rules validate emails with `contains('@')` while users don't validate at all.
+- **Fix**: Enforce the effective password policy in `users::create`; one shared email/username validator.
+
+## Low
+
+### CQ-B27 [LOW] Composition drift in `main.rs`: federation/email/reset services rebuilt per request from cloned repos
+- **File**: `handlers/federation.rs:412-417, 469-474, 631-636, 681-686, 731-736`; `email_verification.rs:62-66`; `password_reset.rs:70-75`
+- **Fix**: Compose once in `main.rs` (like `AuthService`/`TokenService`); a `bootstrap`/`AppState` module would have prevented CQ-B01 too.
+
+### CQ-B28 [LOW] Copy-pasted `client_ip`/`user_agent` helpers with drift (length caps only in one copy)
+- **File**: `handlers/auth.rs:113-124` (uncapped) vs `handlers/webauthn.rs:90-105` (capped)
+- **Fix**: One capped shared implementation.
+
+### CQ-B29 [LOW] Dead code wired into the composition root
+- **File**: `main.rs:211/267` (NotificationPublisher never consumed); `axiam-audit/src/service.rs` (`AuditService`), `notification.rs` (`NotificationDispatcher`) exported but unused — notification rules currently match but never send.
+- **Fix**: Wire up or remove until the email phase lands.
+
+### CQ-B30 [LOW] Pagination count+data non-transactional; `Pagination` unbounded (see SEC-010)
+- **File**: pattern everywhere, e.g. `user.rs:430-476`
+- **Fix**: Clamp in `Pagination`; batch count+select or document approximation; `RETURN BEFORE` + `len()` for delete counts (copy `password_history::prune`).
+
+### CQ-B31 [LOW] Silently dropped errors: passkey decrypt failures and best-effort session invalidation unlogged
+- **File**: `crates/axiam-auth/src/webauthn.rs:200-203` (`.filter_map(|c| ....ok())`); `service.rs:440-443` (`let _ =`)
+- **Fix**: Log decrypt failures with credential ID (a key-rotation bug would currently look like "no credentials"); `warn!` on failed invalidation.
+
+### CQ-B32 [LOW] `DeviceIdentity.org_id` returned as `Uuid::nil()` placeholder
+- **File**: `crates/axiam-pki/src/mtls.rs:69-74`
+- **Fix**: Drop the field or make it `Option<Uuid>` — half-initialized typed structs invite bugs.
+
+### CQ-B33 [LOW] Stringly-typed `AxiamError`; misc API-shape inconsistencies
+- **File**: `crates/axiam-core/src/error.rs:22-47`; revoke endpoints returning `200 {"status":"revoked"}` vs deletes 204; PUT-with-PATCH-semantics everywhere; `GET /oauth2/authorize` returns 401 JSON instead of redirecting (doc comment promises redirect); multiple adjacent `Uuid` params with per-method argument orders (`add_member(tenant, user, group)` vs `get_members(tenant, group, ...)`).
+- **Fix**: Structured error variants/codes before the API ossifies; pick one state-transition response convention; consider PATCH or documented merge semantics; consider newtype IDs (`UserId`, `GroupId`) to kill swap-bug risk.
+
+### CQ-B34 [LOW] Dependency hygiene: unused deps, non-unified workspace versions, three `rand` majors
+- **File**: `crates/axiam-authz/Cargo.toml` (serde/tokio/tracing/thiserror unused), `axiam-pki` (base64/rand/tokio unused; `rand_core 0.6` vs workspace rand 0.9; `time`/`smallvec` pinned directly), `axiam-auth` (webauthn-rs-proto unused), `axiam-db` (tokio unused, `surrealdb-types` pinned directly); rand 0.8 + 0.9 + 0.10 simultaneously in tree.
+- **Fix**: `cargo machete`/`cargo udeps`; move stragglers into `[workspace.dependencies]`; consolidate rand.
+
+### CQ-B35 [LOW] `check_hibp` signature is vestigial `Result` whose future `Err` would be silently swallowed
+- **File**: `crates/axiam-auth/src/policy.rs:173-220, 310-315` (`let Ok(Some(violation)) = ...`)
+- **Issue**: Also note HIBP enforcement depends on callers passing `http_client: Some(_)` — policy can be skipped by call-site omission.
+- **Fix**: Return `Option<PolicyViolation>` (best-effort by contract) or propagate with `?`.
+
+### CQ-B36 [LOW] Audit middleware drops entries on channel-full/DB-failure with no metric
+- **File**: `crates/axiam-audit/src/middleware.rs:52-58, 161-163`
+- **Fix**: Acceptable backpressure design, but make drops a counted/alertable event (metric + rate-limited error log).
+
+---
+
+# Frontend findings
+
+## High
+
+### CQ-F01 [HIGH] Hardcoded placeholder user ID sent to the PGP key API
+- **File**: `frontend/src/pages/pgp/PgpKeysPage.tsx:268`
+- **Issue**: `const currentUserId = "current-user";` — every generated PGP key is attributed to that literal string instead of `useAuthStore` `user.id`.
+- **Fix**: `const userId = useAuthStore((s) => s.user?.id)`; block submission if absent.
+
+### CQ-F02 [HIGH] ConfirmDialog hardcodes the confirm button label to "Delete"
+- **File**: `frontend/src/components/ConfirmDialog.tsx:103-107`
+- **Issue**: No `confirmLabel` prop; "Revoke Certificate", "Rotate Client Secret", "Reset MFA", "Revoke Permission" dialogs all show a destructive **Delete** button — wrong and misleading for irreversible-but-different actions.
+- **Fix**: Add `confirmLabel`/`variant` props (default "Delete").
+
+### CQ-F03 [HIGH] Audit log "Clear" doesn't cancel pending debounce timers — cleared filters resurrect invisibly
+- **File**: `frontend/src/pages/audit/AuditLogsPage.tsx:1018-1065`
+- **Issue**: Timers stored in `useState` (extra re-render per keystroke), never cleared in `clearFilters` or on unmount — type "alice", click Clear within 400 ms, and the table silently filters by an invisible value.
+- **Fix**: Timers in `useRef`, cleared in `clearFilters` and unmount cleanup — or reuse the existing debounced `SearchInput` component.
+
+### CQ-F04 [HIGH] Duplicated debounced user search with a stale-response race and no unmount cleanup
+- **File**: `frontend/src/pages/roles/RoleDetailPage.tsx:285-307`; `frontend/src/pages/groups/GroupDetailPage.tsx:83-104`
+- **Issue**: No request sequencing/AbortController — a slow older response overwrites newer results (classic typeahead race); the timer survives dialog close and `setResults` fires after unmount. The whole dialog is a near-verbatim duplicate across the two pages.
+- **Fix**: One shared `UserSearchDialog` using `useQuery({ queryKey: ["user-search", debouncedTerm] })` — react-query solves race, caching, and cleanup.
+
+### CQ-F05 [HIGH] Logout doesn't clear the react-query cache (or call the backend)
+- **File**: `frontend/src/components/layout/Topbar.tsx:86-89`; `frontend/src/lib/api.ts:111`
+- **Issue**: All cached queries survive logout; logging in as a different user/tenant briefly renders the previous tenant's cached data (staleTime 60 s). Server-side revocation gap tracked as SEC-015.
+- **Fix**: `queryClient.clear()` on logout and on the 401-refresh-failure path; call `POST /auth/logout`.
+
+### CQ-F06 [HIGH] `npm run lint` fails — 9 ESLint errors, two of them real hook bugs
+- **File**: `frontend/package.json:10`
+- **Inventory**: `react-hooks/refs` in OrganizationDetailPage.tsx:633 (CQ-F07); `react-hooks/set-state-in-effect` in MfaManagementPage.tsx:99 and ResourceTree.tsx:302; `react-refresh/only-export-components` in button/badge/PasswordPolicyChecker; `no-empty-object-type` in input/textarea.
+- **Fix**: Fix the two hook-rule errors, move non-component exports to separate files, then **wire lint into CI** so the gate stays green. (`tsc -b` is clean.)
+
+### CQ-F07 [HIGH] Org Settings tab: dead "sync" logic + display/save drift
+- **File**: `frontend/src/pages/organizations/OrganizationDetailPage.tsx:631-635`
+- **Issue**: `const syncedRef = { current: false }` is a plain object recreated every render — the whole block is a no-op (and an eslint error). Inputs display defaults (`merged.password_min_length ?? 12`) but `handleSubmit` sends `merged` without those defaults — what the user sees as "12" is not what gets saved.
+- **Fix**: Delete the dead block; adopt the `DEFAULT_SETTINGS`-merged-via-`useMemo` pattern already used in SettingsPage.tsx:149-151 (the two settings screens implement the same concept two different ways).
+
+### CQ-F08 [HIGH] Tenants table fabricates "Status: Active" for every tenant
+- **File**: `frontend/src/pages/tenants/TenantsPage.tsx:~370`
+- **Issue**: `render: () => <StatusBadge status="active" />` — `Tenant` has no status field; the column unconditionally shows "Active". Fabricated data in an IAM admin console.
+- **Fix**: Remove the column or add a real status field to the DTO.
+
+## Medium
+
+### CQ-F09 [MEDIUM] Mutation errors surface raw Axios messages — or nothing at all
+- **File**: pervasive; e.g. `UsersPage.tsx:247-251`, `TenantsPage.tsx` deleteMutation, `CertificatesPage.tsx:710-716`
+- **Issue**: (1) `err.message` is "Request failed with status code 409" — the backend's error body is discarded everywhere except Login/Profile/MfaManagement. (2) Every delete/revoke/rotate mutation lacks `onError`: on failure the ConfirmDialog spinner stops, the dialog stays open, zero feedback. `@radix-ui/react-toast` is installed but unused.
+- **Fix**: One `getApiErrorMessage(err)` helper in `lib/api.ts`; global `MutationCache.onError` toast on the `QueryClient`.
+
+### CQ-F10 [MEDIUM] Dashboard duplicates server state under parallel query keys — counts stay stale after mutations
+- **File**: `frontend/src/pages/DashboardPage.tsx:568-591`
+- **Issue**: `["dashboard-users"]` etc. vs canonical `["users", ...]` — CRUD invalidations never reach the dashboard; failed stat queries silently render "—".
+- **Fix**: Reuse canonical key prefixes so existing invalidations cover the dashboard; add error states.
+
+### CQ-F11 [MEDIUM] `FormDialog` sets `noValidate`, making every `required`/`type="email"`/`type="url"` attribute inert
+- **File**: `frontend/src/components/FormDialog.tsx:99`; consumers UsersPage.tsx:109-117, WebhooksPage.tsx:132-140
+- **Issue**: Manual handlers only check non-emptiness — email format (user create/edit), URL format (webhooks, SAML/OIDC fields) are never validated anywhere; `"not-an-email"` goes to the API. Only NotificationRulesPage has a real email regex.
+- **Fix**: Drop `noValidate` or lift NotificationRulesPage's validators into a shared module. (Backend should validate too — CQ-B26.)
+
+### CQ-F12 [MEDIUM] Resource parent picker allows cycles; parent/resource scope can never be cleared
+- **File**: `frontend/src/pages/resources/ResourcesPage.tsx` (ResourceFormFields ~line 70; handleEditSubmit); `ResourceTree.tsx:20-41`; same pattern in PermissionsPage
+- **Issue**: (1) Edit excludes only the resource itself from the parent dropdown, not its descendants — cycles possible, and `buildTree` then drops the whole subtree from the view (no node appears as root). (2) "Move to root" sends `parent_id: undefined` (= unchanged in a Partial PUT), so de-parenting is impossible; same for making a resource-scoped permission global. Pairs with backend CQ-B04/CQ-B08.
+- **Fix**: Exclude descendants from the dropdown; send explicit `parent_id: null` once the backend accepts it.
+
+### CQ-F13 [MEDIUM] Federation edit dialog reuses stale form state across providers and silently ignores type switches
+- **File**: `frontend/src/pages/federation/FederationPage.tsx:320-338, 503-543`
+- **Issue**: `load()` overwrites only fields present on the loaded provider — editing a SAML provider then an OIDC one leaves SAML fields populated; the type `<select>` is editable in edit mode but `UpdateProviderRequest` has no `type` field, producing half-applied edits.
+- **Fix**: `editForm.reset()` before `load()`; type selector read-only in edit mode.
+
+### CQ-F14 [MEDIUM] Users pagination: skeleton flash on every page change; stranded empty page after deleting the last row
+- **File**: `frontend/src/pages/users/UsersPage.tsx:216-224, 469-491`
+- **Issue**: No `placeholderData` (AuditLogsPage has it — inconsistent); `page` isn't clamped when `total` shrinks, leaving "No users found" with Next disabled.
+- **Fix**: `placeholderData: keepPreviousData`; clamp page in delete `onSuccess`.
+
+### CQ-F15 [MEDIUM] ~14 near-identical CRUD pages; small components copy-pasted up to 6×
+- **File**: `frontend/src/pages/{users,roles,groups,permissions,resources,webhooks,oauth2,federation,service-accounts,notifications,pgp,certificates,tenants,organizations}/*.tsx`
+- **Issue**: Identical create/edit/delete state-cluster + mutation + reset template repeated per page (~3,000+ lines). `ToggleField` defined **6 times**, `SectionCard`/`InfoRow` 3×, `ActionBadge` 2×, `slugify` 2×. The copies have already drifted (placeholderData, error extraction, debouncing each have 2-3 competing implementations) — CQ-F09's fix must currently be applied 14 times.
+- **Fix**: Extract `useCrudMutations(entityKey, service)`, shared `ToggleField`, move `SectionCard`/`InfoRow`/`ActionBadge` into `components/`.
+
+### CQ-F16 [MEDIUM] Whole-store zustand subscriptions in layout components re-render the entire tree on token refresh
+- **File**: `AppLayout.tsx:9`, `Topbar.tsx:20`, `DashboardPage.tsx:566`
+- **Issue**: `const { isAuthenticated } = useAuthStore()` subscribes to the whole store — every silent `updateAccessToken` re-renders AppLayout → entire page tree.
+- **Fix**: Selector form: `useAuthStore((s) => s.isAuthenticated)`.
+
+### CQ-F17 [MEDIUM] Profile/MFA/auth pages bypass the services layer; `MfaMethod` defined 3 times with diverging types
+- **File**: `ProfilePage.tsx:489-506`, `MfaManagementPage.tsx:17-50`, vs `services/users.ts:17`
+- **Issue**: Inline `api.get(...)` calls and three competing declarations of the same DTO (`method_type: "totp" | "webauthn"` vs `string`).
+- **Fix**: `services/profile.ts` (or extend the users service with `me` endpoints); import the single `MfaMethod`.
+
+### CQ-F18 [MEDIUM] Role/group assignments are write-only in the UI; unassign service methods are dead code
+- **File**: `UserDetailPage.tsx` ("Role Assignments" renders static help text), `RoleDetailPage.tsx:851-871` (`onAssigned={() => {}}`), `services/roles.ts:66-81` (unassign methods never imported)
+- **Issue**: Admins can assign roles but can never see or remove existing assignments anywhere in the app.
+- **Fix**: Fetch and render assignments (needs a list endpoint) or remove the misleading sections; wire up or delete the unassign methods.
+
+### CQ-F19 [MEDIUM] VerifyEmailPage fires a state-changing GET twice under StrictMode
+- **File**: `frontend/src/pages/auth/VerifyEmailPage.tsx:41-67`
+- **Issue**: The `cancelled` flag stops stale state updates but not the duplicate request; with a single-use token the second call fails and the winner is timing-dependent — flaky "Verification failed" screens. Verification via GET is semantically a mutation. (The deeper proxy bug is SEC-030.)
+- **Fix**: `useRef` fired-guard or a mutation keyed by token; prefer POST.
+
+## Low
+
+### CQ-F20 [LOW] TenantsPage shows "No tenants found" while organizations are still loading; N+1 tenant fan-out
+- **File**: `frontend/src/pages/tenants/TenantsPage.tsx:~190-210`
+- **Fix**: Treat `orgsLoading || tenantsPending` as loading; gate on `orgsQuery.isSuccess`.
+
+### CQ-F21 [LOW] Dead code: `Placeholder.tsx` (124 lines, nothing imports it); stray icon re-exports at the bottom of RoleDetailPage
+- **Fix**: Delete both.
+
+### CQ-F22 [LOW] Five unused @radix-ui dependencies while their functionality is hand-rolled
+- **File**: `frontend/package.json:11-18`
+- **Issue**: Only `react-slot` and `react-label` are imported; `react-dialog`, `react-dropdown-menu`, `react-select`, `react-separator`, `react-toast` sit unused while FormDialog/ConfirmDialog/Topbar reimplement focus traps (duplicated in 2 files) and menus by hand.
+- **Fix**: Adopt the Radix primitives (removes ~250 lines of a11y plumbing) or drop the deps.
+
+### CQ-F23 [LOW] Client-side password policy hardcoded — can diverge from server policy; absent on admin user creation
+- **File**: `frontend/src/components/PasswordPolicyChecker.tsx:45-53`; UsersPage "New User" applies no policy check
+- **Fix**: Fetch the effective policy from the settings endpoint and pass it through; reuse the checker on user creation.
+
+### CQ-F24 [LOW] DataTable fallback row key relies on an unchecked double cast
+- **File**: `frontend/src/components/DataTable.tsx:79`
+- **Fix**: Constrain `T extends { id?: string }` or require `getRowKey`.
+
+### CQ-F25 [LOW] No i18n; dates hardcoded to `en-US`
+- **File**: entire frontend; `lib/utils.ts:40, 48`
+- **Fix**: Use `navigator.language` for `Intl.DateTimeFormat` now; decide on an i18n framework before more pages land (GDPR/EU target market).
+
+### CQ-F26 [LOW] DOM selector built by interpolating API-supplied IDs
+- **File**: `frontend/src/components/ResourceTree.tsx:81`
+- **Issue**: An ID containing `"` or `]` throws or matches the wrong node (keyboard-nav breakage; not XSS).
+- **Fix**: `CSS.escape(id)`.
+
+---
+
+## Architecture observations
+
+**Backend.** Layering is clean and consistent: RPITIT repository traits in axiam-core with no DB dependency; services generic over traits; SurrealDB impls isolated in axiam-db; thin handlers; a complete OpenAPI registration that actually matches the route table (verified by diffing). The three systemic weaknesses: (1) the repository layer's mechanical duplication with measurable drift (tenant guarding, `.check()` usage, NotFound-on-delete, edge dedup each done differently per file); (2) no transactions around multi-statement graph mutations; (3) composition drift in `main.rs` — some services built once, some rebuilt per request, one built with wrong arguments (CQ-B01). A single `bootstrap`/`AppState` module would eliminate that class. The AMQP layer has good publisher-confirm hygiene but no consumer reliability story (DLQ/requeue policy); reconnect is "exit(1) and let the orchestrator restart" — workable but should be documented.
+
+**Frontend.** Clear 3-layer shape (typed services → react-query for server state → pages over shared primitives), correct zustand/react-query separation, good query-key/invalidation discipline (dashboard excepted), and unusually good hand-rolled accessibility. The dominant debt is the unfactored CRUD-page template (~80 % identical, already diverging) and systematically missing mutation-error surfacing. Profile/auth pages bypassing the services layer and a few display-only sections presenting incomplete or fabricated data round out the list.
+
+## Test coverage summary
+
+| Area | State |
+|---|---|
+| axiam-api-rest | **Good**: 20 integration files, ~230 tests, real in-memory SurrealDB, negative cases (oauth2_flow_test.rs alone: 37 tests). Gaps: webauthn, email_verification, password_reset, notification_rules, mfa_methods handlers. |
+| axiam-auth | Best-covered crate (1,253-line service test + solid unit tests). `webauthn.rs` itself untested. |
+| axiam-authz | One good 793-line engine test. Missing: cycles/depth-limit, duplicate assignments, ancestor scopes, concurrency. |
+| axiam-db | ~Half the repos tested (good tenant-isolation assertions where present). Untested: audit, settings, oauth2*, federation*, certs/CA, pgp, webhook, notification, email tokens. |
+| axiam-email | Good template/factory/mock tests; HTTP providers + SMTP untested. |
+| axiam-pki | **Zero tests.** |
+| axiam-api-grpc / axiam-amqp / axiam-federation / axiam-audit | **Zero tests** (audit covered indirectly via REST middleware test). |
+| Frontend | 11 Playwright specs (~2,166 lines) with fully mocked APIs — effectively UI component tests; decent happy-path CRUD coverage. **No unit tests at all** (no vitest/jest/RTL). Untested pure logic: `buildTree`, `checkPasswordPolicy`, `formatRelativeTime`, parsers, and especially the concurrency-sensitive axios refresh-queue interceptor. `tsc` clean; `eslint` failing (CQ-F06). |
+
+## Static analysis results
+
+- `cargo clippy --workspace --all-targets`: **clean, zero warnings** (with `clippy.toml` present — good baseline discipline).
+- `cargo audit`: 7 advisories — tracked as **SEC-013** in the security review.
+- `tsc -b`: clean. `eslint .`: 9 errors (CQ-F06). `npm audit`: 7 vulnerabilities — tracked as **SEC-029**.
+- Note: the build requires `protoc` (axiam-api-grpc build script); document it as a prerequisite or vendor via `protoc-bin-vendored`.

--- a/claude_dev/security-review.md
+++ b/claude_dev/security-review.md
@@ -1,0 +1,311 @@
+# AXIAM — Full Security Review
+
+- **Date**: 2026-06-09
+- **Scope**: Entire repository at commit `6f2676d` — all 13 Rust crates, React frontend, proto definitions, docker/, k8s/, dependency audit (`cargo audit`, `npm audit`).
+- **Method**: Manual line-level review of all security-relevant code (auth, oauth2, federation, pki, authz, db layer, REST/gRPC/AMQP surface, frontend auth/token handling), full route-table enumeration of the REST API, plus automated dependency scanning. Each finding was verified against the actual code; file:line references point at the evidence.
+- **Companion document**: [`code-review.md`](code-review.md) — code-quality findings. Items that are both quality and security issues are cross-referenced.
+
+Finding IDs (`SEC-NNN`) are stable — use them to drive and track remediation.
+
+---
+
+## Executive summary
+
+The codebase shows strong security *primitives* (Argon2id at OWASP parameters, EdDSA JWTs with no alg-confusion, AES-256-GCM with fresh nonces, hashed single-use refresh tokens, constant-time secret comparisons, parameterized SurrealQL everywhere — **no injection found**), but the *enforcement layer is not wired up*. The most severe theme: the authorization engine exists and is tested, yet **no REST handler calls it**, organizations/tenants endpoints don't even check ownership, and gRPC has no authentication at all while being publicly ingressed. Federation (SAML + OIDC) currently performs **no signature verification**, and an MFA-challenge JWT is accepted as a full access token. Until SEC-001…SEC-006 are fixed, any authenticated user is effectively a global administrator, and federation is an authentication bypass.
+
+| Severity | Count |
+|---|---|
+| Critical | 6 |
+| High | 12 |
+| Medium | 15 |
+| Low | 10 |
+
+### Top remediation priorities (suggested order)
+
+1. **SEC-001 / SEC-002 / SEC-003** — wire RBAC into REST, fix org/tenant IDOR, authenticate gRPC (the management plane is currently open to any token holder).
+2. **SEC-004 / SEC-005** — implement OIDC JWKS + SAML XML-signature verification, or hard-disable federation endpoints until done.
+3. **SEC-006** — add `token_use`/`aud` claims and enforce them in `decode_access_token` (MFA bypass).
+4. **SEC-007** — tenant-scope the role/permission RELATE repository methods.
+5. **SEC-012 / SEC-017 / SEC-018** — stop the zero-key fallback and plaintext secrets at rest / in API responses.
+6. **SEC-013 / SEC-029** — dependency upgrades (`lettre`, `axios`, `react-router`, `vite`).
+
+---
+
+## Critical findings
+
+### SEC-001 [CRITICAL] No authorization (RBAC) enforced on any REST handler
+- **File**: `crates/axiam-api-rest/src/handlers/*.rs` (all of users.rs, roles.rs, groups.rs, permissions.rs, resources.rs, certificates.rs, service_accounts.rs, webhooks.rs, …); unused guard at `crates/axiam-api-rest/src/authz.rs:67-113`
+- **Category**: AuthZ / Privilege escalation
+- **Issue**: Every handler requires only `AuthenticatedUser` (a valid JWT). The `RequirePermission`/`AuthzChecker` infrastructure exists and is unit-tested, but a grep across `handlers/` shows it is never invoked; `AuthorizationEngine` is built in `main.rs` but only wired to gRPC/AMQP — `AuthzData` is never inserted into the REST app.
+- **Impact**: Any user with a valid JWT can create/delete users, create roles, **assign any role (including admin roles) to themselves** via `POST /api/v1/roles/{role_id}/users {user_id: <self>}`, grant permissions, mint certificates, read audit logs, manage webhooks — complete privilege escalation within the tenant.
+- **Fix**: Insert `web::Data<Arc<dyn AuthzChecker>>` into the REST app and call `RequirePermission::new(action, resource).check(&user, authz).await?` at the top of every state-changing/sensitive handler. Add negative tests asserting a non-privileged user is denied. Re-enable `reset_mfa` (auth.rs:465) once done.
+
+### SEC-002 [CRITICAL] Cross-organization / cross-tenant IDOR on organizations & tenants endpoints
+- **File**: `crates/axiam-api-rest/src/handlers/organizations.rs:24-116`, `crates/axiam-api-rest/src/handlers/tenants.rs:49-187`; same pattern in `ca_certificates.rs` (no `org_id` comparison)
+- **Category**: IDOR / Broken object-level authorization
+- **Issue**: Both modules bind the caller as `_user: AuthenticatedUser` (extracted then **ignored**) and operate purely on path IDs. Tenants only validate `tenant.organization_id == path.org_id`, never that the caller belongs to `org_id`. Contrast with `settings.rs:38`, which does the check correctly.
+- **Impact**: Any authenticated user from any tenant can list **all organizations**, read/update/delete **any organization**, create/read/update/delete **any tenant in any org**, and manage other orgs' CA certificates — full multi-tenant isolation breach.
+- **Fix**: Enforce `path.org_id == user.org_id` (as settings.rs does) plus an org-admin permission check (depends on SEC-001). Restrict org creation/listing to system administrators.
+
+### SEC-003 [CRITICAL] gRPC services have no authentication and are exposed via public ingress
+- **File**: `crates/axiam-api-grpc/src/server.rs:39-44` (no interceptor); `k8s/ingress.yml:36-62` (public `grpc.axiam.example.com`)
+- **Category**: AuthN / Authorization bypass
+- **Issue**: `Server::builder().add_service(...).serve(addr)` with no JWT/mTLS interceptor. `UserServiceImpl::get_user` and `validate_credentials` take `tenant_id` straight from the request with no caller identity; `CheckAccess`/`BatchCheckAccess` trust request-supplied `tenant_id`/`subject_id`.
+- **Impact**: Anyone who can reach the gRPC endpoint can read any user in any tenant, brute-force passwords via `ValidateCredentials` (which checks lockout but never increments it — see SEC-026/CQ cross-ref), and query authorization decisions for any tenant/subject.
+- **Fix**: Add a Tonic auth interceptor that validates the bearer JWT (or mTLS identity) and derives `tenant_id` from verified claims. Remove gRPC from the public ingress; keep it mesh-internal with mTLS.
+
+### SEC-004 [CRITICAL] OIDC federation accepts ID tokens with NO signature verification
+- **File**: `crates/axiam-federation/src/oidc.rs:284-295, 398-425`
+- **Category**: AuthN / Federation
+- **Evidence**: `// TODO(T19.6): Implement JWKS-based JWT signature verification` followed by `decode_id_token_claims`, which just base64-decodes the payload. nonce/exp/aud are checked; the signature is not.
+- **Impact**: Full authentication bypass via federation — anyone who can reach the callback can forge a token with any `sub`/`email` (matching `aud=client_id` and the expected `nonce`) and AXIAM will provision/link a local user as that identity.
+- **Fix**: Fetch JWKS from `discovery.jwks_uri`, verify the JWT signature (RS256/ES256/EdDSA per IdP) with `jsonwebtoken` using `set_issuer`/`set_audience`, validate `iss` against the discovery `issuer`. Fail closed; gate any insecure decode behind an explicit dev-only flag. Until then, disable the federation login endpoints.
+
+### SEC-005 [CRITICAL] SAML assertions accepted with NO XML signature verification
+- **File**: `crates/axiam-federation/src/saml.rs:354-362`; SP metadata advertises `WantAssertionsSigned="false"` at saml.rs:468
+- **Category**: AuthN / Federation
+- **Issue**: After a `TODO(T19.7)` warning, the code checks only `Status == Success`, `Conditions` (NotBefore/NotOnOrAfter), and audience, then provisions the user. No verification that the Response/Assertion is signed by the configured IdP.
+- **Impact**: Anyone who can POST to the ACS endpoint can craft a SAML Response with an arbitrary `NameID` and matching `AudienceRestriction` (the SP entity ID is the public `client_id`) and be authenticated as any user.
+- **Fix**: Validate the enveloped XML signature against the IdP's X.509 cert from metadata (samael supports this); reject unsigned assertions; validate `InResponseTo`, `Recipient`, `Destination`, and `SubjectConfirmation` NotOnOrAfter; set `WantAssertionsSigned="true"`.
+
+### SEC-006 [CRITICAL] MFA-challenge token is accepted as a full access token (MFA bypass)
+- **File**: `crates/axiam-auth/src/service.rs:666-689, 720-761`; `crates/axiam-auth/src/token.rs:192-208`; `crates/axiam-auth/src/webauthn.rs:320-339`
+- **Category**: Token handling / AuthN
+- **Issue**: All internal JWTs (access, MFA challenge, MFA setup, WebAuthn state) are signed with the same Ed25519 key and share `iss`. Purpose separation relies on a manual `purpose` claim check — but `decode_access_token` does not check it. The MFA challenge token carries `sub`/`tenant_id`/`org_id`/`exp`/`iat`/`iss`, so it deserializes cleanly into `AccessTokenClaims` (the extra `purpose` field is ignored; `scope` is optional) and passes `validate_access_token`.
+- **Impact**: A user who passes only the password step (before TOTP/WebAuthn) receives a challenge token that the API auth middleware accepts as a full access token → MFA bypass.
+- **Fix**: Add a `token_use` (or `aud`) claim to **every** token type and enforce it on decode: `decode_access_token` must require `token_use == "access"`; challenge/setup/webauthn decoders must require theirs. Add regression tests that each non-access token is rejected by the REST auth extractor.
+
+---
+
+## High findings
+
+### SEC-007 [HIGH] Cross-tenant role assignment & permission grants — repository methods ignore `tenant_id`
+- **File**: `crates/axiam-db/src/repository/role.rs:320-376, 477-532`; `crates/axiam-db/src/repository/permission.rs:314-417`
+- **Category**: Tenant isolation
+- **Issue**: `assign_to_user`, `assign_to_group`, `grant_to_role`, `grant_to_role_with_scopes`, `revoke_from_role`, `unassign_*` all take `_tenant_id` (unused) and `RELATE`/`DELETE` edges by raw UUIDs with no verification that the user/group/role/permission/scope belong to the calling tenant. The REST handler passes `user.tenant_id`, but role_id (path) and user_id (body) are attacker-controlled. Contrast: `group.rs::add_member` (350-383) **does** verify both sides; `certificate.rs::bind_to_service_account` verifies via `THROW`.
+- **Impact**: A tenant-A admin can create or delete role-assignment/permission-grant edges involving tenant-B entities — cross-tenant privilege manipulation and denial of access.
+- **Fix**: Apply the `add_member` verification pattern (or a tenant-guarded subquery / `THROW` inside the statement) to every edge-mutating method. Add tenant-isolation tests for each.
+
+### SEC-008 [HIGH] No replay protection on TOTP codes
+- **File**: `crates/axiam-auth/src/totp.rs:76-95`; `crates/axiam-auth/src/service.rs:287-296`
+- **Category**: AuthN / MFA
+- **Issue**: `check_current` with skew=1 (~90 s window); nothing records that a code/step was consumed.
+- **Impact**: A code observed in transit (phishing proxy, shoulder-surf, replayed request) can be reused within the window — MFA bypass.
+- **Fix**: Persist the last successfully used TOTP step (or code hash) per user and reject same-or-earlier steps (RFC 6238 §5.2).
+
+### SEC-009 [HIGH] WebAuthn `finish_authentication` does not bind the asserting credential to the user
+- **File**: `crates/axiam-auth/src/webauthn.rs:230-268`
+- **Category**: AuthN / MFA
+- **Issue**: After `finish_passkey_authentication`, the code looks up the credential in the user's list only to update `last_used_at`; when no credential matches, the function **still returns `Ok((user_id, org_id))`** — the identity comes from the state token, not the matched credential.
+- **Impact**: Violates fail-closed; if any caller ever starts a ceremony with a broader credential set (or on future refactors), an assertion from one user's key could authenticate as another.
+- **Fix**: Require the matched credential to exist and belong to `user_id`; return an error on `None`. Derive the authenticated identity from the stored credential.
+
+### SEC-010 [HIGH] Unbounded pagination `limit` — DoS on every list endpoint
+- **File**: `crates/axiam-core/src/repository.rs:44-58`; used unclamped in all repos (e.g. `user.rs:455-459`, `role.rs:297`, `audit.rs:308`)
+- **Category**: DoS / Input validation
+- **Issue**: `limit: u64` from the query string flows straight to `LIMIT $limit` with no maximum.
+- **Impact**: `GET /api/v1/users?limit=100000000` forces the DB to materialize huge result sets — memory/CPU exhaustion, repeatable by any authenticated user on every list endpoint.
+- **Fix**: Clamp `limit` (e.g. max 200, reject 0) centrally in `Pagination` deserialization/constructor.
+
+### SEC-011 [HIGH] Internal error details leaked in HTTP responses
+- **File**: `crates/axiam-api-rest/src/error.rs:53-69`; feeding from `crates/axiam-db/src/error.rs` and `crates/axiam-auth/src/error.rs:104`
+- **Category**: Info disclosure
+- **Issue**: `message: self.0.to_string()` serializes the full error `Display` for `Database(_)`, `Crypto(_)`, `Internal(_)`, `Certificate(_)` — SurrealDB engine/query text, crypto library detail, internal messages all reach the client.
+- **Impact**: Leaks schema/query internals and crypto state, aiding attackers.
+- **Fix**: For 5xx categories return a generic message; log details server-side with `tracing` only.
+
+### SEC-012 [HIGH] PKI encryption key silently falls back to an all-zero key
+- **File**: `crates/axiam-server/src/main.rs:129-134`; `crates/axiam-pki/src/ca.rs:84`
+- **Category**: Crypto / Secrets at rest
+- **Issue**: When `AXIAM__PKI__ENCRYPTION_KEY` is unset, the server logs a warning claiming "CA certificate generation will fail" and substitutes `[0u8; 32]`. axiam-pki has no zero-key guard — generation succeeds, and CA/PGP private keys are AES-256-GCM-encrypted with a publicly known constant key.
+- **Impact**: All CA/PGP private keys "encrypted at rest" are trivially decryptable by anyone with DB access; the operator was told the feature would fail, so the misconfiguration goes unnoticed.
+- **Fix**: Make `PkiConfig.encryption_key` an `Option` and **fail at startup** (or at the service call) when unset. Never substitute a constant key.
+
+### SEC-013 [HIGH] Rust dependency vulnerabilities (`cargo audit`: 7 advisories)
+- **File**: `Cargo.lock`
+- **Category**: Supply chain
+- **Issue / inventory**:
+  - `lettre 0.11.19` — **RUSTSEC-2026-0141 (critical 9.1)**: TLS hostname verification disabled with Boring TLS backend → upgrade to ≥0.11.22. (Verify which TLS backend AXIAM compiles; upgrade regardless.)
+  - `hickory-proto 0.25.2` — RUSTSEC-2026-0119 (O(n²) CPU exhaustion, fix ≥0.26.1) and RUSTSEC-2026-0118 (unbounded loop, no fix yet).
+  - `rustls-webpki 0.103.10` — RUSTSEC-2026-0098/0099 (name-constraint bypasses), RUSTSEC-2026-0104 (panic in CRL parsing) → upgrade ≥0.103.13.
+  - `rsa 0.9.10` — RUSTSEC-2023-0071 Marvin timing side-channel (no fix; document residual risk where RSA-4096 certs are used).
+  - Warnings: `atomic-polyfill`, `bincode 2.0.1` unmaintained; `rand` 0.8/0.9/0.10 RUSTSEC-2026-0097 unsoundness with custom loggers (three duplicate `rand` majors in tree — consolidate).
+- **Fix**: Bump `lettre`, `hickory-proto`, `rustls-webpki`; add `cargo audit`/`cargo deny` to CI so this is gated continuously.
+
+### SEC-014 [HIGH] Frontend: access token persisted in `sessionStorage` with no CSP anywhere
+- **File**: `frontend/src/stores/auth.ts:52-61`; `frontend/index.html`; `docker/nginx.conf:20-24`
+- **Category**: Token storage / XSS defense-in-depth
+- **Issue**: The bearer token is persisted via zustand `persist` into `sessionStorage` (`axiam-auth` key). Neither index.html nor nginx sets `Content-Security-Policy`; nginx ships the deprecated `X-XSS-Protection` and no HSTS.
+- **Impact**: Any XSS foothold (including a compromised npm dependency) exfiltrates a valid **IAM admin** bearer token with one line of JS; there is no compensating CSP layer.
+- **Fix**: Keep the access token in memory only and re-establish sessions via the httpOnly refresh cookie + silent `/auth/refresh` on load. Regardless, add a strict CSP (`default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'self'`), `Strict-Transport-Security`, and `Permissions-Policy` in nginx; drop `X-XSS-Protection`.
+
+### SEC-015 [HIGH] Logout is client-side only — refresh token never revoked
+- **File**: `frontend/src/components/layout/Topbar.tsx:86-89`; `frontend/src/lib/api.ts:111`
+- **Category**: Session management
+- **Issue**: "Sign out" only clears the zustand store; `POST /auth/logout` is never called anywhere (grep: zero references). The server-stored refresh token and the httpOnly cookie remain valid.
+- **Impact**: On a shared machine, anyone after "logout" can hit `POST /auth/refresh` (cookie sent automatically) and obtain a fresh access token — logout does not terminate the session.
+- **Fix**: Call `/auth/logout` (revoke + clear cookie) in `handleLogout` and in the 401-refresh-failure path; also clear the react-query cache (see code review FE-005).
+
+### SEC-016 [HIGH] Production nginx does not proxy `/auth/*` or `/oauth2*` — invites insecure workarounds
+- **File**: `docker/nginx.conf:50-61`; compare `frontend/vite.config.ts:13-27`; `docker/docker-compose.prod.yml` publishes `8080:8080`
+- **Category**: Deployment
+- **Issue**: The SPA calls `/auth/login`, `/auth/refresh`, `/auth/mfa/*`, `/oauth2/*` same-origin; production nginx proxies only `/api`. Auth flows are broken in the shipped image, and the prod compose already exposes the backend directly on plain-HTTP :8080 — the natural "fix" operators will reach for, which breaks cookie same-origin assumptions and bypasses nginx security headers.
+- **Fix**: Add `location ^~ /auth/ { proxy_pass ...; }` and `location ^~ /oauth2 { ... }` blocks mirroring the Vite proxy rules (keeping the SPA-only `/auth/...` pages served by the SPA); stop publishing the backend port in prod compose.
+
+### SEC-017 [HIGH] Federation IdP `client_secret` stored in plaintext, serialized into API responses, and pre-filled in the UI
+- **File**: `crates/axiam-db/src/repository/federation_config.rs:162-164, 226-229` (`TODO(T19.8)`); `crates/axiam-core` federation model (`client_secret: String`, plain `Serialize`); `frontend/src/services/federation.ts:12-17`; `frontend/src/pages/federation/FederationPage.tsx:331-336`
+- **Category**: Secrets at rest / Info disclosure
+- **Issue**: The upstream IdP OAuth client secret is written to SurrealDB as cleartext and the domain type has no `#[serde(skip_serializing)]`, so GET/list endpoints return it; the frontend then pre-fills it into an `<input type="password">` (readable via devtools, present in every list response and the React Query cache). This contradicts the write-only/reveal-once pattern used for service accounts/OAuth2 clients/webhooks.
+- **Impact**: Harvesting these secrets enables impersonation of AXIAM against upstream IdPs — cross-domain SSO compromise.
+- **Fix**: Encrypt at rest (planned AES-256-GCM), add `#[serde(skip_serializing)]`, never return the secret on GET (masked placeholder), make the frontend field write-only ("leave blank to keep current").
+
+### SEC-018 [HIGH] SMTP/email-provider secrets serialize into API responses; promised at-rest encryption not implemented
+- **File**: `crates/axiam-core/src/models/email.rs:30-48, 78-91`
+- **Category**: Secrets at rest / Info disclosure
+- **Issue**: `SmtpConfig.password` and `ApiProviderConfig.api_key` are plain `String`s with plain `Serialize` and comments claiming "stored encrypted at rest by the DB layer" — but no `EmailConfigRepository` implementation exists in axiam-db, and `EmailConfig` (which embeds the provider) derives full `Serialize`, so any endpoint returning it exposes the credentials in cleartext JSON.
+- **Fix**: `#[serde(skip_serializing)]` on both fields; implement the at-rest encryption the comments promise before persisting.
+
+---
+
+## Medium findings
+
+### SEC-019 [MEDIUM] Webhook SSRF protection bypassable via DNS-resolved hostnames
+- **File**: `crates/axiam-api-rest/src/handlers/webhooks.rs:244-329`
+- **Issue**: Private-range checks only apply to literal IPs; a hostname resolving to `169.254.169.254`/`10.x` passes validation, and resolution happens later at delivery time (DNS rebinding unguarded). Partially mitigated by `redirect::Policy::none()` + 10 s timeout.
+- **Fix**: Resolve at delivery time and re-check every resolved IP against `is_global_ip`; pin the validated address for the actual connection.
+
+### SEC-020 [MEDIUM] No IP-level rate limiting on auth/MFA/token endpoints
+- **File**: `crates/axiam-server/src/main.rs:247-285`
+- **Issue**: Per-account lockout exists (5 attempts, exponential backoff), but `/auth/login`, `/auth/mfa/verify`, `/oauth2/token`, `/oauth2/introspect` have no per-IP throttling — credential stuffing across many accounts and MFA guessing are unbounded.
+- **Fix**: Add `actix-governor` (or similar) on `/auth/*` and `/oauth2/token|introspect`; confirm MFA verify attempts count toward lockout.
+
+### SEC-021 [MEDIUM] REST API responses lack security headers
+- **File**: `crates/axiam-api-rest/src/server.rs:495-509`; `docker/nginx.conf:55` (`/api` location adds none)
+- **Fix**: `DefaultHeaders` middleware with HSTS, `X-Content-Type-Options: nosniff`, `Cache-Control: no-store` on sensitive responses; replicate on the nginx `/api` location.
+
+### SEC-022 [MEDIUM] AMQP authz consumer fully trusts queue messages
+- **File**: `crates/axiam-amqp/src/authz_consumer.rs:62-90`
+- **Issue**: Any producer with broker access can request authz decisions for any tenant/subject; no signature/claims binding. Dev/prod compose ships `axiam:axiam` broker creds (SEC-023).
+- **Fix**: Authenticate/authorize messages (signed payloads or per-tenant queues with broker ACLs); document the broker trust boundary.
+
+### SEC-023 [MEDIUM] Deployment: hardcoded weak credentials; debug logging in production configmap
+- **File**: `docker/docker-compose.prod.yml:24-29, 70-71` (SurrealDB `root/root`, RabbitMQ `axiam/axiam`); `docker/docker-compose.dev.yml:8, 22-23`; `k8s/server/configmap.yml:16` (`RUST_LOG: "info,axiam=debug"`)
+- **Fix**: Inject credentials via secrets/env; set `RUST_LOG=info` (or `warn`) in production.
+
+### SEC-024 [MEDIUM] mTLS device auth: global fingerprint lookup with no tenant/CA binding
+- **File**: `crates/axiam-pki/src/mtls.rs:35-77`; `crates/axiam-db/src/repository/certificate.rs:382-403, 440-460`
+- **Issue**: Identity is keyed purely on a global fingerprint match; tenant comes from whatever row matches; chain validation is delegated entirely to the proxy; no check that the cert was issued by the tenant's own CA. `get_bound_service_account`/`get_by_fingerprint_global` are deliberately cross-tenant — callers must re-scope.
+- **Fix**: Verify issuer chains to the tenant/org CA in addition to fingerprint; scope lookups by expected tenant where possible; document the proxy trust dependency loudly.
+
+### SEC-025 [MEDIUM] PKCE not enforced for the authorization-code grant
+- **File**: `crates/axiam-oauth2/src/authorize.rs:105-126`; `crates/axiam-oauth2/src/token.rs:184-224`
+- **Issue**: PKCE is validated only when the client volunteers it; there is no public-client concept. Stated standard is "Authorization Code + PKCE"; OAuth 2.1 mandates PKCE.
+- **Fix**: Require `code_challenge` (S256) for the authorization_code grant — at minimum for public clients, ideally for all.
+
+### SEC-026 [MEDIUM] Username enumeration via login timing; gRPC path never increments lockout
+- **File**: `crates/axiam-auth/src/service.rs:159-193`; `crates/axiam-api-grpc/src/services/user.rs:113-131`
+- **Issue**: (a) Unknown users return immediately while existing users incur an Argon2 verification (~tens of ms) — a timing oracle. (b) gRPC `ValidateCredentials` checks `locked_until` but never records failed attempts — an unmetered brute-force path (compounded by SEC-003).
+- **Fix**: Dummy Argon2 verification on user-not-found; route gRPC credential checks through the same failed-login accounting as REST.
+
+### SEC-027 [MEDIUM] Password reset does not invalidate existing sessions
+- **File**: `crates/axiam-auth/src/password_reset.rs:190` (`TODO(T19)`)
+- **Issue**: After a successful reset (the recovery path for a compromised account), all existing sessions/refresh tokens remain valid — the attacker keeps access.
+- **Fix**: Invalidate all sessions and revoke refresh tokens on reset completion.
+
+### SEC-028 [MEDIUM] Password reset allows reusing the current password; initial password never enters history
+- **File**: `crates/axiam-auth/src/password_reset.rs:160-187`; `crates/axiam-auth/src/policy.rs:231-266`
+- **Issue**: `check_history` compares only `password_history` rows; the current `password_hash` is appended only after the check, and the signup password is never recorded — "reset to the same password" always passes.
+- **Fix**: Include `user.password_hash` in the candidate set; record the initial hash at user creation.
+
+### SEC-029 [MEDIUM] Frontend dependency vulnerabilities (`npm audit`: 4 high, 3 moderate)
+- **File**: `frontend/package.json` / `package-lock.json`
+- **Issue / inventory**: `axios` (large advisory set incl. prototype-pollution credential-injection chains), `react-router 7.x < 7.14.2` (**high** — vendored turbo-stream deserialization RCE GHSA-49rj-9fvp-4h2h, open redirect), `vite 8.0.0-8.0.4` (high — dev-server file read/path traversal), `follow-redirects`, `postcss`, `brace-expansion`. All have fixes via `npm audit fix`.
+- **Fix**: Run `npm audit fix`, commit the lockfile, and add `npm audit --audit-level=high` to CI.
+
+### SEC-030 [MEDIUM] Email verification shows a false "Email verified!" success
+- **File**: `frontend/src/pages/auth/VerifyEmailPage.tsx:19-21, 49-50`; `frontend/vite.config.ts:18`; `docker/nginx.conf`
+- **Issue**: The page GETs `/auth/verify-email?token=...`, but that path is excluded from the dev proxy and not proxied by prod nginx — the SPA fallback returns `index.html` with HTTP 200, so the UI claims success while the backend never saw the token.
+- **Impact**: False security state in an identity product; verification-gated controls remain ineffective while the UI says otherwise.
+- **Fix**: Route the call through a proxied path (prefer `POST`), and validate response content, not just status.
+
+### SEC-031 [MEDIUM] Webhook HMAC `secret` plaintext at rest and only conventionally excluded from responses
+- **File**: `crates/axiam-db/src/repository/webhook.rs:18-44, 120-128`; core `Webhook.secret` derives `Serialize` (doc comment promises "never returned" but nothing enforces it)
+- **Fix**: `#[serde(skip_serializing)]` on `Webhook::secret`; consider envelope encryption at rest.
+
+### SEC-032 [MEDIUM] Failed-login counter uses non-atomic read-modify-write — lockout weakened under concurrency
+- **File**: `crates/axiam-auth/src/service.rs:763-793`
+- **Issue**: Counter read at login start, written back as an absolute value — concurrent failed attempts (exactly the brute-force scenario) lose increments.
+- **Fix**: Atomic `UPDATE user SET failed_login_attempts += 1 ... RETURN AFTER` repository method; compute lockout from the returned value.
+
+### SEC-033 [MEDIUM] Tenant settings snapshot freezes org security baselines (MFA enforcement included)
+- **File**: `crates/axiam-api-rest/src/handlers/settings.rs:134-149`; `crates/axiam-db/src/repository/settings.rs:524-542`
+- **Issue**: `PUT /settings` persists the *merged* org-baseline+overrides row. When the org later tightens its baseline (e.g. enforces MFA — consumed by `login` via auth.rs:155-160), tenants that ever saved settings keep the stale values: the diff-based re-merge logic cannot distinguish overrides from stale baseline copies.
+- **Impact**: Org-level security policy changes silently fail to propagate to tenants.
+- **Fix**: Persist only the sparse override set (`Option` fields) and merge against the live org baseline at read time. (Cross-ref: code review CQ-003.)
+
+---
+
+## Low findings
+
+### SEC-034 [LOW] Audit logs readable by any authenticated tenant user; system audit log readable by everyone
+- **File**: `crates/axiam-api-rest/src/handlers/audit.rs:22-59`
+- **Fix**: Gate behind an `audit:read` permission (depends on SEC-001); restrict `list_system` to system admins.
+
+### SEC-035 [LOW] Tenant update mass-assignment surface
+- **File**: `crates/axiam-api-rest/src/handlers/tenants.rs:139-155` (raw `UpdateTenant` body); pattern repeated where core domain `Update*` structs bind directly to JSON (certificates, groups, etc.)
+- **Fix**: Explicit request DTOs; never deserialize ownership fields (org/tenant ids) from bodies. (Cross-ref CQ-024.)
+
+### SEC-036 [LOW] Revealed secrets/private keys retained in React state after modal close
+- **File**: `frontend/src/pages/certificates/CertificatesPage.tsx:345-351` (same in PgpKeysPage, ServiceAccountsPage, OAuth2ClientsPage, WebhooksPage)
+- **Fix**: Clear secret state in `onClose` (the `EncryptDataModal` in PgpKeysPage already does this correctly).
+
+### SEC-037 [LOW] Reset/verification tokens persist in URL history and server logs
+- **File**: `frontend/src/pages/auth/ResetPasswordPage.tsx:39-40`; `VerifyEmailPage.tsx:34-35`
+- **Fix**: `history.replaceState` to strip `?token=` after capture; submit the verify token via POST body.
+
+### SEC-038 [LOW] CSRF posture of `/auth/refresh` depends on unverified cookie attributes
+- **File**: `frontend/src/lib/api.ts:87-91`
+- **Issue**: Bearer-token APIs are CSRF-safe; the only ambient-credential endpoint is `POST /auth/refresh`, which a cross-site page can trigger blind (rotation → session desync/DoS at worst).
+- **Fix**: Confirm the backend sets `SameSite=Lax/Strict`, `Path=/auth/refresh`, and add an `Origin` check on the refresh endpoint.
+
+### SEC-039 [LOW] Crypto library error detail propagates toward clients
+- **File**: `crates/axiam-auth/src/error.rs:104` (`AuthError::Crypto(msg)` → `AxiamError::Crypto(msg)`), e.g. token.rs:69, totp.rs:23/46
+- **Fix**: Subsumed by SEC-011's generic-5xx-message fix; log detail server-side only.
+
+### SEC-040 [LOW] AuthZ engine is additive-only — documented "override" cascade absent
+- **File**: `crates/axiam-authz/src/engine.rs:81-171`
+- **Issue**: CLAUDE.md says parent role assignments cascade "unless overridden", but no deny/override mechanism exists — purely additive allow with default deny. Not an escalation bug; operators expecting deny-overrides will mis-model permissions.
+- **Fix**: Implement explicit deny/override precedence or update the documented model to "purely additive".
+
+### SEC-041 [LOW] Full Axios error object logged to console on the enumeration-sensitive forgot-password page
+- **File**: `frontend/src/pages/auth/ForgotPasswordPage.tsx:43`
+- **Fix**: Log nothing or only `err.message`/status.
+
+### SEC-042 [LOW] Route protection is client-side only with no role gating in the UI
+- **File**: `frontend/src/components/layout/AppLayout.tsx:21-23`
+- **Issue**: A forged `sessionStorage` entry renders the full admin shell. Acceptable **only** once the backend enforces authz on every endpoint (SEC-001); currently the backend does not, making this consequential.
+- **Fix**: Fix SEC-001 first; longer-term fetch the user's permissions to gate UI sections.
+
+### SEC-043 [LOW] CA/PGP encrypted key blobs hydrated on reads and exposed in `Debug`
+- **File**: `crates/axiam-db/src/repository/ca_certificate.rs:97-137`; `pgp_key.rs:110-145`
+- **Issue**: Ciphertext only (and `skip_serializing` is present), but `Debug` derives could put blobs into logs; list endpoints don't need the field at all.
+- **Fix**: Redacting `Debug` impl; skip hydration on list paths.
+
+---
+
+## Positive observations (verified)
+
+- **No SurrealQL injection found**: every query binds user-controlled values via `$param`; `format!` interpolation is limited to server-generated `Uuid`s in `RELATE` and compile-time column-name constants.
+- Argon2id at OWASP parameters (m=19456 KiB, t=2, p=1) with per-hash salts and optional pepper; password reset flow is enumeration-safe and rate-limited.
+- EdDSA-only JWT encode/decode (no alg confusion, no `none`), issuer + required-claims enforcement.
+- AES-256-GCM used correctly (fresh random 12-byte nonce per encryption, nonce prepended) for TOTP secrets, CA keys, PGP keys, WebAuthn state.
+- Refresh/auth/reset/verification tokens: 32-byte CSPRNG, stored as SHA-256 hashes, single-use with rotation; atomic `UPDATE ... WHERE used=false` consumption (race-safe).
+- OAuth2: constant-time client-secret and PKCE comparisons; redirect_uri validated against the registered set before any redirectable error; PKCE verified before code consumption; introspection enforces tenant + client ownership.
+- Tenant-scoped entities (users/roles/groups/webhooks/certs/audit) consistently take `tenant_id` from the validated JWT, never from the request.
+- Audit table is append-only via schema permissions; email templating HTML-escapes and strips CR/LF from headers (no header injection); SMTP enforces TLS.
+- Frontend: zero XSS sinks (no `dangerouslySetInnerHTML`/`eval`/`innerHTML`/`target="_blank"` issues); refresh token httpOnly; solid 401-refresh queueing; reveal-once secret UX; no `VITE_` secret baking; unprivileged nginx image.
+- Containers: non-root user, `readOnlyRootFilesystem`, resource limits, TLS ingress with ssl-redirect; k8s secret manifests intentionally blank.
+
+## Coverage notes
+
+Fully read: all of axiam-auth, axiam-oauth2, axiam-federation, axiam-pki, axiam-authz, axiam-db (all 27 repositories + schema), axiam-core models/errors, axiam-email, axiam-amqp consumers, axiam-audit middleware, axiam-server main.rs, REST route table + extractors + the majority of handlers, gRPC server + services, all of docker/ and k8s/, and 100 % of frontend/src auth/secret-handling code (remaining CRUD pages exhaustively pattern-scanned for sink classes). Follow-up deep-dives recommended (lower-confidence areas): `handlers/oauth2.rs`/`oauth2_clients.rs` fine detail, `webauthn.rs` REST handlers, CI workflows in `.github/`.


### PR DESCRIPTION
merging Claude Fable 5 (1M) review findings on main branch