### PR TITLE
fix(bootstrap): create org + default tenant + admin in one first-run call

### DIFF
--- a/crates/axiam-api-rest/src/handlers/bootstrap.rs
+++ b/crates/axiam-api-rest/src/handlers/bootstrap.rs
@@ -447,7 +447,8 @@ pub async fn bootstrap<C: Connection + Clone>(
 
     // 7. Return 201 — no token (user must login via /api/v1/auth/login, per D-11).
     Ok(HttpResponse::Created().json(BootstrapResponse {
-        message: "Organization, tenant and admin user created. Login via /api/v1/auth/login.".into(),
+        message: "Organization, tenant and admin user created. Login via /api/v1/auth/login."
+            .into(),
         organization_id: org.id,
         organization_slug: org_slug,
         tenant_id,

--- a/crates/axiam-api-rest/src/handlers/bootstrap.rs
+++ b/crates/axiam-api-rest/src/handlers/bootstrap.rs
@@ -1,13 +1,21 @@
 //! Admin bootstrap endpoint — first-run setup.
 //!
-//! Creates the initial admin user and seeds default roles when no admin
-//! exists. First-super-admin creation is atomic (SECHRD-04 / SEC-049 /
-//! D-03c): a uniqueness-invariant `bootstrap_lock` CREATE inside the same
-//! transaction that creates the admin user means two concurrent first-run
-//! requests can create AT MOST ONE super-admin — the loser gets
+//! On a brand-new deployment the database is empty: there are no organizations,
+//! tenants or users. This endpoint performs the entire first-run provisioning
+//! in one call — it creates the **organization**, the **default tenant**, seeds
+//! the permission set and default roles, and creates the initial **admin user**
+//! bound to the super-admin role. Org/tenant creation is get-or-create by slug
+//! so a retry after a transient failure reuses them.
+//!
+//! It is a one-shot operation. First-super-admin creation is atomic (SECHRD-04
+//! / SEC-049 / D-03c): a uniqueness-invariant `bootstrap_lock:global` CREATE
+//! inside the same transaction that creates the admin user means two concurrent
+//! first-run requests can create AT MOST ONE super-admin — the loser gets
 //! `AxiamError::AlreadyExists` (409) and its whole transaction rolls back.
-//! After the first admin is created, every subsequent call also hits the
-//! same `bootstrap_lock` uniqueness violation and is refused with 409.
+//! After the first admin is created, every subsequent call also hits the same
+//! `bootstrap_lock:global` uniqueness violation and is refused with 409.
+//! Additional organizations/tenants are created afterwards through the
+//! authenticated admin API.
 //!
 //! The endpoint is also gated (D-03a): a request is refused (fail-closed,
 //! no admin created) unless EITHER `AXIAM_BOOTSTRAP_ADMIN_EMAIL` is set and
@@ -18,6 +26,8 @@
 use actix_web::{HttpResponse, web};
 use axiam_auth::password;
 use axiam_core::error::AxiamError;
+use axiam_core::models::organization::CreateOrganization;
+use axiam_core::models::tenant::CreateTenant;
 use axiam_core::repository::{OrganizationRepository, TenantRepository};
 use axiam_db::{seed_default_roles, seed_permissions};
 use chrono::{DateTime, Utc};
@@ -37,15 +47,48 @@ use crate::state::AppState;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct BootstrapRequest {
-    pub org_id: Uuid,
-    pub tenant_id: Uuid,
+    /// Display name of the organization to create (required). On a fresh
+    /// deployment nothing exists yet, so bootstrap provisions the org and its
+    /// default tenant itself rather than requiring pre-existing IDs.
+    pub organization_name: String,
+    /// URL-safe slug for the organization. Derived from `organization_name`
+    /// when omitted or blank.
+    #[serde(default)]
+    pub organization_slug: Option<String>,
+    /// Display name of the default tenant. Defaults to `"Default"`.
+    #[serde(default)]
+    pub tenant_name: Option<String>,
+    /// URL-safe slug for the default tenant. Defaults to `"default"`.
+    #[serde(default)]
+    pub tenant_slug: Option<String>,
+    /// Admin email address.
     pub email: String,
+    /// Admin username.
     pub username: String,
+    /// Admin password (hashed with Argon2id before storage).
     pub password: String,
     /// One-time first-run setup token (D-03a/D-03b). Required when
     /// `AXIAM_BOOTSTRAP_ADMIN_EMAIL` is not set; ignored otherwise.
     #[serde(default)]
     pub setup_token: Option<String>,
+}
+
+/// Convert an arbitrary display name into a URL-safe slug: ASCII alphanumerics
+/// are lower-cased, every other run of characters collapses to a single `-`,
+/// and leading/trailing dashes are trimmed.
+fn slugify(input: &str) -> String {
+    let mut slug = String::with_capacity(input.len());
+    for ch in input.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+        } else if !slug.ends_with('-') && !slug.is_empty() {
+            slug.push('-');
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    slug
 }
 
 // -----------------------------------------------------------------------
@@ -62,6 +105,12 @@ struct SetupTokenRow {
 struct ConsumedTokenRow {
     #[allow(dead_code)]
     consumed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, SurrealValue)]
+struct BootstrapLockRow {
+    #[allow(dead_code)]
+    locked_at: DateTime<Utc>,
 }
 
 /// sha256 hex hash of `token`.
@@ -106,6 +155,10 @@ async fn setup_token_is_valid<C: Connection + Clone>(
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BootstrapResponse {
     pub message: String,
+    pub organization_id: Uuid,
+    pub organization_slug: String,
+    pub tenant_id: Uuid,
+    pub tenant_slug: String,
     pub user_id: Uuid,
 }
 
@@ -132,10 +185,10 @@ pub struct BootstrapResponse {
     tag = "admin",
     request_body = BootstrapRequest,
     responses(
-        (status = 201, description = "Admin user created", body = BootstrapResponse),
+        (status = 201, description = "Organization, tenant and admin user created", body = BootstrapResponse),
+        (status = 400, description = "Invalid request (missing required fields)"),
         (status = 403, description = "Bootstrap gate not satisfied (email mismatch or invalid/missing setup token)"),
-        (status = 409, description = "Bootstrap already completed for this tenant"),
-        (status = 400, description = "Organization or tenant not found"),
+        (status = 409, description = "Bootstrap already completed"),
     )
 )]
 pub async fn bootstrap<C: Connection + Clone>(
@@ -189,29 +242,102 @@ pub async fn bootstrap<C: Connection + Clone>(
         }
     }
 
-    // 2. Verify org and tenant exist.
-    state.org_repo.get_by_id(req.org_id).await.map_err(|_| {
-        AxiamApiError(AxiamError::Validation {
-            message: "organization not found".into(),
-        })
-    })?;
-    state
-        .tenant_repo
-        .get_by_id(req.tenant_id)
-        .await
-        .map_err(|_| {
-            AxiamApiError(AxiamError::Validation {
-                message: "tenant not found".into(),
-            })
-        })?;
+    // 2. Validate required fields and derive slugs.
+    if req.organization_name.trim().is_empty()
+        || req.email.trim().is_empty()
+        || req.username.trim().is_empty()
+        || req.password.is_empty()
+    {
+        return Err(AxiamApiError(AxiamError::Validation {
+            message: "organization_name, email, username and password are required".into(),
+        }));
+    }
+    let org_slug = req
+        .organization_slug
+        .as_deref()
+        .map(slugify)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| slugify(&req.organization_name));
+    if org_slug.is_empty() {
+        return Err(AxiamApiError(AxiamError::Validation {
+            message: "organization_name must contain at least one alphanumeric character".into(),
+        }));
+    }
+    let tenant_name = req
+        .tenant_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Default")
+        .to_string();
+    let tenant_slug = req
+        .tenant_slug
+        .as_deref()
+        .map(slugify)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            let s = slugify(&tenant_name);
+            if s.is_empty() { "default".into() } else { s }
+        });
 
-    // 3. Seed permissions (idempotent).
-    seed_permissions(&state.db, req.tenant_id, PERMISSION_REGISTRY)
+    // 3. Fast-fail one-shot gate: if the global bootstrap lock already exists
+    //    the system has been initialized. The authoritative guard is the
+    //    `bootstrap_lock:global` CREATE inside the atomic transaction below;
+    //    this pre-check just avoids creating a duplicate org on a call that is
+    //    going to be refused anyway.
+    let existing_lock: Vec<BootstrapLockRow> = state
+        .db
+        .query("SELECT locked_at FROM type::record('bootstrap_lock', 'global')")
+        .await
+        .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?
+        .take(0)
+        .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?;
+    if !existing_lock.is_empty() {
+        return Err(AxiamApiError(AxiamError::AlreadyExists {
+            entity: "bootstrap".into(),
+        }));
+    }
+
+    // 4. Provision the organization and default tenant. Get-or-create by slug
+    //    so a retry after a transient mid-flight failure reuses the same
+    //    org/tenant instead of leaking duplicates (the `bootstrap_lock:global`
+    //    invariant below still guarantees exactly one successful bootstrap).
+    let org = match state.org_repo.get_by_slug(&org_slug).await {
+        Ok(o) => o,
+        Err(_) => state
+            .org_repo
+            .create(CreateOrganization {
+                name: req.organization_name.trim().to_string(),
+                slug: org_slug.clone(),
+                metadata: None,
+            })
+            .await
+            .map_err(|e| {
+                AxiamApiError(AxiamError::Internal(format!("create organization: {e}")))
+            })?,
+    };
+    let tenant = match state.tenant_repo.get_by_slug(org.id, &tenant_slug).await {
+        Ok(t) => t,
+        Err(_) => state
+            .tenant_repo
+            .create(CreateTenant {
+                organization_id: org.id,
+                name: tenant_name,
+                slug: tenant_slug.clone(),
+                metadata: None,
+            })
+            .await
+            .map_err(|e| AxiamApiError(AxiamError::Internal(format!("create tenant: {e}"))))?,
+    };
+    let tenant_id = tenant.id;
+
+    // 5. Seed permissions (idempotent).
+    seed_permissions(&state.db, tenant_id, PERMISSION_REGISTRY)
         .await
         .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?;
 
-    // 4. Seed default roles and get their IDs.
-    let seed_result = seed_default_roles(&state.db, req.tenant_id, PERMISSION_REGISTRY)
+    // 6. Seed default roles and get their IDs.
+    let seed_result = seed_default_roles(&state.db, tenant_id, PERMISSION_REGISTRY)
         .await
         .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?;
 
@@ -237,7 +363,7 @@ pub async fn bootstrap<C: Connection + Clone>(
     let user_id = Uuid::new_v4();
     let user_id_str = user_id.to_string();
     let role_id_str = seed_result.super_admin_role_id.to_string();
-    let tenant_id_str = req.tenant_id.to_string();
+    let tenant_id_str = tenant_id.to_string();
     let ph_id_str = Uuid::new_v4().to_string();
 
     let password_hash = password::hash_password(&req.password, None)
@@ -245,9 +371,13 @@ pub async fn bootstrap<C: Connection + Clone>(
 
     // The RELATE uses backtick record IDs (required when type::record() is not
     // supported inside RELATE per SurrealDB v3 quirk).
+    // The `bootstrap_lock:global` CREATE is the global one-shot invariant: a
+    // concurrent OR sequential second bootstrap hits a UNIQUE record-ID
+    // violation here and its whole transaction rolls back — no partial admin,
+    // no duplicate super-admin.
     let mut txn_stmts = vec![
         "BEGIN TRANSACTION".to_string(),
-        "CREATE type::record('bootstrap_lock', $tenant_id) SET locked_at = time::now()".to_string(),
+        "CREATE type::record('bootstrap_lock', 'global') SET locked_at = time::now()".to_string(),
         "CREATE type::record('user', $user_id) SET \
            tenant_id = $tenant_id, \
            username = $username, email = $email, \
@@ -317,7 +447,11 @@ pub async fn bootstrap<C: Connection + Clone>(
 
     // 7. Return 201 — no token (user must login via /api/v1/auth/login, per D-11).
     Ok(HttpResponse::Created().json(BootstrapResponse {
-        message: "Admin user created. Login via /api/v1/auth/login.".into(),
+        message: "Organization, tenant and admin user created. Login via /api/v1/auth/login.".into(),
+        organization_id: org.id,
+        organization_slug: org_slug,
+        tenant_id,
+        tenant_slug,
         user_id,
     }))
 }

--- a/crates/axiam-api-rest/tests/bootstrap_test.rs
+++ b/crates/axiam-api-rest/tests/bootstrap_test.rs
@@ -1,12 +1,11 @@
 //! Integration tests for the admin bootstrap endpoint.
 //!
-//! Covers the first-run flow (D-09, D-10, D-11):
+//! Covers the first-run flow:
 //!
-//! - `POST /api/v1/admin/bootstrap` creates the first admin user when the
-//!   tenant has no users yet.
+//! - `POST /api/v1/admin/bootstrap` creates the organization, the default
+//!   tenant AND the first admin user in one call on a fresh, empty database.
 //! - After the first admin is created, the endpoint is disabled (returns 409
-//!   Conflict — SECHRD-04's `bootstrap_lock` uniqueness invariant, not the
-//!   old TOCTOU SELECT-then-branch check).
+//!   Conflict — the global `bootstrap_lock` uniqueness invariant).
 //! - When `AXIAM_BOOTSTRAP_ADMIN_EMAIL` is set, a mismatching email returns 403.
 //! - The mandatory gate refuses bootstrap when neither the env var nor a
 //!   valid setup token is presented (SECHRD-04 / D-03a).
@@ -106,35 +105,38 @@ fn make_authz(db: &Surreal<TestDb>) -> Arc<dyn AuthzChecker> {
     ))
 }
 
-/// Fresh in-memory DB with an org + tenant but NO users and NO seeded roles.
-/// The bootstrap handler is responsible for seeding permissions and default
-/// roles itself, so we deliberately leave the tenant empty.
-async fn setup_empty_tenant() -> (Surreal<TestDb>, Uuid, Uuid) {
+/// Fresh, empty in-memory DB: migrations only, NO organization, tenant, users
+/// or seeded roles. The bootstrap handler creates the organization, the default
+/// tenant, and seeds permissions/roles itself.
+async fn setup_empty_db() -> Surreal<TestDb> {
     let db = Surreal::new::<Mem>(()).await.unwrap();
     db.use_ns("test").use_db("test").await.unwrap();
     axiam_db::run_migrations(&db).await.unwrap();
+    db
+}
 
-    let org_repo = SurrealOrganizationRepository::new(db.clone());
-    let org = org_repo
+/// Fresh DB pre-seeded with an org + default tenant (no users). Used by the
+/// concurrency test so bootstrap's get-or-create reuses them and the only
+/// contention under test is the global `bootstrap_lock`.
+async fn setup_with_org_tenant() -> (Surreal<TestDb>, Uuid, Uuid) {
+    let db = setup_empty_db().await;
+    let org = SurrealOrganizationRepository::new(db.clone())
         .create(CreateOrganization {
-            name: "Bootstrap Org".into(),
-            slug: "bootstrap-org".into(),
+            name: "Race Org".into(),
+            slug: "race-org".into(),
             metadata: None,
         })
         .await
         .unwrap();
-
-    let tenant_repo = SurrealTenantRepository::new(db.clone());
-    let tenant = tenant_repo
+    let tenant = SurrealTenantRepository::new(db.clone())
         .create(CreateTenant {
             organization_id: org.id,
-            name: "Bootstrap Tenant".into(),
-            slug: "bootstrap-tenant".into(),
+            name: "Default".into(),
+            slug: "default".into(),
             metadata: None,
         })
         .await
         .unwrap();
-
     (db, org.id, tenant.id)
 }
 
@@ -184,9 +186,7 @@ async fn bootstrap_setup_token() {
         created_at: DateTime<Utc>,
     }
 
-    let db = Surreal::new::<Mem>(()).await.unwrap();
-    db.use_ns("test").use_db("test").await.unwrap();
-    axiam_db::run_migrations(&db).await.unwrap();
+    let db = setup_empty_db().await;
 
     // Fresh DB, no users: mint must produce a token.
     let minted = axiam_db::mint_bootstrap_setup_token_if_needed(&db)
@@ -234,21 +234,21 @@ async fn bootstrap_setup_token() {
     );
 }
 
-/// `bootstrap_creates_admin`
+/// `bootstrap_creates_org_tenant_admin`
 ///
-/// A fresh tenant with no users accepts the bootstrap request and creates the
-/// first admin with a 201 Created response containing the new user id.
+/// A fresh, empty database accepts the bootstrap request and creates the
+/// organization, the default tenant AND the first admin — 201 Created with the
+/// created ids/slugs in the body.
 #[actix_rt::test]
-async fn bootstrap_creates_admin() {
+async fn bootstrap_creates_org_tenant_admin() {
     let _guard = env_guard().await;
-    // SECHRD-04: the gate is now mandatory — set the env var to match the
-    // request email so the env-var gate path (D-10) is satisfied.
+    // The gate is mandatory — set the env var to match the request email.
     // SAFETY: serialized via env_lock; no other thread reads env in this binary.
     unsafe {
         std::env::set_var("AXIAM_BOOTSTRAP_ADMIN_EMAIL", "first-admin@example.com");
     }
 
-    let (db, org_id, tenant_id) = setup_empty_tenant().await;
+    let db = setup_empty_db().await;
     let auth = test_auth_config();
     let authz = make_authz(&db);
     let app = test_app!(db, auth, authz);
@@ -258,8 +258,10 @@ async fn bootstrap_creates_admin() {
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "First Org",
+            "organization_slug": "first-org",
+            "tenant_name": "Default",
+            "tenant_slug": "default",
             "email": "first-admin@example.com",
             "username": "firstadmin",
             "password": TEST_PASSWORD,
@@ -278,7 +280,7 @@ async fn bootstrap_creates_admin() {
     assert_eq!(
         status,
         201,
-        "bootstrap should return 201 on a fresh tenant, got {status}. body = {}",
+        "bootstrap should return 201 on a fresh database, got {status}. body = {}",
         String::from_utf8_lossy(&body)
     );
 
@@ -287,28 +289,40 @@ async fn bootstrap_creates_admin() {
         body_json.get("user_id").is_some(),
         "response body must include user_id, got {body_json}"
     );
+    assert_eq!(
+        body_json.get("organization_slug").and_then(Value::as_str),
+        Some("first-org")
+    );
+    assert_eq!(
+        body_json.get("tenant_slug").and_then(Value::as_str),
+        Some("default")
+    );
+
+    // The org and tenant were actually created.
+    let org = SurrealOrganizationRepository::new(db.clone())
+        .get_by_slug("first-org")
+        .await
+        .expect("bootstrap must create the organization");
+    SurrealTenantRepository::new(db.clone())
+        .get_by_slug(org.id, "default")
+        .await
+        .expect("bootstrap must create the default tenant");
 }
 
 /// `bootstrap_returns_409_after_admin`
 ///
-/// A second bootstrap call, against a tenant that already has an admin
-/// (with the gate satisfied both times), must be rejected with 409 Conflict
-/// — the `bootstrap_lock` uniqueness invariant (SECHRD-04 / D-03c), not the
-/// old TOCTOU SELECT-then-branch check. The endpoint is one-shot per tenant
-/// (D-09) — mismatched-email gate refusal is covered separately by
-/// `bootstrap_rejects_wrong_email`.
+/// A second bootstrap call, once the system has been initialized (with the
+/// gate satisfied both times), must be rejected with 409 Conflict — the global
+/// `bootstrap_lock` uniqueness invariant.
 #[actix_rt::test]
 async fn bootstrap_returns_409_after_admin() {
     let _guard = env_guard().await;
-    // SECHRD-04: the gate is now mandatory — both calls use the same
-    // matching email so the "already bootstrapped" check (not the gate) is
-    // what's under test here.
     // SAFETY: serialized via env_lock.
     unsafe {
         std::env::set_var("AXIAM_BOOTSTRAP_ADMIN_EMAIL", "first@example.com");
     }
 
-    let (db, org_id, tenant_id) = setup_empty_tenant().await;
+    let db = setup_empty_db().await;
     let auth = test_auth_config();
     let authz = make_authz(&db);
     let app = test_app!(db, auth, authz);
@@ -320,8 +334,7 @@ async fn bootstrap_returns_409_after_admin() {
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "First Org",
             "email": "first@example.com",
             "username": "firstadmin",
             "password": TEST_PASSWORD,
@@ -335,8 +348,7 @@ async fn bootstrap_returns_409_after_admin() {
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "Second Org",
             "email": "first@example.com",
             "username": "secondadmin",
             "password": TEST_PASSWORD,
@@ -358,10 +370,10 @@ async fn bootstrap_returns_409_after_admin() {
 
 /// `bootstrap_concurrent_race_single_admin`
 ///
-/// SECHRD-04 (Task 3, D-03c): two concurrent first-run bootstrap requests
-/// against the SAME tenant must produce AT MOST ONE super-admin. The race
-/// loser gets `AxiamError::AlreadyExists` (409) and its whole transaction
-/// rolls back — no partial admin, no orphan role RELATE.
+/// SECHRD-04 (Task 3, D-03c): two concurrent first-run bootstrap requests must
+/// produce AT MOST ONE super-admin. The race loser gets 409 and its whole
+/// transaction rolls back. The org/tenant are pre-seeded (with the slugs both
+/// racers reference) so the only contention under test is the global lock.
 #[actix_rt::test]
 async fn bootstrap_concurrent_race_single_admin() {
     let _guard = env_guard().await;
@@ -370,16 +382,13 @@ async fn bootstrap_concurrent_race_single_admin() {
         std::env::remove_var("AXIAM_BOOTSTRAP_ADMIN_EMAIL");
     }
 
-    let (db, org_id, tenant_id) = setup_empty_tenant().await;
+    let (db, _org_id, tenant_id) = setup_with_org_tenant().await;
 
-    // Mint a single setup token both racers will present — proves the
-    // gate's fast-fail pre-check and the transaction's consumption-by-
-    // existence CREATE both tolerate/resolve the race correctly (the
-    // loser still loses on `bootstrap_lock`, independent of the token).
+    // Mint a single setup token both racers present.
     let token = axiam_db::mint_bootstrap_setup_token_if_needed(&db)
         .await
         .unwrap()
-        .expect("fresh tenant DB should mint a setup token");
+        .expect("fresh DB should mint a setup token");
 
     let auth = test_auth_config();
     let authz = make_authz(&db);
@@ -392,8 +401,10 @@ async fn bootstrap_concurrent_race_single_admin() {
             .uri("/api/v1/admin/bootstrap")
             .peer_addr(peer)
             .set_json(serde_json::json!({
-                "org_id": org_id,
-                "tenant_id": tenant_id,
+                "organization_name": "Race Org",
+                "organization_slug": "race-org",
+                "tenant_name": "Default",
+                "tenant_slug": "default",
                 "email": email,
                 "username": username,
                 "password": TEST_PASSWORD,
@@ -425,8 +436,7 @@ async fn bootstrap_concurrent_race_single_admin() {
 
     // Exactly one super-admin exists after the race.
     use axiam_core::repository::{Pagination, UserRepository};
-    let user_repo = SurrealUserRepository::new(db.clone());
-    let users = user_repo
+    let users = SurrealUserRepository::new(db.clone())
         .list(
             tenant_id,
             Pagination {
@@ -455,7 +465,7 @@ async fn bootstrap_rejects_wrong_email() {
         std::env::set_var("AXIAM_BOOTSTRAP_ADMIN_EMAIL", "only-me@example.com");
     }
 
-    let (db, org_id, tenant_id) = setup_empty_tenant().await;
+    let db = setup_empty_db().await;
     let auth = test_auth_config();
     let authz = make_authz(&db);
     let app = test_app!(db, auth, authz);
@@ -465,8 +475,7 @@ async fn bootstrap_rejects_wrong_email() {
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "Gated Org",
             "email": "someone-else@example.com",
             "username": "impostor",
             "password": TEST_PASSWORD,
@@ -493,17 +502,23 @@ async fn bootstrap_rejects_wrong_email() {
 ///
 /// SECHRD-04 (Task 2, D-03a): when `AXIAM_BOOTSTRAP_ADMIN_EMAIL` is unset
 /// AND no (valid) setup token is presented, bootstrap must fail closed —
-/// a non-2xx response and zero admins created. An unset gate must never
-/// allow arbitrary bootstrap.
+/// a non-2xx response and nothing created.
 #[actix_rt::test]
 async fn bootstrap_refused_when_gate_unset() {
+    use surrealdb::types::SurrealValue;
+
+    #[derive(Debug, SurrealValue)]
+    struct CountRow {
+        total: u64,
+    }
+
     let _guard = env_guard().await;
     // SAFETY: serialized via env_lock; ensure the email gate is OFF.
     unsafe {
         std::env::remove_var("AXIAM_BOOTSTRAP_ADMIN_EMAIL");
     }
 
-    let (db, org_id, tenant_id) = setup_empty_tenant().await;
+    let db = setup_empty_db().await;
     let auth = test_auth_config();
     let authz = make_authz(&db);
     let app = test_app!(db, auth, authz);
@@ -515,8 +530,7 @@ async fn bootstrap_refused_when_gate_unset() {
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "Nobody Org",
             "email": "nobody@example.com",
             "username": "nobody",
             "password": TEST_PASSWORD,
@@ -534,8 +548,7 @@ async fn bootstrap_refused_when_gate_unset() {
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "Nobody Org 2",
             "email": "nobody2@example.com",
             "username": "nobody2",
             "password": TEST_PASSWORD,
@@ -549,56 +562,58 @@ async fn bootstrap_refused_when_gate_unset() {
         "bootstrap with an invalid setup token must be refused (non-2xx), got {status}"
     );
 
-    // No admin was created by either attempt.
-    use axiam_core::repository::{Pagination, UserRepository};
-    let user_repo = SurrealUserRepository::new(db.clone());
-    let users = user_repo
-        .list(
-            tenant_id,
-            Pagination {
-                offset: 0,
-                limit: 10,
-            },
-        )
+    // Nothing was created by either attempt (no users, no organizations).
+    let mut result = db
+        .query("SELECT count() AS total FROM user GROUP ALL")
         .await
         .unwrap();
+    let users: Vec<CountRow> = result.take(0).unwrap();
     assert_eq!(
-        users.total, 0,
-        "no admin should be created when the gate is unset/invalid, got {} users",
-        users.total
+        users.first().map(|c| c.total).unwrap_or(0),
+        0,
+        "no admin should be created when the gate is unset/invalid"
+    );
+    let mut result = db
+        .query("SELECT count() AS total FROM organization GROUP ALL")
+        .await
+        .unwrap();
+    let orgs: Vec<CountRow> = result.take(0).unwrap();
+    assert_eq!(
+        orgs.first().map(|c| c.total).unwrap_or(0),
+        0,
+        "no organization should be created when the gate is unset/invalid"
     );
 }
 
 /// `bootstrap_admin_can_login`
 ///
 /// After a successful bootstrap, the new admin can log in via `/auth/login`
-/// with the bootstrap credentials. We don't assert the full response body
-/// (that's covered by auth_test.rs); we only assert the request is NOT
-/// rejected as invalid credentials.
+/// with the bootstrap credentials, resolving the workspace by the created
+/// org/tenant.
 #[actix_rt::test]
 async fn bootstrap_admin_can_login() {
     let _guard = env_guard().await;
-    // SECHRD-04: the gate is now mandatory — set the env var to match the
-    // request email so the env-var gate path (D-10) is satisfied.
     // SAFETY: serialized via env_lock.
     unsafe {
         std::env::set_var("AXIAM_BOOTSTRAP_ADMIN_EMAIL", "root@example.com");
     }
 
-    let (db, org_id, tenant_id) = setup_empty_tenant().await;
+    let db = setup_empty_db().await;
     let auth = test_auth_config();
     let authz = make_authz(&db);
     let app = test_app!(db, auth, authz);
 
     let peer: SocketAddr = TEST_PEER.parse().unwrap();
 
-    // 1. Bootstrap.
+    // 1. Bootstrap — creates org "login-org", tenant "default" and the admin.
     let req = test::TestRequest::post()
         .uri("/api/v1/admin/bootstrap")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "org_id": org_id,
-            "tenant_id": tenant_id,
+            "organization_name": "Login Org",
+            "organization_slug": "login-org",
+            "tenant_name": "Default",
+            "tenant_slug": "default",
             "email": "root@example.com",
             "username": "rootadmin",
             "password": TEST_PASSWORD,
@@ -611,51 +626,24 @@ async fn bootstrap_admin_can_login() {
     }
     assert_eq!(resp.status().as_u16(), 201, "bootstrap must succeed");
 
-    // 2. Activate the user directly — bootstrap creates them in
-    //    PendingVerification status, but login requires Active. Production
-    //    flow assumes AXIAM_BOOTSTRAP_ADMIN_EMAIL is verified out-of-band;
-    //    in tests we activate via the repository.
-    {
-        use axiam_core::models::user::{UpdateUser, UserStatus};
-        use axiam_core::repository::{Pagination, UserRepository};
+    // 2. Resolve the created org/tenant ids to drive the login request. The
+    //    admin is created Active, so no extra activation step is needed.
+    let org = SurrealOrganizationRepository::new(db.clone())
+        .get_by_slug("login-org")
+        .await
+        .unwrap();
+    let tenant = SurrealTenantRepository::new(db.clone())
+        .get_by_slug(org.id, "default")
+        .await
+        .unwrap();
 
-        let user_repo = SurrealUserRepository::new(db.clone());
-        let users = user_repo
-            .list(
-                tenant_id,
-                Pagination {
-                    offset: 0,
-                    limit: 10,
-                },
-            )
-            .await
-            .unwrap();
-        let admin = users
-            .items
-            .into_iter()
-            .find(|u| u.username == "rootadmin")
-            .expect("bootstrapped admin should be in the user list");
-        user_repo
-            .update(
-                tenant_id,
-                admin.id,
-                UpdateUser {
-                    status: Some(UserStatus::Active),
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
-    }
-
-    // 3. Login with the bootstrap credentials. LoginRequest expects the
-    //    tenant/org IDs and a username-or-email field.
+    // 3. Login with the bootstrap credentials.
     let req = test::TestRequest::post()
         .uri("/api/v1/auth/login")
         .peer_addr(peer)
         .set_json(serde_json::json!({
-            "tenant_id": tenant_id,
-            "org_id": org_id,
+            "tenant_id": tenant.id,
+            "org_id": org.id,
             "username_or_email": "rootadmin",
             "password": TEST_PASSWORD,
         }))

--- a/frontend/src/pages/BootstrapPage.test.tsx
+++ b/frontend/src/pages/BootstrapPage.test.tsx
@@ -16,13 +16,24 @@ import { renderWithProviders } from "@/test/renderWithProviders";
 
 const STRONG_PASSWORD = "StrongPass1!";
 
+// Typing the organization name auto-derives the org slug ("Acme Corp" ->
+// "acme-corp"); the tenant name/slug default to "Default"/"default".
 async function fillValidForm() {
-  await userEvent.type(screen.getByLabelText("Organization ID"), "org-1");
-  await userEvent.type(screen.getByLabelText("Tenant ID"), "tenant-1");
+  await userEvent.type(screen.getByLabelText("Organization name"), "Acme Corp");
   await userEvent.type(screen.getByLabelText("Email address"), "admin@example.com");
   await userEvent.type(screen.getByLabelText("Username"), "admin");
   await userEvent.type(screen.getByLabelText("Password"), STRONG_PASSWORD);
 }
+
+const EXPECTED_PAYLOAD = {
+  organization_name: "Acme Corp",
+  organization_slug: "acme-corp",
+  tenant_name: "Default",
+  tenant_slug: "default",
+  email: "admin@example.com",
+  username: "admin",
+  password: STRONG_PASSWORD,
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -35,16 +46,20 @@ describe("BootstrapPage", () => {
       screen.getByRole("heading", { name: "Initialize AXIAM" })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     ).toBeInTheDocument();
   });
 
-  it("requires all fields before submitting", async () => {
+  it("requires the core fields before submitting", async () => {
     renderWithProviders(<BootstrapPage />);
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
-    expect(await screen.findByText("All fields are required.")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Organization, email, username and password are required."
+      )
+    ).toBeInTheDocument();
     expect(apiMock.post).not.toHaveBeenCalled();
   });
 
@@ -56,13 +71,12 @@ describe("BootstrapPage", () => {
 
   it("rejects a password that does not meet policy", async () => {
     renderWithProviders(<BootstrapPage />);
-    await userEvent.type(screen.getByLabelText("Organization ID"), "org-1");
-    await userEvent.type(screen.getByLabelText("Tenant ID"), "tenant-1");
+    await userEvent.type(screen.getByLabelText("Organization name"), "Acme Corp");
     await userEvent.type(screen.getByLabelText("Email address"), "admin@example.com");
     await userEvent.type(screen.getByLabelText("Username"), "admin");
     await userEvent.type(screen.getByLabelText("Password"), "weak");
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     expect(
       await screen.findByText("Password does not meet the requirements.")
@@ -71,22 +85,37 @@ describe("BootstrapPage", () => {
   });
 
   it("submits the bootstrap request and navigates on success", async () => {
-    apiMock.post.mockResolvedValue(res({ id: "admin-1" }));
+    apiMock.post.mockResolvedValue(res({ user_id: "admin-1" }));
     renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
+    );
+    await waitFor(() =>
+      expect(apiMock.post).toHaveBeenCalledWith(
+        "/api/v1/admin/bootstrap",
+        EXPECTED_PAYLOAD
+      )
+    );
+    expect(navigate).toHaveBeenCalledWith(
+      "/login?bootstrapped=1&org=acme-corp&tenant=default"
+    );
+  });
+
+  it("includes the setup token when provided", async () => {
+    apiMock.post.mockResolvedValue(res({ user_id: "admin-1" }));
+    renderWithProviders(<BootstrapPage />);
+    await fillValidForm();
+    await userEvent.type(screen.getByLabelText(/Setup token/), "tok-123");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     await waitFor(() =>
       expect(apiMock.post).toHaveBeenCalledWith("/api/v1/admin/bootstrap", {
-        org_id: "org-1",
-        tenant_id: "tenant-1",
-        email: "admin@example.com",
-        username: "admin",
-        password: STRONG_PASSWORD,
+        ...EXPECTED_PAYLOAD,
+        setup_token: "tok-123",
       })
     );
-    expect(navigate).toHaveBeenCalledWith("/login?bootstrapped=1");
   });
 
   it("shows a busy state while the request is in flight", async () => {
@@ -99,38 +128,38 @@ describe("BootstrapPage", () => {
     renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     const submitButton = screen.getByRole("button", {
-      name: "Create Admin Account",
+      name: "Create Organization & Admin",
     });
     await userEvent.click(submitButton);
     await waitFor(() =>
       expect(submitButton).toHaveAttribute("aria-busy", "true")
     );
     expect(submitButton).toBeDisabled();
-    resolvePost(res({ id: "admin-1" }));
+    resolvePost(res({ user_id: "admin-1" }));
     await waitFor(() => expect(navigate).toHaveBeenCalled());
   });
 
-  it("shows an email-authorization error on 403", async () => {
+  it("shows an authorization error on 403", async () => {
     apiMock.post.mockRejectedValue({ response: { status: 403 } });
     renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     expect(
       await screen.findByText(
-        "This email address is not authorized for bootstrap."
+        "Bootstrap is not authorized. Check the email gate or paste a valid setup token."
       )
     ).toBeInTheDocument();
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("shows the already-initialized view on 404 and links back to sign in", async () => {
-    apiMock.post.mockRejectedValue({ response: { status: 404 } });
+  it("shows the already-initialized view on 409 and links back to sign in", async () => {
+    apiMock.post.mockRejectedValue({ response: { status: 409 } });
     renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     expect(
       await screen.findByRole("heading", { name: "Already Initialized" })
@@ -147,7 +176,7 @@ describe("BootstrapPage", () => {
     renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     expect(await screen.findByText("Bootstrap failed")).toBeInTheDocument();
   });
@@ -159,7 +188,7 @@ describe("BootstrapPage", () => {
     const { unmount } = renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     expect(await screen.findByText("err-field")).toBeInTheDocument();
     unmount();
@@ -170,11 +199,11 @@ describe("BootstrapPage", () => {
     renderWithProviders(<BootstrapPage />);
     await fillValidForm();
     await userEvent.click(
-      screen.getByRole("button", { name: "Create Admin Account" })
+      screen.getByRole("button", { name: "Create Organization & Admin" })
     );
     expect(
       await screen.findByText(
-        "Could not create admin account. Verify the server is running and check the server logs."
+        "Could not initialize AXIAM. Verify the server is running and check the server logs."
       )
     ).toBeInTheDocument();
   });

--- a/frontend/src/pages/BootstrapPage.tsx
+++ b/frontend/src/pages/BootstrapPage.tsx
@@ -8,15 +8,18 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PasswordPolicyChecker, checkPasswordPolicy } from "@/components/PasswordPolicyChecker";
 import { PublicLayout } from "@/components/layout/PublicLayout";
+import { slugify } from "@/lib/utils";
 import api from "@/lib/api";
 
 /**
- * BootstrapPage — first-run admin setup.
+ * BootstrapPage — first-run provisioning.
  *
- * Calls `POST /api/v1/admin/bootstrap` with the organization/tenant IDs
- * and the admin credentials. Renders inline error states for the three
- * documented failure modes (403 wrong email, 404 already initialized,
- * generic 4xx/5xx) and redirects to `/login?bootstrapped=1` on success.
+ * On a brand-new deployment nothing exists yet, so this page collects the
+ * organization, the default tenant and the admin credentials and posts them to
+ * `POST /api/v1/admin/bootstrap`, which creates all three in one call. When the
+ * `AXIAM_BOOTSTRAP_ADMIN_EMAIL` env gate is not set, the server mints a one-time
+ * setup token at first boot (logged once) — paste it into the Setup token field.
+ * On success it redirects to `/login` with the org/tenant slugs pre-filled.
  */
 interface BootstrapErrorResponse {
   message?: string;
@@ -26,11 +29,17 @@ interface BootstrapErrorResponse {
 export function BootstrapPage() {
   const navigate = useNavigate();
 
-  const [orgId, setOrgId] = useState("");
-  const [tenantId, setTenantId] = useState("");
+  const [orgName, setOrgName] = useState("");
+  const [orgSlug, setOrgSlug] = useState("");
+  const [tenantName, setTenantName] = useState("Default");
+  const [tenantSlug, setTenantSlug] = useState("default");
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [setupToken, setSetupToken] = useState("");
+
+  const [orgSlugTouched, setOrgSlugTouched] = useState(false);
+  const [tenantSlugTouched, setTenantSlugTouched] = useState(false);
 
   const [isLoading, setIsLoading] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
@@ -45,19 +54,32 @@ export function BootstrapPage() {
     };
   }, []);
 
+  const handleOrgNameChange = (v: string) => {
+    setOrgName(v);
+    if (!orgSlugTouched) setOrgSlug(slugify(v));
+  };
+
+  const handleTenantNameChange = (v: string) => {
+    setTenantName(v);
+    if (!tenantSlugTouched) setTenantSlug(slugify(v));
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setEmailError(null);
     setFormError(null);
 
+    const effectiveOrgSlug = orgSlug.trim() || slugify(orgName);
+    const effectiveTenantSlug = tenantSlug.trim() || slugify(tenantName) || "default";
+
     if (
-      !orgId.trim() ||
-      !tenantId.trim() ||
+      !orgName.trim() ||
+      !effectiveOrgSlug ||
       !email.trim() ||
       !username.trim() ||
       !password.trim()
     ) {
-      setFormError("All fields are required.");
+      setFormError("Organization, email, username and password are required.");
       return;
     }
 
@@ -69,27 +91,35 @@ export function BootstrapPage() {
     setIsLoading(true);
     try {
       await api.post("/api/v1/admin/bootstrap", {
-        org_id: orgId.trim(),
-        tenant_id: tenantId.trim(),
+        organization_name: orgName.trim(),
+        organization_slug: effectiveOrgSlug,
+        tenant_name: tenantName.trim() || "Default",
+        tenant_slug: effectiveTenantSlug,
         email: email.trim(),
         username: username.trim(),
         password,
+        ...(setupToken.trim() ? { setup_token: setupToken.trim() } : {}),
       });
-      navigate("/login?bootstrapped=1");
+      const params = new URLSearchParams({
+        bootstrapped: "1",
+        org: effectiveOrgSlug,
+        tenant: effectiveTenantSlug,
+      });
+      navigate(`/login?${params.toString()}`);
     } catch (err) {
       const axiosErr = err as AxiosError<BootstrapErrorResponse>;
       const status = axiosErr.response?.status;
       if (status === 403) {
         setEmailError(
-          "This email address is not authorized for bootstrap.",
+          "Bootstrap is not authorized. Check the email gate or paste a valid setup token.",
         );
-      } else if (status === 404) {
+      } else if (status === 409) {
         setAlreadyInitialized(true);
       } else {
         const msg =
           axiosErr.response?.data?.message ??
           axiosErr.response?.data?.error ??
-          "Could not create admin account. Verify the server is running and check the server logs.";
+          "Could not initialize AXIAM. Verify the server is running and check the server logs.";
         setFormError(msg);
       }
     } finally {
@@ -125,7 +155,8 @@ export function BootstrapPage() {
           Initialize AXIAM
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          No admin users exist. Create the first administrator to get started.
+          Create your organization, its default tenant and the first
+          administrator to get started.
         </p>
       </div>
 
@@ -142,29 +173,66 @@ export function BootstrapPage() {
       <form onSubmit={handleSubmit} noValidate>
         <div className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="bootstrap-org-id">Organization ID</Label>
+            <Label htmlFor="bootstrap-org-name">Organization name</Label>
             <Input
-              id="bootstrap-org-id"
+              id="bootstrap-org-name"
               type="text"
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={orgId}
-              onChange={(e) => setOrgId(e.target.value)}
-              autoComplete="off"
+              placeholder="Acme Corporation"
+              value={orgName}
+              onChange={(e) => handleOrgNameChange(e.target.value)}
+              autoComplete="organization"
+              autoFocus
               required
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="bootstrap-tenant-id">Tenant ID</Label>
+            <Label htmlFor="bootstrap-org-slug">Organization slug</Label>
             <Input
-              id="bootstrap-tenant-id"
+              id="bootstrap-org-slug"
               type="text"
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={tenantId}
-              onChange={(e) => setTenantId(e.target.value)}
+              placeholder="acme"
+              value={orgSlug}
+              onChange={(e) => {
+                setOrgSlugTouched(true);
+                setOrgSlug(slugify(e.target.value));
+              }}
               autoComplete="off"
               required
             />
+            <p className="text-xs text-muted-foreground">
+              Used to sign in. Lowercase letters, numbers and dashes.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="bootstrap-tenant-name">Tenant name</Label>
+              <Input
+                id="bootstrap-tenant-name"
+                type="text"
+                placeholder="Default"
+                value={tenantName}
+                onChange={(e) => handleTenantNameChange(e.target.value)}
+                autoComplete="off"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="bootstrap-tenant-slug">Tenant slug</Label>
+              <Input
+                id="bootstrap-tenant-slug"
+                type="text"
+                placeholder="default"
+                value={tenantSlug}
+                onChange={(e) => {
+                  setTenantSlugTouched(true);
+                  setTenantSlug(slugify(e.target.value));
+                }}
+                autoComplete="off"
+                required
+              />
+            </div>
           </div>
 
           <div className="space-y-2">
@@ -221,6 +289,24 @@ export function BootstrapPage() {
               </div>
             )}
           </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="bootstrap-setup-token">
+              Setup token{" "}
+              <span className="text-muted-foreground">(if required)</span>
+            </Label>
+            <Input
+              id="bootstrap-setup-token"
+              type="text"
+              placeholder="From the server's first-boot logs"
+              value={setupToken}
+              onChange={(e) => setSetupToken(e.target.value)}
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground">
+              Required unless the server sets AXIAM_BOOTSTRAP_ADMIN_EMAIL.
+            </p>
+          </div>
         </div>
 
         <Button
@@ -232,7 +318,7 @@ export function BootstrapPage() {
           {isLoading ? (
             <Loader2 size={14} className="animate-spin" aria-hidden="true" />
           ) : (
-            "Create Admin Account"
+            "Create Organization & Admin"
           )}
         </Button>
       </form>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -52,19 +52,33 @@ export function LoginPage() {
   );
 
   useEffect(() => {
-    if (searchParams.get("bootstrapped") === "1") {
-      // Strip the query param so a refresh doesn't re-show the notice.
+    if (
+      searchParams.get("bootstrapped") === "1" ||
+      searchParams.get("org") ||
+      searchParams.get("tenant")
+    ) {
+      // Strip the query params so a refresh doesn't re-show the notice or
+      // re-seed the workspace fields.
       const next = new URLSearchParams(searchParams);
       next.delete("bootstrapped");
+      next.delete("org");
+      next.delete("tenant");
       setSearchParams(next, { replace: true });
     }
   }, [searchParams, setSearchParams]);
 
-  const [step, setStep] = useState<LoginStep>("org-tenant");
-  const [orgTenantData, setOrgTenantData] = useState<OrgTenantData>({
-    orgSlug: "",
-    tenantSlug: "",
-  });
+  // After bootstrap, /login?bootstrapped=1&org=…&tenant=… pre-fills the
+  // workspace and jumps straight to the credentials step. Lazy initializers
+  // read the initial URL once (no setState in an effect).
+  const [step, setStep] = useState<LoginStep>(() =>
+    searchParams.get("org") || searchParams.get("tenant")
+      ? "credentials"
+      : "org-tenant"
+  );
+  const [orgTenantData, setOrgTenantData] = useState<OrgTenantData>(() => ({
+    orgSlug: searchParams.get("org") ?? "",
+    tenantSlug: searchParams.get("tenant") ?? "",
+  }));
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [totpCode, setTotpCode] = useState("");

--- a/scripts/e2e-bootstrap.sh
+++ b/scripts/e2e-bootstrap.sh
@@ -13,7 +13,7 @@
 # Environment variables (with E2E defaults):
 #   E2E_ORG_NAME      — organization name  (default: E2E Test Org)
 #   E2E_ORG_SLUG      — organization slug  (default: test-org)
-#   E2E_TENANT_NAME   — tenant name        (default: Default)
+#   E2E_TENANT_NAME   — tenant name        (default: E2E Default Tenant)
 #   E2E_TENANT_SLUG   — tenant slug        (default: default)
 #   E2E_ADMIN_EMAIL   — admin email        (default: admin@axiam.dev)
 #   E2E_ADMIN_PASSWORD — admin password    (default: Test@Admin123!)
@@ -23,7 +23,7 @@ set -euo pipefail
 
 ORG_NAME="${E2E_ORG_NAME:-E2E Test Org}"
 ORG_SLUG="${E2E_ORG_SLUG:-test-org}"
-TENANT_NAME="${E2E_TENANT_NAME:-Default}"
+TENANT_NAME="${E2E_TENANT_NAME:-E2E Default Tenant}"
 TENANT_SLUG="${E2E_TENANT_SLUG:-default}"
 ADMIN_EMAIL="${E2E_ADMIN_EMAIL:-admin@axiam.dev}"
 ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-Test@Admin123!}"

--- a/scripts/e2e-bootstrap.sh
+++ b/scripts/e2e-bootstrap.sh
@@ -2,30 +2,34 @@
 # e2e-bootstrap.sh — Seed the E2E database with an org, tenant, and admin user.
 #
 # Called after `docker compose -f docker/docker-compose.e2e.yml up -d --wait`.
-# Creates the org + tenant directly via SurrealDB HTTP API (no AXIAM auth required),
-# then calls POST /api/v1/admin/bootstrap (public endpoint, D-09) to create the
-# admin user with the super-admin role.
+# Performs the entire first-run provisioning through the public
+# POST /api/v1/admin/bootstrap endpoint, which creates the organization, the
+# default tenant, the seeded permissions/roles, and the admin user with the
+# super-admin role — all in one call. No direct SurrealDB access is needed.
+#
+# The bootstrap gate is satisfied by AXIAM_BOOTSTRAP_ADMIN_EMAIL (set in
+# docker-compose.e2e.yml to E2E_ADMIN_EMAIL); no setup token is required.
 #
 # Environment variables (with E2E defaults):
-#   E2E_ORG_SLUG      — organization slug (default: test-org)
+#   E2E_ORG_NAME      — organization name  (default: E2E Test Org)
+#   E2E_ORG_SLUG      — organization slug  (default: test-org)
+#   E2E_TENANT_NAME   — tenant name        (default: Default)
 #   E2E_TENANT_SLUG   — tenant slug        (default: default)
 #   E2E_ADMIN_EMAIL   — admin email        (default: admin@axiam.dev)
 #   E2E_ADMIN_PASSWORD — admin password    (default: Test@Admin123!)
 #   AXIAM_URL         — backend base URL   (default: http://localhost:8090)
-#   SURREAL_URL       — SurrealDB HTTP URL (default: http://localhost:8000)
 
 set -euo pipefail
 
+ORG_NAME="${E2E_ORG_NAME:-E2E Test Org}"
 ORG_SLUG="${E2E_ORG_SLUG:-test-org}"
+TENANT_NAME="${E2E_TENANT_NAME:-Default}"
 TENANT_SLUG="${E2E_TENANT_SLUG:-default}"
 ADMIN_EMAIL="${E2E_ADMIN_EMAIL:-admin@axiam.dev}"
 ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-Test@Admin123!}"
 AXIAM_URL="${AXIAM_URL:-http://localhost:8090}"
-SURREAL_URL="${SURREAL_URL:-http://localhost:8000}"
-# Must match the database name the server reads (DbConfig default: "main").
-AXIAM_DB="${AXIAM__DB__DATABASE:-main}"
 
-echo "[e2e-bootstrap] org=${ORG_SLUG} tenant=${TENANT_SLUG} email=${ADMIN_EMAIL} db=${AXIAM_DB}"
+echo "[e2e-bootstrap] org=${ORG_SLUG} tenant=${TENANT_SLUG} email=${ADMIN_EMAIL}"
 
 # ---------------------------------------------------------------------------
 # Step 1: Wait for AXIAM server to be ready
@@ -49,72 +53,20 @@ if [ "${STATUS}" != "200" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2: Create org + tenant directly via SurrealDB HTTP API.
+# Step 2: Call POST /api/v1/admin/bootstrap (public endpoint).
 #
-# The AXIAM API endpoints for org/tenant require authentication, but no admin
-# user exists yet (that's what we're bootstrapping). We use SurrealDB's built-in
-# HTTP SQL endpoint instead, which accepts root credentials.
-# ---------------------------------------------------------------------------
-echo "[e2e-bootstrap] Creating org '${ORG_SLUG}' and tenant '${TENANT_SLUG}' via SurrealDB..."
-
-# Generate fresh random UUIDs for the org and tenant so the bootstrap call
-# can reference them. Each run uses new IDs against a fresh (memory-mode) DB.
-ORG_ID=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
-TENANT_ID=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
-
-# NOTE: SurrealQL uses the double-colon `type::record(...)` function (single
-# colon `type:record(...)` is a syntax error). Critically, SurrealDB's /sql
-# endpoint returns HTTP 200 even when an individual statement fails, so
-# `curl -sf` alone does NOT catch SQL errors — we MUST inspect each
-# statement's "status" field in the JSON response (W8: no silent false-green).
-SURREAL_RESPONSE=$(curl -sf \
-  -X POST "${SURREAL_URL}/sql" \
-  -H "Accept: application/json" \
-  -H "Content-Type: text/plain" \
-  -H "surreal-ns: axiam" \
-  -H "surreal-db: ${AXIAM_DB}" \
-  -u "root:root" \
-  --data-binary "
-CREATE type::record('organization', '${ORG_ID}') SET
-  name = 'E2E Test Org',
-  slug = '${ORG_SLUG}',
-  metadata = {},
-  created_at = time::now(),
-  updated_at = time::now();
-
-CREATE type::record('tenant', '${TENANT_ID}') SET
-  organization_id = '${ORG_ID}',
-  name = 'E2E Default Tenant',
-  slug = '${TENANT_SLUG}',
-  metadata = {},
-  created_at = time::now(),
-  updated_at = time::now();
-" 2>&1) || {
-  echo "[e2e-bootstrap] ERROR: SurrealDB SQL request failed (HTTP/transport). Response: ${SURREAL_RESPONSE}"
-  exit 1
-}
-
-# Fail closed if ANY statement returned a non-OK status (HTTP 200 hides these).
-if printf '%s' "${SURREAL_RESPONSE}" | grep -q '"status":"ERR"' \
-   || ! printf '%s' "${SURREAL_RESPONSE}" | grep -q '"status":"OK"'; then
-  echo "[e2e-bootstrap] ERROR: SurrealDB statement-level failure during seed. Response: ${SURREAL_RESPONSE}"
-  exit 1
-fi
-
-echo "[e2e-bootstrap] Org and tenant created (both statements OK)."
-
-# ---------------------------------------------------------------------------
-# Step 3: Call POST /api/v1/admin/bootstrap (public endpoint).
-#
-# This creates the admin user with the super-admin role and seeds all
-# permissions for the tenant. Returns 201 on success, 404 if already done.
+# Creates the organization, the default tenant, all permissions/roles, and the
+# admin user with the super-admin role. Returns 201 on success, 409 if the
+# system has already been initialized.
 # ---------------------------------------------------------------------------
 echo "[e2e-bootstrap] Calling /api/v1/admin/bootstrap ..."
 
 BOOTSTRAP_BODY=$(cat <<EOF
 {
-  "org_id": "${ORG_ID}",
-  "tenant_id": "${TENANT_ID}",
+  "organization_name": "${ORG_NAME}",
+  "organization_slug": "${ORG_SLUG}",
+  "tenant_name": "${TENANT_NAME}",
+  "tenant_slug": "${TENANT_SLUG}",
   "email": "${ADMIN_EMAIL}",
   "username": "admin",
   "password": "${ADMIN_PASSWORD}"
@@ -130,10 +82,10 @@ for i in $(seq 1 5); do
     -d "${BOOTSTRAP_BODY}" 2>/dev/null || echo "000")
 
   if [ "${HTTP_STATUS}" = "201" ]; then
-    echo "[e2e-bootstrap] Bootstrap complete (201). Admin user created."
+    echo "[e2e-bootstrap] Bootstrap complete (201). Org, tenant and admin user created."
     break
-  elif [ "${HTTP_STATUS}" = "404" ]; then
-    echo "[e2e-bootstrap] Bootstrap already completed (404) — skipping."
+  elif [ "${HTTP_STATUS}" = "409" ]; then
+    echo "[e2e-bootstrap] Bootstrap already completed (409) — skipping."
     break
   else
     echo "[e2e-bootstrap] Attempt ${i}/5: bootstrap returned ${HTTP_STATUS}, retrying in 3s..."
@@ -143,7 +95,7 @@ for i in $(seq 1 5); do
 done
 
 # Final check
-if [ "${HTTP_STATUS}" != "201" ] && [ "${HTTP_STATUS}" != "404" ]; then
+if [ "${HTTP_STATUS}" != "201" ] && [ "${HTTP_STATUS}" != "409" ]; then
   echo "[e2e-bootstrap] ERROR: bootstrap endpoint returned unexpected status ${HTTP_STATUS}"
   cat /tmp/bootstrap_resp.json 2>/dev/null || true
   exit 1


### PR DESCRIPTION
## First-run bootstrap: create the organization, default tenant and admin in one call

On a brand-new deployment the database is empty, but `POST /api/v1/admin/bootstrap` still required a pre-existing `org_id`/`tenant_id` and only validated they exist — so there was no in-product way to create the first workspace. The web BootstrapPage asked the operator to paste UUIDs that could not exist, and the only working path was the e2e script writing org/tenant rows directly with SurrealDB root credentials.

This PR makes bootstrap provision everything in one call, **preserving main's security hardening** (SECHRD-04 env/setup-token gate, atomic admin transaction, `password_history` seeding).

### Changes
- **Handler** (`handlers/bootstrap.rs`): accepts organization/tenant **names + slugs** (defaults: tenant `Default`/`default`, slugs derived from names). Get-or-creates the org and default tenant by slug (idempotent under retry), seeds permissions/roles, then creates the admin. One-shot is now **global** via a `bootstrap_lock:global` uniqueness invariant inside the atomic transaction (**409** on a second bootstrap). Response echoes the created org/tenant ids + slugs. The env-email / setup-token gate is unchanged.
- **Frontend** `BootstrapPage.tsx`: collects org/tenant names + auto-derived editable slugs and an optional setup token; maps 409 → already-initialized; redirects to `/login` with the slugs pre-filled. `LoginPage.tsx` restores them and jumps to the credentials step (lazy initializers, no setState-in-effect).
- **`scripts/e2e-bootstrap.sh`**: calls the real endpoint (no direct DB writes); the env-email gate in `docker-compose.e2e.yml` satisfies the bootstrap gate.
- **`bootstrap_test.rs`**: rewritten for the new flow — fresh empty DB, asserts org+tenant+admin are created, 409 on re-bootstrap, concurrent race yields a single admin, gate-unset refusal creates nothing, and the admin logs in by the created workspace.

### Note
This branch was re-scoped: every security fix from the earlier review-verification work already landed on `main` independently, so the branch now carries **only** the bootstrap first-run fix that `main` still lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)