### PR TITLE
ci(release): build both arches + clear Trivy HIGH/CRITICAL gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,15 @@ jobs:
       fail-fast: false
       matrix:
         image: [server, frontend]
+        # `platform` MUST be its own matrix dimension so the build fans out to
+        # the full cross product image × platform = 4 jobs (server/frontend ×
+        # amd64/arm64). If the platforms live only under `include:` (with no
+        # base `platform` key), GitHub treats arch/runner as *added* values and
+        # the second include entry overwrites the first on every image combo —
+        # collapsing the matrix to arm64-only and silently dropping amd64. The
+        # `include:` block below then just attaches arch+runner to each existing
+        # platform combo (matching by the original `platform` value).
+        platform: [linux/amd64, linux/arm64]
         include:
           - platform: linux/amd64
             arch: amd64

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -5,5 +5,12 @@
 # DL3008: Pin versions in apt get install — intentionally not pinned because
 #         the build uses digest-pinned base images; apt versions should float
 #         within the pinned base to pick up security patches.
+# DL3017: Do not use apk upgrade — deliberately used in Dockerfile.frontend to
+#         pull Alpine security fixes the upstream nginx-unprivileged image lags
+#         behind (the digest is already the newest tag, so the CVEs can only be
+#         cleared at build time). Same "float patches within a pinned base"
+#         rationale as DL3008 above; the D-06 Trivy HIGH/CRITICAL gate is the
+#         real backstop that proves the resulting image is clean.
 ignore:
   - DL3008
+  - DL3017

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -28,6 +28,20 @@ RUN npm run build
 # ---------------------------------------------------------------------------
 FROM nginxinc/nginx-unprivileged:1.29-alpine@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6
 
+# ---------------------------------------------------------------------------
+# Patch OS packages before finalizing (D-06 Trivy HIGH/CRITICAL gate).
+# ---------------------------------------------------------------------------
+# The upstream nginx-unprivileged image lags Alpine security releases, so its
+# bundled curl/libcurl, libcrypto3/libssl3, libexpat and libxml2 ship fixable
+# HIGH/CRITICAL CVEs (e.g. CVE-2026-45447 openssl UAF, CVE-2026-6732 libxml2 DoS,
+# the libexpat CVE-2026-5640x set) that the digest pin cannot avoid — it is
+# already the newest 1.29-alpine tag. `apk upgrade` pulls the patched packages
+# from the pinned Alpine 3.23 branch at build time so the scanned image is clean
+# on BOTH architectures. Must run as root (the base image's default user is the
+# unprivileged 101); the final `USER 101` below restores the non-root guarantee.
+USER root
+RUN apk upgrade --no-cache
+
 # Copy built assets from builder
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -133,7 +133,7 @@ RUN set -eux; \
 # ---------------------------------------------------------------------------
 # nonroot = UID 65532 (username "nonroot") — no shell, no package manager.
 # cc variant includes: glibc, libgcc1, libssl3, libstdc++6, ca-certificates.
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:bd2899c12b335c827750ccf2359879eab09c09b206023dcebea408947d54127c
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:66aa873a4a14fb164aa01296058efd8253744606d72715e45acface073359faa
 
 LABEL org.opencontainers.image.title="axiam-server" \
       org.opencontainers.image.description="AXIAM — Access eXtended Identity and Authorization Management" \


### PR DESCRIPTION
The Release workflow never produced images: the build-images matrix put
platform/arch/runner only under `include:` with no base `platform` key, so
GitHub treated arch/runner as added values and the second include entry
(arm64) overwrote the first (amd64) on every image combo. The matrix
collapsed to two arm64-only jobs — amd64 was silently never built — and both
arm64 jobs then failed the D-06 Trivy gate on fixable HIGH/CRITICAL CVEs,
skipping merge/sign/release.

Fixes:
- release.yml: promote `platform` to a real matrix dimension so the build
  fans out to the full image × platform cross product (4 jobs); `include:`
  now only attaches arch+runner to each platform combo.
- Dockerfile.server: bump distroless/cc-debian12:nonroot digest
  bd2899c (debian 12.14) -> 66aa873 (debian 12.15), which clears
  CVE-2026-45447 (libssl3 OpenSSL PKCS7_verify UAF). Verified 0 findings on
  both amd64 and arm64 with Trivy 0.70.0 (HIGH,CRITICAL, --ignore-unfixed).
- Dockerfile.frontend: `apk upgrade --no-cache` (as root, then back to USER
  101) to patch curl/libcurl, libcrypto3/libssl3, libexpat and libxml2 —
  the pinned nginx-unprivileged:1.29-alpine is already the newest tag, so
  these Alpine fixes can only be pulled at build time.
- .hadolint.yaml: ignore DL3017 for the intentional apk upgrade, same
  float-patches-within-a-pinned-base rationale as the existing DL3008 entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016C7fV3sKEULpdM9pvnrNre