### PR TITLE
feat(sdks): mTLS contract clause + Kotlin/Swift/C/C++ SDK support (platform side)

### DIFF
--- a/benchmarks/sdk/c/TODO.md
+++ b/benchmarks/sdk/c/TODO.md
@@ -1,0 +1,21 @@
+# C SDK benchmark — wiring TODO
+
+The C SDK is implemented (`ilpanich/axiam-c-sdk`). This directory is the bench-glue
+scaffold: it currently emits a `pending` record conforming to `../HARNESS-SPEC.md`
+because the bench entrypoint has not been wired to the SDK yet.
+
+## To wire it up
+1. Add the SDK dependency: **CMakeLists.txt (find_package(axiam-c-sdk) via vcpkg/Conan)**.
+2. Implement a bench entrypoint in this directory that:
+   - reads the `BENCH_*` / `SDK_BENCH_*` env (see HARNESS-SPEC.md), including the
+     `BENCH_CLIENT_CERT` / `BENCH_CLIENT_KEY` / `BENCH_CA_CERT` triple for the
+     `p3-mtls` profile (the C SDK exposes client-cert mTLS per CONTRACT §6.1),
+   - times the four ops (`login`, `refresh`, `check_access`, `batch_check`)
+     with a warm-up + measured loop,
+   - prints exactly one `axiam.sdk-bench/v1` JSON object to stdout with
+     `status: "ok"`.
+3. Point `run.sh` at it (replace the `emit_pending` fallback with `cmake --build build && ./build/axiam-bench`).
+4. Verify: `cd benchmarks && just sdk-bench sdk=c` prints a valid record.
+
+See `../typescript/bench.mjs` and `../python/bench.py` for complete reference
+harnesses (timing loop, percentile math, JSON contract) to mirror.

--- a/benchmarks/sdk/c/run.sh
+++ b/benchmarks/sdk/c/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Run the C SDK bench. The C SDK (ilpanich/axiam-c-sdk) is implemented; the bench glue in
+# this directory is not yet wired, so this emits a 'pending' record.
+# Replace the body below with a CMake build + run of the bench binary.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Once wired, implement bench in this directory and exec it here, e.g.:
+#   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build && exec ./build/axiam-bench
+# shellcheck disable=SC1091
+source "$HERE/../_pending.sh"; emit_pending c

--- a/benchmarks/sdk/cpp/TODO.md
+++ b/benchmarks/sdk/cpp/TODO.md
@@ -1,0 +1,21 @@
+# C++ SDK benchmark — wiring TODO
+
+The C++ SDK is implemented (`ilpanich/axiam-cplusplus-sdk`). This directory is the bench-glue
+scaffold: it currently emits a `pending` record conforming to `../HARNESS-SPEC.md`
+because the bench entrypoint has not been wired to the SDK yet.
+
+## To wire it up
+1. Add the SDK dependency: **CMakeLists.txt (find_package(axiam-cpp-sdk) via vcpkg/Conan)**.
+2. Implement a bench entrypoint in this directory that:
+   - reads the `BENCH_*` / `SDK_BENCH_*` env (see HARNESS-SPEC.md), including the
+     `BENCH_CLIENT_CERT` / `BENCH_CLIENT_KEY` / `BENCH_CA_CERT` triple for the
+     `p3-mtls` profile (the C++ SDK exposes client-cert mTLS per CONTRACT §6.1),
+   - times the four ops (`login`, `refresh`, `check_access`, `batch_check`)
+     with a warm-up + measured loop,
+   - prints exactly one `axiam.sdk-bench/v1` JSON object to stdout with
+     `status: "ok"`.
+3. Point `run.sh` at it (replace the `emit_pending` fallback with `cmake --build build && ./build/axiam-bench`).
+4. Verify: `cd benchmarks && just sdk-bench sdk=cpp` prints a valid record.
+
+See `../typescript/bench.mjs` and `../python/bench.py` for complete reference
+harnesses (timing loop, percentile math, JSON contract) to mirror.

--- a/benchmarks/sdk/cpp/run.sh
+++ b/benchmarks/sdk/cpp/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Run the C++ SDK bench. The C++ SDK (ilpanich/axiam-cplusplus-sdk) is implemented; the bench
+# glue in this directory is not yet wired, so this emits a 'pending' record.
+# Replace the body below with a CMake build + run of the bench binary.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Once wired, implement bench in this directory and exec it here, e.g.:
+#   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build && exec ./build/axiam-bench
+# shellcheck disable=SC1091
+source "$HERE/../_pending.sh"; emit_pending cpp

--- a/benchmarks/sdk/kotlin/TODO.md
+++ b/benchmarks/sdk/kotlin/TODO.md
@@ -1,0 +1,21 @@
+# Kotlin SDK benchmark — wiring TODO
+
+The Kotlin SDK is implemented (`ilpanich/axiam-kotlin-sdk`). This directory is the bench-glue
+scaffold: it currently emits a `pending` record conforming to `../HARNESS-SPEC.md`
+because the bench entrypoint has not been wired to the SDK yet.
+
+## To wire it up
+1. Add the SDK dependency: **build.gradle.kts (add io.github.ilpanich:axiam-sdk-kotlin dep)**.
+2. Implement a bench entrypoint in this directory that:
+   - reads the `BENCH_*` / `SDK_BENCH_*` env (see HARNESS-SPEC.md), including the
+     `BENCH_CLIENT_CERT` / `BENCH_CLIENT_KEY` / `BENCH_CA_CERT` triple for the
+     `p3-mtls` profile (the Kotlin SDK exposes client-cert mTLS per CONTRACT §6.1),
+   - times the four ops (`login`, `refresh`, `check_access`, `batch_check`)
+     with a warm-up + measured loop,
+   - prints exactly one `axiam.sdk-bench/v1` JSON object to stdout with
+     `status: "ok"`.
+3. Point `run.sh` at it (replace the `emit_pending` fallback with `./gradlew -q --console=plain run`).
+4. Verify: `cd benchmarks && just sdk-bench sdk=kotlin` prints a valid record.
+
+See `../typescript/bench.mjs` and `../python/bench.py` for complete reference
+harnesses (timing loop, percentile math, JSON contract) to mirror.

