### PR TITLE
Add OCI annotations to Docker images for GHCR metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [server, frontend]
+        include:
+          - image: server
+            description: "AXIAM — Access eXtended Identity and Authorization Management"
+          - image: frontend
+            description: "AXIAM IAM admin dashboard"
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -214,8 +218,24 @@ jobs:
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        env:
+          # GHCR reads a multi-arch package's title/description/source from the
+          # OCI annotations on the manifest INDEX, not from the per-arch image
+          # config LABELs. Emit the annotations at index level so the merge step
+          # below can stamp them onto the manifest list — otherwise the package
+          # page shows "No description provided" and is not linked to the repo.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}
+          # Curated OCI annotations for the manifest index. `source` MUST point at
+          # this repository so GHCR auto-links the package to it (and inherits the
+          # README); `github.repository` resolves to "ilpanich/axiam".
+          annotations: |
+            org.opencontainers.image.title=axiam-${{ matrix.image }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.vendor=AXIAM Contributors
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
           # We publish the version computed in the step above verbatim, so a
           # pre-release like v1.0.0-alpha ships as the image tag "1.0.0-alpha"
           # rather than collapsing to "1.0.0" the way a bare `type=semver` would.
@@ -238,10 +258,14 @@ jobs:
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}
         run: |
           set -euo pipefail
-          # One -t per tag from metadata-action, one source ref per arch digest.
+          # One -t per tag and one --annotation per index annotation from
+          # metadata-action, one source ref per arch digest. The annotations land
+          # on the manifest LIST (index) so GHCR surfaces the description and
+          # links the package to its repository.
           # shellcheck disable=SC2046
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(jq -cr '(.annotations // []) | map("--annotation " + (. | @sh)) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${IMAGE}@sha256:%s " *)
 
       - name: Resolve manifest-list digest

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -58,7 +58,7 @@ EXPOSE 8080
 LABEL org.opencontainers.image.title="axiam-frontend" \
       org.opencontainers.image.description="AXIAM IAM admin dashboard" \
       org.opencontainers.image.vendor="AXIAM Contributors" \
-      org.opencontainers.image.source="https://github.com/emanuele/axiam" \
+      org.opencontainers.image.source="https://github.com/ilpanich/axiam" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -138,7 +138,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot@sha256:66aa873a4a14fb164aa01296058efd
 LABEL org.opencontainers.image.title="axiam-server" \
       org.opencontainers.image.description="AXIAM — Access eXtended Identity and Authorization Management" \
       org.opencontainers.image.vendor="AXIAM Contributors" \
-      org.opencontainers.image.source="https://github.com/emanuele/axiam" \
+      org.opencontainers.image.source="https://github.com/ilpanich/axiam" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR enhances Docker image publishing to the GitHub Container Registry (GHCR) by adding OCI annotations at the manifest index level, enabling proper display of image metadata (title, description, vendor, source, license) on the package page and auto-linking to the repository.

## Key Changes

- **Release workflow (`release.yml`)**:
  - Refactored the build matrix from a simple list to an `include` structure that pairs each image (`server`, `frontend`) with its curated description
  - Added `DOCKER_METADATA_ANNOTATIONS_LEVELS: index` environment variable to emit OCI annotations at the manifest index level (required by GHCR to read multi-arch package metadata)
  - Added comprehensive OCI annotations in the `docker/metadata-action` step:
    - `org.opencontainers.image.title` — image name
    - `org.opencontainers.image.description` — human-readable description
    - `org.opencontainers.image.vendor` — "AXIAM Contributors"
    - `org.opencontainers.image.source` — repository URL (enables GHCR auto-linking and README inheritance)
    - `org.opencontainers.image.licenses` — "Apache-2.0"
  - Updated the `docker buildx imagetools create` command to pass annotations from metadata-action output to the manifest list via `--annotation` flags
  - Enhanced comments to explain why annotations must land on the manifest LIST (index) for GHCR to surface them

- **Dockerfiles (`docker/Dockerfile.server` and `docker/Dockerfile.frontend`)**:
  - Updated repository URL in OCI image labels from `https://github.com/emanuele/axiam` to `https://github.com/ilpanich/axiam` to reflect the correct upstream repository

## Implementation Details

The key insight is that GHCR reads multi-arch package metadata from OCI annotations on the **manifest INDEX** (list), not from per-architecture image config LABELs. Without this change, the package page displays "No description provided" and is not linked to the repository. The workflow now:

1. Configures `docker/metadata-action` to emit annotations at index level
2. Extracts those annotations from the action's JSON output
3. Passes them to `docker buildx imagetools create` when merging per-architecture digests into the final manifest list

This ensures GHCR properly surfaces the curated descriptions and auto-links the package to its repository.

https://claude.ai/code/session_01UGKipAu5n929MDKEiM5zf3