### PR TITLE
feat(website): add framework-guard example to each SDK detail page

### DIFF
--- a/website/src/data.ts
+++ b/website/src/data.ts
@@ -33,6 +33,15 @@ let axiam = AxiamClient::builder()
 
 axiam.login(&email, &password).await?;
 let ok = axiam.can("read", "doc:1").await?;`,
+    guardLabel: "Guard by macro",
+    guardExample: `use axiam_sdk::require;
+
+// The attribute macro runs the authorization check before the
+// handler body — a 403 short-circuits automatically.
+#[require("read", "doc:{id}")]
+async fn get_doc(path: web::Path<String>) -> impl Responder {
+    HttpResponse::Ok().body("secret document")
+}`,
   },
   {
     id: "typescript",
@@ -61,6 +70,18 @@ const axiam = new AxiamClient({
 
 await axiam.login(email, password);
 const ok = await axiam.can('read', 'doc:1');`,
+    guardLabel: "Guard by decorator (NestJS)",
+    guardExample: `import { RequirePermission } from 'axiam-sdk/nest';
+
+@Controller('docs')
+export class DocsController {
+  // The decorator guards the route — the check runs before the method.
+  @Get(':id')
+  @RequirePermission('read', 'doc:{id}')
+  findOne(@Param('id') id: string) {
+    return this.docs.find(id);
+  }
+}`,
   },
   {
     id: "python",
@@ -86,6 +107,17 @@ with AxiamClient(base_url="https://iam.acme.dev",
                  tenant_slug="acme") as axiam:
     axiam.login(email, password)
     ok = axiam.can("resource:read", "doc:1")`,
+    guardLabel: "Guard by dependency (FastAPI)",
+    guardExample: `from fastapi import Depends, FastAPI
+from axiam_sdk.fastapi import requires
+
+app = FastAPI()
+
+# The dependency enforces the check before the handler runs.
+@app.get("/docs/{doc_id}")
+def read_doc(doc_id: str,
+             _=Depends(requires("read", "doc:{doc_id}"))):
+    return {"id": doc_id}`,
   },
   {
     id: "java",
@@ -113,6 +145,18 @@ with AxiamClient(base_url="https://iam.acme.dev",
 
 axiam.login(email, password);
 boolean ok = axiam.can("read", "doc:1");`,
+    guardLabel: "Guard by annotation",
+    guardExample: `import io.github.ilpanich.axiam.RequirePermission;
+
+@RestController
+class DocController {
+    // The annotation guards the endpoint before it is invoked.
+    @GetMapping("/docs/{id}")
+    @RequirePermission(action = "read", resource = "doc:{id}")
+    Doc getDoc(@PathVariable String id) {
+        return service.find(id);
+    }
+}`,
   },
   {
     id: "csharp",
@@ -139,6 +183,16 @@ boolean ok = axiam.can("read", "doc:1");`,
 
 await axiam.LoginAsync(email, password);
 bool ok = await axiam.CanAsync("read", "doc:1");`,
+    guardLabel: "Guard by attribute",
+    guardExample: `[ApiController]
+[Route("docs")]
+public class DocsController : ControllerBase
+{
+    // The attribute guards the action before it executes.
+    [HttpGet("{id}")]
+    [AxiamAuthorize("read", "doc:{id}")]
+    public IActionResult Get(string id) => Ok(_docs.Find(id));
+}`,
   },
   {
     id: "php",
@@ -164,6 +218,18 @@ $axiam = new AxiamClient([
 
 $axiam->login($email, $password);
 $ok = $axiam->can('read', 'doc:1');`,
+    guardLabel: "Guard by attribute",
+    guardExample: `use Axiam\\Attributes\\RequirePermission;
+
+class DocController
+{
+    // The PHP 8 attribute guards the action before it runs.
+    #[RequirePermission('read', 'doc:{id}')]
+    public function show(string $id): Response
+    {
+        return response()->json(Doc::find($id));
+    }
+}`,
   },
   {
     id: "go",
@@ -190,6 +256,13 @@ $ok = $axiam->can('read', 'doc:1');`,
 
 client.Login(ctx, email, password)
 ok, _ := client.Can(ctx, "read", "doc:1")`,
+    guardLabel: "Guard by middleware",
+    guardExample: `mux := http.NewServeMux()
+
+// Require wraps the handler with an authorization check that
+// runs before it — a denied request never reaches getDoc.
+mux.Handle("GET /docs/{id}",
+    axiam.Require("read", "doc:{id}")(http.HandlerFunc(getDoc)))`,
   },
 ];
 

--- a/website/src/pages/SdkDetail.tsx
+++ b/website/src/pages/SdkDetail.tsx
@@ -5,6 +5,60 @@ interface SdkDetailProps {
   go: (page: Page) => void;
 }
 
+const dot = (background: string) => (
+  <span style={{ width: 11, height: 11, borderRadius: "50%", background }} />
+);
+
+/** A macOS-style "terminal" card with a labelled title bar and a code body. */
+function TerminalCard({ label, code }: { label: string; code: string }) {
+  return (
+    <div
+      className="glass-card"
+      style={{
+        borderRadius: 14,
+        overflow: "hidden",
+        border: "1px solid rgba(0,212,255,.2)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "13px 18px",
+          borderBottom: "1px solid rgba(0,212,255,.12)",
+          background: "rgba(255,255,255,.03)",
+        }}
+      >
+        {dot("#ff5f56")}
+        {dot("#ffbd2e")}
+        {dot("#27c93f")}
+        <span
+          style={{
+            marginLeft: 8,
+            font: "12px ui-monospace,Menlo,monospace",
+            color: "#94a3b8",
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: 22,
+          fontSize: 13.5,
+          lineHeight: 1.75,
+          color: "#cbd5e1",
+          overflow: "auto",
+        }}
+      >
+        {code}
+      </pre>
+    </div>
+  );
+}
+
 export default function SdkDetail({ sdk, go }: SdkDetailProps) {
   return (
     <div style={{ maxWidth: 1000, margin: "0 auto", padding: "40px 40px 90px" }}>
@@ -174,70 +228,12 @@ export default function SdkDetail({ sdk, go }: SdkDetailProps) {
         </div>
       </div>
 
-      <div
-        className="glass-card"
-        style={{
-          borderRadius: 14,
-          overflow: "hidden",
-          border: "1px solid rgba(0,212,255,.2)",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-            padding: "13px 18px",
-            borderBottom: "1px solid rgba(0,212,255,.12)",
-            background: "rgba(255,255,255,.03)",
-          }}
-        >
-          <span
-            style={{
-              width: 11,
-              height: 11,
-              borderRadius: "50%",
-              background: "#ff5f56",
-            }}
-          />
-          <span
-            style={{
-              width: 11,
-              height: 11,
-              borderRadius: "50%",
-              background: "#ffbd2e",
-            }}
-          />
-          <span
-            style={{
-              width: 11,
-              height: 11,
-              borderRadius: "50%",
-              background: "#27c93f",
-            }}
-          />
-          <span
-            style={{
-              marginLeft: 8,
-              font: "12px ui-monospace,Menlo,monospace",
-              color: "#94a3b8",
-            }}
-          >
-            quickstart · {sdk.name}
-          </span>
-        </div>
-        <pre
-          style={{
-            margin: 0,
-            padding: 22,
-            fontSize: 13.5,
-            lineHeight: 1.75,
-            color: "#cbd5e1",
-            overflow: "auto",
-          }}
-        >
-          {sdk.quickstart}
-        </pre>
+      <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+        <TerminalCard label={`quickstart · ${sdk.name}`} code={sdk.quickstart} />
+        <TerminalCard
+          label={`${sdk.guardLabel} · ${sdk.name}`}
+          code={sdk.guardExample}
+        />
       </div>
     </div>
   );

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -27,6 +27,13 @@ export interface Sdk {
   blurb: string;
   highlights: string[];
   quickstart: string;
+  /**
+   * A second example showing the declarative framework-guard style idiomatic
+   * to the language — a macro (Rust), annotation (Java), attribute (C#/PHP),
+   * decorator/dependency (TypeScript/Python) or middleware (Go).
+   */
+  guardLabel: string;
+  guardExample: string;
 }
 
 export type PostBlockType = "p" | "h" | "quote";


### PR DESCRIPTION
## Summary

Each SDK detail page on the public website already showed a client-construction **quickstart**. This adds a **second example** demonstrating the declarative framework-guard style idiomatic to each language — showing how to enforce an authorization check at the route boundary, not only imperatively via `can()`.

| SDK | Mechanism | Example |
|-----|-----------|---------|
| Rust | attribute **macro** | `#[require("read", "doc:{id}")]` |
| TypeScript | NestJS **decorator** | `@RequirePermission('read', 'doc:{id}')` |
| Python | FastAPI **dependency** | `Depends(requires("read", "doc:{doc_id}"))` |
| Java | **annotation** | `@RequirePermission(action = "read", resource = "doc:{id}")` |
| C# | **attribute** | `[AxiamAuthorize("read", "doc:{id}")]` |
| PHP | PHP 8 **attribute** | `#[RequirePermission('read', 'doc:{id}')]` |
| Go | net/http **middleware** | `axiam.Require("read", "doc:{id}")(handler)` |

Each example matches the framework guards already listed in that SDK's highlights.

## Changes

- `website/src/types.ts` — add `guardLabel` and `guardExample` to the `Sdk` type.
- `website/src/data.ts` — add a guard example for all seven SDKs.
- `website/src/pages/SdkDetail.tsx` — refactor the terminal-style code card into a reusable `TerminalCard` component and render it twice (quickstart + guard).

## Verification

- `npm run build` (tsc + vite) and `npm run lint` (oxlint) pass.
- Rendered SDK detail pages in a headless browser at desktop and mobile widths — both cards display correctly, no horizontal overflow, no console errors.

This continues the AXIAM public website (deployed to GitHub Pages at https://ilpanich.github.io/axiam/); merging to `main` re-runs `website-publish.yml` and redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DF5knteMfZjVNY6uu18pyJ)_