--- a/benchmarks/sdk/kotlin/run.sh
+++ b/benchmarks/sdk/kotlin/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Run the Kotlin SDK bench. The Kotlin SDK (ilpanich/axiam-kotlin-sdk) is implemented; the
+# bench glue in this directory is not yet wired, so this emits a 'pending' record.
+# Replace the body below with: ./gradlew -q run
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Once wired, implement bench in this directory and exec it here, e.g.:
+#   exec ./gradlew -q --console=plain run
+# shellcheck disable=SC1091
+source "$HERE/../_pending.sh"; emit_pending kotlin

--- a/benchmarks/sdk/swift/TODO.md
+++ b/benchmarks/sdk/swift/TODO.md
@@ -1,0 +1,21 @@
+# Swift SDK benchmark — wiring TODO
+
+The Swift SDK is implemented (`ilpanich/axiam-swift-sdk`). This directory is the bench-glue
+scaffold: it currently emits a `pending` record conforming to `../HARNESS-SPEC.md`
+because the bench entrypoint has not been wired to the SDK yet.
+
+## To wire it up
+1. Add the SDK dependency: **Package.swift (add axiam-swift-sdk dependency)**.
+2. Implement a bench entrypoint in this directory that:
+   - reads the `BENCH_*` / `SDK_BENCH_*` env (see HARNESS-SPEC.md), including the
+     `BENCH_CLIENT_CERT` / `BENCH_CLIENT_KEY` / `BENCH_CA_CERT` triple for the
+     `p3-mtls` profile (the Swift SDK exposes client-cert mTLS per CONTRACT §6.1),
+   - times the four ops (`login`, `refresh`, `check_access`, `batch_check`)
+     with a warm-up + measured loop,
+   - prints exactly one `axiam.sdk-bench/v1` JSON object to stdout with
+     `status: "ok"`.
+3. Point `run.sh` at it (replace the `emit_pending` fallback with `swift run -c release axiam-bench`).
+4. Verify: `cd benchmarks && just sdk-bench sdk=swift` prints a valid record.
+
+See `../typescript/bench.mjs` and `../python/bench.py` for complete reference
+harnesses (timing loop, percentile math, JSON contract) to mirror.

--- a/benchmarks/sdk/swift/run.sh
+++ b/benchmarks/sdk/swift/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Run the Swift SDK bench. The Swift SDK (ilpanich/axiam-swift-sdk) is implemented; the
+# bench glue in this directory is not yet wired, so this emits a 'pending' record.
+# Replace the body below with: swift run -c release axiam-bench
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# Once wired, implement bench in this directory and exec it here, e.g.:
+#   exec swift run -c release axiam-bench
+# shellcheck disable=SC1091
+source "$HERE/../_pending.sh"; emit_pending swift

--- a/claude_dev/publishing-and-secrets.md
+++ b/claude_dev/publishing-and-secrets.md
@@ -16,6 +16,10 @@ exactly how to create them. All destinations are **free for open-source projects
 > | C# | `ilpanich/axiam-csharp-sdk` | |
 > | PHP | `ilpanich/axiam-php-sdk` | |
 > | Go | `ilpanich/axiam-go-sdk` | |
+> | Kotlin | `ilpanich/axiam-kotlin-sdk` | |
+> | Swift | `ilpanich/axiam-swift-sdk` | |
+> | C | `ilpanich/axiam-c-sdk` | |
+> | C++ | `ilpanich/axiam-cplusplus-sdk` | |
 >
 > Those three inputs are **maintained here and vendored (copied) into each SDK repo**. When
 > one of them changes, the copies downstream must be re-synced — nothing enforces this
@@ -50,13 +54,21 @@ reference.
 | C# SDK | `axiam-csharp-sdk` | **NuGet.org** | Yes | **None** — Trusted Publishing (OIDC) via the `production` environment |
 | PHP SDK | `axiam-php-sdk` | **Packagist** | Yes | **None** — Packagist's own GitHub webhook |
 | Go SDK | `axiam-go-sdk` | **pkg.go.dev** | Yes | **None** — the module proxy pulls it from the git tag |
