### PR TITLE
docs+ci: badges, free CI disk space, mark phases 17–18 complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,11 @@ jobs:
       AXIAM__AMQP__URL: "amqp://localhost:5672"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          df -h
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (2026-03-27)
         with:
           toolchain: stable

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo docker image prune --all --force || true
+          df -h
+
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # stable (2026-03-27)
         with:
           toolchain: stable

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # AXIAM
 
+[![CI](https://github.com/ilpanich/axiam/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ilpanich/axiam/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/ilpanich/axiam/badge.svg?branch=main)](https://coveralls.io/github/ilpanich/axiam?branch=main)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 **Access eXtended Identity and Authorization Management**
 
@@ -86,7 +88,7 @@ AXIAM targets compliance with:
 
 ## Development Progress
 
-The project follows a structured roadmap of **64 tasks across 16 phases**:
+The project follows a structured roadmap of **64 tasks across 19 phases**:
 
 | Phase | Focus | Status |
 |-------|-------|--------|
@@ -107,8 +109,8 @@ The project follows a structured roadmap of **64 tasks across 16 phases**:
 | Phase 14 | Advanced MFA | Done |
 | Phase 15 | Admin frontend | Done |
 | Phase 16 | Docker & Kubernetes | Done |
-| Phase 17 | SDKs (Rust, TS, Python, Java, C#, PHP, Go) | Planned |
-| Phase 18 | Security audit, compliance, docs | Planned |
+| Phase 17 | SDKs (Rust, TS, Python, Java, C#, PHP, Go) | Done |
+| Phase 18 | Security audit, compliance, docs | Done |
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Release-prep for `1.0.0-alpha2`.

- **Free disk space** step added as the first step of the heavy Rust jobs — the `test` job (`ci.yml`) and the `cargo-llvm-cov` job (`coverage.yml`). This is the direct fix for the recent CI flakes where RabbitMQ raised a disk-space alarm (`Free bytes: 25047040. Limit: 50000000` → publishers blocked) and `cargo-llvm-cov` ran out of space. Dependency-free (removes preinstalled dotnet/android/ghc/boost + `docker image prune`).
- **README badges**: CI, Coveralls, Apache-2.0 (replaces the lone Coveralls badge). No crates.io badge (server crates aren't published; releases ship Docker images to ghcr.io).
- **Roadmap**: marked **Phase 17 (SDKs)** and **Phase 18 (security audit)** as Done in the "Development Progress" table, and corrected the header count to match the table's 19 phase rows. Verified the existing `## Client SDKs` table links all seven SDK repos with correct package coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5foj8NVCeS9qUW94kJ13g

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5foj8NVCeS9qUW94kJ13g)_