### PR TITLE
fix(release): unblock the 1.0.0-alpha release — aarch64 apt resilience + OpenAPI version drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,34 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
 
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+        shell: bash
+        # The aarch64 leg runs on the native `ubuntu-24.04-arm` runner, whose
+        # apt sources point at ports.ubuntu.com — that mirror is intermittently
+        # unreachable from the runner (IPv6 "network unreachable", IPv4
+        # timeouts), which fails the release build at `apt-get install`. Make it
+        # resilient without changing the installed package set:
+        #   1. Force IPv4 (the IPv6 endpoints are consistently unreachable).
+        #   2. Prefer Azure's in-network ports mirror when the sources use the
+        #      canonical one (no-op on amd64, which uses archive.ubuntu.com).
+        #   3. Retry apt update+install with backoff so a transient mirror hiccup
+        #      does not fail the tag build.
+        run: |
+          set -euo pipefail
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+          sudo sed -i 's|http://ports.ubuntu.com/ubuntu-ports|http://azure.ports.ubuntu.com/ubuntu-ports|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          for attempt in 1 2 3 4 5; do
+            if sudo apt-get update && sudo apt-get install -y \
+              protobuf-compiler libxml2-dev libxmlsec1-dev libxmlsec1-openssl; then
+              echo "apt install succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            echo "::warning::apt install attempt ${attempt} failed; retrying in $((attempt * 15))s"
+            sudo apt-get clean || true
+            sleep "$((attempt * 15))"
+          done
+          echo "::error::apt-get failed to install build dependencies after 5 attempts"
+          exit 1
 
       - name: Build release binary
         run: cargo build --release -p axiam-server

--- a/crates/axiam-api-rest/src/openapi.rs
+++ b/crates/axiam-api-rest/src/openapi.rs
@@ -9,7 +9,11 @@ use crate::handlers;
     info(
         title = "AXIAM API",
         description = "Access eXtended Identity and Authorization Management — REST API",
-        version = "1.0.0-beta",
+        // Track the crate/workspace version automatically so the OpenAPI
+        // `info.version` never drifts from Cargo.toml (axiam-api-rest inherits
+        // `version.workspace = true`). Previously a hardcoded literal, which
+        // silently drifted from the committed sdks/openapi.json on a version bump.
+        version = env!("CARGO_PKG_VERSION"),
         license(name = "Apache-2.0"),
     ),
     paths(

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -50,7 +50,7 @@ describe("Sidebar", () => {
     expect(screen.getByRole("link", { name: /Dashboard/ })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Users/ })).toBeInTheDocument();
     expect(screen.getByText("AXIAM")).toBeInTheDocument();
-    expect(screen.getByText("AXIAM v1.0.0-beta")).toBeInTheDocument();
+    expect(screen.getByText("AXIAM v1.0.0-alpha")).toBeInTheDocument();
   });
 
   it("marks the current route's link as active with aria-current", () => {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -287,7 +287,7 @@ export function Sidebar({ onClose, mobile = false }: SidebarProps) {
       {/* Footer */}
       <div className="px-5 py-3 border-t border-primary/10">
         <p className="text-[10px] text-muted-foreground/50">
-          AXIAM v1.0.0-beta
+          AXIAM v1.0.0-alpha
         </p>
       </div>
     </aside>


### PR DESCRIPTION
Two independent failures block the `axiam-server/v1.0.0-alpha` release; this fixes both.

## 1. aarch64 binary build — `apt-get` can't reach ports.ubuntu.com

The **Release** workflow's `build-binary` job fails on its **aarch64** leg ([run 29479387837](https://github.com/ilpanich/axiam/actions/runs/29479387837/job/87563829941)). It's **not a code bug** — the `Install build dependencies` step can't reach `ports.ubuntu.com` from the native `ubuntu-24.04-arm` runner (IPv6 "network unreachable", IPv4 timeouts), so apt exits 100. The amd64 leg on `ubuntu-latest` (which uses `archive.ubuntu.com`) is unaffected.

Hardened the shared install step **without changing the installed package set**:
- **Force IPv4** (the IPv6 endpoints are consistently unreachable).
- **Rewrite `ports.ubuntu.com` → `azure.ports.ubuntu.com`** (Azure's in-network mirror; a no-op on amd64).
- **Retry** apt update+install up to 5× with backoff.

All three are safe no-ops on the amd64 leg that already passes.

## 2. OpenAPI Drift Gate — `info.version` out of sync

The **OpenAPI Drift Gate** fails on the same tag ([run 29479387871](https://github.com/ilpanich/axiam/actions/runs/29479387871/job/87563544598)). The only diff:

```
<     "version": "1.0.0-alpha"   (committed sdks/openapi.json — matches Cargo.toml + the tag)
>     "version": "1.0.0-beta"    (fresh --dump-openapi)
```

`crates/axiam-api-rest/src/openapi.rs` still hardcoded the old `1.0.0-beta` literal — the `0.1.0 → 1.0.0-beta → 1.0.0-alpha` version moves updated `Cargo.toml` and the committed spec but missed it (and the frontend footer).

- `openapi.rs`: replace the hardcoded literal with **`version = env!("CARGO_PKG_VERSION")`**. Since `axiam-api-rest` inherits `version.workspace = true`, `info.version` now tracks the workspace version automatically and **can't drift on a future bump** — closing this recurring class of failure.
- frontend `Sidebar` footer + its test: `1.0.0-beta → 1.0.0-alpha` (cosmetic; they were self-consistent so no test failed, but the UI showed the wrong version).

**Verified locally**: `cargo build -p axiam-server --no-default-features` + `--dump-openapi` yields `info.version` `1.0.0-alpha`, and `diff` against the committed `sdks/openapi.json` is **empty (zero drift)**.

## Note on releasing

GitHub runs a tag's workflow (and the drift gate) from **that tag's own tree**. After this merges, re-point/re-cut `axiam-server/v1.0.0-alpha` onto a commit that includes these fixes to get a green release. (The Release workflow is tag-triggered, so the aarch64 step itself is only exercised on the tag, not on this PR — this PR's CI just re-runs the unchanged code plus the drift gate, which is now green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)