+| Kotlin SDK | `axiam-kotlin-sdk` | **Maven Central** | Yes | `CENTRAL_TOKEN_USERNAME`, `CENTRAL_TOKEN_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE` |
+| Swift SDK | `axiam-swift-sdk` | **Swift Package Index** (+ CocoaPods trunk) | Yes | **None** for SwiftPM (git-tag) — `COCOAPODS_TRUNK_TOKEN` only if also pushing the podspec to CocoaPods trunk |
+| C SDK | `axiam-c-sdk` | **GitHub Releases** (+ vcpkg / Conan recipes in-repo) | Yes | **None** — `GITHUB_TOKEN` attaches the release artifacts |
+| C++ SDK | `axiam-cplusplus-sdk` | **GitHub Releases** (+ vcpkg / Conan recipes in-repo) | Yes | **None** — `GITHUB_TOKEN` attaches the release artifacts |
 | Rust SDK docs | — | **docs.rs** | Yes | **None** — built from the crates.io release |
 | Java SDK docs | — | **javadoc.io** | Yes | **None** — served from the `-javadoc.jar` on Central |
 | Go SDK docs | — | **pkg.go.dev** | Yes | **None** — automatic |
 | Python/TS/C#/PHP SDK docs | each SDK repo | **that repo's GitHub Pages** | Yes | **None** — but Pages must be enabled per repo |
 | Test coverage (all 7 SDKs) | each SDK repo | **Coveralls** | Yes | **None** if the repo is public (`GITHUB_TOKEN`); otherwise `COVERALLS_REPO_TOKEN` |
 
-**Six secrets in total, spread across three repos.** Everything else is OIDC, a webhook, or
+**A handful of secrets, spread across a few repos.** The original six (Rust `CRATES_IO_TOKEN`,
+npm `NPM_TOKEN`, and the four Java Maven-Central/GPG secrets) are now joined by the **Kotlin
+SDK's four Central/GPG secrets** (which may reuse the same dedicated CI GPG key as Java, §4.10)
+and, only if you opt into CocoaPods, one `COCOAPODS_TRUNK_TOKEN` for Swift (§4.11). The C, C++
+and Swift-via-SwiftPM SDKs need **no** publishing secret. Everything else is OIDC, a webhook, or
 the built-in token. **No secret is a long-lived push credential for another repository** —
 the old PHP mirror PAT is gone (§4.7).
 
@@ -71,6 +83,10 @@ the old PHP mirror PAT is gone (§4.7).
 | NuGet | `Axiam.Sdk`, `Axiam.Sdk.AspNetCore` |
 | Packagist | `axiam/axiam-sdk` |
 | Go | **`github.com/ilpanich/axiam-go-sdk`** — changed, see §4.8 |
+| Maven Central (Kotlin) | `io.github.ilpanich:axiam-sdk-kotlin` |
+| CocoaPods | `AxiamSDK` (Swift; SwiftPM uses the git URL directly) |
+| vcpkg / Conan (C) | `axiam-c-sdk` (port/recipe name; consumed via overlay/remote) |
+| vcpkg / Conan (C++) | `axiam-cpp-sdk` (port/recipe name; consumed via overlay/remote) |
 | GHCR | `ghcr.io/ilpanich/axiam/server`, `.../frontend` |
 
 ---
@@ -121,6 +137,7 @@ gh secret list --repo ilpanich/axiam-rust-sdk                          # verify
    | `axiam-python-sdk` | `pypi` | PyPI Trusted Publishing binds to it |
    | `axiam-csharp-sdk` | `production` | NuGet Trusted Publishing binds to it |
    | `axiam-java-sdk` | `maven-central` | Gates the Central deploy (not OIDC, but the job declares it) |
+   | `axiam-kotlin-sdk` | `maven-central` | Gates the Central deploy (same as Java; reuses the `io.github.ilpanich` namespace) |
 
    Optionally add yourself as a required reviewer on these, so a release needs an explicit
    approval click.
@@ -305,9 +322,69 @@ coverage-delta comment).
 | C# | coverlet (`--collect:"XPlat Code Coverage"`) | lcov |
 | PHP | PHPUnit + pcov | clover |
 | Go | `go test -coverprofile` | golang |
+| Kotlin | Kover (`koverXmlReport`) | jacoco/cobertura xml |
+| Swift | `swift test --enable-code-coverage` + `llvm-cov export -format=lcov` | lcov |
+| C | `gcov` + `lcov` (or `llvm-cov`) | lcov |
+| C++ | `llvm-cov`/`gcov` + `lcov` | lcov |
 
 Setup: add each repo at <https://coveralls.io/repos/new>. Public repos authenticate with the
 built-in `GITHUB_TOKEN` — no secret. Private repos need `COVERALLS_REPO_TOKEN` (§3.2).
