### PR TITLE
Auto-bump release versions across all repos in mass-tag.sh

### DIFF
--- a/claude_dev/publishing-and-secrets.md
+++ b/claude_dev/publishing-and-secrets.md
@@ -22,9 +22,11 @@ exactly how to create them. All destinations are **free for open-source projects
 > automatically yet (see §8).
 >
 > Consequences you must internalise before releasing anything:
-> - **Tags are now per-repo and plain.** An SDK release is `v1.0.0` **in its own repo** — no
->   more `axiam-rust-sdk/v1.0.0` namespacing, which only existed to disambiguate components
->   inside one repository. The **server** keeps `axiam-server/v1.0.0` in *this* repo.
+> - **Tags are now per-repo and plain — everywhere, including the server.** A release is
+>   `v1.0.0` **in its own repo**; no more `axiam-rust-sdk/v1.0.0` namespacing, and the
+>   server's release workflow was reconciled from the old `axiam-server/v1.0.0` prefix to a
+>   plain `v1.0.0` too (`.github/workflows/release.yml` triggers on `v*`, which does not
+>   match a `axiam-server/…` ref). Tags are per-repo, so `v1.0.0` is unambiguous everywhere.
 > - **Secrets live in the SDK repos**, not here. This repo now needs **zero** publishing
 >   secrets.
 > - **Two flows changed shape**, not just location — C# (§4.6) and PHP (§4.7). Read them.
@@ -321,7 +323,7 @@ Every component is versioned and released **independently** — and now from its
 
 | Repo | Tag you push | What happens |
 |---|---|---|
-| `axiam` | `axiam-server/v1.0.0` | Server **and** frontend images (amd64 + arm64) → GHCR, Trivy-scanned, cosign-signed; `x86_64` + `aarch64` binary tarballs → GitHub Release; server rustdoc + docs index → Pages |
+| `axiam` | `v1.0.0` | Server **and** frontend images (amd64 + arm64) → GHCR, Trivy-scanned, cosign-signed; `x86_64` + `aarch64` binary tarballs → GitHub Release; server rustdoc + docs index → Pages |
 | `axiam-rust-sdk` | `v1.0.0` | crates.io → docs.rs picks it up automatically |
 | `axiam-python-sdk` | `v1.0.0` | PyPI (Trusted Publishing) + API docs → that repo's Pages |
 | `axiam-typescript-sdk` | `v1.0.0` | npm (with provenance) + API docs → that repo's Pages |
@@ -330,28 +332,28 @@ Every component is versioned and released **independently** — and now from its
 | `axiam-php-sdk` | `v1.0.0` | Packagist picks up the tag via its webhook + API docs → that repo's Pages |
 | `axiam-go-sdk` | `v1.0.0` | proxy.golang.org nudge → pkg.go.dev |
 
-`axiam-server/…` ships the **admin-UI (frontend) image too**: the two are deployed as a pair
-(`docker-compose.prod.yml` runs both), so they share a version. Split them only if you ever
-want to ship a UI-only patch.
+The `axiam` release ships the **admin-UI (frontend) image too**: the two are deployed as a
+pair (`docker-compose.prod.yml` runs both), so they share a version. Split them only if you
+ever want to ship a UI-only patch.
 
-The server tag keeps its `axiam-server/` prefix because *this* repo still holds more than one
-releasable thing (server images, binaries, docs). The SDK repos hold exactly one artifact
-each, so a bare `v1.0.0` is unambiguous.
+The server tag is a plain `v1.0.0` (its workflow triggers on `v*`). Tags are per-repo, so
+even though *this* repo holds more than one releasable thing (server images, binaries, docs),
+a single `v1.0.0` tag drives them all — no prefix is needed to disambiguate.
 
 ### Colons are not legal in git tags
 
 A tag like `axiamserver:1.0.0` cannot exist — git's `check-ref-format` rejects `:` (along
 with space, `~`, `^`, `?`, `*`, `[`, `\`). The colon in `ghcr.io/ilpanich/axiam/server:1.0.0`
 belongs to the **Docker image reference**, not the git tag; the release workflow derives it
-from the namespaced git tag automatically (`docker/metadata-action` with `type=match`).
+from the `v1.0.0` git tag automatically (`docker/metadata-action`, stripping the leading `v`).
 
 Example:
 
 ```bash
 # Server (+ admin UI) release — in the axiam repo
 git checkout main && git pull
-git tag -s axiam-server/v1.0.0 -m "AXIAM server v1.0.0"
-git push origin axiam-server/v1.0.0
+git tag -s v1.0.0 -m "AXIAM server v1.0.0"
+git push origin v1.0.0
 
 # Rust SDK release — in the axiam-rust-sdk repo, independently
 cd ../axiam-rust-sdk && git checkout main && git pull
