### PR TITLE
chore(release): bump version to 1.0.0-alpha3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha3] - 2026-07-16
+
+Third alpha. Build/release tuning and project-infrastructure changes only. No
+server runtime or API behavior changes — the OpenAPI specification is
+byte-for-byte identical apart from its `info.version` string.
+
+### Added
+
+- **Public marketing & documentation website**, deployed to GitHub Pages.
+
+### Changed
+
+- **Release build profile** — added `[profile.release]` to the workspace-root
+  `Cargo.toml`, tuned for execution speed first and footprint second:
+  `opt-level = 3`, `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"`.
+  Cargo only honors profiles at the workspace root, so this single section
+  covers `axiam-server` and every crate it links. `panic = "abort"` is
+  intentionally omitted to preserve per-request panic isolation on the
+  long-running REST/gRPC/AMQP server. Release builds are slower in exchange for
+  faster runtime.
+
 ## [1.0.0-alpha2] - 2026-07-16
 
 Second alpha. Adds the SDK declarative-authorization contract and release-prep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-amqp"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "axiam-audit",
  "axiam-authz",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-api-grpc"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "axiam-auth",
  "axiam-authz",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-api-rest"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "actix-cors",
  "actix-governor",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-audit"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "actix-web",
  "axiam-auth",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-auth"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "aes-gcm 0.11.0",
  "argon2",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-authz"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "axiam-core",
  "axiam-db",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-core"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "chrono",
  "serde",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-db"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "aes-gcm 0.11.0",
  "argon2",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-email"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "axiam-core",
  "chrono",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-federation"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "axiam-auth",
  "axiam-core",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-oauth2"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "axiam-auth",
  "axiam-core",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-pki"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "aes-gcm 0.11.0",
  "axiam-core",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "axiam-server"
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "1.0.0-alpha2"
+version = "1.0.0-alpha3"
 edition = "2024"
 authors = ["AXIAM Contributors"]
 license = "Apache-2.0"

--- a/frontend/src/components/layout/Sidebar.test.tsx
+++ b/frontend/src/components/layout/Sidebar.test.tsx
@@ -50,7 +50,7 @@ describe("Sidebar", () => {
     expect(screen.getByRole("link", { name: /Dashboard/ })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Users/ })).toBeInTheDocument();
     expect(screen.getByText("AXIAM")).toBeInTheDocument();
-    expect(screen.getByText("AXIAM v1.0.0-alpha2")).toBeInTheDocument();
+    expect(screen.getByText("AXIAM v1.0.0-alpha3")).toBeInTheDocument();
   });
 
   it("marks the current route's link as active with aria-current", () => {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -287,7 +287,7 @@ export function Sidebar({ onClose, mobile = false }: SidebarProps) {
       {/* Footer */}
       <div className="px-5 py-3 border-t border-primary/10">
         <p className="text-[10px] text-muted-foreground/50">
-          AXIAM v1.0.0-alpha2
+          AXIAM v1.0.0-alpha3
         </p>
       </div>
     </aside>

--- a/k8s/frontend/deployment.yml
+++ b/k8s/frontend/deployment.yml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: axiam-frontend
           # Pin a concrete tag, not :latest (KSV-0013). Update per release.
-          image: ghcr.io/OWNER/frontend:1.0.0-alpha2
+          image: ghcr.io/OWNER/frontend:1.0.0-alpha3
           ports:
             - name: http
               containerPort: 8080

--- a/k8s/server/deployment.yml
+++ b/k8s/server/deployment.yml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: axiam-server
           # Pin a concrete tag, not :latest (KSV-0013). Update per release.
-          image: ghcr.io/OWNER/server:1.0.0-alpha2
+          image: ghcr.io/OWNER/server:1.0.0-alpha3
           ports:
             - name: http
               containerPort: 8090

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -9,7 +9,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.0-alpha2"
+    "version": "1.0.0-alpha3"
   },
   "paths": {
     "/.well-known/openid-configuration": {


### PR DESCRIPTION
## Summary

Prepares the repository to be tagged as **`v1.0.0-alpha3`**. This bumps every place the release version appears, **in lockstep**, so the OpenAPI drift gate stays green when the tag is cut.

The `sdks/openapi.json` `info.version` is sourced from `env!("CARGO_PKG_VERSION")`, so once the crate version becomes `1.0.0-alpha3` a fresh `--dump-openapi` emits `1.0.0-alpha3`; the committed spec is updated to match so `sdk-openapi-drift.yml` does not fail.

## Changes (`1.0.0-alpha2` → `1.0.0-alpha3`)

| File | Change |
|---|---|
| `Cargo.toml` | `workspace.package.version` — the source of truth, inherited by all 13 crates |
| `Cargo.lock` | the 13 workspace-member `version` entries |
| `sdks/openapi.json` | `info.version` (the drift-gate-relevant field) |
| `k8s/server/deployment.yml`, `k8s/frontend/deployment.yml` | image tags |
| `frontend/.../Sidebar.tsx` + `Sidebar.test.tsx` | footer version string and its assertion, bumped together |
| `CHANGELOG.md` | new `[1.0.0-alpha3]` section |

The `CHANGELOG` entry records the two changes since alpha2 that this release captures: the public marketing/docs website (#191) and the speed-optimized release build profile (#192).

## Notes

- **No server runtime or API behavior changes.** The OpenAPI specification is byte-for-byte identical apart from its `info.version` string, so the drift `diff` passes.
- The SDK repositories need no change — only the version string moves, which they re-sync from `sdks/openapi.json` / `CONTRACT.md` on their own cadence.
- After merge, the `v1.0.0-alpha3` tag can be cut from `main` (the release workflow's `verify-tag-on-main` gate requires the bump to be on `main` first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nAiMos1y9LaRc2u6Csf8p

---
_Generated by [Claude Code](https://claude.ai/code/session_011nAiMos1y9LaRc2u6Csf8p)_