+
+### 4.10 Maven Central — Kotlin SDK → 4 secrets in `axiam-kotlin-sdk`
+
+Identical mechanics to the Java SDK (§4.5): the Kotlin SDK publishes `io.github.ilpanich:axiam-sdk-kotlin`
+under the same `io.github.ilpanich` namespace (already claimed for Java — **no second namespace
+verification is needed**). The Gradle build (`maven-publish` + `signing` plugins, or the
+`central-publishing` Gradle plugin) signs artifacts with GPG and deploys to the Sonatype Central
+Portal.
+
+```bash
+gh secret set CENTRAL_TOKEN_USERNAME --repo ilpanich/axiam-kotlin-sdk
+gh secret set CENTRAL_TOKEN_PASSWORD --repo ilpanich/axiam-kotlin-sdk
+gh secret set GPG_PRIVATE_KEY        --repo ilpanich/axiam-kotlin-sdk < key.asc
+gh secret set GPG_PASSPHRASE         --repo ilpanich/axiam-kotlin-sdk
+```
+
+You can reuse the **same dedicated CI GPG key** created for Java (§4.5 Step C) — it is already on
+the keyserver — or generate a second one. Create the `maven-central` GitHub environment in the repo
+(§3.2). Docs are served automatically by **javadoc.io** from the released `-javadoc.jar` (Dokka emits
+a Javadoc-format jar).
+
+### 4.11 Swift Package Index + CocoaPods — Swift SDK → 0–1 secret in `axiam-swift-sdk`
+
+SwiftPM has **no registry upload** — like Go, the git tag *is* the release; consumers add the
+package by its GitHub URL and pin `from: "1.0.0"`. To list it on the Swift Package Index, submit the
+repo once at <https://swiftpackageindex.com/add-a-package> (no secret, no token).
+
+CocoaPods is optional and only needed if you want `pod 'AxiamSDK'` support. To push the podspec to the
+CocoaPods trunk on each tag:
+
+1. Register once locally: `pod trunk register you@example.com 'Your Name'` (confirm via email).
+2. `pod trunk me --verbose` prints the session token; store it:
+   `gh secret set COCOAPODS_TRUNK_TOKEN --repo ilpanich/axiam-swift-sdk`
+3. The release workflow runs `pod trunk push AxiamSDK.podspec` with
+   `COCOAPODS_TRUNK_TOKEN` in the environment.
+
+If you skip CocoaPods, **no secret at all** is required for the Swift SDK. DocC HTML is published to
+that repo's GitHub Pages (§3.2).
+
+### 4.12 / 4.13 C and C++ SDKs → no publishing secret (`axiam-c-sdk`, `axiam-cplusplus-sdk`)
+
+C and C++ have no single canonical package registry. Both repos ship:
+
+- a **CMake** build with `install()` + `CPack` producing a `.tar.gz` (headers + static/shared lib +
+  CMake package-config) attached to the **GitHub Release** with the built-in `GITHUB_TOKEN`
+  (`softprops/action-gh-release`) — **no secret**;
+- an in-repo **vcpkg port** (`ports/axiam-*-sdk/{portfile.cmake,vcpkg.json}`) and **Conan recipe**
+  (`conanfile.py`) that CI validates by building the package from source, so consumers can install via
+  a vcpkg overlay-port or a Conan remote pointing at the repo.
+
+Pushing the port/recipe to the **upstream** `microsoft/vcpkg` (`ports/`) or `conan-io/conan-center-index`
+registries is a separate, manual pull-request to those third-party repositories — it is deliberately
+**not** wired into tag-push CI (those registries gate on human review and cannot be published to with a
+repo secret). The in-repo recipes make that upstream PR mechanical when you choose to do it.
+
+Doxygen HTML for both is published to each repo's GitHub Pages (§3.2).
 
 ---
 
@@ -331,6 +408,10 @@ Every component is versioned and released **independently** — and now from its
 | `axiam-csharp-sdk` | `v1.0.0` | NuGet (Trusted Publishing) + API docs → that repo's Pages |
 | `axiam-php-sdk` | `v1.0.0` | Packagist picks up the tag via its webhook + API docs → that repo's Pages |
 | `axiam-go-sdk` | `v1.0.0` | proxy.golang.org nudge → pkg.go.dev |
+| `axiam-kotlin-sdk` | `v1.0.0` | Maven Central (GPG-signed, Dokka javadoc jar) → javadoc.io picks it up automatically |
+| `axiam-swift-sdk` | `v1.0.0` | SwiftPM tag is the release (Swift Package Index re-indexes); optional `pod trunk push` to CocoaPods + DocC → that repo's Pages |
+| `axiam-c-sdk` | `v1.0.0` | CPack tarball + vcpkg/Conan recipe validation → GitHub Release; Doxygen → that repo's Pages |
+| `axiam-cplusplus-sdk` | `v1.0.0` | CPack tarball + vcpkg/Conan recipe validation → GitHub Release; Doxygen → that repo's Pages |
 
 The `axiam` release ships the **admin-UI (frontend) image too**: the two are deployed as a
 pair (`docker-compose.prod.yml` runs both), so they share a version. Split them only if you

--- a/scripts/mass-tag.sh
+++ b/scripts/mass-tag.sh
@@ -44,6 +44,11 @@
 #   axiam-csharp-sdk   the <Version> in both .csproj files.
 #   axiam-php-sdk,     nothing to edit — Composer/Go derive the release version
 #   axiam-go-sdk       from the git tag, so these are tagged as-is.
+#   axiam-kotlin-sdk   gradle.properties version and the README install coords.
+#   axiam-swift-sdk    the CocoaPods AxiamSDK.podspec s.version and README (SwiftPM
+#                      itself is tag-derived, like Go).
+#   axiam-c-sdk,       the CMake project() version, vcpkg.json version, conanfile.py
+#   axiam-cplusplus-sdk version, and the README install coords — kept in lockstep.
 # Each SDK's release workflow asserts the pushed tag equals the manifest
 # version; the bump above is what makes that assertion pass.
 #
@@ -111,6 +116,10 @@ SDK_REPOS=(
   axiam-csharp-sdk
   axiam-php-sdk
   axiam-go-sdk
+  axiam-kotlin-sdk
+  axiam-swift-sdk
+  axiam-c-sdk
+  axiam-cplusplus-sdk
 )
 ALL_REPOS=("$PLATFORM_REPO" "${SDK_REPOS[@]}")
 
@@ -274,6 +283,17 @@ current_version() {
     axiam-php-sdk|axiam-go-sdk)
       printf ''   # version comes from the git tag; nothing declared in-repo
       ;;
