### PR TITLE
fix(bootstrap): hash the admin password with the configured pepper

### DIFF
--- a/crates/axiam-api-rest/src/handlers/bootstrap.rs
+++ b/crates/axiam-api-rest/src/handlers/bootstrap.rs
@@ -31,6 +31,7 @@ use axiam_core::models::tenant::CreateTenant;
 use axiam_core::repository::{OrganizationRepository, TenantRepository};
 use axiam_db::{seed_default_roles, seed_permissions};
 use chrono::{DateTime, Utc};
+use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use surrealdb::types::SurrealValue;
@@ -366,7 +367,13 @@ pub async fn bootstrap<C: Connection + Clone>(
     let tenant_id_str = tenant_id.to_string();
     let ph_id_str = Uuid::new_v4().to_string();
 
-    let password_hash = password::hash_password(&req.password, None)
+    // Apply the server-configured password pepper (REQ-14 AC-1) — the same
+    // pepper the user repository uses at login-time verification. Previously
+    // this hashed with `None`, so a deployment that set AXIAM__AUTH__PEPPER
+    // could never authenticate the bootstrap admin (login verifies WITH the
+    // pepper, but this stored a hash computed WITHOUT it → "invalid credentials").
+    let pepper = state.auth_config.pepper.as_ref().map(|p| p.expose_secret());
+    let password_hash = password::hash_password(&req.password, pepper)
         .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?;
 
     // The RELATE uses backtick record IDs (required when type::record() is not


### PR DESCRIPTION
## Summary

The first-run bootstrap handler hashes the initial admin password **without** the server-configured password pepper, while login verifies **with** it. As a result, any deployment that sets `AXIAM__AUTH__PEPPER` stores a no-pepper hash for the bootstrap admin and can then never authenticate that admin — every login returns `401 "invalid credentials"`.

This is a genuine production footgun: enabling the pepper (a recommended hardening, REQ-14 AC-1) silently locks out the only admin created at first run. It was found while bringing up the benchmark harness with `AXIAM__AUTH__PEPPER` set — seeding failed at the admin login step.

## Root cause

`crates/axiam-api-rest/src/handlers/bootstrap.rs` hashed with a hardcoded `None`:

```rust
let password_hash = password::hash_password(&req.password, None)?;
```

`password::hash_password(password, pepper)` prepends the pepper before Argon2id; `password::verify_password` (used by the `SurrealUserRepository::with_pepper` login path) prepends the same pepper. Passing `None` here means the stored hash is `argon2(password)` while login computes `argon2(pepper + password)` → mismatch.

Note every *other* user (e.g. those created via `POST /api/v1/users`) is hashed through the peppered repository and is unaffected — only the bootstrap admin, created via raw SQL in the bootstrap transaction, bypassed the pepper.

## Fix

Apply the configured pepper from `state.auth_config.pepper`, exactly as `handlers/password_reset.rs` already does:

```rust
let pepper = state.auth_config.pepper.as_ref().map(|p| p.expose_secret());
let password_hash = password::hash_password(&req.password, pepper)?;
```

- When no pepper is configured, `pepper` is `None` — behavior is byte-for-byte unchanged, so existing deployments and tests are unaffected.
- When a pepper is configured, the bootstrap admin's stored hash now matches login-time verification.

## Testing

- Mirrors the established `password_reset.rs` pepper pattern (same `secrecy::ExposeSecret` import, same `Option<&str>` type flow).
- No behavior change when `AXIAM__AUTH__PEPPER` is unset (the default), so the existing bootstrap/E2E suites continue to pass unchanged.
- Manual: with `AXIAM__AUTH__PEPPER` set, bootstrap → login as the admin now succeeds (previously `401 invalid credentials`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEQ27rSiTYmitP6MaVnBTp

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEQ27rSiTYmitP6MaVnBTp)_