### PR TITLE
frontend: apply design-system UI/UX & accessibility audit fixes

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import { Loader2 } from "lucide-react";
+import { useModalA11y } from "@/hooks/useModalA11y";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -24,6 +25,9 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // Restore focus to the trigger and lock background scroll while open.
+  useModalA11y(open);
 
   // Keep Tab cycling within the dialog and close on Escape
   const handleKeyDown = useCallback(
@@ -95,14 +99,14 @@ export function ConfirmDialog({
             ref={cancelRef}
             onClick={onClose}
             disabled={isLoading}
-            className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md text-muted-foreground hover:bg-white/5 hover:text-foreground transition-colors focus:outline-hidden focus:ring-2 focus:ring-primary/40 disabled:opacity-50"
+            className="focus-ring inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md text-muted-foreground hover:bg-white/5 hover:text-foreground transition-colors disabled:opacity-50"
           >
             {cancelLabel ?? "Cancel"}
           </button>
           <button
             onClick={onConfirm}
             disabled={isLoading}
-            className="inline-flex items-center justify-center min-w-[80px] px-4 py-2 text-sm font-medium rounded-md bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity focus:outline-hidden focus:ring-2 focus:ring-primary/40 disabled:opacity-50"
+            className="focus-ring inline-flex items-center justify-center min-w-[80px] px-4 py-2 text-sm font-medium rounded-md bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
           >
             {isLoading ? (
               <Loader2 size={14} className="animate-spin" />

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,11 +1,21 @@
 import type { ReactNode } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, RotateCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+
+export type SortDirection = "asc" | "desc";
 
 export interface Column<T> {
   key: string;
   header: string;
   render?: (row: T) => ReactNode;
   width?: string;
+  /** Enable click-to-sort on this column's header. */
+  sortable?: boolean;
+}
+
+export interface SortState {
+  key: string;
+  direction: SortDirection;
 }
 
 interface DataTableProps<T> {
@@ -14,6 +24,18 @@ interface DataTableProps<T> {
   isLoading?: boolean;
   emptyMessage?: string;
   getRowKey?: (row: T, index: number) => string | number;
+  /**
+   * Error state for failed async loads. When set (and not loading), an error
+   * row with an optional retry affordance is shown instead of the data/empty
+   * state.
+   */
+  error?: string | null;
+  /** Retry handler; renders a "Try again" button in the error state. */
+  onRetry?: () => void;
+  /** Current sort state (for `sortable` columns). */
+  sort?: SortState | null;
+  /** Called with the next sort state when a sortable header is activated. */
+  onSortChange?: (next: SortState) => void;
 }
 
 function SkeletonRow({ colCount }: { colCount: number }) {
@@ -28,39 +50,102 @@ function SkeletonRow({ colCount }: { colCount: number }) {
   );
 }
 
+function SortIcon({ direction }: { direction: SortDirection | null }) {
+  if (direction === "asc") return <ArrowUp size={12} aria-hidden="true" />;
+  if (direction === "desc") return <ArrowDown size={12} aria-hidden="true" />;
+  return <ArrowUpDown size={12} aria-hidden="true" className="opacity-40" />;
+}
+
 export function DataTable<T extends object>({
   columns,
   data,
   isLoading = false,
   emptyMessage = "No data found.",
   getRowKey,
+  error = null,
+  onRetry,
+  sort = null,
+  onSortChange,
 }: DataTableProps<T>) {
+  function handleSort(key: string) {
+    const nextDirection: SortDirection =
+      sort?.key === key && sort.direction === "asc" ? "desc" : "asc";
+    onSortChange?.({ key, direction: nextDirection });
+  }
+
   return (
     <div className="glass-card overflow-hidden p-0">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-primary/20">
-              {columns.map((col) => (
-                <th
-                  key={col.key}
-                  className={cn(
-                    "px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-primary/80",
-                    col.width
-                  )}
-                >
-                  {col.header}
-                </th>
-              ))}
+            <tr className="border-b border-primary/25">
+              {columns.map((col) => {
+                const isSorted = sort?.key === col.key;
+                const ariaSort: React.AriaAttributes["aria-sort"] =
+                  col.sortable
+                    ? isSorted
+                      ? sort?.direction === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                    : undefined;
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    aria-sort={ariaSort}
+                    className={cn(
+                      "px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-primary/80",
+                      col.width
+                    )}
+                  >
+                    {col.sortable && onSortChange ? (
+                      <button
+                        type="button"
+                        onClick={() => handleSort(col.key)}
+                        className="focus-ring inline-flex items-center gap-1.5 uppercase tracking-wider hover:text-primary transition-colors"
+                      >
+                        {col.header}
+                        <SortIcon
+                          direction={isSorted ? sort!.direction : null}
+                        />
+                      </button>
+                    ) : (
+                      col.header
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
-          <tbody className="divide-y divide-white/5">
+          <tbody className="divide-y divide-white/10">
             {isLoading ? (
               <>
                 <SkeletonRow colCount={columns.length} />
                 <SkeletonRow colCount={columns.length} />
                 <SkeletonRow colCount={columns.length} />
               </>
+            ) : error ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-4 py-12 text-center text-muted-foreground"
+                >
+                  <div className="flex flex-col items-center gap-3" role="alert">
+                    <span className="text-sm text-destructive">{error}</span>
+                    {onRetry && (
+                      <button
+                        type="button"
+                        onClick={onRetry}
+                        className="focus-ring inline-flex items-center gap-1.5 rounded-md border border-primary/30 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+                      >
+                        <RotateCw size={12} aria-hidden="true" />
+                        Try again
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
             ) : data.length === 0 ? (
               <tr>
                 <td
@@ -68,7 +153,9 @@ export function DataTable<T extends object>({
                   className="px-4 py-12 text-center text-muted-foreground"
                 >
                   <div className="flex flex-col items-center gap-2">
-                    <span className="text-4xl opacity-30">&#9632;</span>
+                    <span className="text-4xl opacity-30" aria-hidden="true">
+                      &#9632;
+                    </span>
                     <span>{emptyMessage}</span>
                   </div>
                 </td>
@@ -77,7 +164,7 @@ export function DataTable<T extends object>({
               data.map((row, rowIdx) => (
                 <tr
                   key={getRowKey ? getRowKey(row, rowIdx) : String((row as Record<string, unknown>).id ?? rowIdx)}
-                  className="hover:bg-white/[0.03] transition-colors duration-150"
+                  className="hover:bg-white/[0.06] active:bg-white/[0.06] transition-colors duration-150"
                 >
                   {columns.map((col) => (
                     <td

--- a/frontend/src/components/FormDialog.tsx
+++ b/frontend/src/components/FormDialog.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Loader2, X } from "lucide-react";
+import { useModalA11y } from "@/hooks/useModalA11y";
 
 interface FormDialogProps {
   open: boolean;
@@ -23,6 +24,9 @@ export function FormDialog({
 }: FormDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
+
+  // Restore focus to the trigger and lock background scroll while open.
+  useModalA11y(open);
 
   // Keep Tab cycling within the dialog and close on Escape
   const handleKeyDown = useCallback(
@@ -90,7 +94,7 @@ export function FormDialog({
       />
 
       {/* Panel */}
-      <div className="relative z-10 glass-card w-full max-w-md flex flex-col max-h-[90vh] p-6">
+      <div className="relative z-10 glass-card w-full max-w-md flex flex-col max-h-[90dvh] p-6">
         {/* Header */}
         <div className="flex items-center justify-between pb-4 border-b border-primary/10">
           <h2
@@ -102,7 +106,7 @@ export function FormDialog({
           <button
             ref={closeRef}
             onClick={isLoading ? undefined : onClose}
-            className="text-muted-foreground hover:text-foreground transition-colors rounded p-1 focus:outline-hidden focus:ring-2 focus:ring-primary/40"
+            className="focus-ring text-muted-foreground hover:text-foreground transition-colors rounded p-1"
             aria-label="Close dialog"
             disabled={isLoading}
           >

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -7,6 +7,13 @@ interface SearchInputProps {
   onChange: (value: string) => void;
   placeholder?: string;
   className?: string;
+  /**
+   * Accessible name for the field. Falls back to `placeholder` for backwards
+   * compatibility, but prefer an explicit label so the control still has a
+   * name once the user types (a placeholder disappears) or if `placeholder`
+   * is empty.
+   */
+  label?: string;
 }
 
 /**
@@ -18,6 +25,7 @@ export function SearchInput({
   onChange,
   placeholder = "Search…",
   className,
+  label,
 }: SearchInputProps) {
   const [local, setLocal] = useState(value);
   const [prevValue, setPrevValue] = useState(value);
@@ -59,12 +67,12 @@ export function SearchInput({
         value={local}
         onChange={handleChange}
         placeholder={placeholder}
-        aria-label={placeholder}
+        aria-label={label ?? placeholder}
         className={cn(
-          "h-9 w-full rounded-md pl-9 pr-3 text-sm",
+          "focus-ring h-9 w-full rounded-md pl-9 pr-3 text-sm",
           "bg-white/5 border border-primary/20 text-foreground",
           "placeholder:text-muted-foreground",
-          "focus:outline-hidden focus:ring-2 focus:ring-primary/40 focus:border-primary",
+          "focus:border-primary",
           "transition-colors duration-200"
         )}
       />

--- a/frontend/src/components/SecretRevealModal.tsx
+++ b/frontend/src/components/SecretRevealModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { AlertTriangle, Check, Copy } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
+import { useModalA11y } from "@/hooks/useModalA11y";
 
 export interface SecretEntry {
   label: string;
@@ -56,7 +57,7 @@ function CopyButton({ value }: { value: string }) {
       type="button"
       onClick={() => void handleCopy()}
       aria-label={copied ? "Copied!" : "Copy to clipboard"}
-      className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium border transition-all duration-150 focus:outline-hidden focus:ring-2 focus:ring-primary/40"
+      className="focus-ring shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium border transition-all duration-150"
       style={
         copied
           ? {
@@ -97,6 +98,9 @@ export function SecretRevealModal({
 }: SecretRevealModalProps) {
   const ackRef = useRef<HTMLButtonElement>(null);
 
+  // Restore focus to the trigger and lock background scroll while open.
+  useModalA11y(open);
+
   // Focus the acknowledge button when opened; no Escape to close (force acknowledgment)
   useEffect(() => {
     if (!open) return;
@@ -122,7 +126,7 @@ export function SecretRevealModal({
       />
 
       {/* Panel */}
-      <div className="relative z-10 w-full max-w-lg flex flex-col max-h-[90vh] rounded-xl border border-white/10 bg-[#0d0d2b]/95 shadow-2xl shadow-black/60 backdrop-blur-xl">
+      <div className="relative z-10 w-full max-w-lg flex flex-col max-h-[90dvh] rounded-xl border border-white/10 bg-[#0d0d2b]/95 shadow-2xl shadow-black/60 backdrop-blur-xl">
         {/* Warning banner */}
         <div className="flex items-start gap-3 px-5 py-4 rounded-t-xl bg-amber-500/10 border-b border-amber-500/25">
           <AlertTriangle

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,3 +1,5 @@
+import { Ban, Circle, CircleCheck, PauseCircle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type Status = "active" | "revoked" | "inactive" | "suspended";
@@ -18,15 +20,27 @@ const statusStyles: Record<Status, string> = {
     "bg-amber-500/15 text-amber-400 border border-amber-500/30",
 };
 
+// A distinct icon shape per state so the badge is scannable without relying on
+// color alone. Rendered as an SVG (no text content) and aria-hidden, so the
+// text label remains the only accessible/matchable name for the badge.
+const statusIcon: Record<Status, LucideIcon> = {
+  active: CircleCheck,
+  revoked: Ban,
+  inactive: Circle,
+  suspended: PauseCircle,
+};
+
 export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const Icon = statusIcon[status];
   return (
     <span
       className={cn(
-        "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium",
+        "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium",
         statusStyles[status],
         className
       )}
     >
+      <Icon size={11} aria-hidden="true" className="shrink-0" />
       {status.charAt(0).toUpperCase() + status.slice(1)}
     </span>
   );

--- a/frontend/src/components/UserSearchDialog.tsx
+++ b/frontend/src/components/UserSearchDialog.tsx
@@ -4,6 +4,7 @@ import { userService, type User } from "@/services/users";
 import { Button } from "@/components/ui/button";
 import { Loader2, Plus, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useModalA11y } from "@/hooks/useModalA11y";
 
 export interface UserSearchDialogProps {
   open: boolean;
@@ -30,6 +31,9 @@ export function UserSearchDialog({
 }: UserSearchDialogProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [actingId, setActingId] = useState<string | null>(null);
+
+  // Restore focus to the trigger and lock background scroll while open.
+  useModalA11y(open);
 
   const { data, isFetching } = useQuery({
     queryKey: ["user-search", searchTerm],
@@ -70,7 +74,7 @@ export function UserSearchDialog({
         onClick={handleClose}
         aria-hidden="true"
       />
-      <div className="relative z-10 glass-card w-full max-w-md flex flex-col max-h-[80vh]">
+      <div className="relative z-10 glass-card w-full max-w-md flex flex-col max-h-[80dvh]">
         <div className="flex items-center justify-between pb-4 border-b border-primary/10">
           <h2
             id="user-search-dialog-title"
@@ -80,7 +84,7 @@ export function UserSearchDialog({
           </h2>
           <button
             onClick={handleClose}
-            className="text-muted-foreground hover:text-foreground transition-colors rounded p-1 focus:outline-hidden focus:ring-2 focus:ring-primary/40"
+            className="focus-ring text-muted-foreground hover:text-foreground transition-colors rounded p-1"
             aria-label="Close dialog"
           >
             ✕
@@ -101,10 +105,10 @@ export function UserSearchDialog({
               placeholder="Search users…"
               aria-label="Search users"
               className={cn(
-                "h-9 w-full rounded-md pl-9 pr-3 text-sm",
+                "focus-ring h-9 w-full rounded-md pl-9 pr-3 text-sm",
                 "bg-white/5 border border-primary/20 text-foreground",
                 "placeholder:text-muted-foreground",
-                "focus:outline-hidden focus:ring-2 focus:ring-primary/40 focus:border-primary",
+                "focus:border-primary",
                 "transition-colors duration-200",
               )}
             />
@@ -148,7 +152,7 @@ export function UserSearchDialog({
                         <button
                           onClick={() => void handleAction(user)}
                           disabled={actingId === user.id}
-                          className="flex items-center gap-1 text-xs px-2.5 py-1 rounded bg-primary/20 text-primary hover:bg-primary/30 transition-colors disabled:opacity-50"
+                          className="focus-ring flex items-center gap-1 text-xs px-2.5 py-1 rounded bg-primary/20 text-primary hover:bg-primary/30 transition-colors disabled:opacity-50"
                         >
                           {actingId === user.id ? (
                             <Loader2 size={12} className="animate-spin" />

--- a/frontend/src/components/components.test.tsx
+++ b/frontend/src/components/components.test.tsx
@@ -53,6 +53,14 @@ describe("Button", () => {
     expect(cls).toContain("bg-destructive");
     expect(cls).toContain("h-8");
   });
+  it("buttonVariants exposes a 44px touch icon size", () => {
+    const cls = buttonVariants({ size: "icon-touch" });
+    expect(cls).toContain("h-11");
+    expect(cls).toContain("w-11");
+  });
+  it("buttonVariants adds active-state press feedback for touch", () => {
+    expect(buttonVariants({ variant: "default" })).toContain("active:shadow-glow-cyan");
+  });
 });
 
 describe("Badge", () => {
@@ -102,6 +110,37 @@ describe("Input / Textarea / Label", () => {
     );
     expect(screen.getByText("Name")).toBeInTheDocument();
   });
+  it("Input renders an error message and wires aria-invalid/aria-describedby", () => {
+    render(<Input id="email" error="Email is required" />);
+    const el = screen.getByRole("textbox");
+    expect(el).toHaveAttribute("aria-invalid", "true");
+    expect(el).toHaveAttribute("aria-describedby", "email-error");
+    expect(screen.getByText("Email is required")).toHaveAttribute("id", "email-error");
+  });
+  it("Input marks invalid via the invalid prop without a message", () => {
+    render(<Input aria-label="Name" invalid />);
+    const el = screen.getByLabelText("Name");
+    expect(el).toHaveAttribute("aria-invalid", "true");
+    expect(el).not.toHaveAttribute("aria-describedby");
+  });
+  it("Input preserves a caller-provided aria-describedby alongside the error id", () => {
+    render(<Input id="pw" aria-describedby="hint" error="Too short" />);
+    expect(screen.getByRole("textbox")).toHaveAttribute(
+      "aria-describedby",
+      "hint pw-error"
+    );
+  });
+  it("Textarea renders an error message and wires aria-invalid/aria-describedby", () => {
+    render(<Textarea id="bio" error="Bio is required" />);
+    const el = screen.getByRole("textbox");
+    expect(el).toHaveAttribute("aria-invalid", "true");
+    expect(el).toHaveAttribute("aria-describedby", "bio-error");
+    expect(screen.getByText("Bio is required")).toHaveAttribute("id", "bio-error");
+  });
+  it("Input has no aria-invalid when valid", () => {
+    render(<Input aria-label="Clean" />);
+    expect(screen.getByLabelText("Clean")).not.toHaveAttribute("aria-invalid");
+  });
 });
 
 // ─── StatusBadge ──────────────────────────────────────────────────────────────
@@ -117,6 +156,17 @@ describe("StatusBadge", () => {
       expect(screen.getByText(s.charAt(0).toUpperCase() + s.slice(1))).toBeInTheDocument();
       unmount();
     }
+  });
+  it("renders a non-color icon marked aria-hidden alongside the text", () => {
+    const { container } = render(<StatusBadge status="active" />);
+    const icon = container.querySelector('svg[aria-hidden="true"]');
+    expect(icon).toBeInTheDocument();
+    // Text label is still present (meaning never conveyed by the icon alone).
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    // The icon is an SVG with no text content, so the badge's textContent is
+    // exactly the label — this keeps exact-text matchers (used by the E2E
+    // suite, e.g. tenants "Active") working.
+    expect(container.querySelector("span")?.textContent).toBe("Active");
   });
 });
 
@@ -152,6 +202,17 @@ describe("SearchInput", () => {
     const { rerender } = render(<SearchInput value="a" onChange={() => {}} />);
     rerender(<SearchInput value="reset" onChange={() => {}} />);
     expect(screen.getByDisplayValue("reset")).toBeInTheDocument();
+  });
+  it("prefers an explicit label over the placeholder for its accessible name", () => {
+    render(
+      <SearchInput
+        value=""
+        onChange={() => {}}
+        placeholder="Type to filter…"
+        label="Search users"
+      />
+    );
+    expect(screen.getByLabelText("Search users")).toBeInTheDocument();
   });
   it("clears the pending timer on a second keystroke", () => {
     vi.useFakeTimers();
@@ -195,6 +256,12 @@ describe("shared primitives", () => {
     expect(cb).not.toBeChecked();
     await userEvent.click(cb);
     expect(onChange).toHaveBeenCalledWith(true);
+  });
+  it("ToggleField control meets the minimum target size (>=20px)", () => {
+    render(<ToggleField id="t2" label="Enable" checked={false} onChange={() => {}} />);
+    // w-5/h-5 == 20px, up from the previous 16px (below the 24px WCAG minimum).
+    expect(screen.getByRole("checkbox").className).toMatch(/\bw-5\b/);
+    expect(screen.getByRole("checkbox").className).toMatch(/\bh-5\b/);
   });
   it("SectionCard renders title, action and children", () => {
     render(

--- a/frontend/src/components/dialogs.test.tsx
+++ b/frontend/src/components/dialogs.test.tsx
@@ -85,6 +85,56 @@ describe("ConfirmDialog", () => {
   });
 });
 
+// ─── Shared modal a11y (scroll lock + focus restore) ────────────────────────────
+
+describe("modal a11y", () => {
+  it("locks background scroll while open and restores it on close", () => {
+    const { rerender } = render(
+      <ConfirmDialog open onClose={() => {}} onConfirm={() => {}} title="T" description="D" />
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+    rerender(
+      <ConfirmDialog open={false} onClose={() => {}} onConfirm={() => {}} title="T" description="D" />
+    );
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("restores focus to the triggering element on close", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <ConfirmDialog open onClose={() => {}} onConfirm={() => {}} title="T" description="D" />
+    );
+    // Focus moved into the dialog on open.
+    expect(document.activeElement).not.toBe(trigger);
+
+    rerender(
+      <ConfirmDialog open={false} onClose={() => {}} onConfirm={() => {}} title="T" description="D" />
+    );
+    // Focus returned to the trigger on close.
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
+
+  it("FormDialog also locks scroll while open", () => {
+    const { rerender } = render(
+      <FormDialog open onClose={() => {}} onSubmit={(e) => e.preventDefault()} title="T">
+        <input aria-label="F" />
+      </FormDialog>
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+    rerender(
+      <FormDialog open={false} onClose={() => {}} onSubmit={(e) => e.preventDefault()} title="T">
+        <input aria-label="F" />
+      </FormDialog>
+    );
+    expect(document.body.style.overflow).toBe("");
+  });
+});
+
 // ─── FormDialog ────────────────────────────────────────────────────────────────
 
 describe("FormDialog", () => {
@@ -211,6 +261,55 @@ describe("DataTable", () => {
     render(<DataTable columns={cols} data={[{}]} />);
     // No id, no name → renders an empty cell without throwing.
     expect(screen.getByText("Name")).toBeInTheDocument();
+  });
+
+  it("marks every header cell with scope=col", () => {
+    render(<DataTable columns={columns} data={[]} />);
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers).toHaveLength(columns.length);
+    headers.forEach((h) => expect(h).toHaveAttribute("scope", "col"));
+  });
+
+  it("renders an error state with a working retry button", async () => {
+    const onRetry = vi.fn();
+    render(
+      <DataTable columns={columns} data={[]} error="Failed to load" onRetry={onRetry} />
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Failed to load");
+    await userEvent.click(screen.getByRole("button", { name: /Try again/ }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("shows error state (not empty message) even when data is empty", () => {
+    render(
+      <DataTable columns={columns} data={[]} error="Boom" emptyMessage="Nothing here" />
+    );
+    expect(screen.getByText("Boom")).toBeInTheDocument();
+    expect(screen.queryByText("Nothing here")).not.toBeInTheDocument();
+  });
+
+  it("renders sortable headers with aria-sort and reports the next sort state", async () => {
+    const onSortChange = vi.fn();
+    const cols: Column<Row>[] = [
+      { key: "name", header: "Name", sortable: true },
+      { key: "role", header: "Role" },
+    ];
+    render(
+      <DataTable
+        columns={cols}
+        data={[{ id: "1", name: "Alice", role: "admin" }]}
+        sort={{ key: "name", direction: "asc" }}
+        onSortChange={onSortChange}
+      />
+    );
+    const nameHeader = screen.getByRole("columnheader", { name: /Name/ });
+    expect(nameHeader).toHaveAttribute("aria-sort", "ascending");
+    // Non-sortable column has no aria-sort.
+    expect(screen.getByRole("columnheader", { name: "Role" })).not.toHaveAttribute(
+      "aria-sort"
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Name/ }));
+    expect(onSortChange).toHaveBeenCalledWith({ key: "name", direction: "desc" });
   });
 });
 

--- a/frontend/src/components/shared.tsx
+++ b/frontend/src/components/shared.tsx
@@ -25,9 +25,11 @@ export function ToggleField({ id, label, checked, onChange }: ToggleFieldProps) 
         id={id}
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        className="w-4 h-4 accent-cyan-400 cursor-pointer"
+        className="focus-ring w-5 h-5 accent-cyan-400 cursor-pointer rounded-sm"
       />
-      <Label htmlFor={id} className="cursor-pointer">
+      {/* Extend the click/tap target: the whole label row is comfortably large
+          and the htmlFor association keeps the checkbox the control. */}
+      <Label htmlFor={id} className="cursor-pointer py-1.5 flex-1">
         {label}
       </Label>
     </div>
@@ -63,7 +65,7 @@ export interface InfoRowProps {
 
 export function InfoRow({ label, children }: InfoRowProps) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-4 py-2 border-b border-white/5 last:border-0">
+    <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-4 py-2 border-b border-white/10 last:border-0">
       <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground sm:w-36 shrink-0 pt-0.5">
         {label}
       </span>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -8,24 +8,30 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
+        // `active:` states give touch users press feedback since `hover:`
+        // variants only fire on hover-capable pointers (Tailwind gates the
+        // hover variant behind `@media (hover: hover)`).
         default:
-          "bg-primary text-primary-foreground hover:shadow-glow-cyan hover:-translate-y-0.5",
+          "bg-primary text-primary-foreground hover:shadow-glow-cyan hover:-translate-y-0.5 active:shadow-glow-cyan",
         destructive:
-          "bg-destructive text-destructive-foreground hover:opacity-90",
+          "bg-destructive text-destructive-foreground hover:opacity-90 active:opacity-90",
         outline:
-          "border border-primary/30 bg-transparent text-primary hover:bg-primary/10 hover:border-primary hover:shadow-glow-cyan",
+          "border border-primary/30 bg-transparent text-primary hover:bg-primary/10 hover:border-primary hover:shadow-glow-cyan active:bg-primary/10",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "text-muted-foreground hover:bg-white/5 hover:text-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/80",
+        ghost:
+          "text-muted-foreground hover:bg-white/5 hover:text-foreground active:bg-white/5",
+        link: "text-primary underline-offset-4 hover:underline active:underline",
         accent:
-          "bg-accent text-accent-foreground hover:shadow-glow-purple hover:-translate-y-0.5",
+          "bg-accent text-accent-foreground hover:shadow-glow-purple hover:-translate-y-0.5 active:shadow-glow-purple",
       },
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",
+        // 44px — comfortable touch target for tablet/touch contexts.
+        "icon-touch": "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,25 +1,66 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Marks the field invalid without necessarily rendering a message. */
+  invalid?: boolean;
+  /**
+   * Error message text. When set, the field is styled as invalid, gets
+   * `aria-invalid="true"`, and is wired to the message via `aria-describedby`.
+   */
+  error?: string;
+  /**
+   * Explicit id for the rendered error node. Defaults to `${id}-error` when an
+   * `id` is provided. Callers that render their own error node can pass the id
+   * and omit `error` to keep the wiring.
+   */
+  errorId?: string;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  (
+    { className, type, invalid, error, errorId, id, "aria-describedby": describedBy, ...props },
+    ref
+  ) => {
+    const isInvalid = invalid ?? Boolean(error);
+    const resolvedErrorId = errorId ?? (id ? `${id}-error` : undefined);
+    const describedByIds =
+      [describedBy, isInvalid && error ? resolvedErrorId : undefined]
+        .filter(Boolean)
+        .join(" ") || undefined;
+
     return (
-      <input
-        ref={ref}
-        type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md px-3 py-2 text-sm",
-          "bg-white/5 border border-primary/20 text-foreground",
-          "placeholder:text-muted-foreground",
-          "focus:outline-hidden focus:ring-2 focus:ring-primary/40 focus:border-primary",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "transition-colors duration-200",
-          className
-        )}
-        {...props}
-      />
+      <>
+        <input
+          ref={ref}
+          id={id}
+          type={type}
+          aria-invalid={isInvalid || undefined}
+          aria-describedby={describedByIds}
+          className={cn(
+            "focus-ring flex h-10 w-full rounded-md px-3 py-2 text-sm",
+            "bg-white/5 border text-foreground",
+            "placeholder:text-muted-foreground",
+            "focus:border-primary",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            "transition-colors duration-200",
+            isInvalid
+              ? "border-destructive focus:border-destructive"
+              : "border-primary/20",
+            className
+          )}
+          {...props}
+        />
+        {error ? (
+          <p
+            id={resolvedErrorId}
+            className="mt-1.5 text-xs text-destructive"
+          >
+            {error}
+          </p>
+        ) : null}
+      </>
     );
   }
 );

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,24 +1,58 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** Marks the field invalid without necessarily rendering a message. */
+  invalid?: boolean;
+  /**
+   * Error message text. When set, the field is styled as invalid, gets
+   * `aria-invalid="true"`, and is wired to the message via `aria-describedby`.
+   */
+  error?: string;
+  /** Explicit id for the rendered error node. Defaults to `${id}-error`. */
+  errorId?: string;
+}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  (
+    { className, invalid, error, errorId, id, "aria-describedby": describedBy, ...props },
+    ref
+  ) => {
+    const isInvalid = invalid ?? Boolean(error);
+    const resolvedErrorId = errorId ?? (id ? `${id}-error` : undefined);
+    const describedByIds =
+      [describedBy, isInvalid && error ? resolvedErrorId : undefined]
+        .filter(Boolean)
+        .join(" ") || undefined;
+
     return (
-      <textarea
-        ref={ref}
-        className={cn(
-          "flex w-full rounded-md px-3 py-2 text-sm resize-none",
-          "bg-white/5 border border-primary/20 text-foreground",
-          "placeholder:text-muted-foreground",
-          "focus:outline-hidden focus:ring-2 focus:ring-primary/40 focus:border-primary",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "transition-colors duration-200",
-          className
-        )}
-        {...props}
-      />
+      <>
+        <textarea
+          ref={ref}
+          id={id}
+          aria-invalid={isInvalid || undefined}
+          aria-describedby={describedByIds}
+          className={cn(
+            "focus-ring flex w-full rounded-md px-3 py-2 text-sm resize-none",
+            "bg-white/5 border text-foreground",
+            "placeholder:text-muted-foreground",
+            "focus:border-primary",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            "transition-colors duration-200",
+            isInvalid
+              ? "border-destructive focus:border-destructive"
+              : "border-primary/20",
+            className
+          )}
+          {...props}
+        />
+        {error ? (
+          <p id={resolvedErrorId} className="mt-1.5 text-xs text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </>
     );
   }
 );

--- a/frontend/src/hooks/useModalA11y.ts
+++ b/frontend/src/hooks/useModalA11y.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+
+/**
+ * Shared modal accessibility side-effects for hand-rolled dialogs:
+ *
+ * 1. **Focus restore** (WCAG 2.4.3) — captures the element that had focus when
+ *    the dialog opened and returns focus to it on close/unmount, so keyboard
+ *    users aren't dropped at the top of the document.
+ * 2. **Background scroll lock** — sets `overflow: hidden` on `<body>` while the
+ *    dialog is open so the page behind it can't scroll, restoring the previous
+ *    value on close.
+ *
+ * Call this BEFORE any effect that moves initial focus into the dialog, so the
+ * captured `activeElement` is still the triggering control rather than a field
+ * inside the dialog.
+ */
+export function useModalA11y(open: boolean): void {
+  useEffect(() => {
+    if (!open) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      // Only restore focus if it's still safe to do so (element in the DOM).
+      if (previouslyFocused && typeof previouslyFocused.focus === "function") {
+        previouslyFocused.focus();
+      }
+    };
+  }, [open]);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,15 +19,21 @@
     --accent-foreground: 210 40% 98%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
+    /* Decorative hairline (subtle). Structural boundaries (panels, tables)
+       should use the stronger --border-strong token below. */
     --border: 191 100% 50% / 0.15;
+    --border-strong: 191 100% 50% / 0.28;
     --input: 191 100% 50% / 0.15;
     --ring: 191 100% 50%;
     --radius: 0.75rem;
   }
 
-  * {
-    @apply border-border;
-  }
+  /* NOTE: the previous `* { border-color: … }` universal rule was dropped.
+     It forced the cyan hairline color onto every element, so anything that
+     later received a `border` width picked up an unintended cyan edge. Every
+     border/divide in the app already supplies its own color (via `border-…`,
+     `divide-…`, or the `border-border` token), so no universal default is
+     needed and borders are now predictable to reason about (#13). */
 
   html {
     color-scheme: dark;
@@ -35,18 +41,88 @@
 
   body {
     @apply bg-background text-foreground;
-    background: linear-gradient(135deg, #0d0d2b 0%, #1a0a3d 100%);
-    background-attachment: fixed;
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
       Roboto, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Dynamic viewport units so the last row of content is never hidden
+       behind the mobile browser chrome. Plain vh kept as a fallback. */
     min-height: 100vh;
+    min-height: 100dvh;
     margin: 0;
+  }
+
+  /* Paint the app gradient on a fixed layer instead of using
+     `background-attachment: fixed`, which janks / is ignored on iOS Safari.
+     A pinned pseudo-element renders identically across engines with no
+     per-scroll-frame repaint cost. */
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(135deg, #0d0d2b 0%, #1a0a3d 100%);
   }
 
   #root {
     min-height: 100vh;
+    min-height: 100dvh;
+  }
+
+  /* Respect the user's reduced-motion preference across the whole system:
+     hover lifts, glow pulses, ring spins, transitions and spinners are all
+     neutralized (WCAG 2.3.3). Loading spinners stay perceivable via the
+     opacity pulse defined below. */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+
+    /* Keep spinners perceivable without rotation. */
+    .animate-spin {
+      animation: reduced-motion-pulse 1.2s ease-in-out infinite !important;
+    }
+  }
+
+  @keyframes reduced-motion-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+  }
+}
+
+@layer utilities {
+  /* Dynamic-viewport overrides so full-height measures account for the
+     retractable mobile browser chrome. dvh is supported in all current
+     Firefox/Chrome/Safari/Edge; the plain vh line is the fallback. */
+  .min-h-screen {
+    min-height: 100vh;
+    min-height: 100dvh;
+  }
+
+  .h-screen {
+    height: 100vh;
+    height: 100dvh;
+  }
+
+  .max-h-screen {
+    max-height: 100vh;
+    max-height: 100dvh;
+  }
+
+  /* Single, consistent keyboard-focus ring reused by inputs and hand-rolled
+     dialog buttons so focus behavior matches the Button component. */
+  .focus-ring {
+    @apply focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background;
   }
 }
 
@@ -55,9 +131,28 @@
     background: rgba(255, 255, 255, 0.05);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(0, 212, 255, 0.15);
+    border: 1px solid hsl(var(--border-strong));
     border-radius: 0.75rem;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+
+  /* Solid fallback where backdrop-filter is unsupported/disabled, so panels
+     never collapse to a near-transparent 5% white over the gradient. */
+  @supports not (
+    (backdrop-filter: blur(12px)) or (-webkit-backdrop-filter: blur(12px))
+  ) {
+    .glass-card {
+      background: rgba(20, 20, 54, 0.92);
+    }
+  }
+
+  /* Lower the blur radius on small screens where stacking blurred surfaces
+     is GPU-heavy and janks scroll on mid/low-end phones. */
+  @media (max-width: 640px) {
+    .glass-card {
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
   }
 
   .glow-cyan {
@@ -86,9 +181,18 @@
     transition: all 0.2s ease;
   }
 
-  .btn-primary:hover {
+  /* Hover lift only on devices that actually hover, so touch users don't get
+     a "stuck hover" and the glow isn't the sole affordance on tap. */
+  @media (hover: hover) and (pointer: fine) {
+    .btn-primary:hover {
+      box-shadow: 0 0 20px rgba(0, 212, 255, 0.5);
+      transform: translateY(-1px);
+    }
+  }
+
+  /* Press feedback for touch (and mouse) since there's no hover on touch. */
+  .btn-primary:active {
     box-shadow: 0 0 20px rgba(0, 212, 255, 0.5);
-    transform: translateY(-1px);
   }
 
   .input-axiam {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -378,7 +378,7 @@ export function DashboardPage() {
           </CardHeader>
           <CardContent>
             <div
-              className="grid grid-cols-3 gap-3"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
               role="list"
               aria-label="Quick navigation actions"
             >


### PR DESCRIPTION
## Summary

Applies the findings from [`claude_dev/AXIAM-frontend-audit.md`](claude_dev/AXIAM-frontend-audit.md) to the React admin UI (`frontend/src`). The audit was written against the built design-system bundle; each finding was mapped back to its component/CSS source. No open issue tracks this audit, so this PR references the audit document itself.

## Changes

### Accessibility
- **#1** Global `prefers-reduced-motion` guard in `index.css`; loading spinners degrade to an opacity pulse instead of rotation.
- **#3** New shared `useModalA11y` hook — restores focus to the triggering element on close and locks background scroll while open — wired into `ConfirmDialog`, `FormDialog`, `SecretRevealModal`, `UserSearchDialog`.
- **#2** `Input` / `Textarea` gain `error` / `invalid` props that set `aria-invalid`, wire `aria-describedby` to an inline error node, and apply a destructive border.
- **#4** Standardized a single `.focus-ring` (`focus-visible` ring + offset) across inputs, search, and hand-rolled dialog buttons.
- **#7** `ToggleField` control enlarged to 20px with a larger label target.
- **#8** `DataTable` headers get `scope="col"`; decorative empty-state glyph is `aria-hidden`.
- **#9** `SearchInput` accepts an explicit `label` instead of relying on the placeholder as its only accessible name.
- **#10** `Button` gains a 44px `icon-touch` size and `active:` press feedback.
- **#15** `StatusBadge` adds a distinct per-state SVG icon (`aria-hidden`) as a non-color cue, keeping the text label as the sole matchable name.

### Cross-browser / mobile
- **#16** Gradient painted on a fixed `body::before` layer instead of `background-attachment: fixed` (iOS Safari jank).
- **#17** Dynamic-viewport units (`dvh`) for full-height utilities and dialog max-heights so content isn't hidden behind mobile browser chrome.
- **#18** Touch press feedback via `active:` states; hover lift gated to hover-capable pointers.
- **#19** `glass-card` blur radius reduced on small screens for GPU perf.

### UI/UX & consistency
- **#5** `glass-card` solid `@supports` fallback when `backdrop-filter` is unavailable.
- **#6 / #13** Stronger structural borders (`--border-strong` token, `white/10` dividers) and removal of the universal cyan `border-color` rule so borders are predictable (verified safe — every border/divide already supplies its own color).
- **#11 / #12 / #14** `DataTable` stronger row hover, opt-in error slot with retry, and opt-in sortable headers with `aria-sort`.
- **#20** Canonical Dashboard quick-actions grid made responsive (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`).

## Testing
- **Unit tests: 641 pass** (up from 624 — 17 new tests added; no coverage reduced) covering input error wiring, modal focus/scroll-lock behavior, `DataTable` scope/error/sort, `StatusBadge` exact-text invariant, `SearchInput` label, `ToggleField` sizing, and `Button` variants.
- `tsc -b`, `oxlint`, and `vite build` are clean.
- Visual smoke test in Chromium at 1280px and 375px (with reduced-motion) confirmed the gradient layer, glass cards, focus rings, and responsive layout render correctly.
- **Playwright e2e could not be run in the sandbox** (no Docker → no backend stack). All 109 specs were confirmed to still parse and were statically audited against the DOM changes. The one real risk — `tenants.spec.ts` asserting `getByText("Active", { exact: true })` — is covered: `StatusBadge` uses SVG icons (no text content), and a unit test now asserts the badge's `textContent` is exactly `"Active"`. The e2e suite should be run in CI as a final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HySgRSKJyq56aXNiVXq2EJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HySgRSKJyq56aXNiVXq2EJ)_