+    axiam-kotlin-sdk)
+      grep -m1 -oP '^version[[:space:]]*=[[:space:]]*\K.*' gradle.properties
+      ;;
+    axiam-swift-sdk)
+      # SwiftPM derives its version from the git tag; the CocoaPods podspec is the
+      # one in-repo declaration, so bump/discover from there.
+      grep -m1 -oP "s\.version\s*=\s*['\"]\K[^'\"]+" AxiamSDK.podspec
+      ;;
+    axiam-c-sdk|axiam-cplusplus-sdk)
+      grep -m1 -oP '"version"[[:space:]]*:[[:space:]]*"\K[^"]+' vcpkg.json
+      ;;
   esac ; } || true
 }
 
@@ -376,6 +396,24 @@ bump_versions() {
       ;;
     axiam-php-sdk|axiam-go-sdk)
       : # version is derived from the git tag; nothing to rewrite
+      ;;
+    axiam-kotlin-sdk)
+      # Gradle project version lives in gradle.properties; README shows install coords.
+      sub_literal gradle.properties  "$old" "$version"
+      sub_literal README.md          "$old" "$version"
+      ;;
+    axiam-swift-sdk)
+      # SwiftPM is tag-derived; the CocoaPods podspec carries the only in-repo version.
+      sub_literal AxiamSDK.podspec   "$old" "$version"
+      sub_literal README.md          "$old" "$version"
+      ;;
+    axiam-c-sdk|axiam-cplusplus-sdk)
+      # C/C++ declare the version in the CMake project(), the vcpkg manifest and the
+      # Conan recipe; keep all three (and the README install coords) in lockstep.
+      sub_literal vcpkg.json         "$old" "$version"
+      sub_literal CMakeLists.txt     "$old" "$version"
+      sub_literal conanfile.py       "$old" "$version"
+      sub_literal README.md          "$old" "$version"
       ;;
   esac
 }

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -22,6 +22,10 @@ Each SDK is its own repository — the AXIAM repository keeps only this contract
 | C# | [`ilpanich/axiam-csharp-sdk`](https://github.com/ilpanich/axiam-csharp-sdk) |
 | PHP | [`ilpanich/axiam-php-sdk`](https://github.com/ilpanich/axiam-php-sdk) |
 | Go | [`ilpanich/axiam-go-sdk`](https://github.com/ilpanich/axiam-go-sdk) |
+| Kotlin | [`ilpanich/axiam-kotlin-sdk`](https://github.com/ilpanich/axiam-kotlin-sdk) |
+| Swift | [`ilpanich/axiam-swift-sdk`](https://github.com/ilpanich/axiam-swift-sdk) |
+| C | [`ilpanich/axiam-c-sdk`](https://github.com/ilpanich/axiam-c-sdk) |
+| C++ | [`ilpanich/axiam-cplusplus-sdk`](https://github.com/ilpanich/axiam-cplusplus-sdk) |
 
 **This file is the source of truth.** A copy is vendored at the root of every SDK repository
 (alongside a copy of `openapi.json` and of `proto/`); when this file changes, the copies must
@@ -44,6 +48,15 @@ each language uses its own idiomatic naming convention as shown below.
 | single access check | `check_access`    | `checkAccess`             | `check_access`      | `checkAccess`    | `CheckAccess`   | `checkAccess`   | `CheckAccess`   |
 | browser access alias| `can`             | `can`                     | `can`               | `can`            | `Can`           | `can`           | `Can`           |
 | batch access check  | `batch_check`     | `batchCheck`              | `batch_check`       | `batchCheck`     | `BatchCheck`    | `batchCheck`    | `BatchCheck`    |
+
+**Additional languages (Kotlin, Swift, C, C++ — added 2026-07):** these expose the same
+canonical operations with the same `(action, resource[, scope])` argument order. Casing:
+**Kotlin** and **Swift** use camelCase (`login`, `verifyMfa`, `refresh`, `logout`,
+`checkAccess`, `can`, `batchCheck`); **C++** uses snake_case (`login`, `verify_mfa`,
+`refresh`, `logout`, `check_access`, `can`, `batch_check`); **C** uses snake_case with an
+`axiam_` prefix on every symbol (`axiam_login`, `axiam_verify_mfa`, `axiam_refresh`,
+`axiam_logout`, `axiam_check_access`, `axiam_can`, `axiam_batch_check`). No new
+login/auth/authz method names beyond this map are permitted in these SDKs either.
 
 **Argument order:** every operation above takes the acted-upon subject before the object it
 acts on — concretely, `check_access`/`can` take `(action, resource[, scope])` in every SDK,
@@ -70,6 +83,10 @@ convention:
 | Java       | The sync method PLUS a same-named class with an **`*Async` suffix companion method** (e.g. `checkAccess`/`checkAccessAsync`) on the same client object. | **Accepted exception** to the "no additional diverging names" rule above — Java idiom favors suffix-async twins on one object (mirrors `CompletableFuture`-returning sibling methods in the broader Java ecosystem, e.g. `java.util.concurrent` conventions). |
 | C#         | **`*Async`-only** methods (e.g. `CheckAccessAsync`), per the .NET Task-based Asynchronous Pattern (TAP) — no separate non-`Async` sync method is required to exist alongside it. | **Accepted exception**: TAP is the idiomatic .NET convention; C# is not required to also offer a blocking `CheckAccess`. |
 | Rust, TypeScript/JS, Go, PHP | No separate async naming convention — the canonical name IS the (only, or primarily-used) call form for that language's ecosystem (`async fn`/`Promise`-returning function/goroutine-friendly call/Fiber-safe call, respectively, under the same canonical name). | N/A |
+| Kotlin     | The canonical name IS a `suspend` function (coroutines). No `*Async` twin; a caller that needs a blocking form uses `runBlocking`. Optional `Deferred`-returning twins are NOT added. | N/A |
+| Swift      | The canonical name IS an `async` method (`async`/`await`). No `*Async` twin. | N/A |
+| C++        | The canonical name is the (blocking) call form; a language-idiomatic `std::future`-returning twin MAY be offered under a `_async` suffix (`check_access_async`) — accepted per-language exception, mirroring C#/Java suffix-async idiom. | N/A |
+| C          | Synchronous canonical calls only (`axiam_*`); no async surface (an optional non-blocking variant, if ever added, takes a completion callback and is out of scope for v1.0). | N/A |
 
 ---
 
@@ -196,6 +213,10 @@ Per-language guidance:
 | C#       | `HttpClient` with `HttpClientHandler { UseCookies = true, CookieContainer = new() }` |
 | PHP      | Guzzle `CookieJar` with `cookies: true` handler option |
 | Go       | `http.CookieJar` (e.g. `cookiejar.New(nil)`) assigned to `http.Client.Jar` |
+| Kotlin   | OkHttp `CookieJar` backed by a per-client `JavaNetCookieJar(CookieManager(...))` |
+| Swift    | `URLSession` with a per-instance `HTTPCookieStorage` on its `URLSessionConfiguration` |
+| C        | libcurl per-handle in-memory cookie engine (`CURLOPT_COOKIEFILE ""` to enable, share handle per client) |
+| C++      | libcurl per-handle cookie engine (as C), or the HTTP library's per-client cookie store |
 
 ---
 
@@ -247,6 +268,58 @@ AxiamClient(base_url, tenant_slug, custom_ca=pem_bytes)
 
 The `with_custom_ca` parameter accepts PEM-encoded certificate bytes/string for the issuing CA. It does NOT accept raw DER bytes, PKCS#12, or JKS. If a non-PEM format is passed, the SDK MUST return a clear error at construction time.
 
+### §6.1 Client Certificate Authentication (mTLS)
+
+**Additive to §6; strict server verification stays ON.** AXIAM authenticates IoT devices
+and service accounts by **mutual TLS**: the client presents an X.509 identity certificate
+(signed by the tenant's organization CA) that the server binds to a service account
+(`POST /api/v1/auth/device` — "Authenticate a device via its client certificate (mTLS)").
+Every SDK MUST expose an optional way to configure that client identity, and MUST apply it
+to **both** the REST and gRPC transports of the same client instance.
+
+Per-language builder/config API (PEM cert chain + PEM private key is the mandatory baseline):
+
+| Language   | Client-certificate API |
+|------------|-------------------------|
+| Rust       | `AxiamClient::builder().with_client_cert(cert_pem: &[u8], key_pem: &[u8])` |
+| TypeScript | `new AxiamClient({ …, clientCert, clientKey })` (PEM strings; Node only, ignored in browser) |
+| Python     | `AxiamClient(…, client_cert=cert_pem, client_key=key_pem)` |
+| Java       | `AxiamClient.builder(…).clientCertificate(byte[] certPem, byte[] keyPem)` |
+| Kotlin     | `AxiamClient.builder(…).clientCertificate(certPem, keyPem)` |
+| C#         | `AxiamClientOptions { ClientCertificatePem = …, ClientKeyPem = … }` |
+| PHP        | `new AxiamClient(…, clientCert: $certPem, clientKey: $keyPem)` |
+| Go         | `axiam.WithClientCertificate(certPEM, keyPEM []byte)` |
+| Swift      | `AxiamClient(config: .init(…, clientCertificate: .pem(certificate:privateKey:)))` |
+| C          | `axiam_client_config_set_client_cert(cfg, cert_pem, key_pem)` |
+| C++        | `AxiamClient::builder().with_client_cert(cert_pem, key_pem)` |
+
+Rules (normative):
+
+1. **Format.** The mandatory input is a PEM certificate chain plus a PEM private key
+   (PKCS#8 or PKCS#1). A non-PEM value MUST produce a clear error at construction time,
+   consistent with §6's PEM-only rule. A language whose platform TLS stack is natively
+   keystore-based (Java/Kotlin `KeyStore`, C#/Swift PKCS#12) MAY *additionally* accept a
+   PKCS#12 identity via a clearly-named secondary overload
+   (`with_client_identity_pkcs12` / `clientIdentityPkcs12` / `.pkcs12(...)`), but PEM
+   cert+key MUST always be accepted.
+2. **Strict TLS preserved.** Presenting a client certificate NEVER relaxes server
+   verification. The §6 absolute prohibition on any TLS-bypass surface is unchanged; the
+   client-cert code path MUST be kept separate from server-verification code so CI
+   TLS-bypass lint gates are not tripped.
+3. **Key secrecy (§7).** The private key is secret material: it MUST NOT appear in any
+   debug/log/display/serialized output and MUST NOT be exposed via a public getter. Where
+   the SDK retains it in memory it SHOULD be held behind the language's `Sensitive<T>`
+   equivalent (§7).
+4. **Both transports.** The configured identity applies to the REST client and to any
+   gRPC channel the same `AxiamClient` builds (`reqwest::Identity` / `ClientTlsConfig::identity`,
+   `tls.Config.Certificates`, `handler.ClientCertificates` / `SslClientAuthenticationOptions`,
+   OkHttp `KeyManager` + `GrpcSslContexts.keyManager`, Guzzle `cert`/`ssl_key`,
+   `grpc.ssl_channel_credentials(private_key=, certificate_chain=)`, `URLSession`
+   `urlSession(_:didReceive:)` identity challenge, libcurl `CURLOPT_SSLCERT`/`CURLOPT_SSLKEY`).
+5. **Optional.** mTLS is opt-in; omitting the client certificate leaves the SDK's default
+   bearer-cookie behavior unchanged. An SDK that ships §6.1 states conformance to
+   "§1–§10 (including §6.1 mTLS)".
+
 ---
 
 ## §7 `Sensitive<T>` Requirement
@@ -268,6 +341,10 @@ Per-language implementation guidance:
 | C#         | Struct with `ToString()` override returning `"[SENSITIVE]"`      |
 | PHP        | `__toString()` returns `"[SENSITIVE]"`                           |
 | Go         | String type with `String()` method returning `"[SENSITIVE]"`     |
+| Kotlin     | `value class Sensitive<T>` (or final class); `toString()` returns `"[SENSITIVE]"`, no `data class` auto-`toString` leak |
+| Swift      | `struct Sensitive<T>: CustomStringConvertible` whose `description` returns `"[SENSITIVE]"`; not `Encodable` in a way that emits the value |
+| C          | Opaque `axiam_sensitive_t` handle; there is no public accessor returning the raw string, and it is never written to logs/`printf` output |
+| C++        | `class Sensitive<T>` with `operator<<`/`to_string` returning `"[SENSITIVE]"`; raw value only via a private/friend accessor |
 
 **The token MUST NOT appear in:**
 - Log files (structured or unstructured)
@@ -376,6 +453,10 @@ Per-language implementation guidance:
 | C#         | `SemaphoreSlim(1,1)` + `Task<TokenPair>` stored in field        |
 | PHP        | Fiber-safe `Mutex` from `revolt/event-loop` or equivalent        |
 | Go         | `sync.Mutex` + single goroutine holding `chan TokenPair`         |
+| Kotlin     | `Mutex` (kotlinx.coroutines) guarding a shared `Deferred<TokenPair>`   |
+| Swift      | An `actor` serializing refresh, sharing one in-flight `Task<TokenPair, Error>` |
+| C          | `pthread_mutex_t` guarding an in-flight flag + condition variable; waiters block until the single refresh completes |
+| C++        | `std::mutex` + `std::shared_future<TokenPair>` held under the lock   |
 
 **Test requirement:** Each SDK MUST include a test that fires N (≥5) concurrent requests against an expired token and asserts exactly 1 refresh call is made. (See Phase 18 success criterion #2 for Go reference.)
 
@@ -401,6 +482,10 @@ Per-framework expectations:
 | ASP.NET Core                     | C#         | `app.UseMiddleware<AxiamAuthMiddleware>()` in `Program.cs`         |
 | `net/http`                       | Go         | Handler wrapping: `axiamMiddleware(next http.Handler) http.Handler` |
 | Laravel / Symfony                | PHP        | `Middleware` (Laravel) / `EventSubscriber` (Symfony)               |
+| Ktor / Spring Boot               | Kotlin     | Ktor `Plugin` intercepting `ApplicationCallPipeline` injecting `AxiamUser`; Spring Boot reuses the Java `OncePerRequestFilter` |
+| Vapor                            | Swift      | `AsyncMiddleware` (`respond(to:chainingTo:)`) storing `AxiamUser` on `Request.auth` / `Request.storage` |
+| Framework-agnostic guard         | C          | `axiam_middleware_authenticate(client, headers, cookies) -> axiam_user_t*`; adapters documented for embedded HTTP servers (CivetWeb) |
+| Framework-agnostic guard         | C++        | `AxiamGuard` callable `AxiamUser guard(const Request&)`; adapters documented for Crow / Pistache handlers |
 
 **Interface contract:**
 - The middleware/extractor MUST read the `X-Tenant-ID` header (or use the client's configured tenant) to scope the session verification.
@@ -437,6 +522,16 @@ Per-language naming map (follows each language's §1 casing convention):
 | require_auth | `#[require_auth]` | `requireAuth(...)` | `require_authenticated_user` (FastAPI, existing) / `@require_auth` (Django) | `@AxiamRequireAuth` | `[Authorize]` (framework-native, documented) | `#[RequireAuth]` | `middleware.RequireAuth(...)` |
 | require_access | `#[require_access(...)]` | `requireAccess(...)` / `@RequireAccess()` (NestJS) | `require_access(...)` (FastAPI dep) / `@require_access` (Django) | `@AxiamRequireAccess(...)` | `[AxiamAccess(...)]` | `#[RequireAccess(...)]` | `middleware.RequireAccess(...)` |
 | require_role | `#[require_role(...)]` | `requireRole(...)` | `require_role(...)` / `@require_role` | `@AxiamRequireRole(...)` | `[Authorize(Roles = ...)]` (framework-native, documented) | `#[RequireRole(...)]` | `middleware.RequireRole(...)` |
+
+**Additional languages (Kotlin, Swift, C, C++).** Where these SDKs ship the §11 helpers
+(SHOULD-level), they follow the same canonical vocabulary and `(action, resource[, scope])`
+order: **Kotlin** `@AxiamRequireAuth` / `@AxiamRequireAccess(...)` / `@AxiamRequireRole(...)`
+annotations (Spring interceptor / Ktor plugin enforcement); **Swift** `requireAuth` /
+`requireAccess(_:resource:)` / `requireRole(_:)` route-middleware factories (Vapor), and
+optionally a `@RequireAccess` property-wrapper form; **C++** `AXIAM_REQUIRE_ACCESS(...)`
+macro plus a `require_access(action, resolver)` guard functor; **C** `AXIAM_REQUIRE_ACCESS`
+macro over an `axiam_require_access(...)` guard function. All compose strictly on top of the
+§10 guard exactly as specified in §11.2.
 
 ### §11.2 Semantics (normative, identical in all SDKs)
 
@@ -515,6 +610,18 @@ recorded here until one exists.
     methods instead (§1 "Async method naming" table above).
   - Java `*Async` companion methods and C# `*Async`-only (TAP) methods are unaffected —
     formally documented as accepted per-language async conventions (§1).
+- **2026-07 (§6.1 client-certificate / mTLS)** — **non-breaking / additive.** Added §6.1
+  defining an optional client-identity-certificate API (`with_client_cert(cert_pem, key_pem)`
+  and per-language equivalents) applied to both REST and gRPC transports, PEM cert+key as the
+  mandatory baseline (PKCS#12 optional where keystore-native). Strict server verification and
+  the §6 TLS-bypass prohibition are unchanged; this only lets a client *present* an identity
+  for mutual TLS (IoT/service-account auth, `POST /api/v1/auth/device`). SDKs shipping it state
+  "§1–§10 (including §6.1 mTLS)".
+- **2026-07 (Kotlin, Swift, C, C++ SDKs)** — **non-breaking / additive.** Extended the
+  per-language tables (§1 casing + async, §4 cookie-jar, §6.1 mTLS, §7 `Sensitive`, §9
+  single-flight, §10 middleware, §11 helpers) to cover four new SDK languages
+  (`axiam-kotlin-sdk`, `axiam-swift-sdk`, `axiam-c-sdk`, `axiam-cplusplus-sdk`). No change to
+  existing languages' surfaces.
 - **2026-07 (§11 declarative authorization helpers)** — **non-breaking / additive.** Added
   §11 "Declarative Authorization Helpers" (SHOULD-level for v1.0): the `require_auth` /
   `require_access(action, resource[, scope])` / `require_role` vocabulary layered on top of
@@ -530,6 +637,6 @@ recorded here until one exists.
 
 ---
 
-*Contract version: 1.1 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07*
+*Contract version: 1.2 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*


### PR DESCRIPTION
## Summary
Platform-side coordination changes that support **four new SDK languages** (Kotlin, Swift, C, C++) and **client-certificate mutual TLS (mTLS)** across all AXIAM SDKs. The per-language SDK implementations land in their own `axiam-<lang>-sdk` repositories (separate PRs); this PR updates only the source-of-truth artifacts maintained here.

## Changes
- **`sdks/CONTRACT.md`** (the vendored cross-language contract):
  - New **§6.1 Client Certificate Authentication (mTLS)** — optional `with_client_cert(cert_pem, key_pem)` (+ per-language equivalents) applied to REST *and* gRPC transports; PEM cert+key baseline (PKCS#12 optional where keystore-native); strict server verification and the §6 TLS-bypass prohibition unchanged.
  - Extended **every per-language table** (§1 casing + async, §4 cookie-jar, §7 `Sensitive`, §9 single-flight, §10 middleware, §11 helpers) to cover Kotlin, Swift, C and C++.
  - Added the four repos to the "where the SDKs live" table; recorded both additions in the breaking-changes log (non-breaking / additive); bumped the contract to **v1.2**.
- **`scripts/mass-tag.sh`** — registered `axiam-kotlin-sdk`, `axiam-swift-sdk`, `axiam-c-sdk`, `axiam-cplusplus-sdk` with version discovery + bump rules (gradle.properties; CocoaPods podspec; vcpkg.json + CMakeLists.txt + conanfile.py).
- **`claude_dev/publishing-and-secrets.md`** — documented the new registries and secrets: Maven Central for Kotlin (reusing the `io.github.ilpanich` namespace + GPG key), SwiftPM/CocoaPods for Swift, GitHub Releases + in-repo vcpkg/Conan recipes for C/C++; Coveralls tooling rows; tag-publish matrix; the Kotlin `maven-central` environment.
- **`benchmarks/sdk/{kotlin,swift,c,cpp}/`** — additive `pending` bench scaffolds (`run.sh` + `TODO.md`), auto-discovered by `run-all.sh`. The shared harness files (`HARNESS-SPEC.md`, `collect.py`, `_pending.sh`, `justfile`) are intentionally **untouched** to avoid colliding with the in-flight `claude/verify-benchmark-upgrades-l1wjj5` branch.

## Notes
- No change to `sdks/openapi.json` or `proto/` (the OpenAPI drift gate and buf gates are unaffected).
- `mass-tag.sh` passes `bash -n`; the new bench scaffolds emit valid `axiam.sdk-bench/v1` JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FM1xTLBaGvfUv8X3bPw6oj)_