### PR TITLE
Fix docker buildx imagetools create with spaced annotation values

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,11 +262,24 @@ jobs:
           # metadata-action, one source ref per arch digest. The annotations land
           # on the manifest LIST (index) so GHCR surfaces the description and
           # links the package to its repository.
-          # shellcheck disable=SC2046
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(jq -cr '(.annotations // []) | map("--annotation " + (. | @sh)) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf "${IMAGE}@sha256:%s " *)
+          #
+          # Build the argument list in a bash array so annotation values that
+          # contain spaces (e.g. "AXIAM IAM admin dashboard") survive as single
+          # arguments. Command substitution + jq @sh does NOT work here: the
+          # shell word-splits the substituted text and never re-applies the
+          # embedded quotes, so a spaced annotation splinters into stray
+          # positional args ("IAM" -> "failed to parse source").
+          args=()
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          while IFS= read -r ann; do
+            args+=(--annotation "$ann")
+          done < <(jq -r '(.annotations // [])[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          for digest in *; do
+            args+=("${IMAGE}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${args[@]}"
 
       - name: Resolve manifest-list digest
         id: index


### PR DESCRIPTION
## Summary

Refactored the `docker buildx imagetools create` command invocation in the release workflow to properly handle annotation values containing spaces (e.g., "AXIAM IAM admin dashboard"). The previous implementation using command substitution with `jq @sh` failed to preserve quoted arguments through shell word-splitting, causing annotations with spaces to splinter into stray positional arguments.

## Key Changes

- Replaced command substitution + `jq @sh` pattern with explicit bash array construction
- Tags are now read line-by-line from `jq -r '.tags[]'` and appended to an args array with `-t` prefix
- Annotations are similarly read line-by-line from `jq -r '(.annotations // [])[]'` and appended with `--annotation` prefix
- Digest loop now builds full image references and appends them to the args array
- Final `docker buildx imagetools create` invocation uses `"${args[@]}"` to safely expand the array

## Implementation Details

The core issue was that `jq @sh` produces shell-escaped strings suitable for `eval`, but when used in command substitution without `eval`, the shell still performs word-splitting on the substituted text without re-applying the embedded quotes. By building a bash array directly and reading jq output line-by-line, each tag, annotation, and digest is preserved as a single argument regardless of internal whitespace.

This fix ensures that annotation values like "AXIAM IAM admin dashboard" are passed as a single `--annotation` argument rather than being split into multiple positional arguments that cause the `docker buildx imagetools create` command to fail with "failed to parse source" errors.

https://claude.ai/code/session_01R3ufmvfqCozvjpGDpNmgiR