### PR TITLE
build(deps): upgrade samael 0.0.22, rand 0.10, eslint-plugin-react-hooks 7.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
  "hmac",
  "jsonwebtoken",
  "lapin",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rand_core 0.6.4",
  "reqwest 0.12.28",
  "rsa",
@@ -893,7 +893,7 @@ dependencies = [
  "hex",
  "hmac",
  "jsonwebtoken",
- "rand 0.9.5",
+ "rand 0.10.2",
  "reqwest 0.12.28",
  "secrecy",
  "serde",
@@ -953,7 +953,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1023,7 +1023,7 @@ dependencies = [
  "chrono",
  "hex",
  "jsonwebtoken",
- "rand 0.9.5",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1047,7 +1047,7 @@ dependencies = [
  "criterion",
  "hex",
  "pgp",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rand_core 0.6.4",
  "rcgen",
  "serde",
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -5343,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -6203,9 +6203,9 @@ dependencies = [
 
 [[package]]
 name = "samael"
-version = "0.0.19"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20498fc95ccfe0f015d003aa86084b042cc672a9a41fa2bea4ab7d7e3239348"
+checksum = "3507857cc308877abafd0db18e30b2852623db961006ba38b402e0eff048ee7f"
 dependencies = [
  "base64 0.22.1",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ surrealdb = "3"
 jsonwebtoken = "10"
 argon2 = "0.5"
 totp-rs = { version = "5", features = ["gen_secret", "otpauth"] }
-rand = "0.9"
+rand = "0.10"
 hmac = "0.12"
 hkdf = "0.12"
 sha1 = "0.10"
@@ -106,7 +106,7 @@ pgp = "0.19"
 pem = "3"
 
 # SAML
-samael = { version = "0.0.19", features = ["xmlsec"] }
+samael = { version = "0.0.22", features = ["xmlsec"] }
 flate2 = "1"
 # XSW (XML Signature Wrapping) binding check (SECFIX-04/SEC-005). Already
 # resolved transitively via samael's `xmlsec` feature (Cargo.lock pins

--- a/crates/axiam-api-rest/src/handlers/federation.rs
+++ b/crates/axiam-api-rest/src/handlers/federation.rs
@@ -1040,7 +1040,7 @@ pub struct SsoLoginSuccessResponse {
 
 /// Generate 32 random bytes encoded as base64url (no padding).
 fn random_base64url() -> String {
-    use rand::RngCore;
+    use rand::Rng;
     let mut bytes = [0u8; 32];
     rand::rng().fill_bytes(&mut bytes);
     URL_SAFE_NO_PAD.encode(bytes)

--- a/crates/axiam-api-rest/src/handlers/gdpr.rs
+++ b/crates/axiam-api-rest/src/handlers/gdpr.rs
@@ -94,7 +94,7 @@ pub fn sha256_hex(raw: &str) -> String {
 ///
 /// Replaces the previous `Uuid::new_v4().to_string()` (128-bit) token.
 fn generate_cancel_token() -> String {
-    use rand::Rng;
+    use rand::RngExt;
     let bytes: [u8; 32] = rand::rng().random();
     hex::encode(bytes)
 }

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -392,8 +392,9 @@ pub fn validate_access_token(
 /// Generate a cryptographically random opaque refresh token
 /// (32 bytes → base64url-encoded, no padding).
 pub fn generate_refresh_token() -> String {
+    use rand::RngExt;
     let mut rng = rand::rng();
-    let bytes: [u8; 32] = rand::Rng::random(&mut rng);
+    let bytes: [u8; 32] = rng.random();
     URL_SAFE_NO_PAD.encode(bytes)
 }
 

--- a/crates/axiam-db/src/connection.rs
+++ b/crates/axiam-db/src/connection.rs
@@ -60,7 +60,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use rand::Rng;
+use rand::RngExt;
 use serde::Deserialize;
 use surrealdb::Surreal;
 use surrealdb::engine::remote::http::{Client, Http};

--- a/crates/axiam-db/src/repository/oauth2_client.rs
+++ b/crates/axiam-db/src/repository/oauth2_client.rs
@@ -4,7 +4,7 @@ use axiam_core::error::AxiamResult;
 use axiam_core::models::oauth2_client::{CreateOAuth2Client, OAuth2Client, UpdateOAuth2Client};
 use axiam_core::repository::{OAuth2ClientRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use rand::Rng;
+use rand::RngExt;
 use surrealdb::{Connection, Surreal};
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -7,7 +7,7 @@ use axiam_core::models::service_account::{
 use axiam_core::models::user::UserStatus;
 use axiam_core::repository::{PaginatedResult, Pagination, ServiceAccountRepository};
 use chrono::{DateTime, Utc};
-use rand::Rng;
+use rand::RngExt;
 use sha2::{Digest, Sha256};
 use surrealdb::{Connection, Surreal};
 use surrealdb_types::SurrealValue;

--- a/crates/axiam-db/src/seeder.rs
+++ b/crates/axiam-db/src/seeder.rs
@@ -175,7 +175,7 @@ pub async fn mint_bootstrap_setup_token_if_needed<C: Connection>(
     // Generate a cryptographically random 32-byte token, base64url-encoded
     // (same shape as `axiam_auth::token::generate_refresh_token`).
     let mut rng = rand::rng();
-    let bytes: [u8; 32] = rand::Rng::random(&mut rng);
+    let bytes: [u8; 32] = rand::RngExt::random(&mut rng);
     let token = URL_SAFE_NO_PAD.encode(bytes);
 
     let mut hasher = Sha256::new();

--- a/crates/axiam-federation/src/saml.rs
+++ b/crates/axiam-federation/src/saml.rs
@@ -623,9 +623,14 @@ where
             .ok_or(FederationError::ConfigIncomplete)?;
 
         let der = crate::cert::pem_cert_to_der(pem)?;
+        let cert = samael::crypto::CertificateDer::from(der);
 
-        samael::crypto::verify_signed_xml(xml_bytes, &der, Some("ID"))
-            .map_err(|e| FederationError::SamlSignatureInvalid(e.to_string()))
+        <samael::crypto::XmlSec as samael::crypto::CryptoProvider>::verify_signed_xml(
+            xml_bytes,
+            &cert,
+            Some("ID"),
+        )
+        .map_err(|e| FederationError::SamlSignatureInvalid(e.to_string()))
     }
 
     /// Provision a new user or link an existing one to the external

--- a/crates/axiam-oauth2/src/authorize.rs
+++ b/crates/axiam-oauth2/src/authorize.rs
@@ -181,7 +181,7 @@ where
 /// Generate a cryptographically random authorization code (32 bytes, base64url).
 fn generate_auth_code() -> String {
     let mut rng = rand::rng();
-    let bytes: [u8; 32] = rand::Rng::random(&mut rng);
+    let bytes: [u8; 32] = rand::RngExt::random(&mut rng);
     URL_SAFE_NO_PAD.encode(bytes)
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,7 @@
         "@vitest/coverage-v8": "^4.1.8",
         "autoprefixer": "^10.5.2",
         "eslint": "^9.39.5",
-        "eslint-plugin-react-hooks": "7.0.1",
+        "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
         "jsdom": "^25.0.1",
@@ -2947,9 +2947,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2963,7 +2963,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "autoprefixer": "^10.5.2",
     "eslint": "^9.39.5",
-    "eslint-plugin-react-hooks": "7.0.1",
+    "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
     "jsdom": "^25.0.1",

--- a/frontend/src/components/ResourceTree.tsx
+++ b/frontend/src/components/ResourceTree.tsx
@@ -299,7 +299,6 @@ export function ResourceTree({
     if (prevResourcesRef.current !== resources) {
       prevResourcesRef.current = resources;
       const allIds = collectAllIds(roots);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setExpandedIds((prev) => {
         const next = new Set(prev);
         let changed = false;

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -20,12 +20,15 @@ export function SearchInput({
   className,
 }: SearchInputProps) {
   const [local, setLocal] = useState(value);
+  const [prevValue, setPrevValue] = useState(value);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Sync external value → local (e.g. on reset)
-  useEffect(() => {
+  // Sync external value → local (e.g. on reset) by adjusting state during
+  // render when the incoming prop changes, rather than in an effect.
+  if (value !== prevValue) {
+    setPrevValue(value);
     setLocal(value);
-  }, [value]);
+  }
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const next = e.target.value;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -43,11 +43,16 @@ export function LoginPage() {
   const navigate = useNavigate();
   const { setUser, setTenantContext } = useAuthStore();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [bootstrapNotice, setBootstrapNotice] = useState<string | null>(null);
+  // Derive the notice once from the initial URL so it survives stripping the
+  // query param below (lazy initializer — no setState in an effect).
+  const [bootstrapNotice] = useState<string | null>(() =>
+    searchParams.get("bootstrapped") === "1"
+      ? "Admin account created. Sign in to continue."
+      : null
+  );
 
   useEffect(() => {
     if (searchParams.get("bootstrapped") === "1") {
-      setBootstrapNotice("Admin account created. Sign in to continue.");
       // Strip the query param so a refresh doesn't re-show the notice.
       const next = new URLSearchParams(searchParams);
       next.delete("bootstrapped");

--- a/frontend/src/pages/organizations/OrganizationDetailPage.tsx
+++ b/frontend/src/pages/organizations/OrganizationDetailPage.tsx
@@ -697,7 +697,6 @@ function SettingsTab({
   useEffect(() => {
     if (shouldSeedForm(initializedRef.current, settings)) {
       const flattened = flattenOrgSettings(settings!);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setForm(flattened);
       snapshotRef.current = flattened;
       initializedRef.current = true;


### PR DESCRIPTION
## Summary

Lands the three breaking dependency bumps Dependabot could not apply automatically because they required source changes. Each was upgraded, adapted, and verified locally against the full CI command set (all green). This supersedes the corresponding Dependabot PRs:

| Dependency | From → To | Supersedes |
|---|---|---|
| `samael` | 0.0.19 → 0.0.22 | #157 |
| `rand` | 0.9 → 0.10 | #155 |
| `eslint-plugin-react-hooks` | 7.0.1 → 7.1.1 | #161 |

## Code changes

**samael 0.0.22** — the free function `samael::crypto::verify_signed_xml` became a method on the new `CryptoProvider` trait (implemented by `XmlSec`) and now takes `&CertificateDer` instead of `&[u8]`.
- `crates/axiam-federation/src/saml.rs` — wrap the DER bytes in `samael::crypto::CertificateDer::from(der)` and invoke via the trait: `<samael::crypto::XmlSec as samael::crypto::CryptoProvider>::verify_signed_xml(...)`.

**rand 0.10** — the high-level RNG methods (`random`, `random_range`, `fill`) moved from `Rng` to a new `RngExt` trait, and `rand` no longer re-exports `RngCore` (`fill_bytes` now comes via the core `Rng` trait). Only imports / UFCS paths changed (method names were already on 0.9 naming):
- `crates/axiam-auth/src/token.rs` — `use rand::RngExt` + method-call form.
- `crates/axiam-db/src/{connection.rs, repository/oauth2_client.rs, repository/service_account.rs}` — `use rand::Rng` → `use rand::RngExt`.
- `crates/axiam-db/src/seeder.rs`, `crates/axiam-oauth2/src/authorize.rs` — `rand::Rng::random` → `rand::RngExt::random`.
- `crates/axiam-api-rest/src/handlers/gdpr.rs` — `use rand::Rng` → `use rand::RngExt`.
- `crates/axiam-api-rest/src/handlers/federation.rs` — `use rand::RngCore` → `use rand::Rng` (for `fill_bytes`).
- `Cargo.toml` / `Cargo.lock` — `rand = "0.10"` (0.10.2).

**eslint-plugin-react-hooks 7.1.1** — the strengthened `react-hooks/set-state-in-effect` rule produced 2 errors (CI-failing) plus 2 stale-directive warnings. Fixed the errors by removing the effects (React's recommended patterns), not by disabling the rule:
- `frontend/src/components/SearchInput.tsx` — replaced the prop→state sync effect with a render-time previous-value guard.
- `frontend/src/pages/LoginPage.tsx` — replaced `setBootstrapNotice` in an effect with a lazy `useState` initializer; the effect now only strips the query param.
- Removed two now-unused `// eslint-disable-next-line react-hooks/set-state-in-effect` directives (`ResourceTree.tsx`, `OrganizationDetailPage.tsx`).

## Verification (all green, locally)

Rust (with `SWAGGER_UI_DOWNLOAD_URL` set):
- `cargo build --workspace`
- Per-crate unit + integration tests (disk-quota-bounded, so batched with `cargo clean` between) — all pass, including federation, gdpr, oauth2_client, service_account, csrf, auth, and `axiam-server` (incl. `req5_saml_e2e`).
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

Frontend:
- `npm ci`, `npm run lint` (0 problems), `npx tsc -b`, `npx vitest run` (623 tests / 56 files pass).

No production behavior changed beyond what the API breakages required; no tests were removed or weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWxZaJw6wuMd3d5zqyqdcG)_