@@ -383,7 +385,7 @@ for last.
 
 1. Repo settings (§3) — Pages, workflow permissions, and the three GitHub environments
    (`pypi`, `production`, `maven-central`).
-2. `axiam`: tag `axiam-server/v1.0.0` → images on GHCR; make the packages public.
+2. `axiam`: tag `v1.0.0` → images on GHCR; make the packages public.
    **This needs no secrets at all.**
 3. `axiam-go-sdk`: tag `v1.0.0` (no secret).
 4. `axiam-php-sdk`: submit to Packagist, tag `v1.0.0` (no secret).

--- a/scripts/mass-tag.sh
+++ b/scripts/mass-tag.sh
@@ -1,28 +1,62 @@
 #!/usr/bin/env bash
-# mass-tag.sh — Create and push a signed release tag across many AXIAM repos.
+# mass-tag.sh — Cut and push a signed release across many AXIAM repos.
 #
 # AXIAM ships as one platform repo plus seven per-language SDK repos, each in
-# its own clone. Cutting a release means putting the SAME tag on the HEAD of
-# the SAME branch in every repo and pushing it so the per-repo release
-# pipelines fire. Doing that by hand, eight times, is tedious and error-prone
-# — this script does it in one pass.
+# its own clone. Cutting a release means, in every selected repo: writing the
+# release version into every file that must carry it, committing that bump, and
+# putting the SAME signed tag on that commit so the per-repo release pipelines
+# fire. Doing that by hand, across eight repos and their many manifests, is
+# tedious and error-prone — this script does it in one pass.
+#
+# THE VERSION IS TAKEN FROM THE TAG. `--tag axiam-server/v1.4.0` and
+# `--tag v1.4.0` both mean "release 1.4.0": the script strips an optional
+# `prefix/` and a leading `v`, then writes 1.4.0 into every version-bearing
+# file of each selected repo before committing and tagging. So preparing a
+# release is just running this script — no manual version edits first.
 #
 # For each selected repo it will, in order:
 #   1. check out the requested branch,
 #   2. optionally pull it fast-forward from origin (--pull),
-#   3. create a SIGNED annotated tag on HEAD, whose message is the repo name
-#      prepended to your message ("<repo> - <message>"),
-#   4. push the branch and then the tag to origin.
+#   3. rewrite the release version everywhere the repo declares it (unless
+#      --no-bump), and commit the change (signed) — skipped when nothing
+#      changed (e.g. Go/PHP derive their version from the tag alone, or the
+#      repo is already at this version),
+#   4. create a SIGNED annotated tag on the resulting HEAD, whose message is
+#      the repo name prepended to your message ("<repo> - <message>"),
+#   5. push the branch and then the tag to origin.
+#
+# What "everywhere the version is declared" means, per repo (see bump_versions):
+#   axiam (platform)   Cargo.toml [workspace.package] version; all axiam-*
+#                      entries in Cargo.lock; sdks/openapi.json info.version
+#                      (the OpenAPI drift gate — the spec is byte-for-byte
+#                      identical apart from this field, so a targeted rewrite
+#                      keeps the gate green with no rebuild; docs/api/openapi.json
+#                      is a symlink to it); the frontend Sidebar version string
+#                      and its test; the two k8s deployment image tags.
+#   axiam-rust-sdk     Cargo.toml package version and the `=`-pinned
+#                      axiam-sdk-macros dependency; axiam-sdk-macros/Cargo.toml.
+#   axiam-python-sdk   pyproject.toml [project].version and the package
+#                      __version__, both in PEP 440 spelling (1.4.0-rc1 -> 1.4.0rc1).
+#   axiam-typescript-sdk  package.json and package-lock.json versions.
+#   axiam-java-sdk     pom.xml project version, bom/pom.xml (project + managed
+#                      axiam-sdk dep), the example's dependency on axiam-sdk,
+#                      and the README install snippets.
+#   axiam-csharp-sdk   the <Version> in both .csproj files.
+#   axiam-php-sdk,     nothing to edit — Composer/Go derive the release version
+#   axiam-go-sdk       from the git tag, so these are tagged as-is.
+# Each SDK's release workflow asserts the pushed tag equals the manifest
+# version; the bump above is what makes that assertion pass.
 #
 # A pre-flight pass validates EVERY selected repo (exists, is a git repo, the
-# branch exists, the tag is not already present locally or on origin) BEFORE
-# anything is tagged, so a bad argument fails fast instead of half-tagging the
-# fleet.
+# branch exists, the tag is not already present locally or on origin, and the
+# current version is discoverable) BEFORE anything is tagged, so a bad argument
+# fails fast instead of half-releasing the fleet.
 #
