### PR TITLE
build(deps): upgrade aes-gcm 0.11, sha2 0.11, hkdf 0.13, rcgen 0.14 (supersedes #177 #178 #179 #180)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,14 +240,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -256,11 +277,25 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -270,7 +305,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fa2b352dcefb5f7f3a5fb840e02665d311d878955380515e4fd50095dd3d8c"
 dependencies = [
- "aes",
+ "aes 0.8.4",
 ]
 
 [[package]]
@@ -765,12 +800,12 @@ dependencies = [
  "chrono",
  "futures-lite",
  "hex",
- "hkdf",
- "hmac",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "lapin",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "surrealdb",
  "thiserror 2.0.18",
  "tokio",
@@ -835,7 +870,7 @@ dependencies = [
  "futures",
  "futures-lite",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "jsonwebtoken",
  "lapin",
  "rand 0.10.2",
@@ -845,7 +880,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "surrealdb",
  "thiserror 2.0.18",
@@ -883,7 +918,7 @@ dependencies = [
 name = "axiam-auth"
 version = "1.0.0-beta"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "argon2",
  "axiam-core",
  "axiam-db",
@@ -891,7 +926,7 @@ dependencies = [
  "chrono",
  "criterion",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "jsonwebtoken",
  "rand 0.10.2",
  "reqwest 0.12.28",
@@ -899,7 +934,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1 0.11.0",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "surrealdb",
  "thiserror 2.0.18",
  "tokio",
@@ -946,7 +981,7 @@ dependencies = [
 name = "axiam-db"
 version = "1.0.0-beta"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "argon2",
  "axiam-auth",
  "axiam-core",
@@ -956,7 +991,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "surrealdb",
  "surrealdb-types",
  "thiserror 2.0.18",
@@ -1026,7 +1061,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
@@ -1039,7 +1074,7 @@ dependencies = [
 name = "axiam-pki"
 version = "1.0.0-beta"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.11.0",
  "axiam-core",
  "axiam-db",
  "base64 0.22.1",
@@ -1052,7 +1087,7 @@ dependencies = [
  "rcgen",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "surrealdb",
  "thiserror 2.0.18",
@@ -1093,7 +1128,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "surrealdb",
  "surrealdb-types",
  "tokio",
@@ -1263,6 +1298,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitfields"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,7 +1418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1531,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
 dependencies = [
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1546,7 +1590,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1564,7 +1608,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1594,7 +1638,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1668,7 +1712,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1713,7 +1768,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
  "digest 0.10.7",
 ]
@@ -1726,6 +1781,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cms"
@@ -1882,6 +1943,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2046,7 +2113,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2066,7 +2135,25 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -2324,7 +2411,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2354,6 +2441,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2497,10 +2585,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
 dependencies = [
- "aead",
- "cipher",
+ "aead 0.5.2",
+ "cipher 0.4.4",
  "cmac",
- "ctr",
+ "ctr 0.9.2",
  "subtle",
 ]
 
@@ -2562,7 +2650,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3072,7 +3160,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.2",
 ]
 
 [[package]]
@@ -3404,7 +3501,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3414,6 +3520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3726,7 +3841,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3782,6 +3897,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3930,7 +4054,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -4529,9 +4653,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
 dependencies = [
- "aead",
- "cipher",
- "ctr",
+ "aead 0.5.2",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
  "subtle",
 ]
 
@@ -4646,7 +4770,7 @@ dependencies = [
  "der",
  "des",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "pkcs12",
  "pkcs5",
  "rand 0.10.2",
@@ -4780,7 +4904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "password-hash",
  "sha2 0.10.9",
 ]
@@ -4875,9 +4999,9 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cfa4743b28656065ff4c0ba09e46b357a65e8c00fc2341e89084b82f87cbdf1"
 dependencies = [
- "aead",
- "aes",
- "aes-gcm",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "aes-gcm 0.10.3",
  "aes-kw",
  "argon2",
  "base64 0.22.1",
@@ -4891,7 +5015,7 @@ dependencies = [
  "camellia",
  "cast5",
  "cfb-mode",
- "cipher",
+ "cipher 0.4.4",
  "const-oid 0.9.6",
  "crc24",
  "curve25519-dalek",
@@ -4908,7 +5032,7 @@ dependencies = [
  "flate2",
  "generic-array 0.14.7",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "idea",
  "k256",
  "log",
@@ -5069,7 +5193,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "cbc",
  "der",
  "pbkdf2",
@@ -5131,7 +5255,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b20f20e954175de5f463f67781b35583397d916b1d148738923711b2ad16bee8"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -5589,20 +5724,20 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser 0.16.0",
+ "x509-parser 0.18.1",
  "yasna",
 ]
 
@@ -5791,7 +5926,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -6198,7 +6333,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7126,7 +7261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7493,7 +7628,7 @@ checksum = "50e69a15e21b2ff22c415446983978bded3244195f17d59cb113551c1e806f91"
 dependencies = [
  "base32",
  "constant_time_eq 0.3.1",
- "hmac",
+ "hmac 0.12.1",
  "rand 0.9.5",
  "sha1 0.10.7",
  "sha2 0.10.9",
@@ -7698,7 +7833,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7762,6 +7897,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -8508,7 +8653,6 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.7.1",
- "ring",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
@@ -8545,10 +8689,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
+ "bit-vec",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,10 @@ jsonwebtoken = "10"
 argon2 = "0.5"
 totp-rs = { version = "5", features = ["gen_secret", "otpauth"] }
 rand = "0.10"
-hmac = "0.12"
-hkdf = "0.12"
+hmac = "0.13"
+hkdf = "0.13"
 sha1 = "0.11"
-sha2 = "0.10"
+sha2 = "0.11"
 hex = "0.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 url = "2"
@@ -76,7 +76,7 @@ subtle = "2"
 base64 = "0.22"
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 webauthn-rs-proto = "0.5"
-aes-gcm = "0.10"
+aes-gcm = "0.11"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 zeroize = "1"
 secrecy = { version = "0.10", features = ["serde"] }
@@ -100,7 +100,7 @@ utoipa = { version = "5", features = ["actix_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 
 # PKI / X.509 / OpenPGP
-rcgen = "0.13"
+rcgen = "0.14"
 x509-parser = { version = "0.18", features = ["verify"] }
 pgp = "0.20"
 pem = "3"

--- a/crates/axiam-amqp/src/messages.rs
+++ b/crates/axiam-amqp/src/messages.rs
@@ -121,7 +121,8 @@ pub fn derive_tenant_key(master: &[u8], tenant_id: Uuid, key_version: u8) -> [u8
 /// that includes a placeholder signature, making verification impossible.
 /// Use [`sign_payload`] to produce the canonical JSON before signing.
 pub fn sign_payload(key: &[u8], payload_json: &[u8]) -> String {
-    let mut mac = <HmacSha256 as Mac>::new_from_slice(key).expect("HMAC accepts any key length");
+    let mut mac =
+        <HmacSha256 as hmac::KeyInit>::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(payload_json);
     hex::encode(mac.finalize().into_bytes())
 }
@@ -131,7 +132,8 @@ pub fn sign_payload(key: &[u8], payload_json: &[u8]) -> String {
 /// Returns `true` if the signature matches. Uses constant-time comparison
 /// internally (via the `hmac` crate's `verify_slice`).
 pub fn verify_payload(key: &[u8], payload_json: &[u8], signature_hex: &str) -> bool {
-    let mut mac = <HmacSha256 as Mac>::new_from_slice(key).expect("HMAC accepts any key length");
+    let mut mac =
+        <HmacSha256 as hmac::KeyInit>::new_from_slice(key).expect("HMAC accepts any key length");
     mac.update(payload_json);
     let expected = hex::decode(signature_hex).unwrap_or_default();
     mac.verify_slice(&expected).is_ok()

--- a/crates/axiam-api-rest/src/webhook.rs
+++ b/crates/axiam-api-rest/src/webhook.rs
@@ -306,7 +306,8 @@ impl<W: WebhookRepository + Clone + 'static> WebhookDeliveryService<W> {
 /// a valid timestamp (T-26-03-01).
 fn compute_signature_v2(secret: &str, timestamp: i64, body: &str) -> String {
     let signed_payload = format!("{timestamp}.{body}");
-    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC key");
+    let mut mac =
+        <HmacSha256 as hmac::KeyInit>::new_from_slice(secret.as_bytes()).expect("HMAC key");
     mac.update(signed_payload.as_bytes());
     format!(
         "t={timestamp},v1={}",

--- a/crates/axiam-auth/src/crypto.rs
+++ b/crates/axiam-auth/src/crypto.rs
@@ -11,8 +11,8 @@
 //!
 //! Both variants use a fresh 12-byte nonce from `OsRng` and AES-256-GCM.
 
-use aes_gcm::aead::rand_core::RngCore;
-use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::aead::consts::U12;
+use aes_gcm::aead::{Aead, Generate, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
@@ -29,7 +29,7 @@ type HmacSha256 = Hmac<Sha256>;
 // ---------------------------------------------------------------------------
 
 fn build_cipher(key: &[u8; 32]) -> Aes256Gcm {
-    Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key))
+    Aes256Gcm::new(&Key::<Aes256Gcm>::from(*key))
 }
 
 // ---------------------------------------------------------------------------
@@ -44,12 +44,11 @@ fn build_cipher(key: &[u8; 32]) -> Aes256Gcm {
 /// TOTP secret storage — do **not** change the layout.
 pub fn aes256gcm_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Result<String, AuthError> {
     let cipher = build_cipher(key);
-    let mut nonce_bytes = [0u8; 12];
-    OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce_bytes: [u8; 12] = Generate::generate();
+    let nonce = Nonce::<U12>::from(nonce_bytes);
 
     let ciphertext = cipher
-        .encrypt(nonce, plaintext)
+        .encrypt(&nonce, plaintext)
         .map_err(|e| AuthError::Crypto(format!("AES-GCM encrypt: {e}")))?;
 
     let mut combined = nonce_bytes.to_vec();
@@ -71,10 +70,11 @@ pub fn aes256gcm_decrypt(key: &[u8; 32], encoded: &str) -> Result<Vec<u8>, AuthE
 
     let (nonce_bytes, ciphertext) = combined.split_at(12);
     let cipher = build_cipher(key);
-    let nonce = Nonce::from_slice(nonce_bytes);
+    let nonce = Nonce::<U12>::try_from(nonce_bytes)
+        .map_err(|_| AuthError::Crypto("invalid nonce length".into()))?;
 
     cipher
-        .decrypt(nonce, ciphertext)
+        .decrypt(&nonce, ciphertext)
         .map_err(|e| AuthError::Crypto(format!("AES-GCM decrypt: {e}")))
 }
 
@@ -96,12 +96,11 @@ pub fn aes256gcm_decrypt(key: &[u8; 32], encoded: &str) -> Result<Vec<u8>, AuthE
 /// Always use matching encrypt/decrypt pairs.
 pub fn encrypt_separate(key: &[u8; 32], plaintext: &[u8]) -> Result<(String, String), AuthError> {
     let cipher = build_cipher(key);
-    let mut nonce_bytes = [0u8; 12];
-    OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce_bytes: [u8; 12] = Generate::generate();
+    let nonce = Nonce::<U12>::from(nonce_bytes);
 
     let ciphertext = cipher
-        .encrypt(nonce, plaintext)
+        .encrypt(&nonce, plaintext)
         .map_err(|e| AuthError::Crypto(format!("AES-GCM encrypt: {e}")))?;
 
     let nonce_b64 = STANDARD.encode(nonce_bytes);
@@ -133,10 +132,11 @@ pub fn decrypt_separate(
     }
 
     let cipher = build_cipher(key);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let nonce = Nonce::<U12>::try_from(nonce_bytes.as_slice())
+        .map_err(|_| AuthError::Crypto("nonce must be 12 bytes".into()))?;
 
     cipher
-        .decrypt(nonce, ciphertext.as_slice())
+        .decrypt(&nonce, ciphertext.as_slice())
         .map_err(|e| AuthError::Crypto(format!("AES-GCM decrypt: {e}")))
 }
 
@@ -156,7 +156,8 @@ pub fn decrypt_separate(
 /// - **Per-tenant**: `tenant_id` is part of the HMAC input, so the same
 ///   `user_id` in two different tenants produces different pseudonyms.
 pub fn gdpr_pseudonym(pepper: &[u8; 32], tenant_id: Uuid, user_id: Uuid) -> String {
-    let mut mac = <HmacSha256 as Mac>::new_from_slice(pepper).expect("HMAC accepts any key length");
+    let mut mac =
+        <HmacSha256 as hmac::KeyInit>::new_from_slice(pepper).expect("HMAC accepts any key length");
     mac.update(tenant_id.as_bytes());
     mac.update(user_id.as_bytes());
     let tag = mac.finalize().into_bytes();

--- a/crates/axiam-db/src/repository/email_config.rs
+++ b/crates/axiam-db/src/repository/email_config.rs
@@ -6,8 +6,8 @@
 //! `secret_key_version` columns; plaintext is only present in the returned
 //! in-memory domain structs.
 
-use aes_gcm::aead::rand_core::RngCore;
-use aes_gcm::aead::{Aead, KeyInit, OsRng as AeadOsRng};
+use aes_gcm::aead::consts::U12;
+use aes_gcm::aead::{Aead, Generate, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use axiam_core::error::{AxiamError, AxiamResult};
 use axiam_core::models::email::{
@@ -31,12 +31,11 @@ use crate::helpers::{CountRow, take_first_or_not_found};
 // ---------------------------------------------------------------------------
 
 fn encrypt_field(key: &[u8; 32], plaintext: &[u8]) -> Result<(String, String), AxiamError> {
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    let mut nonce_bytes = [0u8; 12];
-    AeadOsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let cipher = Aes256Gcm::new(&Key::<Aes256Gcm>::from(*key));
+    let nonce_bytes: [u8; 12] = Generate::generate();
+    let nonce = Nonce::<U12>::from(nonce_bytes);
     let ct = cipher
-        .encrypt(nonce, plaintext)
+        .encrypt(&nonce, plaintext)
         .map_err(|e| AxiamError::Internal(format!("email secret encrypt: {e}")))?;
     Ok((STANDARD.encode(nonce_bytes), STANDARD.encode(ct)))
 }
@@ -51,10 +50,11 @@ fn decrypt_field(key: &[u8; 32], nonce_b64: &str, ct_b64: &str) -> Result<String
     if nonce_bytes.len() != 12 {
         return Err(AxiamError::Internal("nonce must be 12 bytes".into()));
     }
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    let nonce = Nonce::from_slice(&nonce_bytes);
+    let cipher = Aes256Gcm::new(&Key::<Aes256Gcm>::from(*key));
+    let nonce = Nonce::<U12>::try_from(nonce_bytes.as_slice())
+        .map_err(|_| AxiamError::Internal("nonce must be 12 bytes".into()))?;
     let plaintext = cipher
-        .decrypt(nonce, ct.as_slice())
+        .decrypt(&nonce, ct.as_slice())
         .map_err(|e| AxiamError::Internal(format!("email secret decrypt: {e}")))?;
     String::from_utf8(plaintext).map_err(|e| AxiamError::Internal(format!("utf8 decode: {e}")))
 }

--- a/crates/axiam-pki/benches/cert_bench.rs
+++ b/crates/axiam-pki/benches/cert_bench.rs
@@ -15,7 +15,7 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use rcgen::{CertificateParams, DnType, IsCa, KeyPair};
+use rcgen::{CertificateParams, DnType, IsCa, Issuer, KeyPair};
 use x509_parser::prelude::parse_x509_certificate;
 
 /// Generate a self-signed CA cert + one leaf cert signed by it, returning
@@ -39,8 +39,12 @@ fn build_fixtures() -> (Vec<u8>, Vec<u8>) {
         .distinguished_name
         .push(DnType::CommonName, "bench-test-device-001");
     leaf_params.is_ca = IsCa::NoCa;
+    // rcgen 0.14: sign via an `Issuer` (CA params + signing key) rather than the
+    // old `signed_by(key, &cert, &issuer_key)` 3-arg form. Same CA DN + key, so
+    // the resulting chain is unchanged.
+    let ca_issuer = Issuer::from_params(&ca_params, ca_key_pair);
     let leaf_cert = leaf_params
-        .signed_by(&leaf_key_pair, &ca_cert, &ca_key_pair)
+        .signed_by(&leaf_key_pair, &ca_issuer)
         .expect("leaf signing must succeed");
 
     (ca_cert.der().to_vec(), leaf_cert.der().to_vec())

--- a/crates/axiam-pki/src/cert.rs
+++ b/crates/axiam-pki/src/cert.rs
@@ -8,7 +8,7 @@ use axiam_core::repository::{
     CaCertificateRepository, CertificateRepository, PaginatedResult, Pagination,
 };
 use chrono::{Duration, Utc};
-use rcgen::{CertificateParams, DnType, IsCa, KeyPair};
+use rcgen::{CertificateParams, DnType, IsCa, Issuer, KeyPair};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use uuid::Uuid;
@@ -141,16 +141,16 @@ impl<CA: CaCertificateRepository, CR: CertificateRepository> CertService<CA, CR>
                 // must not linger in the heap buffer (defense-in-depth).
                 ca_private_key_pem.zeroize();
 
-                // Reconstruct the signing CA from its real, stored certificate PEM —
-                // NOT from the (mutable) `subject` field — so the issuer DN embedded
-                // in every leaf cert can never drift from the CA's actual Subject DN
-                // (QUAL-05/D-08, T-29-11).
-                let ca_params = CertificateParams::from_ca_cert_pem(&ca_cert_pem).map_err(|e| {
-                    AxiamError::Certificate(format!("invalid CA certificate PEM: {e}"))
-                })?;
-                let ca_certificate = ca_params
-                    .self_signed(&ca_key_pair)
-                    .map_err(|e| AxiamError::Certificate(format!("CA self-sign failed: {e}")))?;
+                // Reconstruct the signing CA issuer from its real, stored certificate
+                // PEM — NOT from the (mutable) `subject` field — so the issuer DN
+                // embedded in every leaf cert can never drift from the CA's actual
+                // Subject DN (QUAL-05/D-08, T-29-11). rcgen 0.14 moved
+                // `from_ca_cert_pem` onto `Issuer`, which now owns the signing key and
+                // is passed directly to `signed_by`.
+                let ca_issuer =
+                    Issuer::from_ca_cert_pem(&ca_cert_pem, ca_key_pair).map_err(|e| {
+                        AxiamError::Certificate(format!("invalid CA certificate PEM: {e}"))
+                    })?;
 
                 // Generate end-entity key pair.
                 let ee_key_pair = generate_keypair(&key_algorithm)?;
@@ -168,11 +168,9 @@ impl<CA: CaCertificateRepository, CR: CertificateRepository> CertService<CA, CR>
                 ee_params.not_after = time::OffsetDateTime::from_unix_timestamp(not_after_ts)
                     .expect("valid timestamp");
 
-                let cert = ee_params
-                    .signed_by(&ee_key_pair, &ca_certificate, &ca_key_pair)
-                    .map_err(|e| {
-                        AxiamError::Certificate(format!("certificate signing failed: {e}"))
-                    })?;
+                let cert = ee_params.signed_by(&ee_key_pair, &ca_issuer).map_err(|e| {
+                    AxiamError::Certificate(format!("certificate signing failed: {e}"))
+                })?;
 
                 let public_cert_pem = cert.pem();
                 let fingerprint = compute_fingerprint(cert.der());

--- a/crates/axiam-pki/src/crypto.rs
+++ b/crates/axiam-pki/src/crypto.rs
@@ -7,8 +7,9 @@
 //! generation produces a distinct `PgpKeyAlgorithm` + `user_id` -> `SignedSecretKey`
 //! type that is not X.509/rcgen-based and must not be merged into this module.
 
-use aes_gcm::aead::{Aead, OsRng};
-use aes_gcm::{AeadCore, Aes256Gcm, Key, KeyInit, Nonce};
+use aes_gcm::aead::consts::U12;
+use aes_gcm::aead::{Aead, Generate};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
 use axiam_core::error::{AxiamError, AxiamResult};
 use axiam_core::models::certificate::KeyAlgorithm;
 use rcgen::KeyPair;
@@ -33,9 +34,10 @@ pub(crate) fn compute_fingerprint(der: &[u8]) -> String {
 /// Encrypt data with AES-256-GCM. The 12-byte nonce is prepended to the
 /// ciphertext so the caller doesn't need to store it separately.
 pub(crate) fn encrypt_secret(plaintext: &[u8], key_bytes: &[u8; 32]) -> AxiamResult<Vec<u8>> {
-    let key = Key::<Aes256Gcm>::from_slice(key_bytes);
-    let cipher = Aes256Gcm::new(key);
-    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let key = Key::<Aes256Gcm>::from(*key_bytes);
+    let cipher = Aes256Gcm::new(&key);
+    let nonce_bytes: [u8; 12] = Generate::generate();
+    let nonce = Nonce::<U12>::from(nonce_bytes);
     let ciphertext = cipher
         .encrypt(&nonce, plaintext)
         .map_err(|e| AxiamError::Crypto(format!("AES-256-GCM encryption failed: {e}")))?;
@@ -54,10 +56,11 @@ pub(crate) fn decrypt_secret(data: &[u8], key_bytes: &[u8; 32]) -> AxiamResult<V
         ));
     }
     let (nonce_bytes, ciphertext) = data.split_at(12);
-    let key = Key::<Aes256Gcm>::from_slice(key_bytes);
-    let cipher = Aes256Gcm::new(key);
-    let nonce = Nonce::from_slice(nonce_bytes);
+    let key = Key::<Aes256Gcm>::from(*key_bytes);
+    let cipher = Aes256Gcm::new(&key);
+    let nonce = Nonce::<U12>::try_from(nonce_bytes)
+        .map_err(|_| AxiamError::Crypto("invalid nonce length".into()))?;
     cipher
-        .decrypt(nonce, ciphertext)
+        .decrypt(&nonce, ciphertext)
         .map_err(|e| AxiamError::Crypto(format!("AES-256-GCM decryption failed: {e}")))
 }


### PR DESCRIPTION
## Summary

Lands the four breaking crypto-crate upgrades that Dependabot opened but could not apply, because they each require source changes:

| Dependabot PR | Crate | From | To |
|---|---|---|---|
| #178 | aes-gcm | 0.10.3 | **0.11.0** |
| #179 | sha2 | 0.10.9 | **0.11.0** |
| #177 | hkdf | 0.12.4 | **0.13.0** |
| #180 | rcgen | 0.13.2 | **0.14.8** |

This PR **supersedes #177, #178, #179 and #180** — they can be closed once this merges.

These are security-critical crypto crates, so the change is **strictly API-adaptation, behavior-preserving**: no algorithm, key size, nonce handling, KDF parameter, or certificate property is changed. Only call sites are adapted to the new crate APIs so issued output (ciphertexts, HMACs, derived keys, certificates) is byte-for-byte equivalent.

## Why these move together

`aes-gcm 0.11`, `sha2 0.11` and `hkdf 0.13` all cross to the RustCrypto **`digest 0.11` / `crypto-common 0.2`** generation. They are interdependent: any digest-consuming crate (notably **hmac**) must be on the matching 0.11-generation version or the trait bounds won't resolve. So the digest cluster is upgraded as a unit and **hmac is aligned 0.12.1 → 0.13.0**. `rcgen 0.14` is independent (PKI cert generation). The old generations (digest 0.10, hmac 0.12, sha2 0.10, hkdf 0.12, aes-gcm 0.10) remain in the lockfile as transitive deps of `pgp`, `surrealdb`, `jsonwebtoken` etc. and coexist cleanly.

## Version changes (workspace `Cargo.toml`)

- `aes-gcm` 0.10 → 0.11
- `sha2` 0.10 → 0.11
- `hkdf` 0.12 → 0.13
- `hmac` 0.12 → 0.13 (aligned to the digest-0.11 generation)
- `rcgen` 0.13 → 0.14

## Source adaptations

- **`crates/axiam-auth/src/crypto.rs`** — aes-gcm 0.11: generate the 12-byte nonce via the aead `Generate` trait (same OS CSPRNG source), build `Key`/`Nonce` with `From`/`TryFrom` instead of the deprecated `from_slice`, drop the removed `OsRng` import; HMAC `new_from_slice` now on `KeyInit`.
- **`crates/axiam-amqp/src/messages.rs`** — HMAC/HKDF now resolve against digest 0.11; `new_from_slice` moved to `KeyInit`. HKDF-SHA256 derivation and wire order unchanged.
- **`crates/axiam-api-rest/src/webhook.rs`** — HMAC `new_from_slice` qualified to `KeyInit` (webhook HMAC-SHA256 signature format unchanged).
- **`crates/axiam-db/src/repository/email_config.rs`** — aes-gcm 0.11 nonce/key construction (mirrors the auth split-output format; ciphertext/nonce columns unchanged).
- **`crates/axiam-pki/src/crypto.rs`** — aes-gcm 0.11 nonce/key construction for the CA/cert secret encryption (nonce-prepended format unchanged).
- **`crates/axiam-pki/src/cert.rs`** — rcgen 0.14: `CertificateParams::from_ca_cert_pem` moved onto the new `Issuer` type (which now owns the signing key); `signed_by` takes `(&public_key, &issuer)`. Issuer DN is still reconstructed from the CA's stored cert PEM, so leaf issuer DN, validity, SAN, key usage and algorithm are preserved.
- **`crates/axiam-pki/benches/cert_bench.rs`** — same rcgen 0.14 `Issuer`/`signed_by` adaptation for the local micro-bench fixture.
- **`Cargo.toml` / `Cargo.lock`** — version bumps + resolved lockfile.

## Verification

| Command | Result |
|---|---|
| `cargo build -p axiam-auth -p axiam-amqp -p axiam-pki -p axiam-db` | ✅ pass |
| `cargo test -p axiam-auth -p axiam-amqp -p axiam-pki` | ✅ **all pass** (0 failed; incl. AES-GCM round-trip, GDPR HMAC pseudonym, AMQP HMAC/HKDF per-tenant derivation, mTLS chain + cert signing tests) |
| `cargo clippy -p axiam-auth -p axiam-amqp -p axiam-pki --all-targets -- -D warnings` | ✅ pass (0 warnings) |
| `cargo fmt --all -- --check` | ✅ pass |
| `cargo build -p axiam-server` (whole binary graph, incl. api-rest with the swagger-ui build workaround) | ✅ pass — confirms the shared lockfile change breaks no other crate |

Behavior is unchanged; every existing test stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWxZaJw6wuMd3d5zqyqdcG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWxZaJw6wuMd3d5zqyqdcG)_