### PR TITLE
fix(sdk-contract,benches,docs): require organization context for login/refresh

### DIFF
--- a/benchmarks/sdk/HARNESS-SPEC.md
+++ b/benchmarks/sdk/HARNESS-SPEC.md
@@ -54,7 +54,7 @@ The same env the server harness uses, so `runner/*.sh` can drive both:
 
 ```
 BENCH_TARGET, BENCH_SCHEME, BENCH_HOST, BENCH_PORT, BENCH_GRPC_ADDR
-BENCH_TENANT_ID, BENCH_TENANT_SLUG, BENCH_CLIENT_ID, BENCH_CLIENT_SECRET, BENCH_USERNAME, BENCH_PASSWORD
+BENCH_TENANT_ID, BENCH_TENANT_SLUG, BENCH_ORG_ID, BENCH_ORG_SLUG, BENCH_CLIENT_ID, BENCH_CLIENT_SECRET, BENCH_USERNAME, BENCH_PASSWORD
 BENCH_ACTION          (default "read")      # action for check_access/batch_check
 BENCH_RESOURCE_ID     (seeded resource UUID) # subject of the authz checks
 BENCH_SUBJECT_ID      (seeded user UUID)      # the bench user's id
@@ -66,7 +66,10 @@ SDK_BENCH_CONCURRENCY (default 16)
 
 SDK clients authenticate with `tenant_slug` (`BENCH_TENANT_SLUG`, default
 `"default"`), not the tenant UUID — the tenant UUID (`BENCH_TENANT_ID`) is still
-needed for scenarios/adapters that address the tenant by id.
+needed for scenarios/adapters that address the tenant by id. Login/refresh also
+require organization context (CONTRACT.md §5.1): SDK benches send `org_slug`
+(`BENCH_ORG_SLUG`, default `"bench-org"`); `BENCH_ORG_ID` carries the org UUID
+for id-form addressing. Both are written by `runner/seed.sh`.
 
 `BENCH_RESOURCE_ID` and `BENCH_SUBJECT_ID` are written by `runner/seed.sh`, which
 provisions a resource plus a role holding a `read` permission grant assigned to

--- a/benchmarks/sdk/csharp/Program.cs
+++ b/benchmarks/sdk/csharp/Program.cs
@@ -18,6 +18,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Axiam.Sdk;
+using Axiam.Sdk.Options;
 using AccessCheck = Axiam.Sdk.Rest.AuthzRestClient.AccessCheck;
 
 // ---------------------------------------------------------------------------
@@ -35,6 +36,7 @@ string host = Env("BENCH_HOST", "localhost");
 string port = Env("BENCH_PORT", "8090");
 string baseUrl = $"{scheme}://{host}:{port}";
 string tenantSlug = Env("BENCH_TENANT_SLUG", "default");
+string orgSlug = Env("BENCH_ORG_SLUG", "bench-org");
 string username = Env("BENCH_USERNAME", "benchuser");
 string password = Env("BENCH_PASSWORD", "Bench@User123!");
 string action = Env("BENCH_ACTION", "read");
@@ -151,7 +153,7 @@ try
 {
     resourceId = Guid.Parse(resourceIdRaw); // FormatException -> status "error"
 
-    client = new AxiamClient(new Uri(baseUrl), tenantSlug);
+    client = new AxiamClient(new Uri(baseUrl), tenantSlug, new AxiamClientOptions { OrgSlug = orgSlug });
     await client.LoginAsync(username, password);
 
     // Batch of 3 checks, all against the SAME resource (no per-item suffixing —
@@ -179,7 +181,7 @@ var opsFns = new Dictionary<string, (Func<Task> Fn, int Concurrency)>
 {
     ["login"] = (async () =>
     {
-        var fresh = new AxiamClient(new Uri(baseUrl), tenantSlug);
+        var fresh = new AxiamClient(new Uri(baseUrl), tenantSlug, new AxiamClientOptions { OrgSlug = orgSlug });
         try { await fresh.LoginAsync(username, password); }
         finally { fresh.Dispose(); }
     }, CONC),

--- a/benchmarks/sdk/csharp/Program.cs
+++ b/benchmarks/sdk/csharp/Program.cs
@@ -153,7 +153,7 @@ try
 {
     resourceId = Guid.Parse(resourceIdRaw); // FormatException -> status "error"
 
-    client = new AxiamClient(new Uri(baseUrl), tenantSlug, new AxiamClientOptions { OrgSlug = orgSlug });
+    client = new AxiamClient(new Uri(baseUrl), tenantSlug, new AxiamClientOptions { BaseUrl = new Uri(baseUrl), TenantId = tenantSlug, OrgSlug = orgSlug });
     await client.LoginAsync(username, password);
 
     // Batch of 3 checks, all against the SAME resource (no per-item suffixing —
@@ -181,7 +181,7 @@ var opsFns = new Dictionary<string, (Func<Task> Fn, int Concurrency)>
 {
     ["login"] = (async () =>
     {
-        var fresh = new AxiamClient(new Uri(baseUrl), tenantSlug, new AxiamClientOptions { OrgSlug = orgSlug });
+        var fresh = new AxiamClient(new Uri(baseUrl), tenantSlug, new AxiamClientOptions { BaseUrl = new Uri(baseUrl), TenantId = tenantSlug, OrgSlug = orgSlug });
         try { await fresh.LoginAsync(username, password); }
         finally { fresh.Dispose(); }
     }, CONC),

--- a/benchmarks/sdk/java/src/main/java/io/axiam/bench/Bench.java
+++ b/benchmarks/sdk/java/src/main/java/io/axiam/bench/Bench.java
@@ -36,6 +36,7 @@ public final class Bench {
     private static final String PORT = env("BENCH_PORT", "8090");
     private static final String BASE_URL = SCHEME + "://" + HOST + ":" + PORT;
     private static final String TENANT_SLUG = env("BENCH_TENANT_SLUG", "default");
+    private static final String ORG_SLUG = env("BENCH_ORG_SLUG", "bench-org");
     private static final String USERNAME = env("BENCH_USERNAME", "benchuser");
     private static final String PASSWORD = env("BENCH_PASSWORD", "Bench@User123!");
     private static final String ACTION = env("BENCH_ACTION", "read");
@@ -66,7 +67,7 @@ public final class Bench {
         AxiamClient client;
         List<AxiamClient.AccessCheck> checks;
         try {
-            client = AxiamClient.builder(BASE_URL, TENANT_SLUG).build();
+            client = AxiamClient.builder(BASE_URL, TENANT_SLUG).orgSlug(ORG_SLUG).build();
             client.login(USERNAME, PASSWORD);
             // Batch of 3 checks, all against the SAME resource id (no suffix).
             checks = new ArrayList<>();
@@ -85,7 +86,7 @@ public final class Bench {
         final List<AxiamClient.AccessCheck> sharedChecks = checks;
 
         Op login = () -> {
-            try (AxiamClient fresh = AxiamClient.builder(BASE_URL, TENANT_SLUG).build()) {
+            try (AxiamClient fresh = AxiamClient.builder(BASE_URL, TENANT_SLUG).orgSlug(ORG_SLUG).build()) {
                 fresh.login(USERNAME, PASSWORD);
             }
         };

--- a/benchmarks/sdk/php/bench.php
+++ b/benchmarks/sdk/php/bench.php
@@ -36,6 +36,7 @@ $cfg = [
         $env('BENCH_PORT', '8090'),
     ),
     'tenant_slug' => $env('BENCH_TENANT_SLUG', 'default'),
+    'org_slug' => $env('BENCH_ORG_SLUG', 'bench-org'),
     'username' => $env('BENCH_USERNAME', 'benchuser'),
     'password' => $env('BENCH_PASSWORD', 'Bench@User123!'),
     'action' => $env('BENCH_ACTION', 'read'),
@@ -120,7 +121,7 @@ function emit(string $status, array $ops, int $iterations, int $concurrency, str
  */
 function build_ops(array $cfg): array
 {
-    $client = new \Axiam\Sdk\AxiamClient($cfg['base_url'], $cfg['tenant_slug']);
+    $client = new \Axiam\Sdk\AxiamClient($cfg['base_url'], $cfg['tenant_slug'], $cfg['org_slug']);
     $client->login($cfg['username'], $cfg['password']);
 
     // 3 checks, all using the SAME resource id (batch preserves input order).
@@ -132,7 +133,7 @@ function build_ops(array $cfg): array
 
     return [
         'login' => static function () use ($cfg): void {
-            $fresh = new \Axiam\Sdk\AxiamClient($cfg['base_url'], $cfg['tenant_slug']);
+            $fresh = new \Axiam\Sdk\AxiamClient($cfg['base_url'], $cfg['tenant_slug'], $cfg['org_slug']);
             $fresh->login($cfg['username'], $cfg['password']);
         },
         'refresh' => static fn (): mixed => $client->refresh(),

--- a/benchmarks/sdk/rust/src/main.rs
+++ b/benchmarks/sdk/rust/src/main.rs
@@ -35,6 +35,7 @@ fn env(key: &str, default: &str) -> String {
 struct Cfg {
     base_url: String,
     tenant_slug: String,
+    org_slug: String,
     username: String,
     password: String,
     action: String,
@@ -76,6 +77,7 @@ impl Cfg {
         Ok(Cfg {
             base_url,
             tenant_slug: env("BENCH_TENANT_SLUG", "default"),
+            org_slug: env("BENCH_ORG_SLUG", "bench-org"),
             username: env("BENCH_USERNAME", "benchuser"),
             password: env("BENCH_PASSWORD", "Bench@User123!"),
             action: env("BENCH_ACTION", "read"),
@@ -102,11 +104,13 @@ enum Op {
 }
 
 /// Build a tenant-scoped client. `base_url()` validates the scheme (https, or
-/// http on loopback) and returns a `Result`; the tenant slug is required.
+/// http on loopback) and returns a `Result`; the tenant slug is required, and
+/// the org slug is required for login/refresh (CONTRACT.md §5.1).
 fn build_client(cfg: &Cfg) -> Result<AxiamClient, AxiamError> {
     AxiamClient::builder()
         .base_url(cfg.base_url.as_str())?
         .tenant_slug(cfg.tenant_slug.as_str())
+        .org_slug(cfg.org_slug.as_str())
         .build()
 }
 

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -220,7 +220,7 @@ Per-language guidance:
 
 ---
 
-## §5 Tenant Context Contract
+## §5 Tenant & Organization Context Contract
 
 **`tenant_slug` or `tenant_id` is a non-optional constructor parameter.**
 
@@ -237,6 +237,48 @@ AxiamClient::new(base_url, tenant_id: uuid)        // tenant_id UUID form
 ```
 
 **Why this matters:** AXIAM is a multi-tenant system. Omitting the tenant identifier causes every authenticated API call to fail with 400 or 403. Enforcing it at construction time gives a clear, early error.