-# Signing: tags are created with `git tag -s`, which uses whatever signing
-# backend your git is configured with (OpenPGP or SSH — the same one that
-# signs your commits). If signing is not configured, tag creation fails and
-# the script stops; it never pushes an unsigned tag.
+# Signing: tags are created with `git tag -s` and version-bump commits with
+# `git commit -S`, using whatever signing backend your git is configured with
+# (OpenPGP or SSH — the same one that signs your commits). If signing is not
+# configured, tag/commit creation fails and the script stops; it never pushes
+# an unsigned tag.
 #
 # NOTE ON TAG NAMES: the platform repo's release workflow triggers on the
 # namespaced tag `axiam-server/v*`, while every SDK triggers on `v*`. Because
@@ -30,31 +64,36 @@
 # two runs, e.g.:
 #     scripts/mass-tag.sh -r axiam    -b main -t axiam-server/v1.0.0-alpha -m "first alpha release" -p
 #     scripts/mass-tag.sh -r all-sdks -b main -t v1.0.0-alpha              -m "first alpha release" -p
+# Both runs derive the same version (1.0.0-alpha) from their tag.
 #
 # Usage:
 #   scripts/mass-tag.sh --repos <all|all-sdks|name[,name...]> \
 #                       --branch <branch> \
 #                       --tag <tag-name> \
 #                       --message <message> \
-#                       [--pull] [--root <dir>] [--dry-run]
+#                       [--pull] [--no-bump] [--root <dir>] [--dry-run]
 #
 #   -r, --repos    (required) 'all' (platform + 7 SDKs), 'all-sdks' (the 7
 #                  SDKs only), or a comma-separated subset of the known repo
 #                  names below.
 #   -b, --branch   (required) branch to tag; must exist in every selected repo.
-#   -t, --tag      (required) tag name to create (identical across the run).
+#   -t, --tag      (required) tag name to create (identical across the run). The
+#                  release version is derived from it (strip 'prefix/' and 'v').
 #   -m, --message  (required) tag message; the final annotation for each repo
 #                  is "<repo-name> - <message>".
 #   -p, --pull     (optional) fast-forward pull each branch from origin before
-#                  tagging, so the tag lands on the freshest HEAD.
+#                  tagging, so the release lands on the freshest HEAD.
+#       --no-bump  (optional) do NOT edit or commit version strings; just tag
+#                  HEAD as-is (the historical behaviour of this script).
 #       --root DIR (optional) directory that CONTAINS the repo clones as
 #                  siblings. Defaults to the parent of this repository, which
 #                  is correct when all clones sit side by side.
-#   -n, --dry-run  (optional) print every git command instead of running the
-#                  mutating ones (checkout/pull/tag/push). Validation still runs.
+#   -n, --dry-run  (optional) print every mutating action (version edits,
+#                  checkout/pull/commit/tag/push) instead of running it.
+#                  Validation still runs.
 #   -h, --help     show this help and exit.
 #
-# Exit status: 0 if every selected repo was tagged and pushed; non-zero if
+# Exit status: 0 if every selected repo was released and pushed; non-zero if
 # pre-flight validation failed (nothing tagged) or any repo's operations failed.
 
 set -euo pipefail
@@ -88,27 +127,34 @@ TAG=""
 MESSAGE=""
 PULL=false
 DRY_RUN=false
+BUMP=true
 ROOT="$DEFAULT_ROOT"
 
 usage() {
   cat <<'EOF'
-mass-tag.sh — create and push a signed release tag across many AXIAM repos.
+mass-tag.sh — cut and push a signed release across many AXIAM repos.
+
+It derives the release version from the tag (strips a leading 'prefix/' and
+'v'), writes that version into every version-bearing file of each selected
+repo, commits the bump (signed), then tags that commit and pushes.
 
 Usage:
   scripts/mass-tag.sh --repos <all|all-sdks|name[,name...]> \
                       --branch <branch> --tag <tag-name> --message <message> \
-                      [--pull] [--root <dir>] [--dry-run]
+                      [--pull] [--no-bump] [--root <dir>] [--dry-run]
 
   -r, --repos    (required) 'all', 'all-sdks', or a comma-separated subset.
   -b, --branch   (required) branch to tag; must exist in every selected repo.
-  -t, --tag      (required) tag name to create (identical across the run).
+  -t, --tag      (required) tag name to create; the release version is derived
+                 from it (axiam-server/v1.4.0 and v1.4.0 both mean 1.4.0).
   -m, --message  (required) tag message; each tag's annotation is
                  "<repo-name> - <message>".
-  -p, --pull     (optional) fast-forward pull each branch before tagging.
+  -p, --pull     (optional) fast-forward pull each branch before releasing.
+      --no-bump  (optional) skip version edits/commit; tag HEAD as-is.
       --root DIR (optional) directory containing the repo clones as siblings
                  (default: the parent of this repository).
-  -n, --dry-run  (optional) print the git commands instead of running the
-                 mutating ones. Pre-flight validation still runs.
+  -n, --dry-run  (optional) print the mutating actions instead of running them.
+                 Pre-flight validation still runs.
   -h, --help     show this help and exit.
 
 Known repos: axiam (platform) + the seven axiam-<lang>-sdk repos.
@@ -129,6 +175,7 @@ while [[ $# -gt 0 ]]; do
     -t|--tag)     TAG="${2:-}";       shift 2 ;;
     -m|--message) MESSAGE="${2:-}";   shift 2 ;;
     -p|--pull)    PULL=true;          shift ;;
