### PR TITLE
Wire org context into the TypeScript bench; list all 11 SDKs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The project follows a structured roadmap of **64 tasks across 19 phases**:
 | Phase 14 | Advanced MFA | Done |
 | Phase 15 | Admin frontend | Done |
 | Phase 16 | Docker & Kubernetes | Done |
-| Phase 17 | SDKs (Rust, TS, Python, Java, C#, PHP, Go) | Done |
+| Phase 17 | SDKs (Rust, TS, Python, Java, Kotlin, C#, PHP, Go, Swift, C, C++) | Done |
 | Phase 18 | Security audit, compliance, docs | Done |
 
 ## Quick Start
@@ -160,7 +160,7 @@ axiam/
 
 ## Client SDKs
 
-The seven client SDKs live in their own repositories. Each one vendors a copy of
+The eleven client SDKs live in their own repositories. Each one vendors a copy of
 [`sdks/CONTRACT.md`](sdks/CONTRACT.md) (the binding cross-language behavioral contract),
 [`sdks/openapi.json`](sdks/openapi.json) and [`proto/`](proto/), which are maintained here:
 
@@ -170,9 +170,13 @@ The seven client SDKs live in their own repositories. Each one vendors a copy of
 | TypeScript | [axiam-typescript-sdk](https://github.com/ilpanich/axiam-typescript-sdk) | [npm](https://www.npmjs.com/package/axiam-sdk) |
 | Python | [axiam-python-sdk](https://github.com/ilpanich/axiam-python-sdk) | [PyPI](https://pypi.org/project/axiam-sdk/) |
 | Java | [axiam-java-sdk](https://github.com/ilpanich/axiam-java-sdk) | Maven Central (`io.github.ilpanich:axiam-sdk`) |
+| Kotlin | [axiam-kotlin-sdk](https://github.com/ilpanich/axiam-kotlin-sdk) | Maven Central (`io.github.ilpanich:axiam-sdk-kotlin`) |
 | C# | [axiam-csharp-sdk](https://github.com/ilpanich/axiam-csharp-sdk) | [NuGet](https://www.nuget.org/packages/Axiam.Sdk) |
 | PHP | [axiam-php-sdk](https://github.com/ilpanich/axiam-php-sdk) | [Packagist](https://packagist.org/packages/axiam/axiam-sdk) |
 | Go | [axiam-go-sdk](https://github.com/ilpanich/axiam-go-sdk) | [pkg.go.dev](https://pkg.go.dev/github.com/ilpanich/axiam-go-sdk) |
+| Swift | [axiam-swift-sdk](https://github.com/ilpanich/axiam-swift-sdk) | Swift Package Manager (`github.com/ilpanich/axiam-swift-sdk`) |
+| C | [axiam-c-sdk](https://github.com/ilpanich/axiam-c-sdk) | CMake (FetchContent / `find_package`) |
+| C++ | [axiam-cplusplus-sdk](https://github.com/ilpanich/axiam-cplusplus-sdk) | CMake (FetchContent / vcpkg) |
 
 ## Benchmarking
 

--- a/benchmarks/sdk/typescript/bench.mjs
+++ b/benchmarks/sdk/typescript/bench.mjs
@@ -20,6 +20,7 @@ const cfg = {
   host: env("BENCH_HOST", "localhost"),
   port: env("BENCH_PORT", "8090"),
   tenantSlug: env("BENCH_TENANT_SLUG", "default"),
+  orgSlug: env("BENCH_ORG_SLUG", "bench-org"),
   username: env("BENCH_USERNAME", "benchuser"),
   password: env("BENCH_PASSWORD", "Bench@User123!"),
   action: env("BENCH_ACTION", "read"),
@@ -65,7 +66,7 @@ async function buildOps() {
   const { createNodeClient } = await import("axiam-sdk/node");
   const baseUrl = `${cfg.scheme}://${cfg.host}:${cfg.port}`;
 
-  const client = createNodeClient({ baseUrl, tenantSlug: cfg.tenantSlug });
+  const client = createNodeClient({ baseUrl, tenantSlug: cfg.tenantSlug, orgSlug: cfg.orgSlug });
   await client.login(cfg.username, cfg.password);
 
   // Every check reuses the one seeded resource UUID: the server rejects
@@ -86,7 +87,7 @@ async function buildOps() {
 
   return {
     login: async () => {
-      const fresh = createNodeClient({ baseUrl, tenantSlug: cfg.tenantSlug });
+      const fresh = createNodeClient({ baseUrl, tenantSlug: cfg.tenantSlug, orgSlug: cfg.orgSlug });
       await fresh.login(cfg.username, cfg.password);
     },
     refresh: () => client.refresh(),


### PR DESCRIPTION
## Summary

Follow-up to the TypeScript SDK gaining an organization field:

- **`benchmarks/sdk/typescript/bench.mjs`**: add `BENCH_ORG_SLUG` (default `bench-org`, matching the Python bench and `runner/seed.sh`) and forward it as `orgSlug` to every `createNodeClient()` call, so the Node bench's login/refresh succeed against a server that requires org context.
- **`README.md`**: the Client SDKs table and the Phase 17 row listed only 7 languages. Add the **Kotlin, Swift, C, and C++** SDKs (which also live in their own `ilpanich/axiam-<lang>-sdk` repos) with their distribution channels, and correct the "seven" count to "eleven".

No source/behavior changes to the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156crGuZKUBcWe2w5bzD9y1

---
_Generated by [Claude Code](https://claude.ai/code/session_0156crGuZKUBcWe2w5bzD9y1)_