+
+### §5.1 Organization Context (required for login and refresh)
+
+**A tenant slug is only unique *within* an organization, so the login and
+refresh endpoints require organization context in addition to tenant context.**
+
+All SDKs MUST expose an optional organization identifier alongside the tenant
+identifier — `org_slug` (human-readable) or `org_id` (UUID) — settable at client
+construction time (mirroring `tenant_slug`/`tenant_id`), and MUST forward it as
+follows:
+
+1. **`POST /api/v1/auth/login`** — the request body MUST carry organization
+   context: either `org_slug` (paired with `tenant_slug`) or `org_id` (paired
+   with `tenant_id`). A login body without any organization identifier is
+   rejected by the server with `400 Bad Request` — *"must provide org_id or
+   org_slug"*. `LoginRequest` fields: `tenant_id?`, `org_id?`, `tenant_slug?`,
+   `org_slug?` (each optional individually; one tenant form **and** one org form
+   are required together).
+2. **`POST /api/v1/auth/refresh`** — `RefreshRequest` requires **both**
+   `tenant_id` and `org_id` as non-optional UUIDs. An SDK constructed with slugs
+   MUST resolve the authoritative `tenant_id`/`org_id` UUIDs from the
+   access-token claims returned by login (the `tenant_id`/`org_id` JWT claims are
+   read best-effort/unverified purely to populate the refresh body, which the
+   server re-validates) and emit them on refresh.
+
+```
+// Slug form — org + tenant slugs supplied up front
+AxiamClient::new(base_url, tenant_slug: "acme", org_slug: "acme")
+// UUID form
+AxiamClient::new(base_url, tenant_id: uuid, org_id: uuid)
+```
+
+Because the organization identifier is only consumed by the login/refresh flow,
+it is an **optional** constructor parameter (unlike the tenant identifier):
+resource-server / token-verification-only usage (middleware, route guards) that
+never calls `login`/`refresh` does not require it. Any SDK example or benchmark
+that calls `login` MUST supply organization context; omitting it makes login
+fail at runtime.
+
+**Why this matters:** without organization context every `login` call fails with
+`400 "must provide org_id or org_slug"` and every `refresh` fails request
+deserialization. All AXIAM SDKs expose this field uniformly.
 
 ---
 