+    --no-bump)    BUMP=false;         shift ;;
     --root)       ROOT="${2:-}";      shift 2 ;;
     -n|--dry-run) DRY_RUN=true;       shift ;;
     -h|--help)    usage; exit 0 ;;
@@ -144,6 +191,29 @@ done
 [[ -n "$TAG"       ]] || die "--tag is required"
 [[ -n "$MESSAGE"   ]] || die "--message is required"
 [[ -d "$ROOT"      ]] || die "--root '$ROOT' is not a directory"
+
+# ---------------------------------------------------------------------------
+# Derive the release version from the tag: drop an optional "prefix/" segment
+# and a leading "v".   axiam-server/v1.4.0 -> 1.4.0 ;  v1.4.0 -> 1.4.0
+# ---------------------------------------------------------------------------
+version_from_tag() {
+  local t="${1##*/}"    # drop everything up to and including the last '/'
+  printf '%s' "${t#v}"  # drop a leading 'v'
+}
+
+# PEP 440 spelling for Python packaging: 1.4.0-alpha1 -> 1.4.0a1,
+# -beta -> b, -rc -> rc (separator collapsed). Leaves stable versions untouched.
+pep440() {
+  printf '%s' "$1" | sed -E 's/[-_.]?alpha[-_.]?/a/; s/[-_.]?beta[-_.]?/b/; s/[-_.]?rc[-_.]?/rc/'
+}
+
+RELEASE_VERSION="$(version_from_tag "$TAG")"
+if $BUMP; then
+  # SemVer-ish (matches the check the SDK release workflows apply to the tag).
+  if ! printf '%s' "$RELEASE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+    die "tag '$TAG' yields version '$RELEASE_VERSION', which is not a valid release version (expected MAJOR.MINOR.PATCH[-prerelease]). Use --no-bump to tag without editing versions."
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Resolve the selected repo list
@@ -166,6 +236,148 @@ case "$REPOS_ARG" in
 esac
 [[ ${#REPOS[@]} -gt 0 ]] || die "no repos selected"
 
+# ---------------------------------------------------------------------------
+# Version discovery + rewriting
+# ---------------------------------------------------------------------------
+# Files edited by the current repo's bump (staged for the release commit).
+# Set by bump_versions and read by the action loop; declared here for clarity.
+BUMP_FILES=()
+
+# Echo a repo's CURRENT declared version, run from inside the repo's dir.
+# Empty when the repo derives its version purely from the git tag (php, go) or
+# when it cannot be found (so callers can report a clean failure). Always
+# returns 0 — a missing match must not abort the caller under `set -e`.
+current_version() {
+  { case "$1" in
+    axiam)
+      # The [workspace.package] version — the source all crates inherit.
+      sed -n '/^\[workspace\.package\]/,/^\[/{s/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p}' Cargo.toml | head -n1
+      ;;
+    axiam-rust-sdk)
+      grep -m1 -oP '^version[[:space:]]*=[[:space:]]*"\K[^"]+' Cargo.toml
+      ;;
+    axiam-typescript-sdk)
+      grep -m1 -oP '"version"[[:space:]]*:[[:space:]]*"\K[^"]+' package.json
+      ;;
+    axiam-java-sdk)
+      # First <version> in the root pom is the project's own version.
+      grep -m1 -oP '(?<=<version>)[^<]+' pom.xml
+      ;;
+    axiam-csharp-sdk)
+      grep -m1 -oP '(?<=<Version>)[^<]+' Axiam.Sdk/Axiam.Sdk.csproj
+      ;;
+    axiam-python-sdk)
+      grep -m1 -oP '^version[[:space:]]*=[[:space:]]*"\K[^"]+' pyproject.toml
+      ;;
+    axiam-php-sdk|axiam-go-sdk)
+      printf ''   # version comes from the git tag; nothing declared in-repo
+      ;;
+  esac ; } || true
+}
+
+# Replace every literal occurrence of $2 with $3 in file $1, recording the file
+# for staging. No-op (silently) when the file is absent, when old == new, or
+# when the old literal is not present. Honours --dry-run.
+sub_literal() {
+  local file="$1" old="$2" new="$3"
+  [[ -n "$old" ]] || return 0            # empty old would match everywhere — refuse
+  [[ -f "$file" ]] || return 0
+  [[ "$old" == "$new" ]] && return 0
+  grep -qF -- "$old" "$file" || return 0
+  if $DRY_RUN; then
+    printf '      [dry-run] %s: "%s" -> "%s"\n' "$file" "$old" "$new"
+  else
+    OLD="$old" NEW="$new" perl -pi -e 's/\Q$ENV{OLD}\E/$ENV{NEW}/g' "$file"
+    printf '      %s: "%s" -> "%s"\n' "$file" "$old" "$new"
+  fi
+  BUMP_FILES+=("$file")
+}
+
+# Set the first `<prefix>"<value>"` occurrence in file $1 to $3, where $2 is a
+# perl regex matching the prefix (e.g. 'version[[:space:]]*=[[:space:]]*').
+# Used for version fields whose current value we don't rely on (Python, whose
+# __version__ is a drifted placeholder and whose spelling differs from the tag).
+set_quoted_field() {
+  local file="$1" prefix="$2" val="$3" label="$4"
+  [[ -f "$file" ]] || { printf '      [skip] %s (absent)\n' "$file"; return 0; }
+  if $DRY_RUN; then
+    printf '      [dry-run] %s: %s -> "%s"\n' "$file" "$label" "$val"
+  else
+    PRE="$prefix" VAL="$val" perl -0pi -e 's/($ENV{PRE})"[^"]*"/$1 . "\"" . $ENV{VAL} . "\""/e' "$file"
+    printf '      %s: %s -> "%s"\n' "$file" "$label" "$val"
+  fi
+  BUMP_FILES+=("$file")
+}
+
+# Bump every axiam-* crate entry in ./Cargo.lock from $1 to $2. The workspace
+# crates all share one version, so a `cargo build` would rewrite these anyway;
+# doing it here keeps the committed lockfile consistent without a build.
+bump_cargo_lock_axiam() {
+  local old="$1" new="$2"
+  [[ -f Cargo.lock ]] || return 0
+  [[ "$old" == "$new" ]] && return 0
+  grep -q '^name = "axiam-' Cargo.lock || return 0
+  if $DRY_RUN; then
+    printf '      [dry-run] Cargo.lock: axiam-* crate versions "%s" -> "%s"\n' "$old" "$new"
+  else
+    OLD="$old" NEW="$new" perl -0pi -e 's/(name = "axiam-[^"]*"\nversion = )"\Q$ENV{OLD}\E"/$1 . "\"" . $ENV{NEW} . "\""/ge' Cargo.lock
+    printf '      Cargo.lock: axiam-* crate versions "%s" -> "%s"\n' "$old" "$new"
+  fi
+  BUMP_FILES+=("Cargo.lock")
+}
+
+# Rewrite the release version everywhere repo $1 declares it, to version $2.
+# Runs from inside the repo's directory. Populates BUMP_FILES.
+bump_versions() {
+  local repo="$1" version="$2" old
+  BUMP_FILES=()
+  old="$(current_version "$repo")"
+  case "$repo" in
+    axiam)
+      sub_literal Cargo.toml                                       "$old" "$version"
+      sub_literal sdks/openapi.json                                "$old" "$version"
+      sub_literal frontend/src/components/layout/Sidebar.tsx       "$old" "$version"
+      sub_literal frontend/src/components/layout/Sidebar.test.tsx  "$old" "$version"
+      sub_literal k8s/server/deployment.yml                        "$old" "$version"
+      sub_literal k8s/frontend/deployment.yml                      "$old" "$version"
+      bump_cargo_lock_axiam                                        "$old" "$version"
+      ;;
+    axiam-rust-sdk)
+      # Replaces the package version AND the `=`-pinned axiam-sdk-macros dep
+      # (the `=` prefix is preserved because only the literal changes).
+      sub_literal Cargo.toml                    "$old" "$version"
+      sub_literal axiam-sdk-macros/Cargo.toml   "$old" "$version"
+      ;;
+    axiam-typescript-sdk)
+      sub_literal package.json       "$old" "$version"
+      sub_literal package-lock.json  "$old" "$version"
+      ;;
+    axiam-java-sdk)
+      # Every occurrence of the project version literal across the poms is the
+      # project's own version or a managed/declared dependency on this repo's
+      # own axiam-sdk; the example app's independent version (0.1.0) differs and
+      # is left untouched.
+      sub_literal pom.xml                              "$old" "$version"
+      sub_literal bom/pom.xml                          "$old" "$version"
+      sub_literal examples/spring-boot-app/pom.xml     "$old" "$version"
+      sub_literal README.md                            "$old" "$version"
+      ;;
+    axiam-csharp-sdk)
+      sub_literal Axiam.Sdk/Axiam.Sdk.csproj                        "$old" "$version"
+      sub_literal Axiam.Sdk.AspNetCore/Axiam.Sdk.AspNetCore.csproj  "$old" "$version"
+      ;;
+    axiam-python-sdk)
+      # PEP 440 spelling, and __version__ is a placeholder we overwrite outright.
+      local pyver; pyver="$(pep440 "$version")"
+      set_quoted_field pyproject.toml            'version[[:space:]]*=[[:space:]]*'      "$pyver" '[project].version'
+      set_quoted_field src/axiam_sdk/__init__.py '__version__[[:space:]]*=[[:space:]]*' "$pyver" '__version__'
+      ;;
+    axiam-php-sdk|axiam-go-sdk)
+      : # version is derived from the git tag; nothing to rewrite
+      ;;
+  esac
+}
+
 # Helper: run a mutating git command, honouring --dry-run. In dry-run mode the
 # command is printed with shell quoting so it is unambiguous and copy-pasteable.
 run() {
@@ -181,8 +393,10 @@ echo "    root:    $ROOT"
 echo "    repos:   ${REPOS[*]}"
 echo "    branch:  $BRANCH"
 echo "    tag:     $TAG"
+echo "    version: $RELEASE_VERSION"
 echo "    message: <repo> - $MESSAGE"
 echo "    pull:    $PULL"
+echo "    bump:    $BUMP"
 echo "    dry-run: $DRY_RUN"
 echo ""
 
@@ -209,15 +423,25 @@ for repo in "${REPOS[@]}"; do
   if [[ -n "$(git -C "$dir" ls-remote --tags origin "refs/tags/$TAG" 2>/dev/null)" ]]; then
     echo "    [FAIL] $repo — tag '$TAG' already exists on origin"; preflight_ok=false; continue
   fi
-  echo "    [ ok ] $repo"
+  # When bumping, the repo's current version must be discoverable (except for
+  # the tag-derived repos), so the rewrite has a known starting point.
+  if $BUMP; then
+    cv="$(cd "$dir" && current_version "$repo")"
+    if [[ "$repo" != axiam-php-sdk && "$repo" != axiam-go-sdk && -z "$cv" ]]; then
+      echo "    [FAIL] $repo — could not determine current version to bump"; preflight_ok=false; continue
+    fi
+    echo "    [ ok ] $repo (${cv:-tag-derived} -> $RELEASE_VERSION)"
+  else
+    echo "    [ ok ] $repo"
+  fi
 done
 $preflight_ok || die "pre-flight validation failed; nothing was tagged."
 echo ""
 
 # ---------------------------------------------------------------------------
-# Action: tag + push each repo.
+# Action: bump + commit, then tag + push each repo.
 # ---------------------------------------------------------------------------
-echo "==> Tagging & pushing"
+echo "==> Releasing"
 FAIL_COUNT=0
 FAILED_REPOS=""
 for repo in "${REPOS[@]}"; do
@@ -234,6 +458,24 @@ for repo in "${REPOS[@]}"; do
     if $PULL; then
       echo "    pull --ff-only origin $BRANCH"
       run git pull --ff-only origin "$BRANCH"
+    fi
+
+    if $BUMP; then
+      echo "    bump version -> $RELEASE_VERSION"
+      bump_versions "$repo" "$RELEASE_VERSION"
+      if $DRY_RUN; then
+        echo "    [dry-run] git add <bumped files> && git commit -S (if anything changed)"
+      elif [[ ${#BUMP_FILES[@]} -gt 0 ]]; then
+        git add -- "${BUMP_FILES[@]}"
+        if git diff --cached --quiet; then
+          echo "    already at $RELEASE_VERSION — no version commit needed"
+        else
+          echo "    commit version bump"
+          git commit -S -m "chore(release): prepare $repo $RELEASE_VERSION"
+        fi
+      else
+        echo "    no in-repo version to bump (tag-derived) — tagging HEAD as-is"
+      fi
     fi
 
     echo "    sign tag $TAG on HEAD ($(git rev-parse --short HEAD)) — \"$full_msg\""
@@ -256,4 +498,4 @@ if [[ $FAIL_COUNT -gt 0 ]]; then
   echo "==> Completed with failures:$FAILED_REPOS"
   exit 1
 fi
-echo "==> All ${#REPOS[@]} repo(s) tagged '$TAG' and pushed."
+echo "==> All ${#REPOS[@]} repo(s) released as '$TAG' (version $RELEASE_VERSION) and pushed."

--- a/scripts/mass-tag.sh
+++ b/scripts/mass-tag.sh
@@ -8,11 +8,11 @@
 # fire. Doing that by hand, across eight repos and their many manifests, is
 # tedious and error-prone — this script does it in one pass.
 #
-# THE VERSION IS TAKEN FROM THE TAG. `--tag axiam-server/v1.4.0` and
-# `--tag v1.4.0` both mean "release 1.4.0": the script strips an optional
-# `prefix/` and a leading `v`, then writes 1.4.0 into every version-bearing
-# file of each selected repo before committing and tagging. So preparing a
-# release is just running this script — no manual version edits first.
+# THE VERSION IS TAKEN FROM THE TAG. `--tag v1.4.0` means "release 1.4.0":
+# the script strips a leading `v` (and, defensively, any `prefix/` segment),
+# then writes 1.4.0 into every version-bearing file of each selected repo
+# before committing and tagging. So preparing a release is just running this
+# script — no manual version edits first.
 #
 # For each selected repo it will, in order:
 #   1. check out the requested branch,
@@ -58,13 +58,14 @@
 # configured, tag/commit creation fails and the script stops; it never pushes
 # an unsigned tag.
 #
-# NOTE ON TAG NAMES: the platform repo's release workflow triggers on the
-# namespaced tag `axiam-server/v*`, while every SDK triggers on `v*`. Because
-# a single run applies ONE tag name to its selected repos, cut a release in
-# two runs, e.g.:
-#     scripts/mass-tag.sh -r axiam    -b main -t axiam-server/v1.0.0-alpha -m "first alpha release" -p
-#     scripts/mass-tag.sh -r all-sdks -b main -t v1.0.0-alpha              -m "first alpha release" -p
-# Both runs derive the same version (1.0.0-alpha) from their tag.
+# TAG NAMES: every repo — the platform included — now releases on a plain
+# `v*` tag (the platform's release workflow was reconciled from the old
+# namespaced `axiam-server/v*` to `v*`). Tags are per-repo, so the same
+# `v1.0.0-alpha` in each repo is unambiguous. A single run can therefore cut
+# the whole fleet:
+#     scripts/mass-tag.sh -r all -b main -t v1.0.0-alpha -m "first alpha release" -p
+# (Use --repos to release a subset — e.g. -r axiam or -r all-sdks — when the
+# platform and SDKs are versioned on different cadences.)
 #
 # Usage:
 #   scripts/mass-tag.sh --repos <all|all-sdks|name[,name...]> \
@@ -145,8 +146,8 @@ Usage:
 
   -r, --repos    (required) 'all', 'all-sdks', or a comma-separated subset.
   -b, --branch   (required) branch to tag; must exist in every selected repo.
-  -t, --tag      (required) tag name to create; the release version is derived
-                 from it (axiam-server/v1.4.0 and v1.4.0 both mean 1.4.0).
+  -t, --tag      (required) tag name to create (plain v* for every repo); the
+                 release version is derived from it (v1.4.0 means 1.4.0).
   -m, --message  (required) tag message; each tag's annotation is
                  "<repo-name> - <message>".
   -p, --pull     (optional) fast-forward pull each branch before releasing.
@@ -158,8 +159,8 @@ Usage:
   -h, --help     show this help and exit.
 
 Known repos: axiam (platform) + the seven axiam-<lang>-sdk repos.
-The platform repo's release tag is namespaced (axiam-server/v*); the SDKs use
-v* — so cut a release in two runs (one per tag name) using --repos.
+Every repo releases on a plain v* tag, so one run (e.g. -r all -t v1.0.0) can
+cut the whole fleet; use --repos to release a subset on its own cadence.
 EOF
 }
 
@@ -193,8 +194,9 @@ done
 [[ -d "$ROOT"      ]] || die "--root '$ROOT' is not a directory"
 
 # ---------------------------------------------------------------------------
-# Derive the release version from the tag: drop an optional "prefix/" segment
-# and a leading "v".   axiam-server/v1.4.0 -> 1.4.0 ;  v1.4.0 -> 1.4.0
+# Derive the release version from the tag: drop a leading "v" (and, defensively,
+# any legacy "prefix/" segment such as the old axiam-server/ namespace).
+#   v1.4.0 -> 1.4.0 ;  axiam-server/v1.4.0 -> 1.4.0
 # ---------------------------------------------------------------------------
 version_from_tag() {
   local t="${1##*/}"    # drop everything up to and including the last '/'


### PR DESCRIPTION
## Summary

Makes `scripts/mass-tag.sh` a one-command release tool. It now derives the release version from the tag and **rewrites that version into every version-bearing file of each selected repo, commits the bump (signed), then tags that commit** — so cutting a release is just running the script, with no manual version edits beforehand.

This is what each SDK's release CI requires: those workflows assert the pushed tag equals the manifest version, and the platform's OpenAPI drift gate requires `sdks/openapi.json` to match the generated spec. The script now satisfies both.

## What the bump touches, per repo

| Repo | Files rewritten |
|---|---|
| **axiam** (platform) | `Cargo.toml` `[workspace.package]` version; all `axiam-*` entries in `Cargo.lock`; `sdks/openapi.json` `info.version` (**the OpenAPI drift gate** — the spec is byte-for-byte identical apart from this field, confirmed by the CHANGELOG, so a targeted rewrite keeps the gate green with no rebuild; `docs/api/openapi.json` is a symlink to it); the frontend `Sidebar.tsx` version string **and its test**; both k8s deployment image tags |
| **axiam-rust-sdk** | `Cargo.toml` package version + the `=`-pinned `axiam-sdk-macros` dep; `axiam-sdk-macros/Cargo.toml` |
| **axiam-python-sdk** | `pyproject.toml` `[project].version` and package `__version__`, normalized to **PEP 440** (`1.4.0-rc1` → `1.4.0rc1`) |
| **axiam-typescript-sdk** | `package.json` + both root mirrors in `package-lock.json` |
| **axiam-java-sdk** | root `pom.xml`, `bom/pom.xml` (project + managed `axiam-sdk` dep), the example's `axiam-sdk` dep, README install snippets |
| **axiam-csharp-sdk** | `<Version>` in both `.csproj` files |
| **axiam-php-sdk** / **axiam-go-sdk** | no-op — version is git-tag-derived; tagged as-is |

Dependency, parent, plugin and unrelated example versions (e.g. Java's example `0.1.0`) are left untouched — replacements are scoped per file to the unique version literal, not a blind global sed.

## Tag convention reconciled to plain `v*`

The platform release workflow was reconciled to trigger on `v*` (not the old namespaced `axiam-server/v*`). Since a `v*` tag filter does not match a `axiam-server/…` ref, the server must be tagged with a plain `v1.0.0`. Updated accordingly:

- `mass-tag.sh` drops the "namespaced platform tag / two runs" guidance — every repo now releases on a plain `v*` tag, so a single `-r all -t v1.0.0` run can cut the whole fleet. `version_from_tag` keeps the leading-`v` strip and retains defensive `prefix/` stripping for any legacy tag.
- `claude_dev/publishing-and-secrets.md` — the server release rows/examples updated from `axiam-server/v1.0.0` to `v1.0.0`.

## Safety & behaviour

- **Idempotent**: re-running at the same version makes no commit and just tags HEAD.
- **Pre-flight** now also verifies each repo's current version is discoverable, and validates the derived version as SemVer — failing fast before anything is tagged.
- **`--no-bump`** preserves the previous tag-only behaviour; **`--dry-run`** previews every edit and git action.
- Bump commits are signed (`git commit -S`), matching the existing signed-tag requirement.

## Testing

- Verified each `perl` transformation on real file copies: workspace/package versions bump while dependency versions stay put; the Rust `=` pin and Java own-SDK dep move in lockstep; Java example's own `0.1.0` and parent version untouched; `openapi.json` remains valid JSON; `package-lock.json` updates both root mirrors; Python normalizes to PEP 440.
- Verified the stage → commit → idempotent-rerun mechanics end-to-end in a throwaway git repo.
- `bash -n` clean; dry-runs for `-r axiam`, `-r all-sdks`, and `-r all` produce correct plans.

## Notes for the reviewer

- SDK repos currently sit at different versions (rust `1.0.0-alpha7`, others `1.0.0-alpha2`); an `all-sdks` run applies one tag/version to all of them, so tag intentionally.
- No PR was requested for the SDK repos — this change is entirely within the `axiam` platform repo (the script and its runbook); the script operates on the sibling SDK clones at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA9CJHepNkXt6w84gjJphB)_