### PR TITLE
docs: post-remediation security and code-quality re-review

### DIFF
--- a/claude_dev/code-review-postremediation.md
+++ b/claude_dev/code-review-postremediation.md
@@ -1,0 +1,216 @@
+# AXIAM — Post-Remediation Code Review (Quality & Correctness)
+
+- **Date**: 2026-07-01
+- **Commit reviewed**: `ea85872` (HEAD of `claude/post-remediation-review-994pto`)
+- **Baseline**: the previous review at `d69323b` ([`code-review.md`](code-review.md)) and the [`remediation-plan.md`](remediation-plan.md). 246 commits / ~40k insertions since `d69323b`.
+- **Method**: per-finding re-verification of every active `CQ-*` finding with file:line evidence; fresh line-level review of remediation-touched modules (cleanup/GDPR, email_config, seeder, mtls chain verify, schema migrations, AMQP DLX/HMAC, gRPC interceptor + governor, frontend services/hooks/api/shared-components, SurrealDB connection resilience).
+- **Verification run in this environment**:
+  - `cargo build --workspace` → **green** (4m27s; `axiam-server` binary produced — **CQ-B37 fixed**).
+  - `cargo clippy` → all 12 library crates clean.
+  - Frontend `eslint .` → **0 errors** (was 9 — **CQ-F06 source fixed**); `tsc -b` → clean; `npm audit` → 0 vulnerabilities.
+- **Companion**: [`security-review-postremediation.md`](security-review-postremediation.md). Security-primary items live there (`SEC-*`).
+
+Statuses: ✅ FIXED, 🔶 PARTIAL, ❌ OPEN. New findings continue at **CQ-B45 / CQ-F36**.
+
+---
+
+## Executive summary
+
+Unlike the previous wave (which the last review found "did not touch the structural backlog"), this round closed a meaningful slice of it. The build compiles and the frontend lints clean — both were red at `d69323b`. Concrete correctness fixes landed across the stack: resource-hierarchy cycle/orphan protection (CQ-B08 ✅), a single hashing path with the configured pepper so REST-created users can log in (CQ-B01 ✅), `spawn_blocking` around most crypto (CQ-B02 partial), atomic lockout (SEC-032), migration transactionality (CQ-B06 partial), unique edge indexes (CQ-B17 partial), a seeder that skips unchanged work (CQ-B42 ✅), PKI/gRPC test suites where there were zero (CQ-B24 partial), and a genuinely well-built cookie-auth + refresh-interceptor rewrite on the frontend.
+
+Three themes remain:
+
+1. **The "wired-but-broken" class persists in new places.** Webhook delivery is still dead code that would now *fail 100% of the time* if wired (it decrypts a secret that is stored in plaintext — CQ-B22/SEC-031); the notification dispatcher still has zero call sites (CQ-B29); the frontend's extracted shared components ship as dead code with the duplication they were meant to remove still intact (CQ-F15); and the CI "e2e" job runs vitest, not Playwright, so all 12 Playwright specs — including the auth contract test — never execute (**CQ-F36, new**).
+2. **Structural debt is dented, not cleared.** `main.rs` still has no `AppState` and ~45 inline `app_data` registrations (CQ-B43 partial); 24 repos still define their own `CountRow` and there's still no generic `paginate<T>` (CQ-B10 partial); the GDPR/email repos institutionalized the `DbError::Migration` misuse into the shared helper (CQ-B11, CQ-B44-adjacent); OAuth2 still collapses repo errors to `invalid_client` (CQ-B18).
+3. **A few remediations are incorrect.** The gRPC governor was "fixed" into `per_second(100)` semantics that throttle to ~1 token/100s — worse than the original bug (CQ-B44). The XFF rate-limit fallback returns the client-controlled hop (SEC-060). The SurrealDB token-expiry fix deferred a 1-hour failure to a 4-week one with no renewal loop (**CQ-B45, new**).
+
+### Active finding counts
+
+| Priority | Backend | Frontend |
+|---|---|---|
+| High | 6 | 6 |
+| Medium | 17 | 9 |
+| Low | 11 | 9 |
+
+**Fully fixed this round**: 11 backend + 12 frontend previously-active findings (see per-finding verdicts).
+
+### Suggested fix order
+
+1. **CQ-B44** (gRPC governor semantics — currently throttles the mesh to a crawl) and **CQ-F36** (run Playwright in CI so the contract/auth specs actually gate).
+2. **CQ-B22 + SEC-031** (webhook: wire delivery via AMQP *and* encrypt the secret, or the first delivery fails on decrypt).
+3. **CQ-B45** (SurrealDB token renewal loop — a 4-week uptime ceiling on an IAM control plane).
+4. Structural leverage: **CQ-B10** (repo helpers + generic paginate), **CQ-B43** (AppState), **CQ-F15** (actually adopt the shared components), **CQ-B11** (error taxonomy).
+5. **CQ-F27/F29/F31** (frontend auth-flow bodies, tenant-context-on-reload, MFA-setup landing).
+
+---
+
+# Backend findings
+
+## High
+
+### CQ-B37 [HIGH] ✅ FIXED — axiam-server compiles
+`crates/axiam-server/Cargo.toml:37-40` moves `uuid`/`chrono`/`serde_json` to `[dependencies]` and adds `sha2`; `cleanup.rs` uses `sha2::{Digest, Sha256}` (no `rsa::sha2`), with `rsa` correctly dev-only. Verified: `cargo build --workspace` is green and produces the `axiam-server` binary.
+
+### CQ-B45 [HIGH] 🆕 — SurrealDB root token given a fixed 4-week TTL with no renewal or reconnect
+- **File**: `crates/axiam-db/src/connection.rs:23,104-136` (`ROOT_TOKEN_DURATION = "4w"`, `extend_root_token_duration` — one call site, in `connect`)
+- **Issue**: the Phase-13 "connection resilience" work fixed a 1-hour token expiry by `DEFINE USER OVERWRITE … DURATION FOR TOKEN 4w` at startup, but added no renewal task and no reconnect-on-auth-failure path (the code itself notes re-`signin` on the live handle is rejected). `health_check` only runs `RETURN 1`. A process with >~4 weeks of uptime (routine for an IAM control plane) hits the cached-JWT expiry and every DB request begins to 401 — login, audit, cleanup — until an operator restarts. This defers the exact failure mode the phase set out to eliminate rather than removing it.
+- **Fix**: a periodic re-`signin`/handle-refresh well inside the TTL, or reconnect-on-auth-error; failing that, document the hard uptime ceiling and add a readiness alarm.
+
+### CQ-B01 [HIGH] ✅ FIXED — pepper wired into the user repo
+`main.rs:312-314` builds `SurrealUserRepository::with_pepper(db, config.auth.pepper…)`; create hashes with `self.pepper` (`user.rs:242`), login verifies with the same pepper (`service.rs:250-252`). `hash_password(Some(""))` equals `hash_password(None)`, so the `unwrap_or_default()` case is consistent. REST-created users log in with or without a pepper set.
+
+### CQ-B02 [HIGH] 🔶 PARTIAL — spawn_blocking around most, not all, crypto
+Login verify + dummy verify, both change-password verifies, the history-check loop, and all PKI keygen/sign now run in `spawn_blocking` behind a bounding `crypto_semaphore`. Remaining inline Argon2 on executor threads: db-repo `create`/`update_password` hashes (`user.rs:242,639`), the **new-password hash** in `change_password` (`service.rs:728` — the verifies around it are wrapped, the hash isn't), and gRPC `ValidateCredentials` verify (`services/user.rs:128`).
+
+### CQ-B08 [HIGH] ✅ FIXED — resource hierarchy cycles/truncation/orphans
+`resource.rs:205-221` rejects self-parent and cycle-creating re-parents (`Validation("cycle detected")`); `delete` blocks when `child_of` edges exist (`:275-294`); `get_ancestors` now errors past `MAX_ANCESTOR_DEPTH` instead of silently truncating (`:386-401`). (The delete edge-cleanup is still non-transactional — that's CQ-B07; and the guard+delete is a TOCTOU — see CQ-B46.)
+
+### CQ-B40 [HIGH] ✅ FIXED — federation operable via API
+`handlers/federation.rs:68-88` adds `idp_signing_cert_pem` + `allowed_algorithms` to the create/update DTOs; `validate_pem_cert` runs before persistence; the repo persists both columns; PEM parsing uses the `pem` crate + `x509_parser` (line-concatenation parser gone). SAML configs can reach a complete state and OIDC configs get a working allow-list via the API. Gap: the specifically-requested *create-via-API-then-complete-a-login* e2e is still absent.
+
+### CQ-B38 [HIGH] 🔶 PARTIAL — GDPR purge/export correctness
+Fixed: purge flags cleared last (re-selectable on failure), missing `webauthn_credential`/`password_history` deletes added, `unwrap_or_default()` swallowing replaced with `?`, audit export paginated past 10k, and a `Failed` job status added. Open: per-item shutdown checks still absent (only between sweeps); `sessions` is still hardcoded `[]` in the export while attesting `schema_version "1.0"`; a swallowed audit-pseudonymize failure certifies erasure with residual PII (SEC-063).
+
+### CQ-B03 / CQ-B05 / CQ-B06 / CQ-B07 — see per-topic notes
+- **CQ-B03** ✅ FIXED — sparse `Option` override mask (see SEC-033).
+- **CQ-B05** 🔶 PARTIAL — audit/authz queues now declare real DLXs matching `MAIL_OUTBOUND`; the audit permanent-drop and authz hot-loop nacks are fixed. Remaining: mail retry republish still has no backoff delay.
+- **CQ-B06** 🔶 PARTIAL — apply+record is now one `BEGIN/COMMIT` and a `_migration_lock` record is written, but the legacy v1 DDL is still plain `DEFINE` (non-idempotent on bare re-run) and the "lock" is a plain `UPSERT` that provides no mutual exclusion (double-apply is prevented only by the version UNIQUE index + per-migration transaction).
+- **CQ-B07** ❌ OPEN — role/permission edge deletes are still non-transactional and keyed by UUID without a tenant predicate (cross-tenant edge-strip; see SEC-007/SEC-058 in the security report).
+
+## Medium
+
+### CQ-B44 [MEDIUM] ❌ OPEN (remediation is wrong — now worse) — gRPC governor throttles to ~1 token / 100 s
+- **File**: `crates/axiam-api-grpc/src/middleware/rate_limit.rs:40-47`
+- **Issue**: the code now calls `.per_second(authz_per_sec as u64).burst_size(authz_per_sec * 2)`, but tower_governor 0.8's `per_second(n)` sets the *replenish period* to `n` seconds ("one token every n seconds"). With the default `grpc_authz_per_sec = 100`, this becomes "1 token every 100 s, burst 200" — sustained ~0.01 req/s, and *raising* the config makes the limiter slower. The original `per_second(1)` bug was 1 req/s; this is 100× worse and inverted.
+- **Fix**: use `per_millisecond(1000 / authz_per_sec)` (or `Quota::per_second`) with a separate burst; add a test asserting sustained throughput.
+
+### CQ-B10 [MEDIUM] 🔶 PARTIAL — shared repo helpers exist but adoption is thin
+A `helpers` module now offers `CountRow`, `parse_uuid`, `take_first_or_not_found`, adopted by ~4 repos. But **24 repositories still define their own `CountRow`**, there is still **no generic `paginate<T>`**, and unconverted repos still inline `Uuid::parse_str(...).map_err(DbError::Migration)`.
+
+### CQ-B11 [MEDIUM] ❌ OPEN — duplicate-create still 500; `Migration` catch-all institutionalized
+`AlreadyExists`→409 is produced only in `federation_login_state.rs`/`saml_replay.rs`; mainstream create paths (e.g. user create's `.check()` at `user.rs:275-276`) still map index violations to `DbError::Migration`→500. The new GDPR repos add ~18 more `Migration` misuses, and `helpers::parse_uuid:33-36` bakes the same mapping into the shared path — a corrupt-data read now surfaces as a 500 labeled "Migration failed".
+
+### CQ-B17 [MEDIUM] 🔶 PARTIAL — unique edge indexes added; error mapping + drift remain
+Migration v19 adds UNIQUE `(in,out)` indexes on the edge tables (`schema.rs:1057-1070`), so duplicate edges now error instead of silently inserting. Remaining: the false "IF NOT EXISTS avoids duplicates" comment is still above a plain `RELATE` (`group.rs:391`); a unique-violation maps to `Database`→500, not `AlreadyExists`→409; and `get_members` total/items still drift (count over edges vs selected rows).
+
+### CQ-B24 [MEDIUM] 🔶 PARTIAL — big test-coverage gains; two gaps remain
+`axiam-pki/tests/` (ca/cert/mtls/mtls_chain/pgp/failfast) and `axiam-api-grpc/tests/` (grpc_auth/grpc_authz) now exist where there were zero. Still missing: dedicated webauthn REST-handler tests and any `notification_rules` test.
+
+### Carried-forward mediums (verdicts)
+- **CQ-B13** 🔶 PARTIAL — assignments batched; grant queries + ancestor walk still N+1; dead `group_repo` still `#[allow(dead_code)]`.
+- **CQ-B15** ❌ OPEN — `CertService` still rebuilds the CA from the subject CN (no `from_ca_cert_pem`); keypair/fingerprint/encrypt helpers still triplicated across ca/cert/pgp.
+- **CQ-B16** ❌ OPEN — org/user delete still silently succeeds for missing ids; no cascade (tenant handler has a `get_by_id`-first mitigation only).
+- **CQ-B18** ❌ OPEN — OAuth2 grant handlers still inline the client lookup and collapse DB outages to `invalid_client`; `authenticate_client()` used only by revoke/introspect.
+- **CQ-B19** 🔶 PARTIAL — discovery cleaned up, but token/revoke/introspect still hard-require `?tenant_id=` (which discovery omits) and there's still no `QueryConfig` for RFC-shaped 400s.
+- **CQ-B20** 🔶 PARTIAL — gRPC now sets frame-size/timeout/concurrency limits + env-gated TLS; still no graceful shutdown, and `batch_check_access` is unbounded/serial.
+- **CQ-B21** 🔶 PARTIAL — 64 KiB `JsonConfig` now on both scopes; no Query/Path/Form configs; three envelope shapes unremediated.
+- **CQ-B22** ❌ OPEN — webhook delivery still detached `tokio::spawn`, no persistence, **zero `.deliver(` call sites**, no secret rotation in the update DTO; and it decrypts a secret stored in plaintext, so wiring it as-is fails every delivery.
+- **CQ-B23** 🔶 PARTIAL — SAML attribute_map applied; OIDC discovery still uncached, cap still after buffering, IdP 4xx still → 500, OIDC provisioning still ignores `attribute_map`.
+- **CQ-B25** 🔶 PARTIAL — create paths use DTOs; role/group/tenant/service-account *update* handlers still bind domain structs.
+- **CQ-B26** ✅ FIXED — `users::create` now validates email format + password policy; `notification_rules`/`email` still use `contains('@')`.
+- **CQ-B39** 🔶 PARTIAL — export dedup + factored audit-append + 256-bit cancel token landed; deletion setup still non-transactional (a `create` failure after `mark_deletion_pending` strands an unrecoverable purge with no cancel token — cross-ref SEC-063).
+- **CQ-B41** 🔶 PARTIAL — `set_*` now UPSERTs a deterministic `(scope, scope_id)` record (no row accumulation, deterministic reads); the flagged `Uuid::new_v4()` into `effective_email_config`/`email_config_from_org_input` is unchanged (now cosmetic).
+- **CQ-B43** 🔶 PARTIAL — `load_key_from_env` extracted; still no `AppState`, `main()` still registers ~45 `app_data` inline.
+
+## Low
+- **CQ-B27** ❌ OPEN — federation/reset/verification services still constructed per request (9+ sites).
+- **CQ-B28** ✅ FIXED — single capped `client_ip`/`user_agent` helper module, used uniformly in api-rest.
+- **CQ-B29** ❌ OPEN — `NotificationDispatcher.dispatch()` still has zero production call sites; `NotificationPublisher` constructed but unconsumed; `AuditService` dead.
+- **CQ-B31** 🔶 PARTIAL — impactful silent drops (gdpr/cleanup/webauthn) gone; one benign `let _ = invalidate(...)` remains.
+- **CQ-B32** 🔶 PARTIAL — `DeviceIdentity.org_id` documented + caller-resolved; still `Uuid::nil()` not `Option<Uuid>`.
+- **CQ-B33** 🔶 PARTIAL — revoke endpoints uniform, typed error variants added; `Database/Crypto/Internal/Certificate` still stringly, PUT-with-PATCH everywhere, `GET /oauth2/authorize` still 401-JSONs unauthenticated browsers.
+- **CQ-B34** 🔶 PARTIAL — workspace deps unified; three `rand` majors + non-workspace `rand_core 0.6` in axiam-pki remain; unused deps not pruned.
+- **CQ-B35** 🔶 PARTIAL — HIBP now runs on the sync change-password path; the vestigial `Result` on `check_hibp` is not removed.
+- **CQ-B36** ❌ OPEN — audit-drop still `warn!`-only (no metric); channel still 4096.
+- **CQ-B42** ✅ FIXED — seeder hashes the permission registry and skips the UPSERT loop when unchanged (migration v20 adds `seeder_state`).
+- **CQ-B46 [LOW] 🆕** — `resource::delete` child-guard is a non-atomic TOCTOU: a concurrent create/re-parent between the child-count and the delete reintroduces the orphan state CQ-B08 closes (`resource.rs:278-312`). Wrap guard+delete in a transaction (ties to CQ-B07).
+- **CQ-B47 [LOW] 🆕** — `axiam-db` still publicly exports a second `verify_password` Argon2 implementation (`user.rs:829-852`, re-exported at `mod.rs:69`/`lib.rs:34`), dead in production but inviting a pepper-less caller — delete it now that hashing is centralized.
+
+---
+
+# Frontend findings
+
+## High
+
+### CQ-F36 [HIGH] 🆕 — CI "e2e" job runs vitest, not Playwright; all 12 e2e specs never execute
+- **File**: `.github/workflows/ci.yml:342` runs `npm test` = `vitest run` (`package.json:12`); `vitest.config.ts` includes only `src/**/*.test.ts` (one file). The 12 Playwright specs live in `e2e/` and run via `test:e2e` (`playwright test`), which CI never invokes — even though the job boots a backend, seeds a fixture, installs Chromium, and uploads a `playwright-report`.
+- **Impact**: the auth-flow, login, and frontend↔OpenAPI *contract* specs — the very tests meant to catch the SEC-044/CQ-F27 regressions — are dead in CI. The "contract test in CI" the plan required is not running.
+- **Fix**: change the step to `npx playwright test` (keep vitest as its own step).
+
+### CQ-F27 [HIGH] 🔶 PARTIAL — auth flows: most wired; reset/resend still send wrong bodies
+Change-password, verify-email, and MFA enroll/confirm now hit real `/api/v1/auth/*` routes via `services/auth.ts`. But `requestPasswordReset`/`confirmPasswordReset`/`resendVerification` omit the backend-required `tenant_id` (and resend omits `email`), so all three 400 and stay dead (security framing: SEC-044). The contract spec asserts only paths, not bodies, so it can't catch this even if it ran (CQ-F36).
+
+### CQ-F28 [HIGH] ✅ FIXED — silent refresh + boot refresh
+`lib/api.ts` sends refresh through the `api` instance (CSRF header attached), narrows `SKIP_REFRESH` to login/refresh/logout (no longer skips `/auth/me`), and `useAuthInit` performs one explicit boot refresh before declaring unauthenticated. `_retry` is set before the single-flight queue check. Confirmed by two reviewers.
+
+### CQ-F05 [HIGH] 🔶 PARTIAL — logout calls the endpoint but 400s
+`Topbar.tsx` now posts `/api/v1/auth/logout` and clears the query cache + auth on both logout and refresh-failure. But it posts `{}` while the handler requires `{session_id}` (the SEC-051 fix), so the request 400s and the server session/cookies survive (security framing: SEC-015). Fix requires a server change (revoke from JWT `jti`) or exposing `session_id`.
+
+### CQ-F06 [HIGH] ✅ FIXED — lint clean + CI gates
+`eslint .` reports 0 errors (was 9); `tsc -b` clean. `ci.yml` adds a `frontend-quality` job running `npm run lint && npx tsc -b`. (Caveat: the *e2e* gate is miswired — CQ-F36.)
+
+### CQ-F01 / CQ-F07 / CQ-F08 ✅ FIXED
+`"current-user"` gone (real `user.id`); OrganizationDetailPage dead `syncedRef` removed and the settings form now saves the displayed values; TenantsPage no longer fabricates "Status: Active".
+
+### CQ-F02 [HIGH] 🔶 PARTIAL — `ConfirmDialog.confirmLabel` added, but the bespoke unlock dialog wasn't retired
+`confirmLabel` prop exists and PgpKeysPage uses it, but the ~57-line inline UsersPage unlock dialog remains, and cert-revoke ConfirmDialogs still show the default "Delete".
+
+### CQ-F03 / CQ-F04 ✅ FIXED
+AuditLogsPage clears debounce timers on Clear/unmount/retrigger; user-search moved to a shared `UserSearchDialog` using `useQuery` keyed by term (stale-response race gone).
+
+## Medium
+- **CQ-F09** 🔶 PARTIAL — toast system + `getApiErrorMessage` + `onError` adopted on most pages; TenantsPage delete has no `onError` (silent), and a few create/edit mutations still surface raw `err.message`.
+- **CQ-F10** ✅ FIXED (with a caveat) — dashboard query keys aligned with CRUD invalidations; but `["users",1,""]` now collides with UsersPage at a different page size (**CQ-F37**).
+- **CQ-F11** 🔶 PARTIAL — `noValidate` removed from `FormDialog`; still present on LoginPage (×3) and BootstrapPage.
+- **CQ-F12** ✅ FIXED — resource parent picker excludes descendants (BFS); de-parenting sends explicit `null`.
+- **CQ-F13** ✅ FIXED — federation type select `disabled` in edit mode; payload matches the (now immutable) protocol.
+- **CQ-F14** 🔶 PARTIAL — `placeholderData` added; stranded-empty-page-after-delete still unhandled.
+- **CQ-F15** 🔶 PARTIAL (adoption ~zero) — `components/shared.tsx` (`ToggleField`/`SectionCard`/`InfoRow`/`ActionBadge`), `lib/utils.slugify`, and `hooks/useCrudMutations` were extracted, but **nothing imports them** — `ToggleField` is still defined locally 8×, `SectionCard`/`InfoRow` 3×, `ActionBadge`/`slugify` 2×. The shared module is dead code; the duplication it targets is intact.
+- **CQ-F16** 🔶 PARTIAL — Dashboard/usePermissions use selectors; AppLayout/Topbar still subscribe to the whole store.
+- **CQ-F17** 🔶 PARTIAL — single `MfaMethod` type; profile/MFA pages still make inline `api.*` calls instead of a typed users service.
+- **CQ-F18** ✅ FIXED — role/group unassign methods now have call sites.
+- **CQ-F19** 🔶 PARTIAL — VerifyEmailPage hits the real endpoint, but still relies on a `cancelled` flag (no `useRef` once-guard), so it double-fires under StrictMode and can flip to "failed" after success (dev only).
+- **CQ-F20** 🔶 PARTIAL — TenantsPage loading gate fixed; the N+1 `Promise.all(orgs.map(list))` fan-out remains.
+- **CQ-F29** 🔶 PARTIAL (behaviorally broken) — frontend reads `tenant_slug`/`org_slug` on reload, but `/auth/me`'s `MeResponse`/`LoginUserInfo` never emit them, so the Topbar reverts to "Select tenant" after any hard reload. **Backend fix needed**: add the slugs to `/auth/me`.
+- **CQ-F30** 🔶 PARTIAL — `ProtectedRoute`/`ForbiddenPage` added but wired to only 3 of ~14 gated sections; LoginPage still falls back to `permissions: []` on a transient `/auth/me` failure; Sidebar still ignores `isLoading` and flashes disabled at boot.
+- **CQ-F31** 🔶 PARTIAL — LoginPage routes `mfa_setup_required` to `/profile/mfa`, but that page never reads the `setup_token` and enrolls via the full-session endpoint, so MFA-mandated users hit a dead end.
+
+## Low
+- **CQ-F21** ✅ FIXED — `Placeholder.tsx` deleted.
+- **CQ-F22** ✅ FIXED — unused `@radix-ui` deps removed; the three remaining are all imported.
+- **CQ-F23** ✅ FIXED — `PasswordPolicyChecker` on admin create + bootstrap (policy still client-hardcoded, a separate sub-item).
+- **CQ-F24** ✅ FIXED — safe `getRowKey` fallback in DataTable.
+- **CQ-F25** ✅ FIXED — locale-aware `Intl.DateTimeFormat(undefined, …)` (no hardcoded `en-US`).
+- **CQ-F26** ✅ FIXED — `CSS.escape` in the ResourceTree selector.
+- **CQ-F32** ✅ FIXED — `_retry` guard on the refresh replay; `getCookie` uses a static regex.
+- **CQ-F33** ✅ FIXED — module-level empty-permissions constant.
+- **CQ-F34** 🔶 PARTIAL — BootstrapPage has the policy checker; 404 still maps to "Already Initialized" (now matches the backend contract but a proxy-404 is indistinguishable); `noValidate` remains.
+- **CQ-F35** ✅ FIXED — `useAuthInit` `useRef` once-guard survives StrictMode; dead dep removed.
+- **CQ-F37 [LOW] 🆕** — Dashboard and UsersPage share the query key `["users",1,""]` but request different page sizes (`list(1,1,"")` vs `list(page,20,search)`); whichever refetches last wins the cache, so navigating Dashboard→Users can render a 1-row user list until refetch. Introduced by the CQ-F10 key alignment. Give the dashboard a distinct key.
+- **CQ-F38 [LOW] 🆕** — `OrganizationDetailPage` settings form re-initializes from server data on every background refetch (`useEffect([settings])` with the lint suppressed), silently discarding an admin's in-progress edits on window refocus. Guard the init on first load or track dirtiness.
+- **CQ-F39 [LOW] 🆕** — `components/shared.tsx` + `hooks/useCrudMutations.ts` shipped with zero importers — pure maintenance overhead until CQ-F15 adoption happens (or delete them).
+
+---
+
+## Architecture observations
+
+**Backend.** The remediation followed the established trait-in-core / impl-in-db / thin-handler shape and added real tests where there were none (PKI, gRPC). Four structural weaknesses persist: (1) repository boilerplate still metastasizes and the shared helper even institutionalized the `Migration`-error misuse (CQ-B10/B11); (2) still no transactions around multi-statement mutations (CQ-B07/B38/B46), now including the GDPR purge and resource-delete guard; (3) `main.rs` still has no `AppState` and ~45 inline registrations (CQ-B43); (4) enforcement-by-convention — RBAC, CSRF, secret-encryption, and now the tenant-edge guard (applied to `grant_to_role` but not the REST-reachable `grant_to_role_with_scopes`) — is correct where wired and silently absent where not. The connection-resilience work traded a 1-hour bug for a 4-week one (CQ-B45), and two "fixes" are numerically wrong (CQ-B44 governor, SEC-060 XFF).
+
+**Frontend.** The cookie-auth + refresh-interceptor rewrite is the strongest piece of the wave — correct single-flight, CSRF injection, boot refresh. But the same anti-pattern as last round repeats: the pages that bypassed the services layer still do; the extracted shared components ship unused; the auth-recovery flows send bodies the backend rejects; and the tests meant to catch all of this don't run in CI. The single highest-leverage move remains adopting the shared CRUD/mutation plumbing and running Playwright (with body assertions) as a real gate.
+
+## Test coverage (updated)
+
+| Area | State |
+|---|---|
+| axiam-api-rest | Strong: rbac/gdpr/bootstrap/password-change/security-headers/route-parity suites. Gaps: webauthn handlers, notification_rules (0). |
+| axiam-server | federation e2e (oidc/saml/clock-skew/secret-at-rest/backfill), session lifecycle, service-account aud, cleanup, healthcheck. Missing: create-config-via-API-then-login e2e (CQ-B40). |
+| axiam-pki | **New** — ca/cert/mtls/mtls_chain/pgp/failfast (was zero). |
+| axiam-api-grpc | **New** — grpc_auth/grpc_authz (was zero); covers only AuthorizationService, not UserService/TokenService (SEC-003). |
+| axiam-db | tenant-isolation tests added — but exercise the guarded `grant_to_role`, not the REST-reachable `grant_to_role_with_scopes` (SEC-058). |
+| Frontend | 1 vitest file runs in CI; the 12 Playwright specs **do not run** (CQ-F36). |
+
+## Static analysis (this round)
+- `cargo build --workspace`: **green** (axiam-server binary produced).
+- `cargo clippy`: all 12 library crates clean.
+- `eslint .`: **0 errors** (was 9). `tsc -b`: clean. `npm audit`: 0 vulnerabilities.
+- Build prerequisites remain `protoc` + `libxml2-dev` + `libxmlsec1-dev` (samael); `utoipa-swagger-ui` fetches an asset at build time (needs network or a pre-seeded `SWAGGER_UI_DOWNLOAD_URL`).

--- a/claude_dev/security-review-postremediation.md
+++ b/claude_dev/security-review-postremediation.md
@@ -1,0 +1,248 @@
+# AXIAM — Post-Remediation Security Review
+
+- **Date**: 2026-07-01
+- **Commit reviewed**: `ea85872` (HEAD of `claude/post-remediation-review-994pto`)
+- **Baseline**: the previous review at `d69323b` ([`security-review.md`](security-review.md)) and the [`remediation-plan.md`](remediation-plan.md) it produced. 246 commits / ~40k insertions since `d69323b` (Phases 07–14: build-unblock, compliance verification, critical/high/medium/low remediation waves, SurrealDB connection resilience, frontend list contract).
+- **Method**: per-finding re-verification of every active `SEC-*` finding against current code with file:line evidence, plus a fresh line-level review of all remediation-touched security surface (gRPC auth interceptor, cookie/CSRF/authz middleware, extractors, federation OIDC/SAML/JWKS/secrets, GDPR cleanup + repos, AMQP HMAC signing, mail consumer, PKI mTLS chain verification, lockout/backoff, bootstrap, k8s/docker/CI). Ten parallel review agents; high-impact items independently re-verified by hand.
+- **Build/lint state**: frontend `eslint` clean (0 errors, was 9), `tsc -b` clean, `npm audit` 0 vulnerabilities. All 12 Rust **library** crates pass `cargo clippy` (the workspace binary build was exercised separately; `utoipa-swagger-ui` needs a network-fetched asset in this sandbox). CI now gates fmt/clippy/build/audit/deny/trivy + frontend lint/tsc.
+- **Companion**: [`code-review-postremediation.md`](code-review-postremediation.md).
+
+Statuses: ✅ FIXED (verified), 🔶 PARTIAL (core improved, residual risk), ❌ OPEN. New findings this round continue the sequence at **SEC-058**.
+
+---
+
+## Executive summary
+
+The remediation is substantial and mostly real. Both original criticals from the last round are resolved at the layer they were reported: **cross-organization IDOR is closed** (org/tenant/CA handlers now compare the caller's JWT `org_id` to the path, with cross-org negative tests — SEC-002 ✅), and **the broken auth lifecycle is largely repaired** (silent refresh no longer self-blocks on CSRF, federation secrets now decrypt at use — SEC-045 ✅). Password lockout with exponential backoff was genuinely broken and is now fixed and tested (SEC-032 ✅). Pagination is clamped, 5xx bodies are generic, PKCE is enforced for public clients, CSRF now covers the whole API, self-service status escalation and the logout IDOR are closed, k8s config prefixes are corrected, and CI is pinned by SHA with real gates.
+
+But the wave also **reintroduced the same class of bug it was closing**, and left several controls wired only halfway:
+
+1. **gRPC is still partly unauthenticated (SEC-003, HIGH).** The new interceptor guards `AuthorizationService` correctly but was never attached to `UserService` or `TokenService`; both still trust body-supplied `tenant_id`/`user_id`. Cross-tenant user read and unmetered credential brute-force remain reachable by any mesh peer.
+2. **A tenant guard was applied to the wrong function (SEC-058, HIGH, new).** The per-tenant edge check landed on `grant_to_role`, but the live REST grant path calls the *unguarded* `grant_to_role_with_scopes`. Cross-tenant privilege grants are still possible, and the isolation test exercises the guarded variant, masking it.
+3. **The zero-key anti-pattern was relocated, not eliminated (SEC-059, HIGH, new).** PKI now fails closed when its encryption key is absent — but the webhook subsystem re-added `load_key_from_env(...).unwrap_or([0u8; 32])`, so webhook HMAC secrets are "encrypted" at rest under an all-zero key when the env var is unset.
+4. **Enforcement-by-convention persists.** RBAC (per-handler `RequirePermission`), authz middleware (presence-only, fail-open), rate-limiting (spoofable XFF fallback — SEC-048/SEC-060), and secret encryption (webhook plaintext-at-rest — SEC-031) are all correct where wired and silently absent where not.
+5. **Several recovery/notification paths are wired but non-functional**: password-reset request/confirm and resend-verification still omit the backend-required `tenant_id` (SEC-044); logout POSTs an empty body against a handler that now requires `{session_id}`, so it 400s and never revokes the server session (SEC-015); GDPR ExportReady mail is still undeliverable (SEC-055).
+
+Nothing here is a newly-opened *critical*, but SEC-003, SEC-058, and SEC-059 are exploitable HIGHs, and two of them are regressions introduced by the remediation itself.
+
+### Active finding counts (OPEN + PARTIAL)
+
+| Severity | Active | New this round |
+|---|---|---|
+| Critical | 0 | 0 |
+| High | 6 | 2 |
+| Medium | 20 | 6 |
+| Low | 9 | 2 |
+
+**19 previously-active findings verified fully FIXED** this round (see the Resolved table).
+
+### Top priorities (suggested order)
+
+1. **SEC-003** — attach the interceptor to `UserService`/`TokenService`; derive identity from verified claims (the `AuthorizationService` pattern already exists).
+2. **SEC-058** — move the tenant guard into `grant_to_role_with_scopes` (the method the REST endpoint actually calls); fix the isolation test to hit the live path.
+3. **SEC-059** — make the webhook key fail closed like PKI now does.
+4. **SEC-044 / SEC-015** — thread `tenant_id` into the reset/resend calls; make logout revoke the caller's own session without a client-supplied body.
+5. **SEC-048/SEC-060** — fix the XFF fallback (use `peer_addr()`, not the leftmost hop) and reconcile the `trusted_hops` guidance with nginx's append behaviour.
+6. **SEC-031 / SEC-055 / SEC-047** — wire webhook secret encryption; fix ExportReady producer; enforce permissions at a chokepoint.
+
+---
+
+## High findings (active)
+
+### SEC-003 [HIGH ← was CRITICAL] 🔶 PARTIAL — gRPC UserService / TokenService still unauthenticated
+- **File**: `crates/axiam-api-grpc/src/server.rs:65-70`; `services/user.rs:56-142`; `services/token.rs`
+- **Fixed**: `AuthInterceptor` (`middleware/auth.rs:33-47`) validates a bearer JWT and stashes `ValidatedClaims`; it is attached to `AuthorizationServiceServer` (`server.rs:65`). `CheckAccess`/`BatchCheckAccess` derive `tenant_id`/`subject_id` from claims and reject any mismatched body field (`services/authorization.rs:73-99,122-149`). Public gRPC ingress was removed (`k8s/ingress.yml`). Message-size/timeout/concurrency limits and env-gated TLS were added (`server.rs:78-120`). First gRPC tests exist (`grpc_auth_test.rs`, `grpc_authz_test.rs`).
+- **Open**: `UserServiceServer::new(...)` and `TokenServiceServer::new(...)` are registered **without** the interceptor, and neither handler reads `ValidatedClaims` — `GetUser`, `ValidateCredentials`, and `IntrospectToken` still trust `tenant_id`/`user_id` from the request body. Any mesh peer that reaches `:50051` (TLS is off by default) reads any user cross-tenant (PII) and brute-forces `ValidateCredentials` with no lockout accrual (compounds SEC-026b). Independently confirmed by three reviewers.
+- **Fix**: wrap all three services with the interceptor (or a shared layer); derive identity from claims + cross-validate the body as `authorization.rs` already does; add reject-without-token tests for `UserService`/`TokenService`.
+
+### SEC-058 [HIGH] 🆕 — Live REST permission-grant path bypasses the SEC-007 tenant guard
+- **File**: `crates/axiam-db/src/repository/permission.rs:428-459` (`grant_to_role_with_scopes`, `_tenant_id` unused, raw `RELATE` by UUID); reached from `crates/axiam-api-rest/src/handlers/permissions.rs:219` (`POST /api/v1/roles/{role_id}/permissions`)
+- **Issue**: The SEC-007 remediation added `LET … IF array::len = 0 { THROW }` tenant checks to `grant_to_role`/`revoke_from_role`/`assign_to_user`/… and added tenant-isolation tests — but the REST handler calls the **scoped** variant `grant_to_role_with_scopes`, which was left unguarded (both the empty-scope and scoped branches `RELATE` by raw UUID with no tenant predicate). A caller with `permissions:grant` in tenant A can attach tenant B's permission to a tenant A role, or grant across tenants entirely. `req14_tenant_isolation_test.rs:191` exercises the guarded `grant_to_role`, so the suite is green while production traffic flows through the hole.
+- **Fix**: apply the same `LET/THROW` tenant guard inside `grant_to_role_with_scopes` (both branches, and validate every scope id belongs to the tenant); repoint the isolation test at the REST-reachable path.
+
+### SEC-059 [HIGH] 🆕 — Webhook HMAC secret encryption falls back to an all-zero key
+- **File**: `crates/axiam-server/src/main.rs:389-390` — `load_key_from_env("AXIAM__PKI__ENCRYPTION_KEY").unwrap_or([0u8; 32])`
+- **Issue**: This is the exact SEC-012 anti-pattern the PKI crate was just hardened against (PKI now fails closed with `Option<[u8;32]>`), relocated to the webhook subsystem. Because PKI now fails *lazily*, deploying without `AXIAM__PKI__ENCRYPTION_KEY` is a fully supported boot state — and in that state every webhook signing secret is AES-256-GCM "encrypted" under a hardcoded all-zero key, i.e. trivially recoverable by anyone with DB read access, with only a generic `warn!`.
+- **Fix**: fail fast (as PKI now does) or gate webhook registration off when the key is absent; never substitute a constant key. (See also SEC-031 — the encryption is not even wired on the write path today.)
+
+### SEC-005 [HIGH] 🔶 PARTIAL — SAML: signature + several protocol checks landed; binding gaps remain
+- **File**: `crates/axiam-federation/src/saml.rs`
+- **Fixed**: a `Conditions` block is now mandatory (`saml.rs:443`); NotBefore/NotOnOrAfter + AudienceRestriction validated (`:451-478`); SP metadata now advertises `WantAssertionsSigned="true"` and `AuthnRequestsSigned="true"` (`:553-554`); `InResponseTo` is validated when a stored request id is available (public SSO passes it from `federation_login_state`); assertion-ID replay store intact.
+- **Open**: `Destination` validation exists but **every call site passes `None`** (`handlers/federation.rs:869,1524`), so it never runs; `Recipient`/`SubjectConfirmationData` are never checked; there is still **no XSW binding** — `verify_signature` validates *a* signature over the document, then `handle_saml_response` independently consumes `response.assertion` with no check that the signed element's ID equals the consumed assertion's; the authenticated ACS path still accepts unsolicited responses. Protocol-check parameters are untested (all e2e calls pass `None`).
+- **Fix**: pass the real ACS URL to the Destination check; validate Recipient/SubjectConfirmation; bind the verified signature reference to the consumed assertion; add InResponseTo/Destination negative tests.
+
+### SEC-015 [HIGH] 🔶 PARTIAL — Logout endpoint sound, but the SPA call 400s and never revokes
+- **File**: `frontend/src/components/layout/Topbar.tsx:89-98`; backend `handlers/auth.rs:348-367`
+- **Fixed (backend)**: `POST /api/v1/auth/logout` invalidates the session and clears all three cookies, and now enforces `body.session_id == user.session_id` (the SEC-051 IDOR fix).
+- **Open (frontend, regression interaction)**: `handleLogout` posts `{}`, but the handler requires `web::Json<LogoutRequest>{ session_id: Uuid }`. The body fails to deserialize → **400**, the `catch` swallows it, and the server session + cookies are never invalidated. On a shared machine a reload re-authenticates via `useAuthInit` from the surviving httpOnly cookies — the SEC-015 objective is still unmet, and the fix made it worse by pairing a stricter server contract with a client that cannot satisfy it.
+- **Fix**: make the server revoke the caller's own session from the JWT `jti` with no required body (preferred), or expose `session_id` to the client so it can send it.
+
+### SEC-044 [HIGH] 🔶 PARTIAL — Frontend auth flows: most wired to real routes; reset/resend still dead
+- **File**: `frontend/src/services/auth.ts:39-74`; backend `handlers/password_reset.rs:30-41`, `email_verification.rs:37-40`
+- **Fixed**: change-password, verify-email, and MFA enroll/confirm now call the real `/api/v1/auth/*` routes with correct methods/bodies; a `services/auth.ts` layer and an e2e contract spec were added; verify-email false-success is gone (SEC-030 ✅).
+- **Open**: `requestPasswordReset` sends `{email}` but `RequestResetBody` requires `{tenant_id, email}`; `confirmPasswordReset` sends `{token, new_password}` but `ConfirmResetBody` requires `{tenant_id, …}`; `resendVerification` sends an empty body but the handler requires `{tenant_id, email}`. All three deserialize-fail → 400, so password-reset request, reset-confirm, and resend-verification remain non-functional in an IAM product, and the reset link carries no `tenant_id` for the page to forward. **The contract test does not catch this** — it asserts only URL/path, never the JSON body (and the CI job never runs Playwright anyway — see CQ-F36 in the companion).
+- **Fix**: thread `tenant_id`/`email` into the three calls and carry `tenant_id` on the reset/verify links; make the contract test assert request bodies and actually run in CI.
+
+---
+
+## Medium findings (active)
+
+### SEC-008 [MEDIUM ← was HIGH] 🔶 PARTIAL — TOTP replay: guard added, but non-atomic and skew-boundary-leaky
+- **File**: `crates/axiam-auth/src/totp.rs:85-126`, `service.rs:337-370`, `crates/axiam-db/src/repository/user.rs:484-497`
+- **Fixed**: `verify_code_with_replay_check` rejects a valid code when `current_step <= last_used_step`, the step is persisted per user, and `/auth/mfa/*` is now rate-limited (`mfa_per_min`, default 5).
+- **Open**: (a) the read-check-write is **not atomic** — the UPDATE has no `WHERE totp_last_used_step < $step` guard, so N concurrent submissions of one code all read the stale step and all succeed; (b) `check_current` uses `skew=1`, so a code accepted via the −1 window is replayable in its later wall-clock steps; (c) the enrollment-confirm code is untracked, replayable once at first login.
+- **Fix**: make the step update a conditional compare-and-set in the DB; record the step the presented code actually matched; seed `totp_last_used_step` at confirm time.
+
+### SEC-017 [MEDIUM ← was HIGH] 🔶 PARTIAL — Federation secret: encrypted on write, but model still serializes
+- **File**: `handlers/federation.rs:269-299,447-468` (encrypt on create/update ✅); `crates/axiam-core/src/models/federation.rs:27,43-48`
+- **Open**: the core `FederationConfig` model still has no `#[serde(skip_serializing)]` on `client_secret` / `client_secret_ciphertext` / `_nonce` / `_key_version`. Responses go through `FederationConfigResponse` (which omits them) today, so protection is convention-only — any future handler serializing the model directly leaks ciphertext+nonce.
+- **Fix**: `skip_serializing` on the model secret fields.
+
+### SEC-019 [MEDIUM] 🔶 PARTIAL — Webhook SSRF: re-resolved at delivery, but address not pinned
+- **File**: `crates/axiam-api-rest/src/webhook.rs:62-77,173-186`
+- **Fixed**: each delivery attempt calls `resolve_and_validate_host`, re-resolving and rejecting private/loopback/link-local/ULA IPs; redirects disabled.
+- **Open**: the validated address is not pinned — `client.post(&webhook.url)` lets reqwest re-resolve independently, so a DNS rebind between check and send still reaches an internal IP.
+- **Fix**: pin the validated `IpAddr` into the connection (custom resolver / `resolve()`).
+
+### SEC-022 / SEC-055 [MEDIUM] 🔶 PARTIAL — AMQP message trust: HMAC added (fail-open, global key); ExportReady still undeliverable
+- **File**: `crates/axiam-amqp/src/messages.rs:8-49`, `authz_consumer.rs:88-118`, `mail_consumer.rs:96-137`, `crates/axiam-server/src/cleanup.rs:507-522`, `main.rs:471-485`
+- **Fixed**: HMAC-SHA256 signing/verification with constant-time compare, fail-closed on bad hex; consumers nack unverified messages. Mail recipient hijacking is closed — `to_address` is advisory and the real recipient is resolved from `user_id`+`tenant_id`.
+- **Open**: (a) verification is **fail-open** when `AXIAM__AMQP__SIGNING_KEY` is unset (warn + process); (b) it is a single **global** key, not the per-tenant secret the doc claims, so a signature for tenant A validates a message asserting tenant B; (c) **ExportReady mail is still undeliverable** — `cleanup.rs:510` enqueues `org_id: Uuid::nil()`, the consumer passes it straight to `get_effective_config`, which returns `None` on the org miss → `SendError` → nack; (d) retry republish has no delay.
+- **Fix**: make the key mandatory in production; key per tenant (or per-tenant queues + broker ACLs); resolve org from tenant in the consumer (or fix the producer); add retry backoff.
+
+### SEC-024 [MEDIUM] 🔶 PARTIAL — mTLS now chain-verifies, but ignores CA status/validity
+- **File**: `crates/axiam-pki/src/mtls.rs:72-103`
+- **Fixed**: after the fingerprint lookup, the client cert is cryptographically verified against the issuing CA fetched by `issuer_ca_id` (fail-closed if absent) — closes the fingerprint-only bypass.
+- **Open** (new sub-finding): the CA's own `status` (Active/Revoked) and validity window are not checked before it is trusted, while the client cert is. A revoked or expired org CA still authenticates device certs it previously signed.
+- **Fix**: assert the CA is Active and within its validity window before `verify_signature`.
+
+### SEC-031 [MEDIUM] 🔶 PARTIAL — Webhook HMAC secret: response-excluded, but still plaintext at rest
+- **File**: `crates/axiam-core/src/models/webhook.rs:43` (`#[serde(skip_serializing)]` ✅); `crates/axiam-db/src/repository/webhook.rs:136` (binds `input.secret` verbatim); `handlers/webhooks.rs:111` (passes `req.secret` plaintext)
+- **Open**: `encrypt_webhook_secret` has **zero non-test call sites** — secrets are persisted in cleartext despite the module's "stored AES-256-GCM encrypted" claim. Latent correctness trap: the delivery path unconditionally `aes256gcm_decrypt`s the stored value, so if CQ-B22 (delivery) is ever wired without also encrypting on write, 100% of deliveries fail at the decrypt step. (Encryption key also has the SEC-059 zero-key fallback.)
+- **Fix**: encrypt on create/update; keep the response exclusion; wire the key fail-closed.
+
+### SEC-047 [MEDIUM] 🔶 PARTIAL — Authorization still fail-open by construction; stale public path removed
+- **File**: `crates/axiam-api-rest/src/middleware/authz.rs:114-135`; `permissions.rs:197`; `tests/rbac_test.rs:329,506`
+- **Fixed**: the stale `/api/v1/auth/register` public-path entry is gone.
+- **Open**: the middleware checks only credential *presence*; the real check remains the per-handler `RequirePermission` call, so a forgotten line is a silent bypass. The parity test asserts map↔registry coverage, not handler behaviour, and `no_permission_returns_403` exercises exactly one route.
+- **Fix**: enforce permissions in middleware keyed off `ROUTE_PERMISSION_MAP` (single chokepoint), or add a test that drives every mapped route with a zero-permission user and asserts 403.
+
+### SEC-048 [MEDIUM] 🔶 PARTIAL — Rate-limit key spoofable via XFF fallback; keying contradicts the documented deployment
+- **File**: `crates/axiam-api-rest/src/extractors/rate_limit.rs:54-75`
+- **Fixed**: rewritten to select the rightmost-untrusted hop with configurable `trusted_hops`; per-replica limitation documented.
+- **Open (SEC-060, new)**: two compounding bugs. (1) When `trusted_hops >= hops.len()`, the code sets `idx = 0` and returns `hops[0]` — the **leftmost, client-controlled** value — instead of falling through to `peer_addr()` as its comment claims. (2) The docs tell operators to set `trusted_hops = 1` behind a single nginx, but nginx's `proxy_add_x_forwarded_for` appends the real client as the *rightmost* entry, so the correct value is `trusted_hops = 0`; following the docs makes `idx = 0` select the attacker-controlled hop. Either way, rotating `X-Forwarded-For` per request gives each request its own bucket, defeating the login/reset/OAuth throttles. Multi-replica shared store still not implemented.
+- **Fix**: in the underflow branch ignore XFF and use `peer_addr()`; reconcile the `trusted_hops` guidance with nginx's append semantics; add a shared store (or document the per-replica multiplier loudly).
+
+### SEC-049 [MEDIUM] 🔶 PARTIAL — Bootstrap: create is now atomic; initialized-check TOCTOU and unset-gate remain
+- **File**: `crates/axiam-api-rest/src/handlers/bootstrap.rs:77-83,100-140,171-201`
+- **Fixed**: user-create + role-assign is a single `BEGIN/COMMIT`.
+- **Open**: the "already initialized" read precedes and is not atomic with the create transaction — two concurrent first-run requests can both create super-admins; and the `AXIAM_BOOTSTRAP_ADMIN_EMAIL` gate is still conditional, so an unset var lets **any** caller create the first super-admin.
+- **Fix**: single conditional/transactional create keyed on a uniqueness invariant; require the env gate (or a one-time setup token) unconditionally.
+
+### SEC-053 [MEDIUM] 🔶 PARTIAL — NetworkPolicies/PSA mostly coherent now; no SMTP egress
+- **File**: `k8s/network-policy/*`, `k8s/namespace.yml`
+- **Fixed**: receiver-side ingress policies for SurrealDB (`:8000`) and RabbitMQ (`:5672`) now exist, server egress to DB/MQ/DNS/443 present, and `namespace.yml` sets PSA `enforce: restricted` with matching restricted securityContexts — the deployment no longer breaks under default-deny.
+- **Open**: no SMTP egress rule (ports 25/465/587), so under default-deny the server cannot reach an external relay and verification/GDPR-export mail silently fails in-cluster; pod/service cluster-CIDR exclusions on the `0.0.0.0/0:443` rule are still operator TODOs.
+- **Fix**: add an SMTP egress policy; tighten the CIDR exclusions.
+
+### SEC-054 [MEDIUM] ✅ FIXED — JWKS body cap + private-IP guard (residual SSRF elsewhere)
+- **File**: `crates/axiam-federation/src/jwks_cache.rs:220-307`
+- **Fixed**: 512 KiB body cap before parse; resolves and rejects private/loopback/link-local/ULA IPs; the opt-in test flag is `#[doc(hidden)]` and defaults off in production.
+- **Residual → SEC-064 (new, MEDIUM)**: the IP guard is JWKS-only. Discovery, the token exchange (which POSTs the decrypted `client_secret`), and SAML-metadata fetches are scheme-only, so an internal/loopback `token_endpoint` from a discovery document passes and can exfiltrate the client secret. Also a DNS-rebinding TOCTOU: `validate_jwks_url` resolves once, then reqwest re-resolves at fetch. **Fix**: apply the IP filter to discovery/token/metadata hosts and pin the resolved address.
+
+### SEC-063 [MEDIUM] 🆕 — GDPR erasure certified while audit PII survives
+- **File**: `crates/axiam-server/src/cleanup.rs:327-344`
+- **Issue**: in `purge_single_user`, an `audit_repo.pseudonymize_actor` failure is only logged (`warn`), then the erasure proof is written and `anonymize_user` clears the re-selection flags. A transient failure (DB contention during the sweep) leaves the real `actor_id` (subject PII) in audit rows indefinitely while an Art. 17 erasure proof attests completion — a legally-attested-but-incomplete erasure.
+- **Fix**: treat audit-pseudonymization failure as fatal to the purge (leave flags set so the user is re-selected), or write the proof only after every PII-bearing step succeeds.
+
+### SEC-004 residual [MEDIUM] ❌ OPEN — Authenticated OIDC callback still takes the nonce from the request body
+- **File**: `handlers/federation.rs:595-648` (reads `req.nonce`, passes it as `expected_nonce`)
+- **Issue**: the account-linking callback lets the caller supply both the nonce and (via the IdP) the token, defeating replay protection on that path. The public first-time-SSO path is correct (server-side nonce from login state).
+- **Fix**: derive the expected nonce from server-side state for the authenticated path too.
+
+### Carried-forward mediums (unchanged or lightly touched)
+- **SEC-016** ✅ FIXED — nginx now proxies `/oauth2/*` and `/.well-known`; prod compose documents itself as local-only (host still publishes 8090/50051 in the dev-only compose — k8s exposes neither).
+- **SEC-023** ✅ FIXED — prod compose creds env-required (no `root/root` / `axiam/axiam`); configmap `RUST_LOG: info`.
+- **SEC-025** ✅ FIXED — S256 PKCE enforced for public clients at `/authorize` and verified at token exchange, with tests.
+- **SEC-026a** ✅ FIXED — dummy Argon2 on user-not-found. **SEC-026b** ❌ OPEN — gRPC `ValidateCredentials` still never increments lockout (compounds SEC-003).
+- **SEC-028** 🔶 PARTIAL — self-service change-password blocks current-password reuse; the unauthenticated reset path does not, and initial passwords are still never seeded into history.
+- **SEC-032** ✅ FIXED — atomic `+= 1` failed-login increment; lockout + exponential backoff repaired and tested (commit `e07323f`).
+- **SEC-033** ✅ FIXED — tenant settings now stored as a sparse `Option` override mask merged against the live org baseline; org policy changes propagate (secondary write path has a minor residual).
+- **SEC-046** ✅ FIXED — `CsrfMiddleware` now wraps the `/api/v1` CRUD scope.
+- **SEC-050** ✅ FIXED — self-update strips `status`; a self email change clears `email_verified_at` (forces re-verification).
+- **SEC-051** ✅ FIXED — logout rejects a `session_id` that isn't the caller's JWT `jti`.
+- **SEC-052** ✅ FIXED — k8s env keys renamed to the `AXIAM__…` double-underscore schema; JWT/MFA/PKI keys added to the secret. Residual (LOW): the CI `test` job still sets `AXIAM_DATABASE__*` (wrong prefix, silently ignored — tests pass only because the DB defaults coincide); the k8s secret omits federation/email/GDPR/pepper keys (features silently degrade).
+- **SEC-057** ✅ FIXED — all GitHub Actions pinned by commit SHA.
+
+---
+
+## Low findings (active)
+
+- **SEC-036** ✅ FIXED — revealed secrets cleared on modal close (shared `SecretRevealModal`).
+- **SEC-037** ✅ FIXED — `history.replaceState` strips reset/verify tokens from the URL.
+- **SEC-039** ✅ FIXED — crypto error detail no longer reaches clients (folded into the generic 5xx body).
+- **SEC-040** ✅ FIXED (docs) — additive-only RBAC now accurately documented in CLAUDE.md/design-document.
+- **SEC-041** ✅ FIXED — forgot-password no longer logs the Axios error/email.
+- **SEC-043** 🔶 PARTIAL — `skip_serializing` added on CA/PGP blobs; derived `Debug` still prints them and list queries still hydrate the encrypted column.
+- **SEC-057** — see above (fixed).
+- **SEC-065 [LOW] 🆕** — duplicate erasure-proof rows: if `anonymize_user` fails after the proof is written, the user is re-selected and a second proof is appended (no uniqueness guard), corrupting the erasure ledger (`cleanup.rs:337-380`).
+- **SEC-066 [LOW] 🆕** — export dedup only filters `status IN ['queued']`, so a `ready`-but-undownloaded or `failed` job doesn't block a duplicate export request (`export_job.rs:102-126`).
+
+---
+
+## New findings summary (this round)
+
+| ID | Sev | Summary |
+|---|---|---|
+| SEC-058 | High | `grant_to_role_with_scopes` (live REST grant path) bypasses the SEC-007 tenant guard |
+| SEC-059 | High | Webhook secret encryption falls back to an all-zero key when `AXIAM__PKI__ENCRYPTION_KEY` unset |
+| SEC-060 | Medium | XFF rate-limit fallback returns the client-controlled leftmost hop; keying contradicts the documented nginx setup (SEC-048 regression) |
+| SEC-061 | Medium | mTLS chain verify trusts a CA without checking its status/validity (SEC-024 residual) |
+| SEC-063 | Medium | GDPR erasure certified while audit-actor PII survives a swallowed pseudonymize failure |
+| SEC-064 | Medium | SSRF/secret-exfil guard missing on discovery/token/metadata fetches; JWKS DNS-rebind TOCTOU |
+| SEC-065 | Low | Duplicate erasure-proof rows on late-stage purge retry |
+| SEC-066 | Low | Export dedup misses `ready`/`failed` in-flight jobs |
+
+(SEC-003's gRPC `UserService`/`TokenService` gap and SEC-055's undeliverable ExportReady are tracked under their existing IDs above rather than as new numbers.)
+
+---
+
+## Resolved this round (verified with file:line)
+
+| ID | Was | Verified fix |
+|---|---|---|
+| SEC-002 | CRITICAL — cross-org IDOR | `path.org_id == user.org_id` on every org/tenant/CA route; org create/list gated to super-admin; cross-org 403 tests. |
+| SEC-010 | HIGH — unbounded pagination | `Pagination.limit` clamped to `1..=200` in serde (`core/repository.rs:52-67`). |
+| SEC-011 | HIGH — error-detail leak | 5xx bodies genericized to `internal_error` + fixed message; detail logged via `tracing` (`error.rs:60-98`). |
+| SEC-012 | HIGH — PKI zero-key | `PkiConfig.encryption_key: Option<[u8;32]>`, fail-closed at every use site. (But re-added for webhooks — SEC-059.) |
+| SEC-020 | MEDIUM — rate-limit gaps | `/auth/mfa/*`, `/oauth2/introspect`, `/oauth2/revoke` now throttled. |
+| SEC-025 | MEDIUM — PKCE optional | S256 enforced for public clients, verified at token exchange, tested. |
+| SEC-030 | MEDIUM — verify-email false success | page POSTs the real endpoint with `token`+`tenant_id`; no SPA-fallback GET. |
+| SEC-032 | MEDIUM — non-atomic lockout | atomic `+= 1`; lockout + exponential backoff repaired and tested. |
+| SEC-033 | MEDIUM — settings snapshot | sparse `Option` override mask merged against live org baseline. |
+| SEC-045 | HIGH — fed secret never decrypted | `decrypt_client_secret_or_legacy` wired into the OIDC callback; key plumbed everywhere; tested. |
+| SEC-046 | MEDIUM — CSRF not on `/api/v1` | `CsrfMiddleware` wraps the CRUD scope. |
+| SEC-050 | MEDIUM — self-status escalation | `status` stripped on self-update; email change forces re-verification. |
+| SEC-051 | MEDIUM — logout IDOR | rejects a non-caller `session_id`. |
+| SEC-052 | MEDIUM — k8s env prefix | keys renamed to `AXIAM__…`; JWT/MFA/PKI secrets added. |
+| SEC-054 | MEDIUM — JWKS unbounded/SSRF | body cap + private-IP guard (residual on other fetches — SEC-064). |
+| SEC-016 | MEDIUM — nginx/oauth2 | `/oauth2` + `/.well-known` proxied. |
+| SEC-023 | MEDIUM — deploy creds/logging | env-required creds; `RUST_LOG` sane. |
+| SEC-036 / SEC-037 / SEC-041 | LOW — frontend leaks | secrets cleared on close; tokens stripped from URL; forgot-password logging removed. |
+| SEC-039 / SEC-040 / SEC-057 | LOW | crypto detail hidden; docs corrected; actions SHA-pinned. |
+
+---
+
+## Positive observations
+
+- The `AuthorizationService` gRPC interceptor is a clean chokepoint: identity from the verified JWT, every body field cross-validated and rejected on mismatch (`authorization.rs:73-99`). The gap is only that it wasn't extended to the other two services.
+- CSRF double-submit is textbook: 32-byte CSPRNG, constant-time compare (`csrf.rs:154`), rotation on login and refresh, refresh cookie path-scoped to `/api/v1/auth/refresh`, correct `HttpOnly`/`Secure`/`SameSite=Strict`.
+- The frontend refresh interceptor rewrite is correct — refresh goes through the `api` instance (CSRF header attached), `_retry` set before the single-flight queue, one boot-time refresh before declaring unauthenticated (CQ-F28 genuinely closed).
+- Lockout/backoff fix (`e07323f`) corrected three real defects (SurrealDB v3 `duration::from_secs`, an off-by-one, and wiring the exponential backoff) with regression tests.
+- GDPR purge now hard-deletes `webauthn_credential` + `password_history` + `member_of`/`has_role` edges, runs `anonymize_user` last (re-selectable on failure), paginates the audit export, and consumes the download token atomically.
+- PKCE, PKI fail-closed, mTLS chain verification, JWKS hardening, AMQP HMAC (constant-time), and the sparse-override settings rework are all real, well-implemented improvements.
+- CI is genuinely stronger: SHA-pinned actions, fmt + clippy `-D warnings` + build + real-service tests + cargo-audit/deny + npm-audit + trivy, with a first-class gRPC-auth test lane.
+
+## Coverage notes
+
+All active `SEC-*` findings re-verified against `ea85872` with file:line evidence; all remediation-touched security code read. Independently corroborated high-impact items: gRPC service gap (3 reviewers), XFF fallback (2), webhook secret at rest (2). Lower-confidence areas for a future pass: samael xmlsec XSW internals, SurrealDB SET-evaluation-order assumption underpinning the lockout off-by-one (encoded only in a comment — pin with a version-locked test), and live boundary behaviour of the backoff `math::pow`/cast under extreme multipliers.


### PR DESCRIPTION
Re-verify all active SEC-*/CQ-* findings from the d69323b audit against HEAD (ea85872) after the Phase 07-14 remediation waves, and record new findings.

Verified in this pass: cargo build --workspace green (axiam-server compiles, CQ-B37 fixed); all library crates clippy-clean; frontend eslint 0 errors (was 9), tsc clean, npm audit clean.

Key results:
- Both prior criticals resolved at the reported layer (SEC-002 cross-org IDOR fixed with tests; SEC-045 federation secret decrypt wired).
- Remaining/regressed HIGHs: SEC-003 (gRPC UserService/TokenService still unauthenticated), SEC-058 (tenant guard applied to grant_to_role but not the REST-reachable grant_to_role_with_scopes), SEC-059 (webhook secret key falls back to all-zero), plus SEC-005/015/044 partial.
- New findings: SEC-058..066, CQ-B44..47, CQ-F36..39 (notably CI runs vitest not Playwright, so the contract/auth e2e specs never gate).

Reports: claude_dev/security-review-postremediation.md, claude_dev/code-review-postremediation.md


Claude-Session: https://claude.ai/code/session_01Bc6W8kyg2wpRVXtemdFHvW