--- a/website/src/data.ts
+++ b/website/src/data.ts
@@ -29,6 +29,7 @@ export const SDKS: Sdk[] = [
 let axiam = AxiamClient::builder()
     .base_url("https://iam.acme.dev")
     .tenant_slug("acme")
+    .org_slug("acme")
     .build()?;
 
 axiam.login(&email, &password).await?;
@@ -66,6 +67,7 @@ async fn get_doc(path: web::Path<String>) -> impl Responder {
 const axiam = new AxiamClient({
   baseUrl: 'https://iam.acme.dev',
   tenantSlug: 'acme',
+  orgSlug: 'acme',
 });
 
 await axiam.login(email, password);
@@ -104,7 +106,8 @@ export class DocsController {
     quickstart: `from axiam_sdk import AxiamClient
 
 with AxiamClient(base_url="https://iam.acme.dev",
-                 tenant_slug="acme") as axiam:
+                 tenant_slug="acme",
+                 org_slug="acme") as axiam:
     axiam.login(email, password)
     ok = axiam.can("resource:read", "doc:1")`,
     guardLabel: "Guard by dependency (FastAPI)",
@@ -141,6 +144,7 @@ def read_doc(doc_id: str,
     quickstart: `AxiamClient axiam = AxiamClient.builder()
     .baseUrl("https://iam.acme.dev")
     .tenantSlug("acme")
+    .orgSlug("acme")
     .build();
 
 axiam.login(email, password);
@@ -179,6 +183,7 @@ class DocController {
     quickstart: `var axiam = new AxiamClient(new AxiamOptions {
     BaseUrl = "https://iam.acme.dev",
     TenantSlug = "acme",
+    OrgSlug = "acme",
 });
 
 await axiam.LoginAsync(email, password);
@@ -214,6 +219,7 @@ public class DocsController : ControllerBase
 $axiam = new AxiamClient([
     'baseUrl' => 'https://iam.acme.dev',
     'tenantSlug' => 'acme',
+    'orgSlug' => 'acme',
 ]);
 
 $axiam->login($email, $password);
@@ -252,6 +258,7 @@ class DocController
     quickstart: `client, _ := axiam.New(axiam.Config{
     BaseURL:    "https://iam.acme.dev",
     TenantSlug: "acme",
+    OrgSlug:    "acme",
 })
 
 client.Login(ctx, email, password)

--- a/website/src/docs.ts
+++ b/website/src/docs.ts
@@ -75,7 +75,7 @@ export const DOC_PAGES: DocPage[] = [
       {
         type: "code",
         caption: "quickstart · TypeScript",
-        code: "import { AxiamClient } from 'axiam-sdk';\n\nconst axiam = new AxiamClient({\n  baseUrl: 'https://iam.acme.dev',\n  tenantSlug: 'acme',\n});\n\nawait axiam.login(email, password);\nconst ok = await axiam.can('read', 'doc:1');",
+        code: "import { AxiamClient } from 'axiam-sdk';\n\nconst axiam = new AxiamClient({\n  baseUrl: 'https://iam.acme.dev',\n  tenantSlug: 'acme',\n  orgSlug: 'acme',\n});\n\nawait axiam.login(email, password);\nconst ok = await axiam.can('read', 'doc:1');",
       },
       {
         type: "note",


### PR DESCRIPTION
Login and refresh require organization context in addition to tenant
context (a tenant slug is only unique within an organization). The
server rejects a login body without an org identifier ("must provide
org_id or org_slug") and RefreshRequest requires both tenant_id and
org_id as UUIDs. This documents the constraint in the SDK contract and
fixes the SDK benchmarks and public quickstart snippets that still
constructed clients / logged in with tenant context only.

- CONTRACT.md: add §5.1 Organization Context (required for login and
  refresh); rename §5 to "Tenant & Organization Context Contract".
- benches: add BENCH_ORG_SLUG (default "bench-org") and forward org
  context on login in the Java, PHP, C#, and Rust SDK benches (Python
  and TypeScript benches already sent it). Document BENCH_ORG_SLUG /
  BENCH_ORG_ID in HARNESS-SPEC.md.
- website: add orgSlug/org_slug to the Rust, TypeScript, Python, Java,
  C#, PHP, and Go quickstart snippets (data.ts) and the docs quickstart
  (docs.ts).

openapi.json already documents org_slug/org_id on LoginRequest and
requires tenant_id/org_id on RefreshRequest — no change needed there.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NLne4MVNrTAPorNno4PZdD