### PR TITLE
Benchmark improvement plan: Phases A–D + E2 (harness honesty, server perf, mTLS, authz cache)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "sha2 0.11.0",
  "surrealdb",
  "surrealdb-types",
+ "tikv-jemallocator",
  "tokio",
  "tokio-test",
  "tracing",
@@ -7355,6 +7356,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,7 @@ dependencies = [
  "uuid",
  "webauthn-rs-proto",
  "wiremock",
+ "x509-parser 0.18.1",
 ]
 
 [[package]]
@@ -1127,6 +1128,7 @@ version = "1.0.0-alpha12"
 dependencies = [
  "actix-http",
  "actix-rt",
+ "actix-tls",
  "actix-web",
  "axiam-amqp",
  "axiam-api-grpc",
@@ -1145,6 +1147,7 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "rand_core 0.6.4",
+ "rcgen",
  "reqwest 0.12.28",
  "rsa",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,7 @@ version = "1.0.0-alpha12"
 dependencies = [
  "axiam-core",
  "axiam-db",
+ "chrono",
  "criterion",
  "futures",
  "serde",

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,6 +1,12 @@
 # Generated benchmark artifacts
 results/**
 !results/.gitkeep
+# Seed fixtures: client secrets + the bench user's password (runner/seed.sh).
+# Kept out of results/ (which we share via `just bench-pack`) — see A7 in
+# claude_dev/benchmark-improvement-plan.md.
+.seed/
+# Packed shareable result bundles (just bench-pack)
+results-*.tar.xz
 # Throwaway TLS/mTLS material (regenerate with `just bench-certs`)
 profiles/certs/
 

--- a/benchmarks/PRIVATE_BENCH_ANALYSIS.md
+++ b/benchmarks/PRIVATE_BENCH_ANALYSIS.md
@@ -240,6 +240,89 @@ enable rustls session tickets + verify keep-alive; do NOT enable 0-RTT (replay
 risk on POST token endpoints — explicitly document that decision). Whatever
 the cause, it's worth ~2× on our two most marketable numbers.
 
+#### 4.3.1 B2 root-cause analysis (code landed; measurement pending laptop re-run)
+
+**Status:** durable fixes + instrumentation implemented in the server and bench
+harness; the *measured* confirmation is **pending a laptop re-run** (this
+working environment has no k6, no live stack, and an empty `results/` tree — the
+raw 2026-07-19 k6 JSON with the sub-metrics named below lives on the
+maintainer's laptop). Nothing below claims a measured result yet.
+
+**Ranked hypotheses**
+
+1. **[LEADING] ALPN/protocol asymmetry — h2 (p2) vs http/1.1 (p0).** Over TLS,
+   k6 (Go `net/http`, `ForceAttemptHTTP2=true`) negotiates **h2** whenever the
+   server offers it; the plaintext p0 listener is **http/1.1**. So p2 and p0 are
+   not the same protocol. Confirmed from source that AXIAM's TLS bind *does*
+   offer h2: actix-web's `HttpServer::bind_rustls_0_23` →
+   `actix_http::HttpService::rustls_0_23_with_config` unconditionally sets
+   `config.alpn_protocols = ["h2","http/1.1", …]` (actix-http 3.13.1,
+   `src/service.rs`), h2 first, so it wins. Under h2, k6 funnels all 50 VUs'
+   requests through a **single multiplexed TCP/h2 connection** with default
+   flow-control windows, where http/1.1 uses a per-VU connection pool — a
+   plausible ~2× serialization ceiling with no CPU wall, exactly matching the
+   observed p50-doubling-without-saturation signature. Why introspection
+   (−0.3%) and jwks (−13.9%) barely move: introspection/jwks are GETs that are
+   cheaper/cacheable and less sensitive to the single-conn ceiling than the POST
+   token grants.
+   *Confirm/refute on the laptop with ZERO new runs:* read the **`http_version`**
+   tag already present in the 2026-07-19 k6 JSON — p2 token cells should show
+   `2`, p0 `1.1`. If p2 is already `1.1`, this hypothesis is refuted.
+
+2. **[SECONDARY] No TLS session resumption — full handshake per connection.**
+   The old `tls.rs` set neither a ticketer nor a session store, so rustls did a
+   **full ECDHE handshake on every connection**. k6 opens many short-lived
+   connections, making the handshake a per-request fixed cost — the same
+   "fixed cost, not record crypto" signature. This is additive to (1).
+   *Confirm/refute with ZERO new runs:* inspect **`http_req_tls_handshaking`**
+   (and `http_req_connecting`) in the existing p2 JSON — if handshaking time is
+   a large, roughly-constant slice of `http_req_duration` on the degraded cells,
+   resumption is a real contributor; if it's near-zero (connections reused),
+   it's not the dominant term and (1) dominates.
+
+3. **Keep-alive parity — checked, not a factor.** The plaintext and rustls
+   binds are the **same** `HttpServer` builder in `main.rs` (only the bind
+   method differs); actix keep-alive/`client_request_timeout` are therefore
+   identical across p0/p2. Corroborate on the laptop via `http_req_connecting`
+   being ~0 on warm iterations (connection reuse) in both profiles.
+
+4. **TCP_NODELAY — checked, not a factor.** actix-server sets `TCP_NODELAY` by
+   default on accepted sockets, and both binds share that accept path, so Nagle
+   is off equally in p0 and p2.
+
+**What changed (code)**
+
+- `crates/axiam-server/src/tls.rs`: (a) new `AXIAM__SERVER__TLS__HTTP2` knob
+  (default `true`) driving `config.alpn_protocols` (h2+h1.1 vs h1.1-only), via a
+  unit-tested `alpn_protocols()` helper; (b) **TLS 1.3 ticket resumption**
+  enabled — `config.ticketer = rustls::crypto::ring::Ticketer::new()?` plus a
+  bounded `ServerSessionMemoryCache::new(512)` (rustls 0.23.42). 0-RTT/early
+  data left **off** (default `max_early_data_size=0`).
+- `crates/axiam-api-rest/src/config/mod.rs`: `TlsConfig.http2: bool` (custom
+  `Default` → `true`).
+- `crates/axiam-server/src/main.rs`: TLS-bind logging of `http2_offered` /
+  `resumption` / `early_data`, plus a startup **warning** when `http2=false`
+  that actix re-adds h2 (so the knob is not silently misleading).
+- Bench: `benchmarks/targets/axiam/tls/tls13-h1.conf` (an http/1.1-only TLS 1.3
+  nginx edge) + `AXIAM__SERVER__TLS__HTTP2` pass-through on the native-tls
+  overlay, so p2 can be run **both ways** to isolate the h2 effect in one
+  sitting.
+
+**Important honesty caveat on the knob:** because actix-web's rustls bind
+re-adds h2 to ALPN, `http2=false` on the *native* listener does not by itself
+produce an http/1.1-only server. The genuine apples-to-apples h1 cell is run via
+the `tls13-h1.conf` nginx edge (or, later, a native H1-only actix service — not
+built here to avoid an untestable hand-rolled `actix_server` path). Session
+resumption, by contrast, is a real unconditional server-side improvement that
+landed.
+
+**Acceptance (pending laptop):** re-run only the p2 vs p0 cells for
+`oauth2_client_credentials` and `token_refresh`; success = p2 within ~15% of p0
+throughput with introspection/jwks not regressed. Expected path: the
+`http_version`/`http_req_tls_handshaking` reads above first attribute the split
+between h2 (1) and handshakes (2); resumption is already in; if h2 is confirmed
+dominant, run the `tls13-h1.conf` cell to show p2-h1 ≈ p0.
+
 ### 4.4 [MEDIUM] Native mTLS (and the TLS 1.2 decision)
 
 Discovered during bench tuning: AXIAM's native rustls listener is TLS 1.3

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -125,15 +125,35 @@ just target=axiam bench-down
 just target=keycloak bench-down
 ```
 
-Or run the entire matrix (all targets × all profiles × all scenarios) unattended:
+Or run the entire matrix (all targets × all profiles × all scenarios) unattended.
+By default this repeats the whole matrix 3× (`repeat := "3"`) into
+`results/run-1/`, `results/run-2/`, `results/run-3/`, and `report.py` medians
+each cell across the valid runs (see
+[methodology §8](docs/methodology.md#8-multiple-runs--median-of-n-c1)); pass
+`repeat=1` for a single quick pass instead:
 
 ```bash
 just targets="axiam keycloak" profiles="p0-plaintext p2-tls13 p3-mtls" bench-matrix
+# just repeat=1 targets="axiam keycloak" profiles="p0-plaintext p2-tls13 p3-mtls" bench-matrix
 ```
 
 See [`docs/methodology.md`](docs/methodology.md) for the rules that make a run
 comparable, and [`docs/security-profiles.md`](docs/security-profiles.md) for the
 profile definitions.
+
+Running the matrix on a laptop rather than dedicated hardware? See
+[**"Running on a laptop"**](docs/methodology.md#10-running-on-a-laptop-c3) in
+the methodology doc for the variance-control runbook (AC power, CPU governor,
+turbo-boost mode, cooldown pauses between cells) before trusting absolute
+numbers.
+
+For a repeatable, noise-resistant run, use `repeat=N` (default 3) so
+`bench-matrix` runs the whole matrix N times and `report.py` medians each
+cell — see [§8 "Multiple runs — median-of-N"](docs/methodology.md#8-multiple-runs--median-of-n-c1):
+
+```bash
+just repeat=3 targets="axiam keycloak" profiles="p0-plaintext p2-tls13" bench-matrix
+```
 
 ## Status of components
 

--- a/benchmarks/docs/amqp-authz-harness-design.md
+++ b/benchmarks/docs/amqp-authz-harness-design.md
@@ -1,0 +1,119 @@
+# AMQP Async-Authz Load Harness — Design (E2)
+
+**Status:** DESIGN (the plan's mandated "design doc first" deliverable for E2).
+Implementation is scaffolded per §5 but its acceptance is a **measured run
+against a live RabbitMQ + AXIAM authz consumer** and is therefore pending the
+benchmark environment — no throughput/latency numbers appear here until that
+run exists.
+
+## 1. Why a separate tool
+
+The k6-based matrix cannot exercise the AMQP path — k6 speaks HTTP/gRPC, not
+AMQP, and the async-authz flow is request/response over two queues with
+HMAC-signed, replay-protected messages. `benchmarks/README.md` lists AMQP as
+explicitly out of scope for the first matrix. E2 closes that gap with a
+dedicated publisher/consumer load tool that measures the metric that matters
+for deferred authz: **end-to-end decision latency** (publish → correlated
+response) and **consumer throughput** (decisions/s the AXIAM consumer
+sustains).
+
+## 2. The contract being measured (from `crates/axiam-amqp`)
+
+- **Request queue:** `axiam.authz.request` (`connection::queues::AUTHZ_REQUEST`).
+- **Response queue:** `axiam.authz.response` (`AUTHZ_RESPONSE`).
+- **Request message** (`messages::AuthzRequest`): `correlation_id`,
+  `tenant_id`, `subject_id`, `action`, `resource_id`, `scope?`, `key_version`
+  (currently `2`), `nonce` (unique per message), `issued_at`, and an
+  `hmac_signature` over the canonical payload.
+- **Signing:** HMAC-SHA256 with a **per-tenant subkey** derived as
+  `derive_tenant_key(master_key, tenant_id, key_version)`. The harness must
+  hold the same tenant master key the AXIAM consumer verifies against (a bench
+  secret, sourced from `.seed/` like every other bench credential — never
+  committed).
+- **Replay/freshness gates the harness must satisfy:** `key_version >= 2`,
+  `issued_at` within `DEFAULT_FRESHNESS_SKEW_SECS` (300 s), and a **unique
+  `nonce` per message** (the consumer records consumed nonces in the durable
+  `amqp_nonce_replay` store and rejects duplicates — so the load tool must
+  generate a fresh nonce every publish or it will measure rejections, not
+  decisions).
+- **Response** (`messages::AuthzResponse`): carries the same `correlation_id`
+  so the harness can pair a response to its request and compute latency.
+
+## 3. Metrics
+
+Per run, over a measured window (after warm-up):
+
+- **Decision latency** end-to-end: `t(response received) − t(request
+  published)`, correlated by `correlation_id`. Report p50/p95/p99 + max.
+- **Consumer throughput:** responses/s sustained at steady state.
+- **Publish rate vs. drain rate:** offered load vs. responses/s, to find the
+  saturation knee (where latency diverges = the consumer's ceiling).
+- **In-flight depth:** outstanding (published-not-yet-answered) count over
+  time — a proxy for queue backlog.
+- **Rejections:** responses that are errors, plus publishes with no response
+  within a timeout (surfaced separately — a silent timeout is a failure, not a
+  slow success).
+
+Emit one JSON record per run mirroring the k6 harness's shape
+(`bench_ok`/`bench_failed`/latency percentiles) so `runner/report.py` /
+`sdk/collect.py` can fold AMQP cells into the same report with a clear
+`protocol: amqp` label (not comparable head-to-head with REST/gRPC single
+checks — it measures a *deferred* decision, a different logical op).
+
+## 4. Load model
+
+- **Open model, fixed arrival rate** (like k6's `constant-arrival-rate`):
+  publish at R req/s regardless of in-flight depth, so latency reflects the
+  consumer's true service time under offered load rather than a closed loop
+  that self-throttles. Sweep R across a few points to trace the latency knee.
+- **Bounded in-flight cap** as a safety valve (stop publishing if outstanding
+  exceeds a ceiling) to avoid unbounded memory on a saturated consumer —
+  logged as a saturation event, never silently.
+- **Request shape** matches the k6 authz scenario's seeded subject/resource so
+  the AMQP number is comparable *within AXIAM* to the REST/gRPC authz cells
+  (same evaluation cost, different transport/dispatch).
+
+## 5. Implementation plan (scaffold; build behind a live broker)
+
+Two viable implementations; **prefer (a)** for signature fidelity:
+
+- **(a) Rust bench binary** under `benchmarks/amqp/` (its own tiny crate,
+  *not* in the server workspace to keep server build times unaffected) that
+  depends on `axiam-amqp` for `AuthzRequest`/`AuthzResponse`,
+  `derive_tenant_key`, and canonical signing — guaranteeing byte-identical
+  signatures/nonce handling with the server. Uses `lapin` (already a
+  server dep) for publish/consume. A publisher task fans out at rate R; a
+  consumer task drains `axiam.authz.response`, matches `correlation_id` in a
+  `DashMap`/`HashMap`, timestamps, and records latencies into an `hdrhistogram`.
+- **(b) Python + `pika`** — faster to iterate but must re-implement the exact
+  `derive_tenant_key` HKDF + canonical JSON signing, which risks drift from
+  the Rust canonicalization. Only if (a)'s build cost is prohibitive.
+
+Wire-up: a `just bench-amqp target=axiam rate=<R> duration=<s>` recipe that
+brings up the AXIAM stack (which already starts the authz consumer),
+sources the tenant master key from `.seed/`, runs the tool, and drops a JSON
+record into `results/<target>/amqp/`.
+
+## 6. Acceptance (to verify on the benchmark environment)
+
+1. A short run against a seeded AXIAM stack produces a valid record with real
+   correlated end-to-end latency percentiles and a steady-state responses/s.
+2. Every published request either gets a correlated response or is counted as
+   a timeout — no silent drops.
+3. Signatures/nonces are accepted by the live consumer (zero rejections on the
+   happy path), proving contract fidelity.
+4. The latency-vs-rate sweep shows a saturation knee, locating the consumer
+   ceiling.
+
+## 7. Out of scope
+
+- Multi-tenant fan-out and DLQ/retry-storm behavior (a follow-up).
+- Comparing AMQP decisions/s head-to-head with REST/gRPC — different logical
+  op (deferred vs. synchronous); the report labels it, never ranks it against
+  them.
+
+---
+
+*Design grounded in `crates/axiam-amqp/{messages,authz_consumer,connection}.rs`
+at branch `claude/benchmark-improvement-plan-9yxx7g`. Implementation to land as
+its own PR with measured numbers once a live broker run is available.*

--- a/benchmarks/docs/methodology.md
+++ b/benchmarks/docs/methodology.md
@@ -223,8 +223,8 @@ defaults instead of a recorded `cpu_cap`) rather than crashing the report.
 
 Two runs with the same embedded config on the same hardware should agree within
 run-to-run noise (typically <5% on throughput). Always report the **median of
-N≥3 runs** for any published figure; the report's `--repeat` summarization does
-this for you.
+N≥3 runs** for any published figure — see §8 "Multiple runs — median-of-N
+(C1)" below for how `bench-matrix`/`report.py` do this for you automatically.
 
 **Sharing results.** `runner/seed.sh` writes client secrets and the bench
 user's password to `.seed/<target>.seed.env`, which is gitignored and lives
@@ -234,3 +234,216 @@ publish a run, use `just bench-pack`: it archives only `*.k6.json`,
 `results-<date>.tar.xz`, and verifies (grepping the packed content for
 `SECRET`/`PASSWORD`) that nothing sensitive made it in before leaving the
 archive on disk.
+
+## 8. Multiple runs — median-of-N (C1)
+
+Single-run numbers hide run-to-run noise (thermal state, background load,
+scheduler jitter). `just repeat=<N> … bench-matrix` (default `repeat := "3"`
+in `justfile`) runs the *entire* target×profile×scenario matrix `N` times,
+each pass writing into its own `results/run-<i>/` subtree using the exact
+same flat `<target>/<profile>/<scenario>.*` layout underneath — so every
+per-cell mechanism described elsewhere in this document (the seed-ok marker,
+`run-benchmark.sh`'s meta/k6/resource/host outputs) is reused completely
+unchanged, just once per repeat.
+
+`report.py` auto-detects which layout is present in the directory passed to
+`--results`:
+* **`results/run-<i>/` subdirectories present** → median-of-N mode. For each
+  `(target, profile, scenario)` cell, every metric is aggregated **medianed
+  independently per metric** across that cell's valid runs — throughput,
+  p50/p95/p99, cpu, mem (whole-stack and per-container), and the host
+  telemetry columns. Derived numbers (`thr/core`, `cpu_ms/req`, …) are then
+  recomputed from those medians, not separately medianed themselves.
+  * A cell is only marked **`valid`** if **≥2 of its runs were individually
+    valid** — with 0 or 1 valid runs there's no meaningful median, so the
+    aggregated cell is still shown (for visibility, using whatever data is
+    available) but excluded from headline comparisons, same as any other
+    invalid cell.
+  * The report adds a `runs(valid/n)` column (e.g. `3/3`) and a `±thr%`
+    column: the throughput spread across valid runs, `(max−min)/2` expressed
+    as a percentage of the median — a quick read on how noisy that cell was.
+* **No `run-*/` subdirectories** (the classic single-pass layout, e.g. the
+  existing 2026-07-19 `results/` tree, or a manual `bench-up`/`bench-seed`/
+  `bench-run` workflow that never went through `bench-matrix`) → the report
+  is generated exactly as before this change, with no `runs`/`±thr%` columns.
+
+`just repeat=1 … bench-matrix` still works — it just produces a single
+`results/run-1/` tree (report.py medians a single-element list, i.e. reports
+that one run's numbers, with `runs(valid/n)` = `1/1` or `0/1` and a cell
+marked invalid since 1 < 2 required valid runs).
+
+## 9. Datastore sensitivity & fair DB tuning (C2)
+
+**Uncapped-DB sensitivity pass.** `just dbcaps=uncapped …` (default
+`dbcaps := "capped"`) raises the datastore's envelope from the standard 2
+CPUs / 1024 MiB to **4 CPUs / 2048 MiB** — `BENCH_DB_CPUS`/`BENCH_DB_MEM` were
+already read directly by every target's `docker-compose.yml`
+(`surrealdb`/`postgres` services' `cpus:`/`mem_limit:`); `dbcaps` just wires
+the two values through `bench-up`. Use it to check whether the *datastore* —
+not the server process — is the ceiling on a given scenario: run the same
+cell `capped` vs `uncapped` and see whether throughput moves. The chosen caps
+are recorded per-container in `meta.json`'s `containers[].cpu_cap` /
+`containers[].mem_cap_mib`, read straight off the running container
+(`docker inspect`'s `HostConfig.NanoCpus`/`HostConfig.Memory`) rather than
+trusted from the shell that ran `bench-up` — so a separate `bench-run`
+invocation still records whatever cap the DB container actually started
+with, and the "Appendix: per-container resource breakdown" table renders
+both `cpu_cap` and `mem_cap(MiB)` per cell.
+
+**Fair competitor DB tuning.** Both Keycloak's and Zitadel's `postgres`
+service now start with minimal, uniform, non-durability tuning applied
+identically to both — `shared_buffers=256MB`, `effective_cache_size=512MB`,
+`max_connections=200` via compose `command:` flags — sized sensibly for the
+standard 1 GiB cap rather than left at Postgres's stock defaults (which
+target a much larger box). This is a "same DB, sane settings" fix, not a
+thumb on the scale: both competitors get the exact same flags, and nothing
+about *durability* is touched (see below).
+
+**Durability parity note.** Postgres (used by both Keycloak and Zitadel here)
+defaults to `synchronous_commit = on`: a transaction's WAL record is written
+and fsynced to disk before the client's `COMMIT` returns — durable-by-default.
+AXIAM's bench target (`targets/axiam/docker-compose.yml`) runs
+`surrealdb/surrealdb:v3` with the **SurrealKV** storage engine
+(`surrealkv:/data/axiam.db`), no `SURREAL_SYNC_DATA` override — i.e. whatever
+the `v3` image defaults to. SurrealKV itself exposes two per-transaction
+durability levels: **Eventual** (data written to the OS page cache, fsync
+deferred — SurrealKV's own stated default and "best performance" mode) and
+**Immediate** (fsync before `commit()` returns — the slower, durable mode).
+Publicly, SurrealDB has stated that **2.x did not enable disk sync by
+default**, and that **3.x does** (`SURREAL_SYNC_DATA` on by default), in
+direct response to community criticism that its earlier benchmark numbers
+were measured with every engine's writes sitting in the page cache rather
+than actually flushed to disk. Since the AXIAM bench compose pins `:v3` and
+sets no override, it should inherit that "sync on" default — but this
+framework has **not independently verified live fsync behavior against a
+running container** (no `strace`/`fsync`-call instrumentation has been run;
+this environment currently has no live bench stack to check against). Until
+that's verified with an actual run:
+* **Treat the Postgres-vs-SurrealKV durability comparison as *not confirmed
+  equivalent*.** If AXIAM's numbers were ever found to come from a
+  configuration with fsync effectively off while Postgres's `synchronous_commit
+  = on` stayed on, that would inflate AXIAM's write-heavy throughput
+  (login, token issuance, refresh — anything that writes) unfairly relative
+  to the competitors, and must be corrected before publishing head-to-head
+  numbers on those scenarios.
+* This belongs on the **public caveats list** (`PUBLIC_BENCH_ANALYSIS.md` §4,
+  "Other comparability caveats") as an open item, not silently assumed fine.
+  `PUBLIC_BENCH_ANALYSIS.md` itself is regenerated as part of the plan's E4
+  task (after Phase C's re-run lands) rather than edited here — this
+  methodology note is the source-of-truth statement E4 should carry forward
+  verbatim into that caveats list.
+* We do **not** change either engine's durability settings to make AXIAM look
+  faster — the caps/tuning above are the full extent of C2's changes.
+
+## 10. Running on a laptop (C3)
+
+*This is not the intended long-term benchmark environment* (see the plan's
+operating constraint — a server-class re-run is deferred until dedicated
+hardware is available), but until then, every run happens on a laptop with
+all the variance that implies: thermal throttling, power-management clock
+scaling, background processes, and battery-vs-AC behavior. This section is
+the runbook for controlling what can be controlled and *measuring* what
+can't (via the A6 host telemetry columns — `mhz_avg`, `mhz_min/max`,
+`temp_max(C)`, `k6_cores`, `host_flags` in the "All results" table).
+
+**Before starting a matrix:**
+1. **Plug into AC.** Battery power profiles throttle far more aggressively
+   than plugged-in ones on most laptops, and some platforms cap turbo boost
+   entirely on battery.
+2. **Set the CPU governor to `performance`:**
+   ```bash
+   sudo cpupower frequency-set -g performance
+   ```
+   `run-benchmark.sh` reads `/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor`
+   for `meta.json`'s `cpu_governor` field regardless, but now also **warns**
+   (not fails — some kernels/VMs don't expose a governor at all, in which
+   case it reads `unknown` and the warning is skipped) at the start of every
+   `bench-run` when the governor isn't `performance`.
+3. **Optional stability mode — disable turbo boost entirely:**
+   ```bash
+   echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo
+   ```
+   Turbo boost is itself a source of variance (it ramps and backs off based
+   on thermal headroom that changes cell-to-cell). Disabling it trades a
+   lower ceiling for a flatter one. **Run the *entire* matrix in ONE mode —
+   never mix turbo and no-turbo runs in the same dataset**; a cell run with
+   turbo on is not comparable to one run with it off, and nothing in the
+   harness currently detects or flags a mixed-mode dataset, so this is on the
+   operator to enforce.
+4. **Close background applications** — browsers, IDEs with language servers,
+   sync clients, anything that periodically bursts CPU. `k6` itself runs on
+   the host (methodology §1.6), so anything competing with it or with the
+   capped containers adds noise on both sides of the measurement.
+5. **Raise the laptop for airflow** (a stand, books, anything that isn't
+   flush against a desk/lap) — closed intake vents are one of the most common
+   causes of a laptop hitting its thermal ceiling under sustained load.
+
+**During the run — the idle gap between cells.** `run-benchmark.sh` now
+pauses `BENCH_CELL_PAUSE` seconds (default **60s**, `0` disables it) between
+scenarios within a `bench-run` invocation, so the previous cell's heat has a
+chance to dissipate and its connection pools/allocations settle before the
+next measurement starts — rather than every cell after the first starting
+from a warmer, more-loaded baseline than the one before it.
+
+**After the run — verify with telemetry, don't just trust the numbers.**
+Check the "All results" table's `host_flags` column:
+* `clock_variance` — this cell's mean clock sagged >15% below its own
+  window's peak; treat its absolute numbers with more caution.
+* `generator_saturated` — k6 itself was eating most of the host's non-stack
+  CPU headroom; the load generator may have been the bottleneck, not the
+  target.
+
+If neither flag appears across the run and `mhz_avg` stays roughly flat
+scenario-to-scenario, per §5's interpretation rule the cross-target/
+cross-profile comparisons are not distorted by throttling.
+
+See also [`../README.md`](../README.md) for the quick-start commands this
+runbook assumes.
+
+## 11. Production rate-limit posture (C4)
+
+All AXIAM numbers elsewhere in a normal run use the **`neutralized`** rate-limit
+posture (`rl := "neutralized"` in `justfile`, the default) — AXIAM's per-IP
+limiter raised to effectively unlimited, so a single-source-IP `k6` run
+measures endpoint capacity rather than the limiter (see §1's principles and
+the comment above `AXIAM_BENCH_RL_POSTURE` in
+`targets/axiam/docker-compose.yml`). Competitors ship no equivalent per-IP
+limiter, so `neutralized` is the only posture that is head-to-head-comparable.
+
+To also publish what an operator actually gets out of the box, run the AXIAM
+matrix **once** with `rl=prod` — the server's production rate-limit defaults
+active. Because the results path (`results/<target>/<profile>/<scenario>.*`)
+doesn't encode posture, a `prod` run must **not** land in the same `results/`
+tree as a `neutralized` run for the same target/profile/scenario (it would
+silently overwrite it). Direct it to its own tree instead:
+
+```bash
+BENCH_RESULTS_DIR="$PWD/results/axiam-prod-posture" \
+  just target=axiam profile=p0-plaintext rl=prod bench-up
+BENCH_RESULTS_DIR="$PWD/results/axiam-prod-posture" \
+  just target=axiam bench-seed
+BENCH_RESULTS_DIR="$PWD/results/axiam-prod-posture" \
+  just target=axiam profile=p0-plaintext rl=prod bench-run
+just target=axiam bench-down
+
+python3 runner/report.py --results results/axiam-prod-posture
+```
+
+`run-benchmark.sh` stamps every cell's `meta.json` with the posture it
+actually ran under (`rate_limits`, read back from the running container via
+`docker inspect` rather than trusted from the invoking shell — see the
+comment above `detect_rl_posture()`), so `report.py` always knows which cells
+are `prod`. It renders them in a dedicated **"AXIAM production rate-limit
+posture — NOT comparable to competitors"** section, separate from the "All
+results" head-to-head tables, and `posture_bucket()` makes the "Efficiency
+comparison" tables **refuse** to render a comparison group that mixes
+postures (or contains an `unknown`/unstamped one) — verified by feeding
+`report.py` a synthetic `prod`-posture AXIAM cell alongside a `neutralized`
+Keycloak cell for the same (scenario, profile): the group is rejected with
+an explicit "Not comparable — mixed or unknown rate-limit posture" note
+instead of being silently averaged in.
+
+Publish the `prod`-posture report *alongside* the neutralized matrix, not as
+a replacement for it — the framing is "AXIAM ships per-IP rate limits by
+default; Keycloak and Zitadel don't," turning what would otherwise read as a
+benchmark asterisk into a documented security-posture advantage.

--- a/benchmarks/docs/methodology.md
+++ b/benchmarks/docs/methodology.md
@@ -93,6 +93,53 @@ Sampled every `BENCH_SAMPLE_INTERVAL` (default 1s) over the measure stage via
 * **cpu_cores_avg / cpu_cores_p95** — CPU cores consumed (1.0 = one full core).
 * **mem_mib_avg / mem_mib_p95** — resident memory in MiB.
 
+`report.py` also keeps a **per-container** breakdown of `cpu_avg`/`mem_avg`
+(not just the whole-stack sum) and computes, per cell, a **bottleneck**
+column: the container(s) whose `cpu_avg ≥ 0.95 ×` their configured CPU cap
+(read from `meta.json`'s `containers[].cpu_cap`, falling back to the
+`docker-compose.yml` default for that role — server 2 CPU, DB 2 CPU, broker
+1 CPU, TLS edge 1 CPU — if the meta predates that field), or `none` if nothing
+in the stack saturated. `none` is itself informative: it means the client, the
+network, or an un-pegged serialization point is the limiter, not raw CPU — see
+the "Appendix: per-container resource breakdown" section of the generated
+report for the full per-container table.
+
+### Host telemetry — CPU frequency, temperature, generator headroom
+`docker stats` measures *time-based core utilization*: it cannot distinguish a
+core spinning at 3.9 GHz from one throttled to 2.2 GHz. On laptop hardware
+(see "Running on a laptop" in `docs/security-profiles.md` / the runbook) that
+gap matters, so `resource/host-sampler.sh` runs alongside the container
+sampler at the same cadence and writes `<scenario>.host.csv`
+(`epoch_ms, cpu_mhz_avg, cpu_mhz_min, temp_c_max, host_cpu_util_pct,
+k6_cpu_cores`), all from no-sudo `/sys`/`/proc` reads:
+* **mhz_avg** — mean, over the window, of the per-sample mean CPU frequency
+  across all online cores (`/sys/…/cpufreq/scaling_cur_freq`).
+* **mhz_min / mhz_max ratio** — the lowest single-core frequency seen anywhere
+  in the window, divided by the window's peak mean frequency. A number near
+  1.0 means the clock stayed flat; a low number means at least one core spent
+  time markedly slower than the pack.
+* **temp_max** — the hottest thermal zone's peak reading in the window (°C).
+* **k6_cores_avg** — CPU cores (not %) consumed by the `k6` process(es)
+  themselves during the window.
+
+**Interpretation rule** (from the re-examination of the first full run,
+2026-07-19): if repeated CPU-bound cells ~30 min apart agree closely (e.g.
+AXIAM introspection p0 vs p2: 2199 vs 2192 req/s) **and** `mhz_avg` stays flat
+across the run, cross-target/cross-profile comparisons are not distorted by
+throttling — a *constant* sustained-clock reduction depresses all absolute
+numbers uniformly, which is invisible to `docker stats` alone but would make
+every cell in the run conservative by the same factor, not selectively unfair
+to one target. `report.py` flags two conditions automatically:
+* **clock_variance** — this cell's `mhz_avg` sagged more than 15% below its
+  own window's peak `mhz_avg` — the clock was *not* flat during this specific
+  measurement, so treat its absolute numbers with more caution than a
+  flagged-clean cell.
+* **generator_saturated** — `k6_cores_avg > 0.8 × (host_cpus − stack_cap_cpus)`,
+  i.e. k6 itself was eating most of the CPU headroom left after the target
+  stack's caps — the load generator may be the bottleneck, not the target.
+
+Both flags appear in the `host_flags` column of the "All results" table.
+
 ### Efficiency (derived, the headline numbers)
 * **throughput_per_core** = `throughput / cpu_cores_avg`
   → *requests per second per CPU core.* Higher is better.
@@ -104,6 +151,30 @@ Sampled every `BENCH_SAMPLE_INTERVAL` (default 1s) over the measure stage via
 These derived numbers are the answer to *"can AXIAM deliver competitor-level
 performance at a lower resource cost?"* — compare `throughput_per_core` and
 `cpu_ms_per_request` across targets at equal latency.
+
+`report.py`'s efficiency tables also render a **server-container-only**
+variant of both numbers, computed against just the primary server/app
+container's CPU+mem (excluding the database, broker, and TLS edge
+containers). AXIAM's stack includes a broker (RabbitMQ) that Keycloak and
+Zitadel don't; the whole-stack numbers above fold that cost in silently, while
+the server-only variant isolates it so it stays visible rather than
+understating AXIAM's per-request server cost relative to a single-process
+competitor.
+
+### Comparability flags (fallback operations)
+Some logical ops can't always be measured for real on every target — e.g.
+Zitadel generally ships ROPC disabled, so its `login()` adapter falls back to
+`client_credentials` (see `scenarios/lib/targets.js`); `token_refresh.js`
+falls back the same way when a target issues no refresh token to rotate; and
+`userinfo.js`'s `setup()` falls back to a client_credentials token only if
+minting a real user token fails. Every fallback increments the `bench_fallback`
+k6 counter for that iteration. A cell with `bench_fallback > 0` is still
+**valid** (it passed the normal validity gates) but is annotated
+`comparability: fallback-op`, shown with `fallback: yes` in the full results
+table, and **excluded from head-to-head efficiency/winner tables** — a
+fallback op measures a different (usually cheaper) operation than its label,
+so ranking it against a real login/refresh would be comparing different
+things under the same name.
 
 ### Security cost (derived across profiles)
 For a fixed (target, scenario), the report computes the **relative cost** of each
@@ -128,8 +199,38 @@ them in a separate "excluded" section.
 
 ## 7. Reproducibility
 
-Every result record embeds: target image digest, security profile, resource caps,
-k6 version, scenario file hash, VU/duration config, and host CPU/RAM. Two runs with
-the same embedded config on the same hardware should agree within run-to-run noise
-(typically <5% on throughput). Always report the **median of N≥3 runs** for any
-published figure; the report's `--repeat` summarization does this for you.
+Every result record's `meta.json` embeds, per cell: `target`/`profile`/`scenario`,
+security profile (`scheme`, `tls_min`, `client_auth`), resource caps (`caps`),
+rate-limit posture, VU/duration config, and host CPU/RAM (`host`). It also
+records, for full reproducibility of *what actually ran*:
+* **containers** — for every container in the target's stack: `name`, `role`
+  (server/db/mq/edge), `image`, `image_digest` (from
+  `docker inspect --format '{{.Config.Image}} {{index .RepoDigests 0}}'`), and
+  the `cpu_cap` it was measured against.
+* **scenario_sha256** — hash of the exact `scenarios/<name>.js` file executed
+  (`sha256sum`), so a report can be traced back to the harness code that
+  produced it even after the scenario file later changes.
+* **batch_size** — `BENCH_BATCH_SIZE` (default 5), the batch-authz request size.
+* **host_kernel**, **docker_version**, **cpu_model**, **cpu_governor** — host
+  facts (`uname -r`, `docker version`, `/proc/cpuinfo`,
+  `/sys/…/cpufreq/scaling_governor`).
+* **k6_cpu_cores_avg** — the generator's own CPU consumption over the measure
+  window (from the A6 host sampler), the basis for `generator_saturated`.
+
+`report.py` tolerates older `meta.json` files that predate any of the above —
+missing fields degrade to sensible defaults (e.g. compose-file CPU cap
+defaults instead of a recorded `cpu_cap`) rather than crashing the report.
+
+Two runs with the same embedded config on the same hardware should agree within
+run-to-run noise (typically <5% on throughput). Always report the **median of
+N≥3 runs** for any published figure; the report's `--repeat` summarization does
+this for you.
+
+**Sharing results.** `runner/seed.sh` writes client secrets and the bench
+user's password to `.seed/<target>.seed.env`, which is gitignored and lives
+outside `results/`. `results/` itself holds nothing secret. To hand off or
+publish a run, use `just bench-pack`: it archives only `*.k6.json`,
+`*.res.csv`, `*.host.csv`, `*.meta.json`, and `report.md` into
+`results-<date>.tar.xz`, and verifies (grepping the packed content for
+`SECRET`/`PASSWORD`) that nothing sensitive made it in before leaving the
+archive on disk.

--- a/benchmarks/docs/methodology.md
+++ b/benchmarks/docs/methodology.md
@@ -53,6 +53,7 @@ Each cell produces one **result record** (JSON) under `results/`.
 | `authz_batch_rest.js`           | Batch authorization decision (REST)            | HTTP/REST     | AXIAM-only*  |
 | `authz_check_grpc.js`           | Low-latency authorization decision             | gRPC          | AXIAM-only*  |
 | `authz_batch_grpc.js`           | Batch authorization decision                    | gRPC          | AXIAM-only*  |
+| `zitadel_userinfo_grpc.js`      | Identity read (`AuthService/GetMyUser`)        | gRPC          | Zitadel-only†|
 
 \* Most competitors do not expose a directly equivalent authorization-decision
 endpoint (REST or gRPC, single or batch); these scenarios are reported separately
@@ -60,6 +61,36 @@ as AXIAM capability metrics, not head-to-head numbers. The REST authz scenarios
 also serve as the wire baseline for SDK `check_access`/`batch_check` overhead
 (see `sdk/HARNESS-SPEC.md`). All four require a seeded resource + role grant and a
 logged-in user token; the authz scenarios log in as the bench user in `setup()`.
+
+† Zitadel's primary API surface is gRPC (maintainer requirement to benchmark
+it — see `claude_dev/benchmark-improvement-plan.md` D4), so
+`zitadel_userinfo_grpc.js` calls `zitadel.auth.v1.AuthService/GetMyUser`
+against the minimal vendored proto in `scenarios/proto/zitadel/` (see that
+directory's `README.md` for exactly what was vendored/trimmed and why —
+short version: the real upstream `.proto` files at the pinned `v4.15.2` tag
+were fetched, then hand-trimmed to just the one RPC and the message fields
+this benchmark decodes, to avoid pulling in Zitadel's full transitive proto
+graph for options/docs annotations that don't affect the wire format).
+Neither AXIAM nor Keycloak expose an equivalent gRPC identity RPC, so this
+scenario is wired into `runner/run-benchmark.sh`'s Zitadel-only scenario list
+(`ZITADEL_ONLY_SCENARIOS`) and never appears for the other two targets. It
+pairs with Zitadel's own `userinfo.js` cell as a **protocol-efficiency**
+comparison (REST vs gRPC, same logical operation, same vendor) — see
+"Comparability: protocol-efficiency (gRPC vs REST, same vendor)" below. It is
+**not** a cross-vendor head-to-head number, and `runner/report.py` excludes
+it from the cross-vendor "Efficiency comparison" tables the same way it
+excludes the AXIAM-only authz scenarios above (both are listed in
+`report.py`'s `NON_COMPARATIVE_SCENARIOS`).
+
+A comparable gRPC "introspect" scenario was considered and deliberately
+**not** added: Zitadel's `session.v2.SessionService` (`GetSession`,
+`CreateSession`, …) operates on Zitadel's own session-ID/session-token
+identity model, not on an OAuth2 access/refresh token, so `GetSession` is not
+a genuine equivalent to `token_introspection.js`'s RFC 7662 "is this token
+active" check — forcing that equivalence would benchmark a different logical
+operation under a misleading label, which §1's "identical logical workload"
+principle rules out. `SessionService.CreateSession` (the gRPC login
+counterpart) is task D5's concern, not D4's.
 
 ## 4. Load model
 
@@ -160,6 +191,31 @@ Zitadel don't; the whole-stack numbers above fold that cost in silently, while
 the server-only variant isolates it so it stays visible rather than
 understating AXIAM's per-request server cost relative to a single-process
 competitor.
+
+### Comparability: protocol-efficiency (gRPC vs REST, same vendor)
+A second, distinct comparability class alongside the fallback flag below:
+some scenarios exist specifically to compare **two wire protocols against
+the same logical operation on the same vendor**, not to compare vendors
+against each other. Today that's:
+
+* AXIAM: `authz_check_rest.js`/`authz_batch_rest.js` (REST) vs
+  `authz_check_grpc.js`/`authz_batch_grpc.js` (gRPC) — the authorization
+  decision, over both wire protocols AXIAM exposes it on.
+* Zitadel: `userinfo.js` (REST `/oidc/v1/userinfo`) vs
+  `zitadel_userinfo_grpc.js` (gRPC `AuthService/GetMyUser`) — the identity
+  read, over both wire protocols Zitadel exposes it on.
+
+These are **within-vendor** pairs: "does gRPC cost less than REST for the
+same operation on the same server?" is a meaningful, fair comparison because
+nothing about the target, resource caps, or logical workload differs between
+the two rows — only the wire encoding does. They answer a materially
+different question than the cross-vendor "Efficiency comparison" tables
+(*"is target A faster than target B?"*), so `report.py` keeps them out of
+those tables entirely (`NON_COMPARATIVE_SCENARIOS`) rather than trying to
+average a gRPC cell into a REST-only cross-vendor group. To read a
+protocol-efficiency pair, compare the two scenarios' rows directly in the
+"All results" table for the same `(target, profile)` — e.g.
+`zitadel_userinfo_grpc` vs `userinfo` at `zitadel / p0-plaintext`.
 
 ### Comparability flags (fallback operations)
 Some logical ops can't always be measured for real on every target — e.g.

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -162,12 +162,19 @@ bench-up:
         # stack inside its CPU cap — comparable to keycloak/zitadel native TLS.
         # See targets/axiam/docker-compose.native-tls.yml.
         OVERRIDE_ARG="-f targets/axiam/docker-compose.native-tls.yml"
+      elif [ "{{profile}}" = "p3-mtls" ]; then
+        # p3 = TLS 1.3 + X.509 client-cert auth. AXIAM now verifies client certs
+        # in-process (D3: rustls WebPkiClientVerifier over profiles/certs/ca.crt),
+        # so terminate mTLS natively — no nginx edge — making the VERIFIED peer
+        # cert the identity source (not a proxy header) and keeping the crypto
+        # inside AXIAM's cap. Layers the mTLS overlay on top of the native-TLS
+        # one (same pattern p2 used in 649798e).
+        OVERRIDE_ARG="-f targets/axiam/docker-compose.native-tls.yml -f targets/axiam/docker-compose.native-mtls.yml"
       else
-        # p1-tls12 / p3-mtls: the native stack can't do TLS 1.2 or client-cert
-        # auth, so keep the nginx edge for those.
+        # p1-tls12: the native stack is TLS 1.3-only by policy and can't do
+        # TLS 1.2, so keep the nginx edge for that profile (see docs/security-profiles.md).
         case "{{profile}}" in
           p1-tls12) export BENCH_NGINX_CONF=tls12.conf ;;
-          p3-mtls)  export BENCH_NGINX_CONF=mtls.conf ;;
         esac
         PROFILE_ARG="--profile tls"
       fi
@@ -219,8 +226,9 @@ bench-up:
       fi
     }
     port_conflict=0
-    if [ "{{target}}" = "axiam" ] && [ "{{profile}}" = "p2-tls13" ]; then
-      # Native TLS: the server publishes the TLS port (+ grpc); no plaintext 8090.
+    if [ "{{target}}" = "axiam" ] && [ -n "$OVERRIDE_ARG" ]; then
+      # Native TLS/mTLS (p2-tls13, p3-mtls): the server publishes the TLS port
+      # (+ grpc); no plaintext 8090. Detected via the native compose override.
       check_port "${BENCH_TLS_PORT:-8443}" "TLS / BENCH_TLS_PORT" || port_conflict=1
     else
       check_port "${BENCH_APP_PORT:-8090}" "app / BENCH_APP_PORT" || port_conflict=1
@@ -253,8 +261,16 @@ bench-up:
     esac
     echo "[bench-up] waiting for {{target}} to serve at $READY_URL (timeout 180s)"
     ready_deadline=$(( $(date +%s) + 180 ))
+    # Native mTLS (axiam p3-mtls, client_auth=required): the listener rejects any
+    # connection without a verified client cert, so the readiness probe must
+    # present one too. BENCH_CLIENT_CERT/KEY come from the sourced profile env.
+    READY_MTLS=""
+    if [ "{{target}}" = "axiam" ] && [ "{{profile}}" = "p3-mtls" ] \
+       && [ -n "${BENCH_CLIENT_CERT:-}" ] && [ -n "${BENCH_CLIENT_KEY:-}" ]; then
+      READY_MTLS="--cert ${BENCH_CLIENT_CERT} --key ${BENCH_CLIENT_KEY}"
+    fi
     # -k: the TLS profiles front a throwaway private CA k6 also can't verify.
-    until curl -skf -o /dev/null "$READY_URL"; do
+    until curl -skf $READY_MTLS -o /dev/null "$READY_URL"; do
       if [ "$(date +%s)" -ge "$ready_deadline" ]; then
         echo "[bench-up] TIMEOUT: {{target}} did not become ready at $READY_URL" >&2
         docker compose -f "$COMPOSE" $PROFILE_ARG ps >&2 || true
@@ -277,9 +293,12 @@ bench-seed:
     #!/usr/bin/env bash
     set -euo pipefail
     if { [ "{{target}}" = "zitadel" ] && [ "{{profile}}" != "p0-plaintext" ]; } \
-       || { [ "{{target}}" = "axiam" ] && [ "{{profile}}" = "p2-tls13" ]; }; then
+       || { [ "{{target}}" = "axiam" ] && { [ "{{profile}}" = "p2-tls13" ] || [ "{{profile}}" = "p3-mtls" ]; }; }; then
       # TLS-only listeners (zitadel built-in TLS; axiam native rustls) have no
       # plaintext side port, so seed over https at the TLS port (seed.sh uses -k).
+      # For axiam p3-mtls the native listener also REQUIRES a client cert, so
+      # sourcing the profile env exports BENCH_CLIENT_CERT/KEY, which seed.sh
+      # presents transparently on every request (see its curl wrapper).
       source profiles/{{profile}}.env
       BASE="${BENCH_SCHEME:-https}://${BENCH_HOST:-localhost}:${BENCH_PORT:-8443}"
       bash runner/seed.sh {{target}} "$BASE"

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -31,6 +31,24 @@ build := "0"
 #                           ACTIVE). Head-to-head numbers taken this way are NOT
 #                           comparable to competitors and report.py will flag them.
 rl := "neutralized"
+# dbcaps selects the datastore's CPU/mem envelope (C2):
+#   capped (default) — the standard envelope, same as every other container
+#                       (BENCH_DB_CPUS/BENCH_DB_MEM defaults in each target's
+#                       docker-compose.yml, normally 2 CPUs / 1024 MiB).
+#   uncapped          — raises the datastore to 4 CPUs / 2048 MiB so a run can
+#                       show whether the datastore — not the server — is the
+#                       ceiling. BENCH_DB_CPUS/BENCH_DB_MEM are already
+#                       env-driven in every target's compose file; this just
+#                       wires the two values through. An operator-supplied
+#                       BENCH_DB_CPUS/BENCH_DB_MEM still wins over either mode.
+dbcaps := "capped"
+# repeat controls how many times `bench-matrix` runs the whole target×profile
+# ×scenario matrix (C1: median-of-N). Each pass writes into its own
+# results/run-<i>/ subtree (same flat per-cell layout underneath), and
+# `bench-report`/`report.py` auto-detect the results/run-*/ layout and median
+# every metric per cell across the valid runs. Set repeat=1 for a quick single
+# pass (still lands under results/run-1/).
+repeat := "3"
 
 # Generate throwaway TLS/mTLS certs for the security profiles (idempotent).
 bench-certs:
@@ -109,6 +127,24 @@ bench-up:
         VER="$(grep -m1 '^version' ../Cargo.toml | cut -d'"' -f2)"
         export BENCH_AXIAM_IMAGE="ghcr.io/ilpanich/axiam/server:${VER}"
       fi
+    fi
+
+    # DB CPU/mem envelope (C2, all targets — see `dbcaps` at the top of this
+    # file). BENCH_DB_CPUS/BENCH_DB_MEM are already read directly by every
+    # target's docker-compose.yml (surrealdb/postgres `cpus:`/`mem_limit:`),
+    # so this only needs to set the two env vars before `docker compose up`;
+    # an operator-supplied BENCH_DB_CPUS/BENCH_DB_MEM still wins. The chosen
+    # values are recorded in meta.json automatically — run-benchmark.sh reads
+    # each container's actual cpu/mem cap straight off `docker inspect`
+    # (HostConfig.NanoCpus/Memory) rather than trusting this shell's env, so a
+    # separate `bench-run` invocation still captures whatever cap the running
+    # DB container was actually started with.
+    if [ "{{dbcaps}}" = "uncapped" ]; then
+      export BENCH_DB_CPUS="${BENCH_DB_CPUS:-4}"
+      export BENCH_DB_MEM="${BENCH_DB_MEM:-2048m}"
+      echo "[bench-up] DB caps: UNCAPPED (${BENCH_DB_CPUS} CPUs / ${BENCH_DB_MEM}) — measuring the server ceiling, not the datastore's"
+    elif [ "{{dbcaps}}" != "capped" ]; then
+      echo "[bench-up] unknown dbcaps='{{dbcaps}}' (use dbcaps=capped or dbcaps=uncapped)" >&2; exit 1
     fi
 
     PROFILE_ARG=""
@@ -277,18 +313,33 @@ bench-report:
     python3 runner/report.py --results results
 
 # Full unattended matrix: every target × profile × scenario, with up/seed/run/down.
+# repeat=N (default 3, see `repeat` above): runs the whole matrix N times,
+# each pass writing into its own results/run-<i>/ subtree using the SAME flat
+# target/profile/scenario layout underneath, so the existing per-cell code
+# (seed marker, run-benchmark.sh) is reused unchanged. report.py auto-detects
+# the results/run-*/ layout and medians each cell across the valid runs (C1).
+# `rl` and `dbcaps` are forwarded to every bench-up so
+# `just target=axiam rl=prod bench-matrix` / `just dbcaps=uncapped bench-matrix`
+# work end-to-end (not just for a single manual bench-up).
 bench-matrix:
     #!/usr/bin/env bash
     set -euo pipefail
-    for t in {{targets}}; do
-      for p in {{profiles}}; do
-        echo "=== $t / $p ==="
-        just target=$t profile=$p bench-up
-        just target=$t profile=$p bench-seed
-        just target=$t profile=$p bench-run
-        just target=$t bench-down
+    for i in $(seq 1 {{repeat}}); do
+      RUN_DIR="results/run-$i"
+      echo "### repeat $i/{{repeat}} -> $RUN_DIR ###"
+      mkdir -p "$RUN_DIR"
+      export BENCH_RESULTS_DIR="$PWD/$RUN_DIR"
+      for t in {{targets}}; do
+        for p in {{profiles}}; do
+          echo "=== run $i: $t / $p (rl={{rl}} dbcaps={{dbcaps}}) ==="
+          just target=$t profile=$p rl={{rl}} dbcaps={{dbcaps}} build={{build}} bench-up
+          just target=$t profile=$p bench-seed
+          just target=$t profile=$p bench-run
+          just target=$t bench-down
+        done
       done
     done
+    unset BENCH_RESULTS_DIR
     just bench-report
 
 # --- SDK client benchmarks --- (pass the language as sdk=, e.g. sdk=python)

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -229,7 +229,10 @@ bench-up:
     done
     echo "[bench-up] {{target}} is ready."
 
-# Provision org/tenant/user/client for a target; writes results/<target>.seed.env.
+# Provision org/tenant/user/client for a target; writes .seed/<target>.seed.env
+# (client secrets/passwords — gitignored, kept out of the results/ tree we
+# share) and, once the post-seed smoke checks pass, results/<target>.seed.ok
+# (a no-secret marker bench-run refuses to start the k6 matrix without).
 # Seeding talks to the plaintext app port (:8090) for AXIAM/Keycloak, which keep
 # HTTP alongside HTTPS. Zitadel under a TLS profile serves TLS-only, so its seed
 # must go over https:<tls-port> — derived from the profile env here and passed as
@@ -299,3 +302,33 @@ sdk-bench-all:
 # Remove all run artifacts (keeps the dir).
 bench-clean:
     find results -type f ! -name '.gitkeep' -delete || true
+
+# Package shareable results into results-<date>.tar.xz. Only k6 summaries,
+# resource/host CSVs, run metadata, and the generated report are included —
+# NOT .seed/ (client secrets, bench user password), which report.py and this
+# recipe never read from and which `git` never sees (see .gitignore / A7 in
+# claude_dev/benchmark-improvement-plan.md). Verifies the archive is clean
+# before leaving it on disk.
+bench-pack:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    OUT="results-$(date +%Y-%m-%d).tar.xz"
+    FILELIST="$(mktemp)"
+    trap 'rm -f "$FILELIST"' EXIT
+    find results \( -name '*.k6.json' -o -name '*.res.csv' -o -name '*.host.csv' \
+      -o -name '*.meta.json' -o -name 'report.md' \) -type f > "$FILELIST"
+    if [ ! -s "$FILELIST" ]; then
+      echo "[bench-pack] nothing to pack — run a benchmark + 'just bench-report' first" >&2
+      exit 1
+    fi
+    tar -cJf "$OUT" -T "$FILELIST"
+    echo "[bench-pack] wrote $OUT ($(wc -l < "$FILELIST") files)"
+    echo "[bench-pack] verifying no secret material leaked in..."
+    if tar -tJf "$OUT" | grep -qiE '\.seed/|seed\.env'; then
+      echo "[bench-pack] ERROR: a .seed/ path made it into the archive" >&2; exit 1
+    fi
+    if tar -xJOf "$OUT" | grep -qiE 'SECRET|PASSWORD'; then
+      echo "[bench-pack] ERROR: SECRET/PASSWORD text found in packed content — investigate before sharing" >&2
+      exit 1
+    fi
+    echo "[bench-pack] OK — $OUT contains no secret material."

--- a/benchmarks/profiles/p2-tls13.env
+++ b/benchmarks/profiles/p2-tls13.env
@@ -11,3 +11,12 @@ export BENCH_CA_CERT=${BENCH_CERTS_DIR:-profiles/certs}/ca.crt
 # Skip server-cert verification — we measure TLS termination cost, not trust.
 export BENCH_VERIFY_TLS=false
 export BENCH_PORT=${BENCH_TLS_PORT:-8443}
+# D2: p2's native overlay (targets/axiam/docker-compose.native-tls.yml) also
+# enables in-process TLS on the axiam-server gRPC listener (:50051, same
+# throwaway server cert as REST) via AXIAM__GRPC_TLS_CERT_PATH/KEY_PATH, so the
+# k6 gRPC scenarios must dial with TLS too instead of the cross-profile plaintext
+# default (lib/config.js's BENCH_GRPC_PLAINTEXT). This var is consumed directly
+# by the k6 process (run-benchmark.sh sources this file into the same shell that
+# invokes k6), not by the axiam-server container — setting it in the compose
+# overlay's `environment:` would be a no-op there.
+export BENCH_GRPC_PLAINTEXT=false

--- a/benchmarks/resource/host-sampler.sh
+++ b/benchmarks/resource/host-sampler.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# host-sampler.sh — sample host-level telemetry (CPU frequency, thermal, host
+# utilization, k6 CPU headroom) at a fixed cadence over the measure window.
+#
+# This is the thermal-throttling honesty telemetry (A6 in
+# claude_dev/benchmark-improvement-plan.md): docker stats (resource/sampler.sh)
+# measures time-based core utilization and cannot tell a core running at
+# 3.9 GHz from one at 2.2 GHz. A *constant* sustained-clock reduction would
+# depress absolute numbers uniformly and be invisible to it — this script
+# records the clock/thermal state directly so the report can say so honestly.
+#
+# Writes one CSV row per sample over the measure window:
+#   epoch_ms,cpu_mhz_avg,cpu_mhz_min,temp_c_max,host_cpu_util_pct,k6_cpu_cores
+#
+# All sources are no-sudo:
+#   - cpu_mhz_avg/min: mean/min over /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
+#   - temp_c_max:      max over /sys/class/thermal/thermal_zone*/temp (skips
+#                      zones that error to read; value is milli-C, divided by 1000)
+#   - host_cpu_util_pct: delta of (total-idle)/total between samples, from /proc/stat
+#   - k6_cpu_cores:    sum of %cpu (as cores, i.e. /100) for `pgrep -x k6` processes
+#
+# A host with no cpufreq driver (e.g. some VMs/containers) reports 0 for the
+# MHz columns rather than failing — the columns are best-effort telemetry, not
+# a validity gate.
+#
+# Usage: host-sampler.sh <out.csv> <interval-seconds> <duration-seconds>
+set -euo pipefail
+
+OUT="${1:?output csv path}"
+INTERVAL="${2:-1}"
+DURATION="${3:-120}"
+
+echo "epoch_ms,cpu_mhz_avg,cpu_mhz_min,temp_c_max,host_cpu_util_pct,k6_cpu_cores" > "$OUT"
+
+# Read the aggregate `cpu ` line from /proc/stat as "idle total" (jiffies).
+read_proc_stat() {
+  awk '/^cpu /{
+    idle = $5
+    total = 0
+    for (i = 2; i <= NF; i++) total += $i
+    print idle, total
+  }' /proc/stat
+}
+
+prev_idle=0
+prev_total=0
+read -r prev_idle prev_total < <(read_proc_stat)
+
+end=$(( $(date +%s) + DURATION ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  ts=$(($(date +%s%N)/1000000))
+
+  # --- CPU frequency (mean/min), MHz, over all online cores -----------------
+  mhz_avg=0
+  mhz_min=0
+  freqs=()
+  for f in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_cur_freq; do
+    [ -r "$f" ] || continue
+    v="$(cat "$f" 2>/dev/null || echo '')"
+    [ -n "$v" ] && freqs+=("$v")
+  done
+  if [ "${#freqs[@]}" -gt 0 ]; then
+    mhz_avg="$(printf '%s\n' "${freqs[@]}" | awk '{s+=$1; n++} END{if(n>0) printf "%.1f", s/n/1000; else print 0}')"
+    mhz_min="$(printf '%s\n' "${freqs[@]}" | awk 'NR==1{m=$1} {if($1<m) m=$1} END{printf "%.1f", m/1000}')"
+  fi
+
+  # --- Thermal: max zone temperature, C -------------------------------------
+  temp_max=0
+  for z in /sys/class/thermal/thermal_zone*/temp; do
+    [ -r "$z" ] || continue
+    t="$(cat "$z" 2>/dev/null || echo '')"
+    [ -z "$t" ] && continue
+    t_c="$(awk -v t="$t" 'BEGIN{printf "%.1f", t/1000}')"
+    if awk -v a="$t_c" -v b="$temp_max" 'BEGIN{exit !(a>b)}'; then temp_max="$t_c"; fi
+  done
+
+  # --- Host CPU utilization: delta of (total-idle)/total --------------------
+  host_util=0
+  idle=0; total=0
+  read -r idle total < <(read_proc_stat)
+  d_idle=$(( idle - prev_idle ))
+  d_total=$(( total - prev_total ))
+  if [ "$d_total" -gt 0 ]; then
+    host_util="$(awk -v di="$d_idle" -v dt="$d_total" 'BEGIN{printf "%.1f", (1 - di/dt) * 100}')"
+  fi
+  prev_idle=$idle; prev_total=$total
+
+  # --- k6 CPU headroom: sum %cpu across k6 processes, as cores --------------
+  k6_cores=0
+  k6_pids="$(pgrep -x k6 2>/dev/null | paste -sd, - || true)"
+  if [ -n "$k6_pids" ]; then
+    k6_cores="$(ps -o %cpu= -p "$k6_pids" 2>/dev/null | awk '{s+=$1} END{printf "%.2f", s/100}')"
+    [ -n "$k6_cores" ] || k6_cores=0
+  fi
+
+  echo "${ts},${mhz_avg},${mhz_min},${temp_max},${host_util},${k6_cores}" >> "$OUT"
+  sleep "$INTERVAL"
+done
+
+echo "[host-sampler] wrote $(($(wc -l < "$OUT") - 1)) samples to $OUT" >&2

--- a/benchmarks/runner/report.py
+++ b/benchmarks/runner/report.py
@@ -227,6 +227,37 @@ SERVER_CONTAINER = {
 }
 
 
+# D4: scenarios with no genuine cross-vendor equivalent — either an AXIAM-only
+# capability (gRPC authz) or a vendor-specific native-API scenario (Zitadel's
+# gRPC identity RPC). Each of these is wired into exactly one target's
+# scenario list in runner/run-benchmark.sh (AXIAM_ONLY_SCENARIOS /
+# ZITADEL_ONLY_SCENARIOS), so a same-name cell from a second target never
+# actually exists — the "Efficiency comparison (across targets)" loop below
+# would already skip them via its `len(group_all) < 2` guard. This set makes
+# that exclusion explicit/defensive (self-documenting, and robust to a future
+# scenario coincidentally sharing a name across targets) rather than relying
+# only on that structural accident. See docs/methodology.md §5 "Comparability:
+# protocol-efficiency (gRPC vs REST, same vendor)".
+NON_COMPARATIVE_SCENARIOS = {
+    "authz_check_grpc", "authz_batch_grpc", "authz_check_rest", "authz_batch_rest",
+    "zitadel_userinfo_grpc",
+}
+
+# Within-vendor REST-vs-gRPC pairs for the same logical operation — the
+# "protocol-efficiency" comparison docs/methodology.md describes, distinct
+# from (and never merged into) the cross-vendor tables. Keyed by target;
+# value is (rest_scenario, grpc_scenario, logical_op_label).
+PROTOCOL_EFFICIENCY_PAIRS = {
+    "axiam": [
+        ("authz_check_rest", "authz_check_grpc", "authorization decision"),
+        ("authz_batch_rest", "authz_batch_grpc", "batch authorization decision"),
+    ],
+    "zitadel": [
+        ("userinfo", "zitadel_userinfo_grpc", "identity read (userinfo)"),
+    ],
+}
+
+
 def derive(perf, res):
     thr = perf["throughput"]
     cpu = res["cpu_cores_avg"]
@@ -612,6 +643,13 @@ def build_report(cells, multi_run=False):
               "AXIAM's RabbitMQ+SurrealDB inclusion in the whole-stack numbers "
               "is visible rather than silently folded in (A5.5).", ""]
     for sc in scenarios:
+        # D4: never render AXIAM-only/vendor-only scenarios here, even if a
+        # future scenario file name collision would otherwise let >=2 cells
+        # slip into group_all below — these are protocol-efficiency-only
+        # (see the dedicated section below) or single-vendor capability
+        # metrics, not cross-vendor numbers (docs/methodology.md §5).
+        if sc in NON_COMPARATIVE_SCENARIOS:
+            continue
         for pr in profiles:
             group_all = [c for c in valid if c["scenario"] == sc and c["profile"] == pr]
             if len(group_all) < 2:
@@ -659,6 +697,52 @@ def build_report(cells, multi_run=False):
                 ["target", "thr(req/s)", "p50(ms)", "p95(ms)", "thr/core", "thr/GiB",
                  "cpu_ms/req", "server-only thr/core", "server-only cpu_ms/req"],
                 rows), ""]
+
+    # 2b. Protocol efficiency: REST vs gRPC for the same logical op, WITHIN a
+    # single vendor (D4). Distinct from — and deliberately never merged into —
+    # section 2's cross-vendor tables: this answers "does gRPC cost less than
+    # REST for the same operation on the same server?", not "is target A
+    # faster than target B?" (docs/methodology.md §5, "Comparability:
+    # protocol-efficiency (gRPC vs REST, same vendor)").
+    lines += ["## Protocol efficiency (gRPC vs REST, within a vendor)", "",
+              "Same logical operation, two wire protocols, same target — NOT a "
+              "cross-vendor comparison (see docs/methodology.md §5). "
+              "`Δ-throughput` and `Δ-cpu_ms/req` are gRPC relative to REST "
+              "(negative Δ-cpu_ms/req = gRPC cheaper per request).", ""]
+    any_pair_rendered = False
+    for tg, pairs in PROTOCOL_EFFICIENCY_PAIRS.items():
+        for rest_sc, grpc_sc, op_label in pairs:
+            for pr in profiles:
+                rest_c = next((c for c in valid
+                               if c["target"] == tg and c["scenario"] == rest_sc and c["profile"] == pr), None)
+                grpc_c = next((c for c in valid
+                               if c["target"] == tg and c["scenario"] == grpc_sc and c["profile"] == pr), None)
+                if not rest_c or not grpc_c:
+                    continue
+                if rest_c["is_fallback"] or grpc_c["is_fallback"]:
+                    continue  # A3: a fallback-op cell measures a different operation — skip the pair.
+                any_pair_rendered = True
+                lines += [f"### {tg}: {op_label} @ {pr}", ""]
+                rp, gp = rest_c["perf"], grpc_c["perf"]
+                rd, gd = rest_c["der"], grpc_c["der"]
+                d_thr = ((gp["throughput"] - rp["throughput"]) / rp["throughput"] * 100.0
+                         if rp["throughput"] else 0.0)
+                d_cpu_ms = gd["cpu_ms_per_request"] - rd["cpu_ms_per_request"]
+                rows = [
+                    ["REST (" + rest_sc + ")", f"{rp['throughput']:.0f}", f"{rp['p50']:.1f}",
+                     f"{rp['p95']:.1f}", f"{rd['throughput_per_core']:.0f}",
+                     f"{rd['cpu_ms_per_request']:.3f}", "baseline"],
+                    ["gRPC (" + grpc_sc + ")", f"{gp['throughput']:.0f}", f"{gp['p50']:.1f}",
+                     f"{gp['p95']:.1f}", f"{gd['throughput_per_core']:.0f}",
+                     f"{gd['cpu_ms_per_request']:.3f}", f"{d_thr:+.1f}% thr, {d_cpu_ms:+.3f} cpu_ms/req"],
+                ]
+                lines += [md_table(
+                    ["protocol (scenario)", "thr(req/s)", "p50(ms)", "p95(ms)",
+                     "thr/core", "cpu_ms/req", "Δ vs REST"],
+                    rows), ""]
+    if not any_pair_rendered:
+        lines += ["_No matching (REST, gRPC) pair had both cells valid and "
+                  "non-fallback for the same (target, profile) yet._", ""]
 
     # 3. Security-cost matrix per (target, scenario)
     lines += ["## Security cost (relative to p0-plaintext)", "",

--- a/benchmarks/runner/report.py
+++ b/benchmarks/runner/report.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Aggregate raw benchmark outputs into a comparative Markdown report.
 
-Walks results/<target>/<profile>/<scenario>.{meta.json,k6.json,res.csv}, joins
-them, computes performance + resource + efficiency metrics, the security-cost
-matrix, and validity gates (see docs/methodology.md), then writes a report.
+Walks results/<target>/<profile>/<scenario>.{meta.json,k6.json,res.csv,host.csv},
+joins them, computes performance + resource + efficiency metrics, the
+security-cost matrix, host-telemetry honesty flags, and validity gates (see
+docs/methodology.md), then writes a report.
 
 Stdlib only — no external dependencies.
 
@@ -30,6 +31,12 @@ def pct(values, p):
     lo = int(k)
     hi = min(lo + 1, len(s) - 1)
     return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def dash(value, fmt):
+    """Format `value` with `fmt`, or an em dash when `value` is None (used to
+    blank throughput/latency columns on a 100%-error cell — A5.2)."""
+    return "—" if value is None else format(value, fmt)
 
 
 def load_k6_summary(path):
@@ -69,33 +76,137 @@ def load_k6_summary(path):
         "p95": trend("bench_op_latency_ms", "p(95)"),
         "p99": trend("bench_op_latency_ms", "p(99)"),
         "avg": trend("bench_op_latency_ms", "avg"),
+        # A3: iterations that measured a fallback op (e.g. Zitadel login() ->
+        # client_credentials, or a userinfo setup() that fell back) rather than
+        # the labelled logical op.
+        "fallback_count": counter_count("bench_fallback"),
     }
 
 
 def load_resource_csv(path):
-    """Sum per-timestamp across containers, then aggregate cpu/mem over time."""
-    if not os.path.exists(path):
-        return {"cpu_cores_avg": 0.0, "cpu_cores_p95": 0.0,
-                "mem_mib_avg": 0.0, "mem_mib_p95": 0.0, "samples": 0}
+    """Sum per-timestamp across containers for the whole-stack aggregate, and
+    keep per-container time-averages for bottleneck attribution (A5.3) and the
+    server-container-only efficiency variant (A5.5)."""
+    empty = {
+        "cpu_cores_avg": 0.0, "cpu_cores_p95": 0.0,
+        "mem_mib_avg": 0.0, "mem_mib_p95": 0.0, "samples": 0,
+        "containers": {},
+    }
+    if not path or not os.path.exists(path):
+        return empty
     by_ts_cpu = defaultdict(float)
     by_ts_mem = defaultdict(float)
+    by_container_cpu = defaultdict(list)
+    by_container_mem = defaultdict(list)
     with open(path) as f:
         for row in csv.DictReader(f):
             try:
                 ts = row["epoch_ms"]
-                by_ts_cpu[ts] += float(row["cpu_cores"])
-                by_ts_mem[ts] += float(row["mem_mib"])
+                cname = row["container"]
+                cpu = float(row["cpu_cores"])
+                mem = float(row["mem_mib"])
             except (ValueError, KeyError):
                 continue
+            by_ts_cpu[ts] += cpu
+            by_ts_mem[ts] += mem
+            by_container_cpu[cname].append(cpu)
+            by_container_mem[cname].append(mem)
     cpu = list(by_ts_cpu.values())
     mem = list(by_ts_mem.values())
+    containers = {}
+    for cname, vals in by_container_cpu.items():
+        mvals = by_container_mem.get(cname, [])
+        containers[cname] = {
+            "cpu_avg": statistics.fmean(vals) if vals else 0.0,
+            "mem_avg": statistics.fmean(mvals) if mvals else 0.0,
+        }
     return {
         "cpu_cores_avg": statistics.fmean(cpu) if cpu else 0.0,
         "cpu_cores_p95": pct(cpu, 95),
         "mem_mib_avg": statistics.fmean(mem) if mem else 0.0,
         "mem_mib_p95": pct(mem, 95),
         "samples": len(cpu),
+        "containers": containers,
     }
+
+
+def load_host_csv(path):
+    """A6 host telemetry: CPU frequency, thermal, host utilization, k6 CPU
+    headroom over the measure window. Missing/old cells (no host.csv) degrade
+    to all-zero rather than crashing report generation (A4 tolerance)."""
+    empty = {
+        "mhz_avg": 0.0, "mhz_min": 0.0, "mhz_max": 0.0, "temp_max": 0.0,
+        "host_cpu_util_avg": 0.0, "k6_cores_avg": 0.0, "samples": 0,
+    }
+    if not path or not os.path.exists(path):
+        return empty
+    mhz_avgs, mhz_mins, temps, utils, k6cores = [], [], [], [], []
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            try:
+                mhz_avgs.append(float(row["cpu_mhz_avg"]))
+                mhz_mins.append(float(row["cpu_mhz_min"]))
+                temps.append(float(row["temp_c_max"]))
+                utils.append(float(row["host_cpu_util_pct"]))
+                k6cores.append(float(row["k6_cpu_cores"]))
+            except (ValueError, KeyError):
+                continue
+    return {
+        "mhz_avg": statistics.fmean(mhz_avgs) if mhz_avgs else 0.0,
+        "mhz_min": min(mhz_mins) if mhz_mins else 0.0,
+        # "the window's max" for the clock_variance rule is the max of the
+        # per-sample mean-MHz-across-cores series (mirrors mhz_avg's series).
+        "mhz_max": max(mhz_avgs) if mhz_avgs else 0.0,
+        "temp_max": max(temps) if temps else 0.0,
+        "host_cpu_util_avg": statistics.fmean(utils) if utils else 0.0,
+        "k6_cores_avg": statistics.fmean(k6cores) if k6cores else 0.0,
+        "samples": len(mhz_avgs),
+    }
+
+
+# Compose-file CPU cap defaults (targets/*/docker-compose.yml), used as a
+# fallback when a container isn't listed in meta.json["containers"] (old
+# results predating A4, or a container the sampler saw but run-benchmark.sh's
+# containers_json() didn't — e.g. it exited between sampling and inspection).
+def default_cpu_cap(container_name):
+    if container_name.endswith("-surrealdb") or container_name.endswith("-postgres"):
+        return 2.0  # BENCH_DB_CPUS
+    if container_name.endswith("-rabbitmq"):
+        return 1.0  # BENCH_MQ_CPUS
+    if container_name.endswith("-tls"):
+        return 1.0  # BENCH_EDGE_CPUS
+    return 2.0  # BENCH_CPUS (the main server/app container)
+
+
+def bottleneck(meta, res):
+    """The container(s) whose average CPU >= 0.95x their configured cap, or
+    'none'. Caps come from meta.json's "containers" (A4); fall back to the
+    compose defaults above when meta predates that field or omits a
+    container. (A5.3)"""
+    containers_meta = {c.get("name"): c for c in (meta.get("containers") or [])}
+    hot = []
+    for cname, stats in (res.get("containers") or {}).items():
+        cap = None
+        cm = containers_meta.get(cname)
+        if cm is not None and cm.get("cpu_cap") not in (None, ""):
+            try:
+                cap = float(cm["cpu_cap"])
+            except (TypeError, ValueError):
+                cap = None
+        if cap is None:
+            cap = default_cpu_cap(cname)
+        if cap and stats.get("cpu_avg", 0.0) >= 0.95 * cap:
+            hot.append(cname)
+    return ",".join(sorted(hot)) if hot else "none"
+
+
+# Primary app/server container per target (excludes db/mq/edge), used for the
+# server-container-only efficiency variant (A5.5).
+SERVER_CONTAINER = {
+    "axiam": "bench-axiam-server",
+    "keycloak": "bench-keycloak",
+    "zitadel": "bench-zitadel",
+}
 
 
 def derive(perf, res):
@@ -107,6 +218,47 @@ def derive(perf, res):
         "throughput_per_gib": (thr / mem_gib) if mem_gib > 0 else 0.0,
         "cpu_ms_per_request": (cpu * 1000.0 / thr) if thr > 0 else 0.0,
     }
+
+
+def derive_server_only(perf, res, target):
+    """Same derived numbers as derive(), but scoped to just the server
+    container's CPU/mem — so AXIAM's broker (RabbitMQ) + DB inclusion in the
+    whole-stack numbers doesn't silently understate its per-request cost
+    relative to a single-process competitor (A5.5)."""
+    cname = SERVER_CONTAINER.get(target)
+    stats = (res.get("containers") or {}).get(cname) if cname else None
+    if not stats:
+        return {"throughput_per_core": 0.0, "throughput_per_gib": 0.0, "cpu_ms_per_request": 0.0}
+    server_res = {"cpu_cores_avg": stats.get("cpu_avg", 0.0), "mem_mib_avg": stats.get("mem_avg", 0.0)}
+    return derive(perf, server_res)
+
+
+def host_flags(meta, host):
+    """A6: clock_variance (window mean MHz sagged >15% below the window max —
+    i.e. the run was not at a flat sustained clock) and generator_saturated
+    (k6 itself was eating too much of the host's non-stack CPU headroom to
+    trust it as a clean load generator)."""
+    flags = []
+    mhz_avg, mhz_max = host.get("mhz_avg", 0.0), host.get("mhz_max", 0.0)
+    if mhz_max > 0 and mhz_avg < 0.85 * mhz_max:
+        flags.append("clock_variance")
+
+    containers = meta.get("containers") or []
+    if containers:
+        stack_cap_cpus = sum(float(c.get("cpu_cap", 0) or 0) for c in containers)
+    else:
+        try:
+            stack_cap_cpus = float((meta.get("caps") or {}).get("cpus", 2))
+        except (TypeError, ValueError):
+            stack_cap_cpus = 2.0
+    try:
+        host_cpus = float((meta.get("host") or {}).get("cpus"))
+    except (TypeError, ValueError):
+        host_cpus = 0.0
+    headroom = host_cpus - stack_cap_cpus
+    if headroom > 0 and host.get("k6_cores_avg", 0.0) > 0.8 * headroom:
+        flags.append("generator_saturated")
+    return flags
 
 
 def collect(results_dir, max_error, min_samples):
@@ -123,12 +275,19 @@ def collect(results_dir, max_error, min_samples):
                 if not fn.endswith(".meta.json"):
                     continue
                 meta = json.load(open(os.path.join(pdir, fn)))
-                k6file = os.path.join(pdir, meta.get("k6_summary_file", ""))
+                k6_name = meta.get("k6_summary_file")
+                if not k6_name:
+                    continue
+                k6file = os.path.join(pdir, k6_name)
                 if not os.path.exists(k6file):
                     continue
                 perf = load_k6_summary(k6file)
-                res = load_resource_csv(os.path.join(pdir, meta.get("resource_csv", "")))
+                res_name = meta.get("resource_csv")
+                res = load_resource_csv(os.path.join(pdir, res_name) if res_name else None)
+                host_name = meta.get("host_csv")  # A6/A4: absent on pre-A6 meta
+                host = load_host_csv(os.path.join(pdir, host_name) if host_name else None)
                 der = derive(perf, res)
+                der_server = derive_server_only(perf, res, meta.get("target", target))
                 reasons = []
                 if perf["error_rate"] > max_error:
                     reasons.append(f"error_rate {perf['error_rate']:.3f} > {max_error}")
@@ -140,7 +299,10 @@ def collect(results_dir, max_error, min_samples):
                     "target": meta["target"], "profile": meta["profile"],
                     "scenario": meta["scenario"], "meta": meta,
                     "rate_limits": meta.get("rate_limits", "unknown"),
-                    "perf": perf, "res": res, "der": der,
+                    "perf": perf, "res": res, "der": der, "der_server": der_server,
+                    "host": host, "host_flags": host_flags(meta, host),
+                    "bottleneck": bottleneck(meta, res),
+                    "is_fallback": perf["fallback_count"] > 0,
                     "valid": not reasons, "reasons": reasons,
                 })
     return cells
@@ -191,36 +353,83 @@ def build_report(cells):
         "**cpu_ms_per_request** answer *can AXIAM match competitors at lower cost?* "
         "Compare across targets at equal profile + latency.",
         "",
+        "> `fallback` = the cell measured a fallback operation instead of the "
+        "labelled logical op (e.g. Zitadel's login() falling back to "
+        "client_credentials — see docs/methodology.md). Fallback cells are "
+        "excluded from head-to-head winner tables but kept here for the full "
+        "picture.",
+        "",
+        "> `bottleneck` names the stack container(s) whose average CPU reached "
+        "≥ 95% of their configured cap during the measure window — `none` "
+        "means nothing in the stack saturated (the client, network, or an "
+        "un-pegged serialization point is the limiter instead).",
+        "",
+        "> Cells with `err`=100% have their throughput/latency columns blanked "
+        "(`—`) — those numbers would describe the failure path, not the "
+        "operation being measured.",
+        "",
     ]
 
     # 1. Full results table
     lines += ["## All results", ""]
     rows = []
     for c in sorted(cells, key=lambda c: (c["scenario"], c["profile"], c["target"])):
-        p, r, d = c["perf"], c["res"], c["der"]
+        p, r, d, h = c["perf"], c["res"], c["der"], c["host"]
+        full_outage = p["error_rate"] >= 1.0
+        thr = None if full_outage else p["throughput"]
+        p50 = None if full_outage else p["p50"]
+        p95 = None if full_outage else p["p95"]
+        p99 = None if full_outage else p["p99"]
+        thr_core = None if full_outage else d["throughput_per_core"]
+        cpu_ms = None if full_outage else d["cpu_ms_per_request"]
+        mhz_ratio = (h["mhz_min"] / h["mhz_max"]) if h["mhz_max"] > 0 else 0.0
+        flags = list(c["host_flags"])
+        if c["is_fallback"]:
+            flags.append("fallback-op")
         rows.append([
             c["scenario"], c["profile"], c["target"], c["rate_limits"],
-            f"{p['throughput']:.0f}", f"{p['p95']:.1f}", f"{p['p99']:.1f}",
+            dash(thr, ".0f"), dash(p50, ".1f"), dash(p95, ".1f"), dash(p99, ".1f"),
             f"{p['error_rate']*100:.2f}%",
             f"{r['cpu_cores_avg']:.2f}", f"{r['mem_mib_avg']:.0f}",
-            f"{d['throughput_per_core']:.0f}", f"{d['cpu_ms_per_request']:.3f}",
+            dash(thr_core, ".0f"), dash(cpu_ms, ".3f"),
+            c["bottleneck"],
+            "yes" if c["is_fallback"] else "no",
+            f"{h['mhz_avg']:.0f}", f"{mhz_ratio:.2f}", f"{h['temp_max']:.0f}",
+            f"{h['k6_cores_avg']:.2f}",
+            ";".join(flags) or "-",
             "✓" if c["valid"] else "✗",
         ])
     lines += [md_table(
-        ["scenario", "profile", "target", "rate_limits", "thr(req/s)", "p95(ms)",
-         "p99(ms)", "err", "cpu(cores)", "mem(MiB)", "thr/core", "cpu_ms/req",
-         "valid"],
+        ["scenario", "profile", "target", "rate_limits", "thr(req/s)", "p50(ms)",
+         "p95(ms)", "p99(ms)", "err", "cpu(cores)", "mem(MiB)", "thr/core",
+         "cpu_ms/req", "bottleneck", "fallback", "mhz_avg", "mhz_min/max",
+         "temp_max(C)", "k6_cores", "host_flags", "valid"],
         rows), ""]
 
     # 2. Efficiency comparison per (scenario, profile) across targets
     lines += ["## Efficiency comparison (across targets)", "",
-              "Higher `thr/core` and lower `cpu_ms/req` is better.", ""]
+              "Higher `thr/core` and lower `cpu_ms/req` is better. "
+              "`server-only` recomputes both against just the primary "
+              "server/app container's CPU+mem (excludes DB/broker/edge), so "
+              "AXIAM's RabbitMQ+SurrealDB inclusion in the whole-stack numbers "
+              "is visible rather than silently folded in (A5.5).", ""]
     for sc in scenarios:
         for pr in profiles:
-            group = [c for c in valid if c["scenario"] == sc and c["profile"] == pr]
-            if len(group) < 2:
+            group_all = [c for c in valid if c["scenario"] == sc and c["profile"] == pr]
+            if len(group_all) < 2:
                 continue
+            fallback_cells = [c for c in group_all if c["is_fallback"]]
+            group = [c for c in group_all if not c["is_fallback"]]
             lines += [f"### {sc} @ {pr}", ""]
+            if fallback_cells:
+                lines += [
+                    "> ⚠️ fallback-op cell(s) excluded from this head-to-head: "
+                    + ", ".join(sorted(f"{c['target']}" for c in fallback_cells))
+                    + " (see the full matrix above; comparability: fallback-op).", "",
+                ]
+            if len(group) < 2:
+                lines += ["_Fewer than 2 non-fallback targets — nothing to compare._", ""]
+                continue
             # Refuse to render a head-to-head across incomparable rate-limit
             # postures (e.g. AXIAM throttled vs an unthrottled competitor, or a
             # cell with an unknown posture). This is the guard that stops the
@@ -241,13 +450,16 @@ def build_report(cells):
             rows = []
             best = max(group, key=lambda c: c["der"]["throughput_per_core"])
             for c in sorted(group, key=lambda c: -c["der"]["throughput_per_core"]):
-                d, p = c["der"], c["perf"]
+                d, ds, p = c["der"], c["der_server"], c["perf"]
                 marker = " 🏆" if c is best else ""
                 rows.append([c["target"] + marker, f"{p['throughput']:.0f}",
-                             f"{p['p95']:.1f}", f"{d['throughput_per_core']:.0f}",
-                             f"{d['throughput_per_gib']:.0f}", f"{d['cpu_ms_per_request']:.3f}"])
+                             f"{p['p50']:.1f}", f"{p['p95']:.1f}",
+                             f"{d['throughput_per_core']:.0f}", f"{d['throughput_per_gib']:.0f}",
+                             f"{d['cpu_ms_per_request']:.3f}",
+                             f"{ds['throughput_per_core']:.0f}", f"{ds['cpu_ms_per_request']:.3f}"])
             lines += [md_table(
-                ["target", "thr(req/s)", "p95(ms)", "thr/core", "thr/GiB", "cpu_ms/req"],
+                ["target", "thr(req/s)", "p50(ms)", "p95(ms)", "thr/core", "thr/GiB",
+                 "cpu_ms/req", "server-only thr/core", "server-only cpu_ms/req"],
                 rows), ""]
 
     # 3. Security-cost matrix per (target, scenario)
@@ -262,19 +474,50 @@ def build_report(cells):
                 continue
             lines += [f"### {tg} / {sc}", ""]
             rows = [["p0-plaintext (base)", f"{base['perf']['throughput']:.0f}",
-                     f"{base['perf']['p95']:.1f}", "baseline", "baseline"]]
+                     f"{base['perf']['p50']:.1f}", f"{base['perf']['p95']:.1f}",
+                     "baseline", "baseline"]]
             for c in sorted(others, key=lambda c: PROFILE_RANK.get(c["profile"], 99)):
                 tb, pb = base["perf"]["throughput"], base["perf"]["p95"]
                 t, p = c["perf"]["throughput"], c["perf"]["p95"]
                 d_thr = (1 - t / tb) * 100 if tb else 0.0
                 d_p95 = p - pb
-                rows.append([c["profile"], f"{t:.0f}", f"{p:.1f}",
+                rows.append([c["profile"], f"{t:.0f}", f"{c['perf']['p50']:.1f}", f"{p:.1f}",
                              f"{-d_thr:+.1f}%", f"{d_p95:+.1f}"])
             lines += [md_table(
-                ["profile", "thr(req/s)", "p95(ms)", "Δ-throughput", "Δ-p95(ms)"],
+                ["profile", "thr(req/s)", "p50(ms)", "p95(ms)", "Δ-throughput", "Δ-p95(ms)"],
                 rows), ""]
 
-    # 4. Excluded
+    # 4. Appendix: per-container resource breakdown (A5.3)
+    lines += ["## Appendix: per-container resource breakdown", "",
+              "Per-cell, per-container average CPU/mem from the resource sampler, "
+              "the cap it was measured against (from meta.json, falling back to "
+              "the compose default), and whether it hit the bottleneck threshold "
+              "(cpu_avg ≥ 95% of cap).", ""]
+    rows = []
+    for c in sorted(valid, key=lambda c: (c["scenario"], c["profile"], c["target"])):
+        containers_meta = {cm.get("name"): cm for cm in (c["meta"].get("containers") or [])}
+        for cname, stats in sorted((c["res"].get("containers") or {}).items()):
+            cm = containers_meta.get(cname)
+            if cm is not None and cm.get("cpu_cap") not in (None, ""):
+                try:
+                    cap = float(cm["cpu_cap"])
+                except (TypeError, ValueError):
+                    cap = default_cpu_cap(cname)
+            else:
+                cap = default_cpu_cap(cname)
+            hot = "✓" if stats.get("cpu_avg", 0.0) >= 0.95 * cap else "·"
+            rows.append([c["scenario"], c["profile"], c["target"], cname,
+                         f"{stats.get('cpu_avg', 0.0):.2f}", f"{cap:.2f}",
+                         f"{stats.get('mem_avg', 0.0):.0f}", hot])
+    if rows:
+        lines += [md_table(
+            ["scenario", "profile", "target", "container", "cpu_avg(cores)",
+             "cpu_cap", "mem_avg(MiB)", "hot"],
+            rows), ""]
+    else:
+        lines += ["_No per-container samples available (no res.csv rows)._", ""]
+
+    # 5. Excluded
     if invalid:
         lines += ["## Excluded (invalid) cells", ""]
         rows = [[c["target"], c["profile"], c["scenario"], "; ".join(c["reasons"])]

--- a/benchmarks/runner/report.py
+++ b/benchmarks/runner/report.py
@@ -16,6 +16,7 @@ import argparse
 import csv
 import json
 import os
+import re
 import statistics
 import sys
 from collections import defaultdict
@@ -31,6 +32,11 @@ def pct(values, p):
     lo = int(k)
     hi = min(lo + 1, len(s) - 1)
     return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def median(values):
+    """statistics.median with an empty-list guard (C1: median-of-N)."""
+    return statistics.median(values) if values else 0.0
 
 
 def dash(value, fmt):
@@ -178,6 +184,18 @@ def default_cpu_cap(container_name):
     return 2.0  # BENCH_CPUS (the main server/app container)
 
 
+# Same fallback, for mem (MiB) — used by the C2 DB-sensitivity appendix column
+# below when a meta.json predates the "mem_cap_mib" field.
+def default_mem_cap(container_name):
+    if container_name.endswith("-surrealdb") or container_name.endswith("-postgres"):
+        return 1024.0  # BENCH_DB_MEM
+    if container_name.endswith("-rabbitmq"):
+        return 512.0  # BENCH_MQ_MEM
+    if container_name.endswith("-tls"):
+        return 128.0  # BENCH_EDGE_MEM
+    return 1024.0  # BENCH_MEM (the main server/app container)
+
+
 def bottleneck(meta, res):
     """The container(s) whose average CPU >= 0.95x their configured cap, or
     'none'. Caps come from meta.json's "containers" (A4); fall back to the
@@ -261,7 +279,12 @@ def host_flags(meta, host):
     return flags
 
 
-def collect(results_dir, max_error, min_samples):
+def collect_dir(results_dir, max_error, min_samples):
+    """Walk ONE flat results tree (results/<target>/<profile>/<scenario>.*) and
+    return its raw (unaggregated) cells. This is the entire single-run
+    collection logic from before C1 — unchanged — reused both for the classic
+    single-run layout and, once per `results/run-<i>/` directory, by the C1
+    median-of-N aggregator below."""
     cells = []
     for target in sorted(os.listdir(results_dir)):
         tdir = os.path.join(results_dir, target)
@@ -308,6 +331,122 @@ def collect(results_dir, max_error, min_samples):
     return cells
 
 
+# --- C1: median-of-N run aggregation ----------------------------------------
+# `bench-matrix` (justfile) now runs the whole target×profile×scenario matrix
+# `repeat` times (default 3), each pass writing into its own
+# `results/run-<i>/<target>/<profile>/...` tree using the exact same flat
+# per-cell layout `collect_dir` already understands. When one or more
+# `results/run-*/` directories are present, aggregate each (target, profile,
+# scenario) cell by taking the MEDIAN independently per metric across the
+# valid runs, rather than reporting a single run's numbers. Results trees that
+# predate this (no `run-*/` dirs — e.g. the existing 2026-07-19 tree) fall
+# through to the old single-run behavior completely unchanged.
+RUN_DIR_RE = re.compile(r"run-\d+")
+
+# Fields medianed independently per the C1 spec ("throughput, p50/p95/p99,
+# cpu, mem"), plus the other numeric perf/res/host fields for consistency.
+PERF_MEDIAN_FIELDS = [
+    "throughput", "ok_count", "failed_count", "error_rate",
+    "p50", "p95", "p99", "avg", "fallback_count",
+]
+RES_MEDIAN_FIELDS = ["cpu_cores_avg", "cpu_cores_p95", "mem_mib_avg", "mem_mib_p95", "samples"]
+HOST_MEDIAN_FIELDS = ["mhz_avg", "mhz_min", "mhz_max", "temp_max", "host_cpu_util_avg", "k6_cores_avg", "samples"]
+
+
+def _median_of(dicts, fields):
+    return {f: median([d.get(f, 0.0) for d in dicts]) for f in fields}
+
+
+def _median_res(res_list):
+    """Median the whole-stack res fields AND, per container, cpu_avg/mem_avg —
+    so bottleneck() and the per-container appendix still work on aggregated
+    cells exactly as they do on single-run ones."""
+    agg = _median_of(res_list, RES_MEDIAN_FIELDS)
+    names = set()
+    for r in res_list:
+        names.update((r.get("containers") or {}).keys())
+    containers = {}
+    for name in names:
+        cpu_vals = [(r.get("containers") or {}).get(name, {}).get("cpu_avg", 0.0)
+                    for r in res_list if name in (r.get("containers") or {})]
+        mem_vals = [(r.get("containers") or {}).get(name, {}).get("mem_avg", 0.0)
+                    for r in res_list if name in (r.get("containers") or {})]
+        containers[name] = {"cpu_avg": median(cpu_vals), "mem_avg": median(mem_vals)}
+    agg["containers"] = containers
+    return agg
+
+
+def aggregate_cell(runs):
+    """Median-aggregate one (target, profile, scenario)'s per-run raw cells
+    (as produced by collect_dir, one per results/run-<i>/) into a single cell
+    with the same shape build_report expects, plus n_valid_runs/n_runs and the
+    throughput min-max spread. A cell is only marked `valid` when >=2 of its
+    runs were individually valid (C1) — with 0 or 1 valid runs there is no
+    meaningful median, so it's reported (for visibility) but excluded from
+    headline comparisons, same as any other invalid cell."""
+    target, profile, scenario = runs[0]["target"], runs[0]["profile"], runs[0]["scenario"]
+    valid_runs = [r for r in runs if r["valid"]]
+    n_valid, n_total = len(valid_runs), len(runs)
+    basis = valid_runs if valid_runs else runs
+
+    perf = _median_of([r["perf"] for r in basis], PERF_MEDIAN_FIELDS)
+    res = _median_res([r["res"] for r in basis])
+    host = _median_of([r["host"] for r in basis], HOST_MEDIAN_FIELDS)
+
+    thr_vals = [r["perf"]["throughput"] for r in basis]
+    thr_median = perf["throughput"]
+    thr_spread_pct = (((max(thr_vals) - min(thr_vals)) / 2.0) / thr_median * 100.0
+                       if thr_vals and thr_median else 0.0)
+
+    meta = basis[0]["meta"]  # containers/caps/scenario_sha etc. are stable across runs
+    der = derive(perf, res)
+    der_server = derive_server_only(perf, res, target)
+
+    reasons = []
+    if n_valid < 2:
+        reasons.append(f"only {n_valid}/{n_total} valid run(s) (need >=2 for a median)")
+
+    return {
+        "target": target, "profile": profile, "scenario": scenario, "meta": meta,
+        "rate_limits": basis[0]["rate_limits"],
+        "perf": perf, "res": res, "der": der, "der_server": der_server,
+        "host": host, "host_flags": host_flags(meta, host),
+        "bottleneck": bottleneck(meta, res),
+        "is_fallback": any(r["is_fallback"] for r in runs),
+        "valid": n_valid >= 2 and not reasons,
+        "reasons": reasons,
+        "n_valid_runs": n_valid, "n_runs": n_total, "thr_spread_pct": thr_spread_pct,
+    }
+
+
+def collect(results_dir, max_error, min_samples):
+    """Top-level entry point: detect whether `results_dir` holds a
+    `results/run-*/` median-of-N layout or the classic flat single-run layout,
+    and branch (C1). Returns (cells, multi_run)."""
+    try:
+        entries = sorted(os.listdir(results_dir))
+    except OSError:
+        entries = []
+    run_dirs = [os.path.join(results_dir, e) for e in entries
+                if RUN_DIR_RE.fullmatch(e) and os.path.isdir(os.path.join(results_dir, e))]
+
+    if not run_dirs:
+        # Classic single-run layout — completely unchanged behavior.
+        cells = collect_dir(results_dir, max_error, min_samples)
+        for c in cells:
+            c["n_valid_runs"] = 1 if c["valid"] else 0
+            c["n_runs"] = 1
+            c["thr_spread_pct"] = 0.0
+        return cells, False
+
+    grouped = defaultdict(list)
+    for run_dir in run_dirs:
+        for c in collect_dir(run_dir, max_error, min_samples):
+            grouped[(c["target"], c["profile"], c["scenario"])].append(c)
+    cells = [aggregate_cell(runs) for runs in grouped.values()]
+    return cells, True
+
+
 def posture_bucket(posture):
     """Collapse a rate-limit posture into a comparability class.
 
@@ -336,7 +475,7 @@ def md_table(headers, rows):
 PROFILE_RANK = {"p0-plaintext": 0, "p1-tls12": 1, "p2-tls13": 2, "p3-mtls": 3}
 
 
-def build_report(cells):
+def build_report(cells, multi_run=False):
     lines = ["# AXIAM Benchmark Report", ""]
     valid = [c for c in cells if c["valid"]]
     invalid = [c for c in cells if not c["valid"]]
@@ -369,6 +508,20 @@ def build_report(cells):
         "operation being measured.",
         "",
     ]
+    if multi_run:
+        max_n = max((c.get("n_runs", 1) for c in cells), default=1)
+        lines += [
+            f"> **Median-of-N aggregation (C1):** this report was generated from "
+            f"`results/run-*/` (up to N={max_n} repeats per cell). Every metric "
+            "below (throughput, p50/p95/p99, cpu, mem, host telemetry) is the "
+            "MEDIAN taken independently across that cell's valid runs — not a "
+            "single run. `runs(valid/n)` shows how many of the N repeats were "
+            "individually valid; a cell needs **≥2 valid runs** to be marked "
+            "`valid` itself (fewer than that, there's no meaningful median — see "
+            "docs/methodology.md). `±thr%` is the throughput spread across valid "
+            "runs, `(max−min)/2` as a percentage of the median.",
+            "",
+        ]
 
     # 1. Full results table
     lines += ["## All results", ""]
@@ -386,7 +539,7 @@ def build_report(cells):
         flags = list(c["host_flags"])
         if c["is_fallback"]:
             flags.append("fallback-op")
-        rows.append([
+        row = [
             c["scenario"], c["profile"], c["target"], c["rate_limits"],
             dash(thr, ".0f"), dash(p50, ".1f"), dash(p95, ".1f"), dash(p99, ".1f"),
             f"{p['error_rate']*100:.2f}%",
@@ -398,13 +551,58 @@ def build_report(cells):
             f"{h['k6_cores_avg']:.2f}",
             ";".join(flags) or "-",
             "✓" if c["valid"] else "✗",
-        ])
-    lines += [md_table(
-        ["scenario", "profile", "target", "rate_limits", "thr(req/s)", "p50(ms)",
-         "p95(ms)", "p99(ms)", "err", "cpu(cores)", "mem(MiB)", "thr/core",
-         "cpu_ms/req", "bottleneck", "fallback", "mhz_avg", "mhz_min/max",
-         "temp_max(C)", "k6_cores", "host_flags", "valid"],
-        rows), ""]
+        ]
+        if multi_run:
+            row += [f"{c.get('n_valid_runs', 0)}/{c.get('n_runs', 1)}",
+                    f"±{c.get('thr_spread_pct', 0.0):.1f}%"]
+        rows.append(row)
+    headers = ["scenario", "profile", "target", "rate_limits", "thr(req/s)", "p50(ms)",
+               "p95(ms)", "p99(ms)", "err", "cpu(cores)", "mem(MiB)", "thr/core",
+               "cpu_ms/req", "bottleneck", "fallback", "mhz_avg", "mhz_min/max",
+               "temp_max(C)", "k6_cores", "host_flags", "valid"]
+    if multi_run:
+        headers += ["runs(valid/n)", "±thr%"]
+    lines += [md_table(headers, rows), ""]
+
+    # 1b. C4: AXIAM production rate-limit-posture cells, called out separately
+    # so they never get lost among (or silently averaged into) the neutralized
+    # comparison numbers above. posture_bucket()/the efficiency-comparison loop
+    # below already refuse to place a `prod`-posture cell head-to-head against
+    # an unthrottled competitor; this section is the human-readable label for
+    # the same rule, and the one place a `prod` run is summarized on its own.
+    prod_cells = [c for c in cells if c["rate_limits"] == "prod"]
+    if prod_cells:
+        lines += [
+            "## AXIAM production rate-limit posture — NOT comparable to competitors",
+            "",
+            "> These cells were run with `rl=prod` (`just target=axiam rl=prod …`): "
+            "AXIAM's shipped-default per-IP rate limits ACTIVE (see the `rl` "
+            "variable at the top of `justfile`). They measure the limiter's "
+            "throttling behavior, not raw endpoint capacity, and are excluded "
+            "from every head-to-head table above/below (`posture_bucket()` "
+            "buckets `prod` separately from `neutralized`/`n/a`, so a mixed or "
+            "unknown-posture comparison group is refused rather than silently "
+            "rendered). The intended framing: *AXIAM ships per-IP rate limits by "
+            "default; Keycloak and Zitadel don't* — compare a `prod` row only "
+            "against AXIAM's own `neutralized` row for the same "
+            "(scenario, profile), never against another target.",
+            "",
+        ]
+        rows = []
+        for c in sorted(prod_cells, key=lambda c: (c["scenario"], c["profile"])):
+            p = c["perf"]
+            full_outage = p["error_rate"] >= 1.0
+            rows.append([
+                c["scenario"], c["profile"],
+                dash(None if full_outage else p["throughput"], ".0f"),
+                dash(None if full_outage else p["p50"], ".1f"),
+                dash(None if full_outage else p["p95"], ".1f"),
+                f"{p['error_rate'] * 100:.2f}%",
+                "posture: prod — NOT comparable to competitors",
+            ])
+        lines += [md_table(
+            ["scenario", "profile", "thr(req/s)", "p50(ms)", "p95(ms)", "err", "label"],
+            rows), ""]
 
     # 2. Efficiency comparison per (scenario, profile) across targets
     lines += ["## Efficiency comparison (across targets)", "",
@@ -490,9 +688,12 @@ def build_report(cells):
     # 4. Appendix: per-container resource breakdown (A5.3)
     lines += ["## Appendix: per-container resource breakdown", "",
               "Per-cell, per-container average CPU/mem from the resource sampler, "
-              "the cap it was measured against (from meta.json, falling back to "
-              "the compose default), and whether it hit the bottleneck threshold "
-              "(cpu_avg ≥ 95% of cap).", ""]
+              "the caps it was measured against (from meta.json's `cpu_cap`/"
+              "`mem_cap_mib` — C2 — falling back to the compose default when "
+              "absent), and whether it hit the CPU bottleneck threshold "
+              "(cpu_avg ≥ 95% of cpu_cap). `mem_cap(MiB)` is what a "
+              "`dbcaps=uncapped` (C2) run shows raised for the `-surrealdb`/"
+              "`-postgres` container.", ""]
     rows = []
     for c in sorted(valid, key=lambda c: (c["scenario"], c["profile"], c["target"])):
         containers_meta = {cm.get("name"): cm for cm in (c["meta"].get("containers") or [])}
@@ -505,14 +706,21 @@ def build_report(cells):
                     cap = default_cpu_cap(cname)
             else:
                 cap = default_cpu_cap(cname)
+            if cm is not None and cm.get("mem_cap_mib") not in (None, ""):
+                try:
+                    mem_cap = float(cm["mem_cap_mib"])
+                except (TypeError, ValueError):
+                    mem_cap = default_mem_cap(cname)
+            else:
+                mem_cap = default_mem_cap(cname)
             hot = "✓" if stats.get("cpu_avg", 0.0) >= 0.95 * cap else "·"
             rows.append([c["scenario"], c["profile"], c["target"], cname,
                          f"{stats.get('cpu_avg', 0.0):.2f}", f"{cap:.2f}",
-                         f"{stats.get('mem_avg', 0.0):.0f}", hot])
+                         f"{stats.get('mem_avg', 0.0):.0f}", f"{mem_cap:.0f}", hot])
     if rows:
         lines += [md_table(
             ["scenario", "profile", "target", "container", "cpu_avg(cores)",
-             "cpu_cap", "mem_avg(MiB)", "hot"],
+             "cpu_cap", "mem_avg(MiB)", "mem_cap(MiB)", "hot"],
             rows), ""]
     else:
         lines += ["_No per-container samples available (no res.csv rows)._", ""]
@@ -540,11 +748,13 @@ def main():
     if not os.path.isdir(args.results):
         print(f"no results dir: {args.results}", file=sys.stderr)
         sys.exit(1)
-    cells = collect(args.results, args.max_error, args.min_samples)
+    cells, multi_run = collect(args.results, args.max_error, args.min_samples)
     if not cells:
         print("no result cells found — run a benchmark first", file=sys.stderr)
         sys.exit(1)
-    report = build_report(cells)
+    if multi_run:
+        print(f"[report] median-of-N layout detected ({len(cells)} aggregated cells)")
+    report = build_report(cells, multi_run=multi_run)
     out = args.out or os.path.join(args.results, "report.md")
     with open(out, "w") as f:
         f.write(report)

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -84,6 +84,13 @@ fi
 # The authz scenarios (gRPC and REST) are AXIAM-only; drop them for other targets.
 AXIAM_ONLY_SCENARIOS="authz_check_grpc.js authz_batch_grpc.js authz_check_rest.js authz_batch_rest.js"
 
+# D4: Zitadel's gRPC identity scenario (AuthService/GetMyUser, the gRPC
+# counterpart of userinfo.js — see scenarios/zitadel_userinfo_grpc.js and
+# scenarios/proto/zitadel/README.md) dials Zitadel's own vendored proto and
+# has no equivalent on AXIAM or Keycloak; drop it for other targets, mirroring
+# how AXIAM_ONLY_SCENARIOS is handled above.
+ZITADEL_ONLY_SCENARIOS="zitadel_userinfo_grpc.js"
+
 # OAuth2 client-flow scenarios need a seeded confidential client (and, ideally, a
 # configured OIDC issuer). Skip them when OAuth2 isn't set up so a missing OAuth2
 # config doesn't fail the run — either the operator opts out (BENCH_SKIP_OAUTH2=1)
@@ -102,6 +109,9 @@ filter_scenarios() {
   for s in "${SCENARIOS[@]}"; do
     if [ "$TARGET" != "axiam" ] && [[ " $AXIAM_ONLY_SCENARIOS " == *" $s "* ]]; then
       echo "[run] skipping $s (AXIAM-only) for target $TARGET"; continue
+    fi
+    if [ "$TARGET" != "zitadel" ] && [[ " $ZITADEL_ONLY_SCENARIOS " == *" $s "* ]]; then
+      echo "[run] skipping $s (Zitadel-only) for target $TARGET"; continue
     fi
     if [[ " $OAUTH2_SCENARIOS " == *" $s "* ]] && skip_oauth2; then
       echo "[run] skipping $s (OAuth2 not configured — seed a client or unset BENCH_SKIP_OAUTH2)"; continue
@@ -300,6 +310,7 @@ run_one() {
   # Run k6. summary-export gives end-of-test aggregated metrics as JSON.
   set +e
   ( cd "$BENCH/scenarios" && BENCH_PROTO_ROOT="$BENCH/../proto" \
+      BENCH_ZITADEL_PROTO_ROOT="$BENCH/scenarios/proto/zitadel" \
       k6 run --quiet --summary-export "$k6sum" "$scenario" )
   local k6rc=$?
   set -e

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -154,6 +154,20 @@ CPU_MODEL="$(awk -F: '/model name/ {gsub(/^ +/,"",$2); print $2; exit}' /proc/cp
 CPU_GOVERNOR="$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown)"
 BATCH_SIZE="${BENCH_BATCH_SIZE:-5}"
 
+# C3: warn (never fail) when the governor isn't 'performance' — on laptop
+# hardware, 'powersave'/'ondemand'/'schedutil' let the CPU idle down between
+# k6 iterations and ramp back up mid-measurement, adding run-to-run variance
+# that the A6 host telemetry (mhz_avg / clock_variance) can catch after the
+# fact but can't prevent. See "Running on a laptop" in docs/methodology.md.
+if [ "$CPU_GOVERNOR" != "performance" ] && [ "$CPU_GOVERNOR" != "unknown" ]; then
+  echo "[run] WARN: CPU governor is '$CPU_GOVERNOR', not 'performance' — this can add clock-scaling variance to the run. Fix: sudo cpupower frequency-set -g performance (see docs/methodology.md 'Running on a laptop')." >&2
+fi
+
+# C3: idle gap between cells (default 60s) so heat dissipates and the
+# previous cell's allocations/caches settle before the next measurement
+# starts — set BENCH_CELL_PAUSE=0 to disable.
+CELL_PAUSE="${BENCH_CELL_PAUSE:-60}"
+
 # Naive JSON string escaping (backslash + double-quote only — sufficient for
 # the plain ASCII strings embedded here: image names, kernel/cpu strings).
 json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
@@ -201,17 +215,36 @@ role_default_cpu_cap() {
   esac
 }
 
+# Default mem cap per role (MiB), matching each target's docker-compose.yml
+# default. C2: this is how a `dbcaps=uncapped` DB mem cap (or any other
+# non-default BENCH_*_MEM) ends up recorded in meta.json alongside the CPU
+# cap — same fallback role as role_default_cpu_cap() above.
+role_default_mem_mib() {
+  local raw
+  case "$1" in
+    server) raw="${BENCH_MEM:-1024m}" ;;
+    db)     raw="${BENCH_DB_MEM:-1024m}" ;;
+    mq)     raw="${BENCH_MQ_MEM:-512m}" ;;
+    edge)   raw="${BENCH_EDGE_MEM:-128m}" ;;
+    *)      raw="1024m" ;;
+  esac
+  echo "${raw%[mM]}"
+}
+
 # Emits the JSON array for meta.json's "containers" field: one entry per
 # running container in this target's stack, with image, image_digest (from
-# `docker inspect`), role, and its CPU cap. The cap is read straight off the
-# running container (`HostConfig.NanoCpus`, what `--cpus`/compose `cpus:`
-# actually sets) rather than trusted from this shell's env — BENCH_DB_CPUS/
-# BENCH_MQ_CPUS/BENCH_EDGE_CPUS are only exported inside `just bench-up`'s own
-# subshell, so a separate `bench-run` invocation would otherwise silently miss
-# a non-default cap the operator set at bench-up time. Falls back to the
-# compose-file default only if NanoCpus is unset (no `--cpus` was applied).
+# `docker inspect`), role, and its CPU + mem cap. Both caps are read straight
+# off the running container (`HostConfig.NanoCpus`/`HostConfig.Memory`, what
+# `--cpus`/`--memory` (compose `cpus:`/`mem_limit:`) actually set) rather than
+# trusted from this shell's env — BENCH_DB_CPUS/BENCH_DB_MEM/BENCH_MQ_CPUS/
+# BENCH_EDGE_CPUS are only exported inside `just bench-up`'s own subshell, so
+# a separate `bench-run` invocation would otherwise silently miss a
+# non-default cap the operator set at bench-up time (this is how a C2
+# `dbcaps=uncapped` run ends up correctly recorded even though `bench-run` is
+# a separate process from `bench-up`). Falls back to the compose-file default
+# only if the inspected value is unset (no `--cpus`/`--memory` was applied).
 containers_json() {
-  local first=1 line cname role img dig cap nanocpus
+  local first=1 line cname role img dig cap nanocpus mem_bytes mem_mib
   echo -n "["
   while read -r line; do
     [ -z "$line" ] && continue
@@ -226,10 +259,16 @@ containers_json() {
     else
       cap="$(role_default_cpu_cap "$role")"
     fi
+    mem_bytes="$(docker inspect --format '{{.HostConfig.Memory}}' "$cname" 2>/dev/null || echo 0)"
+    if [ -n "$mem_bytes" ] && [ "$mem_bytes" != "0" ]; then
+      mem_mib="$(awk -v b="$mem_bytes" 'BEGIN{printf "%.0f", b/1048576}')"
+    else
+      mem_mib="$(role_default_mem_mib "$role")"
+    fi
     [ "$first" -eq 1 ] || echo -n ","
     first=0
-    printf '{"name":"%s","role":"%s","image":"%s","image_digest":"%s","cpu_cap":%s}' \
-      "$(json_escape "$cname")" "$role" "$(json_escape "$img")" "$(json_escape "$dig")" "$cap"
+    printf '{"name":"%s","role":"%s","image":"%s","image_digest":"%s","cpu_cap":%s,"mem_cap_mib":%s}' \
+      "$(json_escape "$cname")" "$role" "$(json_escape "$img")" "$(json_escape "$dig")" "$cap" "$mem_mib"
   done < <(container_specs_for_target)
   echo -n "]"
 }
@@ -308,8 +347,17 @@ EOF
   echo "[run] wrote $k6sum, $rescsv, $hostcsv, $meta"
 }
 
+SCENARIO_COUNT=${#SCENARIOS[@]}
+scenario_idx=0
 for s in "${SCENARIOS[@]}"; do
+  scenario_idx=$((scenario_idx + 1))
   run_one "$s"
+  # C3: pause between cells (not after the last one) so heat dissipates and
+  # allocations/caches from this cell settle before the next measurement.
+  if [ "$scenario_idx" -lt "$SCENARIO_COUNT" ] && [ "$CELL_PAUSE" -gt 0 ] 2>/dev/null; then
+    echo "[run] pausing ${CELL_PAUSE}s between cells (BENCH_CELL_PAUSE=0 to disable)"
+    sleep "$CELL_PAUSE"
+  fi
 done
 
 echo "[run] done. Aggregate with: python3 $HERE/report.py --results $RESULTS"

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -185,8 +185,9 @@ json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 # Container names that make up each target's stack, with a role used to look
 # up its CPU cap default (mirrors targets/<name>/docker-compose.yml — see A4/A5
 # in claude_dev/benchmark-improvement-plan.md). The tls-edge container only
-# exists for AXIAM under a non-native TLS profile (p1/p3); docker inspect
-# simply finds nothing for containers that aren't running and is skipped.
+# exists for AXIAM under the nginx-fronted p1-tls12 profile now (p2/p3 terminate
+# TLS/mTLS in-process natively — D3); docker inspect simply finds nothing for
+# containers that aren't running and is skipped.
 container_specs_for_target() {
   case "$TARGET" in
     axiam)

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 BENCH="$(cd "$HERE/.." && pwd)"
 RESULTS="${BENCH_RESULTS_DIR:-$BENCH/results}"
+SEED_DIR="${BENCH_SEED_DIR:-$BENCH/.seed}"
 
 TARGET=axiam
 PROFILE=p0-plaintext
@@ -39,9 +40,34 @@ PROFILE_ENV="$BENCH/profiles/${PROFILE}.env"
 # shellcheck disable=SC1090
 source "$PROFILE_ENV"
 
-SEED_ENV="$RESULTS/${TARGET}.seed.env"
-if [ -f "$SEED_ENV" ]; then source "$SEED_ENV"; else
+# Seed env (client secrets/passwords) lives under .seed/, NOT results/ — see A7
+# in claude_dev/benchmark-improvement-plan.md and docs/methodology.md. Fall back
+# to the old results/ location for one release cycle so a stale seed from before
+# this change still works without a re-seed.
+SEED_ENV="$SEED_DIR/${TARGET}.seed.env"
+LEGACY_SEED_ENV="$RESULTS/${TARGET}.seed.env"
+if [ -f "$SEED_ENV" ]; then
+  source "$SEED_ENV"
+elif [ -f "$LEGACY_SEED_ENV" ]; then
+  echo "[run] WARN: using legacy seed env at $LEGACY_SEED_ENV — re-run 'just target=$TARGET bench-seed' to move it under .seed/"
+  source "$LEGACY_SEED_ENV"
+else
   echo "[run] WARN: no seed env ($SEED_ENV) — scenarios needing a tenant/client may fail"
+fi
+
+# Refuse to start the k6 matrix without a passing post-seed smoke check for this
+# target (runner/seed.sh writes results/<target>.seed.ok only after every
+# scenario-critical flow — ROPC/login, client_credentials, introspect, refresh,
+# userinfo, and for AXIAM a REST authz check — returned the expected status).
+# This is what makes "deliberately break the seeded Keycloak client" refuse to
+# run instead of burning a full k6 matrix on a wall of failed checks.
+SEED_OK_MARKER="$RESULTS/${TARGET}.seed.ok"
+if [ "${BENCH_SKIP_SEED_CHECK:-0}" != "1" ] && [ ! -f "$SEED_OK_MARKER" ]; then
+  echo "[run] REFUSING to start: no seed-ok marker for target '$TARGET' ($SEED_OK_MARKER)." >&2
+  echo "      Run 'just target=$TARGET bench-seed' first — it seeds the target AND" >&2
+  echo "      smoke-checks every scenario-critical flow before writing this marker." >&2
+  echo "      (Override only for debugging: BENCH_SKIP_SEED_CHECK=1.)" >&2
+  exit 1
 fi
 
 export BENCH_TARGET="$TARGET"
@@ -119,6 +145,95 @@ detect_rl_posture() {
 RL_POSTURE="$(detect_rl_posture)"
 echo "[run] rate-limit posture: $RL_POSTURE"
 
+# --- Reproducibility metadata (methodology.md §7 / A4) ----------------------
+# Host facts that don't change across scenarios in this run — gathered once.
+HOST_KERNEL="$(uname -r 2>/dev/null || echo unknown)"
+DOCKER_VERSION="$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+CPU_MODEL="$(awk -F: '/model name/ {gsub(/^ +/,"",$2); print $2; exit}' /proc/cpuinfo 2>/dev/null)"
+[ -n "$CPU_MODEL" ] || CPU_MODEL="unknown"
+CPU_GOVERNOR="$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown)"
+BATCH_SIZE="${BENCH_BATCH_SIZE:-5}"
+
+# Naive JSON string escaping (backslash + double-quote only — sufficient for
+# the plain ASCII strings embedded here: image names, kernel/cpu strings).
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+# Container names that make up each target's stack, with a role used to look
+# up its CPU cap default (mirrors targets/<name>/docker-compose.yml — see A4/A5
+# in claude_dev/benchmark-improvement-plan.md). The tls-edge container only
+# exists for AXIAM under a non-native TLS profile (p1/p3); docker inspect
+# simply finds nothing for containers that aren't running and is skipped.
+container_specs_for_target() {
+  case "$TARGET" in
+    axiam)
+      cat <<EOF
+bench-axiam-server server
+bench-axiam-tls edge
+bench-axiam-surrealdb db
+bench-axiam-rabbitmq mq
+EOF
+      ;;
+    keycloak)
+      cat <<EOF
+bench-keycloak server
+bench-keycloak-postgres db
+EOF
+      ;;
+    zitadel)
+      cat <<EOF
+bench-zitadel server
+bench-zitadel-postgres db
+EOF
+      ;;
+  esac
+}
+
+# Default CPU cap per role, matching each target's docker-compose.yml default
+# (report.py's bottleneck attribution falls back to these when a container's
+# actual cap env var wasn't exported into this shell).
+role_default_cpu_cap() {
+  case "$1" in
+    server) echo "${BENCH_CPUS:-2}" ;;
+    db)     echo "${BENCH_DB_CPUS:-2}" ;;
+    mq)     echo "${BENCH_MQ_CPUS:-1}" ;;
+    edge)   echo "${BENCH_EDGE_CPUS:-1}" ;;
+    *)      echo "2" ;;
+  esac
+}
+
+# Emits the JSON array for meta.json's "containers" field: one entry per
+# running container in this target's stack, with image, image_digest (from
+# `docker inspect`), role, and its CPU cap. The cap is read straight off the
+# running container (`HostConfig.NanoCpus`, what `--cpus`/compose `cpus:`
+# actually sets) rather than trusted from this shell's env — BENCH_DB_CPUS/
+# BENCH_MQ_CPUS/BENCH_EDGE_CPUS are only exported inside `just bench-up`'s own
+# subshell, so a separate `bench-run` invocation would otherwise silently miss
+# a non-default cap the operator set at bench-up time. Falls back to the
+# compose-file default only if NanoCpus is unset (no `--cpus` was applied).
+containers_json() {
+  local first=1 line cname role img dig cap nanocpus
+  echo -n "["
+  while read -r line; do
+    [ -z "$line" ] && continue
+    cname="${line%% *}"; role="${line#* }"
+    docker inspect "$cname" >/dev/null 2>&1 || continue
+    img="$(docker inspect --format '{{.Config.Image}}' "$cname" 2>/dev/null || echo unknown)"
+    dig="$(docker inspect --format '{{index .RepoDigests 0}}' "$cname" 2>/dev/null || echo '')"
+    [ -z "$dig" ] && dig="unknown"
+    nanocpus="$(docker inspect --format '{{.HostConfig.NanoCpus}}' "$cname" 2>/dev/null || echo 0)"
+    if [ -n "$nanocpus" ] && [ "$nanocpus" != "0" ]; then
+      cap="$(awk -v n="$nanocpus" 'BEGIN{printf "%.3f", n/1000000000}')"
+    else
+      cap="$(role_default_cpu_cap "$role")"
+    fi
+    [ "$first" -eq 1 ] || echo -n ","
+    first=0
+    printf '{"name":"%s","role":"%s","image":"%s","image_digest":"%s","cpu_cap":%s}' \
+      "$(json_escape "$cname")" "$role" "$(json_escape "$img")" "$(json_escape "$dig")" "$cap"
+  done < <(container_specs_for_target)
+  echo -n "]"
+}
+
 run_one() {
   local scenario="$1"
   local name="${scenario%.js}"
@@ -126,13 +241,22 @@ run_one() {
   mkdir -p "$outdir"
   local k6sum="$outdir/$name.k6.json"
   local rescsv="$outdir/$name.res.csv"
+  local hostcsv="$outdir/$name.host.csv"
   local meta="$outdir/$name.meta.json"
 
   echo "[run] === $TARGET / $PROFILE / $name ==="
 
-  # Start the resource sampler for the measure window (skip the warm-up first).
+  local scenario_sha256
+  scenario_sha256="$(sha256sum "$BENCH/scenarios/$scenario" 2>/dev/null | awk '{print $1}')"
+  [ -n "$scenario_sha256" ] || scenario_sha256="unknown"
+
+  # Start the resource + host-telemetry samplers for the measure window (skip
+  # the warm-up first) — both write CSVs the report joins against the k6
+  # summary (docs/methodology.md §5/§7, A6).
   ( sleep "$WARM_S"; bash "$BENCH/resource/sampler.sh" "$RES_FILTER" "$rescsv" "$SAMPLE_INTERVAL" "$DUR_S" ) &
   local sampler_pid=$!
+  ( sleep "$WARM_S"; bash "$BENCH/resource/host-sampler.sh" "$hostcsv" "$SAMPLE_INTERVAL" "$DUR_S" ) &
+  local host_sampler_pid=$!
 
   # Run k6. summary-export gives end-of-test aggregated metrics as JSON.
   set +e
@@ -141,6 +265,15 @@ run_one() {
   local k6rc=$?
   set -e
   wait "$sampler_pid" 2>/dev/null || true
+  wait "$host_sampler_pid" 2>/dev/null || true
+
+  # k6_cpu_cores_avg over the measure window, straight from the host.csv this
+  # run just wrote (methodology §7 / A4). Skip the header line; tolerate a
+  # missing/empty file (e.g. host-sampler.sh not executable on this host).
+  local k6_cpu_cores_avg="0"
+  if [ -f "$hostcsv" ]; then
+    k6_cpu_cores_avg="$(awk -F, 'NR>1 && $6!="" {s+=$6; n++} END{if(n>0) printf "%.3f", s/n; else print 0}' "$hostcsv")"
+  fi
 
   # Write run metadata (joined by report.py).
   cat > "$meta" <<EOF
@@ -160,10 +293,19 @@ run_one() {
   "caps": { "cpus": "${BENCH_CPUS:-2}", "mem": "${BENCH_MEM:-1024m}" },
   "host": { "cpus": "$HOST_CPUS", "mem_mib": "$HOST_MEM_MIB" },
   "k6_summary_file": "$name.k6.json",
-  "resource_csv": "$name.res.csv"
+  "resource_csv": "$name.res.csv",
+  "host_csv": "$name.host.csv",
+  "scenario_sha256": "$scenario_sha256",
+  "batch_size": $BATCH_SIZE,
+  "host_kernel": "$(json_escape "$HOST_KERNEL")",
+  "docker_version": "$(json_escape "$DOCKER_VERSION")",
+  "cpu_model": "$(json_escape "$CPU_MODEL")",
+  "cpu_governor": "$(json_escape "$CPU_GOVERNOR")",
+  "k6_cpu_cores_avg": $k6_cpu_cores_avg,
+  "containers": $(containers_json)
 }
 EOF
-  echo "[run] wrote $k6sum, $rescsv, $meta"
+  echo "[run] wrote $k6sum, $rescsv, $hostcsv, $meta"
 }
 
 for s in "${SCENARIOS[@]}"; do

--- a/benchmarks/runner/seed.sh
+++ b/benchmarks/runner/seed.sh
@@ -3,8 +3,21 @@
 # confidential client able to do client_credentials + refresh) for one target,
 # then write a seed env file the runner sources:
 #
-#   results/<target>.seed.env   (BENCH_ORG_ID, BENCH_TENANT_ID, BENCH_CLIENT_ID,
-#                                BENCH_CLIENT_SECRET, BENCH_USERNAME, BENCH_PASSWORD)
+#   .seed/<target>.seed.env   (BENCH_ORG_ID, BENCH_TENANT_ID, BENCH_CLIENT_ID,
+#                              BENCH_CLIENT_SECRET, BENCH_USERNAME, BENCH_PASSWORD)
+#
+# `.seed/` (NOT `results/`) holds this file because it contains client secrets
+# and the bench user's password — `results/` is the tree we publish/share, and
+# `.seed/` is gitignored (see docs/methodology.md + `just bench-pack`).
+#
+# After seeding, this script runs a smoke-check section: one real request per
+# scenario-critical flow, against the objects it just provisioned/verified.
+# Any unexpected status prints the response body, saves it under
+# results/<target>/seed-failure/, and exits non-zero — so a broken seed (e.g. a
+# Keycloak client with directAccessGrantsEnabled=false) is caught here, not
+# discovered as a wall of "status is 200" failures 2 hours into a k6 matrix.
+# On success it touches results/<target>.seed.ok, which run-benchmark.sh
+# requires before it will start the k6 matrix for that target.
 #
 # Usage: seed.sh <target> [base_url]
 set -euo pipefail
@@ -13,7 +26,11 @@ TARGET="${1:?target (axiam|keycloak|zitadel)}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 RESULTS="${BENCH_RESULTS_DIR:-$HERE/../results}"
 mkdir -p "$RESULTS"
-SEED_ENV="$RESULTS/${TARGET}.seed.env"
+SEED_DIR="${BENCH_SEED_DIR:-$HERE/../.seed}"
+mkdir -p "$SEED_DIR"
+SEED_ENV="$SEED_DIR/${TARGET}.seed.env"
+SEED_OK_MARKER="$RESULTS/${TARGET}.seed.ok"
+SMOKE_FAIL_DIR="$RESULTS/${TARGET}/seed-failure"
 
 BENCH_USERNAME="${BENCH_USERNAME:-benchuser}"
 BENCH_PASSWORD="${BENCH_PASSWORD:-Bench@User123!}"
@@ -21,6 +38,10 @@ BENCH_PASSWORD="${BENCH_PASSWORD:-Bench@User123!}"
 # Seeding always talks plaintext to the app port; TLS is a transport concern
 # exercised during the measured run, not during provisioning.
 BASE="${2:-http://localhost:${BENCH_APP_PORT:-8090}}"
+
+# A fresh seed invalidates any prior "this target is known-good" marker until
+# the smoke checks pass again below.
+rm -f "$SEED_OK_MARKER"
 
 write_seed() {
   cat > "$SEED_ENV" <<EOF
@@ -43,6 +64,7 @@ export BENCH_PROJECT_ID=${PROJECT_ID:-}
 export BENCH_INTROSPECT_CLIENT_ID=${INTROSPECT_CLIENT_ID:-}
 export BENCH_INTROSPECT_CLIENT_SECRET='${INTROSPECT_CLIENT_SECRET:-}'
 EOF
+  chmod 600 "$SEED_ENV"
   echo "[seed] wrote $SEED_ENV"
 }
 
@@ -73,7 +95,9 @@ seed_axiam() {
   ORG_SLUG=bench-org
 
   # Authenticated JSON call against /api/v1 with the admin cookie jar + CSRF
-  # double-submit. Usage: api METHOD PATH [JSON-BODY].
+  # double-submit. Usage: api METHOD PATH [JSON-BODY]. Prints the response body
+  # (caller decides whether/how to check it — used where the caller already
+  # tolerates an empty/absent result via create_or_find's own status handling).
   api() {
     local method="$1" path="$2" data="${3:-}" csrf
     csrf="$(awk -F'\t' '$6=="axiam_csrf"{v=$7} END{print v}' "$JAR")"
@@ -83,6 +107,23 @@ seed_axiam() {
     else
       curl -sSk -b "$JAR" -c "$JAR" -X "$method" "$BASE$path" -H "X-CSRF-Token: $csrf"
     fi
+  }
+  # Like api(), but asserts the HTTP status is 2xx or 409 (already-exists,
+  # idempotent), printing the body and exiting non-zero on anything else. Used
+  # for provisioning calls with no create-or-find fallback (grants), where a
+  # silently swallowed failure (the old `|| true`) would seed a fixture that
+  # LOOKS complete but has no actual grant.
+  api_checked() {  # METHOD PATH JSON
+    local method="$1" path="$2" data="$3" resp code body csrf
+    csrf="$(awk -F'\t' '$6=="axiam_csrf"{v=$7} END{print v}' "$JAR")"
+    resp=$(curl -sSk -b "$JAR" -c "$JAR" -X "$method" "$BASE$path" \
+      -H "Content-Type: application/json" -H "X-CSRF-Token: $csrf" -d "$data" \
+      -w $'\n%{http_code}')
+    code="${resp##*$'\n'}"; body="${resp%$'\n'*}"
+    case "$code" in
+      2??|409) printf '%s' "$body" ;;
+      *) echo "[seed/axiam] $method $path -> HTTP $code: $body" >&2; exit 1 ;;
+    esac
   }
   # Create an entity, or find the existing one on re-seed. `.. | objects` walks
   # any response wrapper (bare array, {data:[…]}, {items:[…]}) to find the row
@@ -135,28 +176,27 @@ seed_axiam() {
   USER_ID=$(create_or_find /api/v1/users \
     "{\"username\":\"$BENCH_USERNAME\",\"email\":\"bench@bench.dev\",\"password\":\"$BENCH_PASSWORD\"}" \
     username "$BENCH_USERNAME")
-  [ -z "$USER_ID" ] && echo "[seed/axiam] WARN: could not create/find bench user"
+  [ -n "$USER_ID" ] || { echo "[seed/axiam] could not create/find bench user"; exit 1; }
 
   echo "[seed/axiam] creating benchmark resource"
   RESOURCE_ID=$(create_or_find /api/v1/resources \
     '{"name":"bench-resource","resource_type":"bench"}' name "bench-resource")
-  [ -z "$RESOURCE_ID" ] && echo "[seed/axiam] WARN: could not create/find bench resource"
+  [ -n "$RESOURCE_ID" ] || { echo "[seed/axiam] could not create/find bench resource"; exit 1; }
 
   echo "[seed/axiam] creating role + read permission"
   ROLE_ID=$(create_or_find /api/v1/roles \
     '{"name":"bench-reader","description":"Bench read role","is_global":false}' name "bench-reader")
+  [ -n "$ROLE_ID" ] || { echo "[seed/axiam] could not create/find bench role"; exit 1; }
   PERM_ID=$(create_or_find /api/v1/permissions \
     '{"action":"read","description":"Bench read permission"}' action "read")
+  [ -n "$PERM_ID" ] || { echo "[seed/axiam] could not create/find bench permission"; exit 1; }
 
-  if [ -n "$ROLE_ID" ] && [ -n "$PERM_ID" ]; then
-    echo "[seed/axiam] granting read permission to role (idempotent)"
-    api POST "/api/v1/roles/$ROLE_ID/permissions" "{\"permission_id\":\"$PERM_ID\"}" >/dev/null 2>&1 || true
-  fi
-  if [ -n "$ROLE_ID" ] && [ -n "$USER_ID" ] && [ -n "$RESOURCE_ID" ]; then
-    echo "[seed/axiam] assigning role to bench user (scoped to resource)"
-    api POST "/api/v1/roles/$ROLE_ID/users" \
-      "{\"user_id\":\"$USER_ID\",\"resource_id\":\"$RESOURCE_ID\"}" >/dev/null 2>&1 || true
-  fi
+  echo "[seed/axiam] granting read permission to role (idempotent)"
+  api_checked POST "/api/v1/roles/$ROLE_ID/permissions" "{\"permission_id\":\"$PERM_ID\"}" >/dev/null
+
+  echo "[seed/axiam] assigning role to bench user (scoped to resource)"
+  api_checked POST "/api/v1/roles/$ROLE_ID/users" \
+    "{\"user_id\":\"$USER_ID\",\"resource_id\":\"$RESOURCE_ID\"}" >/dev/null
 
   echo "[seed/axiam] creating confidential oauth2 client (client_credentials+refresh)"
   local CLIENT_RESP
@@ -164,7 +204,9 @@ seed_axiam() {
     '{"name":"bench-client","redirect_uris":["http://localhost/cb"],"grant_types":["client_credentials","refresh_token","authorization_code"],"scopes":["openid"]}')
   CLIENT_ID=$(echo "$CLIENT_RESP" | jq -r '.client_id // empty')
   CLIENT_SECRET=$(echo "$CLIENT_RESP" | jq -r '.client_secret // empty')
-  [ -z "$CLIENT_ID" ] && echo "[seed/axiam] WARN: client creation response: $CLIENT_RESP"
+  if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
+    echo "[seed/axiam] client creation failed: $CLIENT_RESP"; exit 1
+  fi
 
   # Export the authz fixtures the scenarios/SDK benches need.
   BENCH_SUBJECT_ID="$USER_ID"
@@ -174,6 +216,7 @@ seed_axiam() {
 
 # ---------------------------------------------------------------------------
 seed_keycloak() {
+  command -v jq >/dev/null || { echo "[seed/keycloak] jq is required (see README prerequisites)"; exit 1; }
   REALM="${REALM:-bench}"
   local ADMIN="${KC_ADMIN:-admin}" PW="${KC_ADMIN_PASSWORD:-admin}"
   echo "[seed/keycloak] obtaining admin token"
@@ -184,23 +227,87 @@ seed_keycloak() {
   [ -z "$AT" ] && { echo "[seed/keycloak] admin token failed"; exit 1; }
   local H="Authorization: Bearer $AT"
 
+  # POST helper: check status, treat 409 (already exists) as OK, otherwise
+  # print the response body and fail closed. Usage: kc_post PATH JSON
+  kc_post() {
+    local path="$1" data="$2" resp code body
+    resp=$(curl -sS -X POST "$BASE$path" -H "$H" -H "Content-Type: application/json" \
+      -d "$data" -w $'\n%{http_code}')
+    code="${resp##*$'\n'}"; body="${resp%$'\n'*}"
+    case "$code" in
+      201|204|409) return 0 ;;
+      *) echo "[seed/keycloak] POST $path -> HTTP $code: $body" >&2; exit 1 ;;
+    esac
+  }
+  # GET helper: prints the body, fails closed on non-200.
+  kc_get() {
+    local path="$1" resp code body
+    resp=$(curl -sS "$BASE$path" -H "$H" -w $'\n%{http_code}')
+    code="${resp##*$'\n'}"; body="${resp%$'\n'*}"
+    if [ "$code" != "200" ]; then
+      echo "[seed/keycloak] GET $path -> HTTP $code: $body" >&2
+      exit 1
+    fi
+    printf '%s' "$body"
+  }
+
   echo "[seed/keycloak] creating realm $REALM"
-  curl -s -X POST "$BASE/admin/realms" -H "$H" -H "Content-Type: application/json" \
-    -d "{\"realm\":\"$REALM\",\"enabled\":true}" >/dev/null || true
+  kc_post "/admin/realms" "{\"realm\":\"$REALM\",\"enabled\":true}"
 
   echo "[seed/keycloak] creating confidential client"
   CLIENT_ID="bench-client"
-  curl -s -X POST "$BASE/admin/realms/$REALM/clients" -H "$H" -H "Content-Type: application/json" \
-    -d "{\"clientId\":\"$CLIENT_ID\",\"enabled\":true,\"publicClient\":false,\"serviceAccountsEnabled\":true,\"directAccessGrantsEnabled\":true,\"standardFlowEnabled\":true,\"redirectUris\":[\"http://localhost/cb\"]}" >/dev/null || true
+  kc_post "/admin/realms/$REALM/clients" \
+    "{\"clientId\":\"$CLIENT_ID\",\"enabled\":true,\"publicClient\":false,\"serviceAccountsEnabled\":true,\"directAccessGrantsEnabled\":true,\"standardFlowEnabled\":true,\"redirectUris\":[\"http://localhost/cb\"]}"
+
   local CID
-  CID=$(curl -sf "$BASE/admin/realms/$REALM/clients?clientId=$CLIENT_ID" -H "$H" \
-    | sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -1)
-  CLIENT_SECRET=$(curl -sf "$BASE/admin/realms/$REALM/clients/$CID/client-secret" -H "$H" \
-    | sed -n 's/.*"value":"\([^"]*\)".*/\1/p')
+  CID=$(kc_get "/admin/realms/$REALM/clients?clientId=$CLIENT_ID" | jq -r '.[0].id // empty')
+  [ -n "$CID" ] || { echo "[seed/keycloak] could not find created client '$CLIENT_ID'"; exit 1; }
+
+  # VERIFY the client actually has the attributes ROPC/service-account benches
+  # depend on — an object *existing* (409 on re-seed) is not proof it is
+  # *configured* correctly. This is the presumed cause of the 100% ROPC
+  # failures: a stale client from a previous seed with direct-access grants off.
+  local client_json direct_grants svc_accounts
+  client_json=$(kc_get "/admin/realms/$REALM/clients/$CID")
+  direct_grants=$(echo "$client_json" | jq -r '.directAccessGrantsEnabled')
+  svc_accounts=$(echo "$client_json" | jq -r '.serviceAccountsEnabled')
+  if [ "$direct_grants" != "true" ]; then
+    echo "[seed/keycloak] client '$CLIENT_ID' has directAccessGrantsEnabled=$direct_grants (must be true for ROPC/login) — fix it in the admin console or delete the client and re-seed" >&2
+    exit 1
+  fi
+  if [ "$svc_accounts" != "true" ]; then
+    echo "[seed/keycloak] client '$CLIENT_ID' has serviceAccountsEnabled=$svc_accounts (must be true for client_credentials) — fix it in the admin console or delete the client and re-seed" >&2
+    exit 1
+  fi
+
+  CLIENT_SECRET=$(kc_get "/admin/realms/$REALM/clients/$CID/client-secret" | jq -r '.value // empty')
+  [ -n "$CLIENT_SECRET" ] || { echo "[seed/keycloak] could not read client secret for '$CLIENT_ID'"; exit 1; }
 
   echo "[seed/keycloak] creating benchmark user"
-  curl -s -X POST "$BASE/admin/realms/$REALM/users" -H "$H" -H "Content-Type: application/json" \
-    -d "{\"username\":\"$BENCH_USERNAME\",\"enabled\":true,\"email\":\"bench@bench.dev\",\"emailVerified\":true,\"credentials\":[{\"type\":\"password\",\"value\":\"$BENCH_PASSWORD\",\"temporary\":false}]}" >/dev/null || true
+  kc_post "/admin/realms/$REALM/users" \
+    "{\"username\":\"$BENCH_USERNAME\",\"enabled\":true,\"email\":\"bench@bench.dev\",\"emailVerified\":true,\"credentials\":[{\"type\":\"password\",\"value\":\"$BENCH_PASSWORD\",\"temporary\":false}]}"
+
+  local KC_USER_ID
+  KC_USER_ID=$(kc_get "/admin/realms/$REALM/users?username=$BENCH_USERNAME&exact=true" | jq -r '.[0].id // empty')
+  [ -n "$KC_USER_ID" ] || { echo "[seed/keycloak] could not find created user '$BENCH_USERNAME'"; exit 1; }
+
+  # VERIFY the user is enabled and actually has a password credential set — a
+  # re-seed (409) with a pre-existing disabled user or a wiped credential is
+  # the other presumed cause of the 100% ROPC failures.
+  local user_json enabled has_pw_cred
+  user_json=$(kc_get "/admin/realms/$REALM/users/$KC_USER_ID")
+  enabled=$(echo "$user_json" | jq -r '.enabled')
+  if [ "$enabled" != "true" ]; then
+    echo "[seed/keycloak] bench user '$BENCH_USERNAME' is disabled (enabled=$enabled) — fix it or delete+re-seed" >&2
+    exit 1
+  fi
+  has_pw_cred=$(kc_get "/admin/realms/$REALM/users/$KC_USER_ID/credentials" \
+    | jq -r '[.[] | select(.type=="password")] | length')
+  if [ "${has_pw_cred:-0}" -lt 1 ]; then
+    echo "[seed/keycloak] bench user '$BENCH_USERNAME' has no password credential set — fix it or delete+re-seed" >&2
+    exit 1
+  fi
+
   write_seed
 }
 
@@ -304,9 +411,173 @@ seed_zitadel() {
   write_seed
 }
 
+# ---------------------------------------------------------------------------
+# Post-seed smoke checks: exercise one real request per scenario-critical flow
+# per target against the objects just seeded/verified above. A seed step that
+# LOOKS complete (objects exist, attributes verified) can still fail at request
+# time (wrong grant type, wrong scope, misconfigured issuer, …) — this section
+# catches that before the k6 matrix does, and run-benchmark.sh refuses to start
+# without the resulting results/<target>.seed.ok marker (see A2.3).
+smoke_fail() {  # LABEL BODY
+  mkdir -p "$SMOKE_FAIL_DIR"
+  local label="$1" body="$2" f
+  f="$SMOKE_FAIL_DIR/${label}.txt"
+  printf '%s\n' "$body" > "$f"
+  echo "[seed/smoke] FAIL: $label — response saved to $f" >&2
+  echo "$body" >&2
+  exit 1
+}
+
+# Form-encoded POST; asserts status; prints body. Usage:
+#   smoke_form LABEL URL "k=v&k2=v2" [expected_status=200]
+smoke_form() {
+  local label="$1" url="$2" data="$3" expect="${4:-200}" resp code body
+  resp=$(curl -sSk -X POST "$url" -H 'Content-Type: application/x-www-form-urlencoded' \
+    -d "$data" -w $'\n%{http_code}') || smoke_fail "$label" "curl request failed"
+  code="${resp##*$'\n'}"; body="${resp%$'\n'*}"
+  [ "$code" = "$expect" ] || smoke_fail "${label} (HTTP $code, expected $expect)" "$body"
+  printf '%s' "$body"
+}
+
+# Bearer-authenticated GET; asserts status; prints body.
+# Usage: smoke_get LABEL URL "Authorization: Bearer <token>" [expect=200]
+smoke_get() {
+  local label="$1" url="$2" auth="$3" expect="${4:-200}" resp code body
+  resp=$(curl -sSk -H "$auth" "$url" -w $'\n%{http_code}') || smoke_fail "$label" "curl request failed"
+  code="${resp##*$'\n'}"; body="${resp%$'\n'*}"
+  [ "$code" = "$expect" ] || smoke_fail "${label} (HTTP $code, expected $expect)" "$body"
+  printf '%s' "$body"
+}
+
+smoke_axiam() {
+  echo "[seed/smoke/axiam] client_credentials"
+  local cc_body cc_token cc_refresh
+  cc_body=$(smoke_form axiam-client-credentials \
+    "$BASE/oauth2/token?tenant_id=$TENANT_ID" \
+    "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=openid")
+  cc_token=$(echo "$cc_body" | jq -r '.access_token // empty')
+  [ -n "$cc_token" ] || smoke_fail axiam-client-credentials-no-token "$cc_body"
+
+  echo "[seed/smoke/axiam] introspect (of the just-minted token)"
+  smoke_form axiam-introspect "$BASE/oauth2/introspect?tenant_id=$TENANT_ID" \
+    "token=$cc_token&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" >/dev/null
+
+  cc_refresh=$(echo "$cc_body" | jq -r '.refresh_token // empty')
+  if [ -n "$cc_refresh" ]; then
+    echo "[seed/smoke/axiam] refresh"
+    smoke_form axiam-refresh "$BASE/oauth2/token?tenant_id=$TENANT_ID" \
+      "grant_type=refresh_token&refresh_token=$cc_refresh&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" >/dev/null
+  else
+    echo "[seed/smoke/axiam] no refresh_token in the client_credentials response — skipping refresh smoke check (token_refresh.js tags this comparability: fallback-op)"
+  fi
+
+  echo "[seed/smoke/axiam] user login (ROPC-equivalent, /api/v1/auth/login)"
+  local LJAR; LJAR="$(mktemp)"
+  local login_resp login_code login_body user_access user_csrf
+  login_resp=$(curl -sSk -c "$LJAR" -X POST "$BASE/api/v1/auth/login" -H "Content-Type: application/json" \
+    -d "{\"org_slug\":\"$ORG_SLUG\",\"tenant_slug\":\"$TENANT_SLUG\",\"username_or_email\":\"$BENCH_USERNAME\",\"password\":\"$BENCH_PASSWORD\"}" \
+    -w $'\n%{http_code}')
+  login_code="${login_resp##*$'\n'}"; login_body="${login_resp%$'\n'*}"
+  if [ "$login_code" != "200" ]; then rm -f "$LJAR"; smoke_fail axiam-user-login "$login_body"; fi
+  user_access="$(awk -F'\t' '$6=="axiam_access"{v=$7} END{print v}' "$LJAR")"
+  user_csrf="$(awk -F'\t' '$6=="axiam_csrf"{v=$7} END{print v}' "$LJAR")"
+  if [ -z "$user_access" ]; then rm -f "$LJAR"; smoke_fail axiam-user-login-no-cookie "$login_body"; fi
+
+  echo "[seed/smoke/axiam] userinfo (with the user token)"
+  local ui_resp ui_code ui_body
+  ui_resp=$(curl -sSk -H "Authorization: Bearer $user_access" "$BASE/oauth2/userinfo" -w $'\n%{http_code}')
+  ui_code="${ui_resp##*$'\n'}"; ui_body="${ui_resp%$'\n'*}"
+  if [ "$ui_code" != "200" ]; then rm -f "$LJAR"; smoke_fail axiam-userinfo "$ui_body"; fi
+
+  echo "[seed/smoke/axiam] REST authz check"
+  local az_resp az_code az_body allowed
+  az_resp=$(curl -sSk -b "$LJAR" -X POST "$BASE/api/v1/authz/check" -H "Content-Type: application/json" \
+    -H "X-CSRF-Token: $user_csrf" -d "{\"action\":\"read\",\"resource_id\":\"$RESOURCE_ID\"}" -w $'\n%{http_code}')
+  az_code="${az_resp##*$'\n'}"; az_body="${az_resp%$'\n'*}"
+  rm -f "$LJAR"
+  [ "$az_code" = "200" ] || smoke_fail axiam-authz-check "$az_body"
+  allowed=$(echo "$az_body" | jq -r '.allowed // empty')
+  [ "$allowed" = "true" ] || smoke_fail axiam-authz-check-not-allowed "$az_body"
+
+  echo "[seed/smoke/axiam] all smoke checks passed"
+}
+
+smoke_keycloak() {
+  echo "[seed/smoke/keycloak] ROPC login"
+  local ropc_body ropc_token ropc_refresh
+  ropc_body=$(smoke_form keycloak-ropc-login "$BASE/realms/$REALM/protocol/openid-connect/token" \
+    "grant_type=password&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&username=$BENCH_USERNAME&password=$BENCH_PASSWORD&scope=openid")
+  ropc_token=$(echo "$ropc_body" | jq -r '.access_token // empty')
+  ropc_refresh=$(echo "$ropc_body" | jq -r '.refresh_token // empty')
+  [ -n "$ropc_token" ] || smoke_fail keycloak-ropc-login-no-token "$ropc_body"
+
+  echo "[seed/smoke/keycloak] client_credentials"
+  smoke_form keycloak-client-credentials "$BASE/realms/$REALM/protocol/openid-connect/token" \
+    "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=openid" >/dev/null
+
+  echo "[seed/smoke/keycloak] introspect (of the just-minted ROPC token)"
+  smoke_form keycloak-introspect "$BASE/realms/$REALM/protocol/openid-connect/token/introspect" \
+    "token=$ropc_token&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" >/dev/null
+
+  if [ -n "$ropc_refresh" ]; then
+    echo "[seed/smoke/keycloak] refresh"
+    smoke_form keycloak-refresh "$BASE/realms/$REALM/protocol/openid-connect/token" \
+      "grant_type=refresh_token&refresh_token=$ropc_refresh&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" >/dev/null
+  else
+    echo "[seed/smoke/keycloak] no refresh_token issued by ROPC — skipping refresh smoke check"
+  fi
+
+  echo "[seed/smoke/keycloak] userinfo (with the user token)"
+  smoke_get keycloak-userinfo "$BASE/realms/$REALM/protocol/openid-connect/userinfo" \
+    "Authorization: Bearer $ropc_token" >/dev/null
+
+  echo "[seed/smoke/keycloak] all smoke checks passed"
+}
+
+smoke_zitadel() {
+  if [ -z "${CLIENT_ID:-}" ] || [ -z "${CLIENT_SECRET:-}" ]; then
+    echo "[seed/smoke/zitadel] skip: no client provisioned (BENCH_ZITADEL_ALLOW_UNSEEDED jwks-only mode)"
+    return
+  fi
+  local scope="openid"
+  [ -n "${PROJECT_ID:-}" ] && scope="openid urn:zitadel:iam:org:project:id:${PROJECT_ID}:aud"
+
+  echo "[seed/smoke/zitadel] client_credentials (login is a fallback op for zitadel — see A3)"
+  local cc_body cc_token cc_refresh
+  cc_body=$(smoke_form zitadel-client-credentials "$BASE/oauth/v2/token" \
+    "grant_type=client_credentials&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET&scope=$scope")
+  cc_token=$(echo "$cc_body" | jq -r '.access_token // empty')
+  [ -n "$cc_token" ] || smoke_fail zitadel-client-credentials-no-token "$cc_body"
+
+  if [ -n "${INTROSPECT_CLIENT_ID:-}" ] && [ -n "${INTROSPECT_CLIENT_SECRET:-}" ]; then
+    echo "[seed/smoke/zitadel] introspect (of the just-minted token, via the resource-server app)"
+    smoke_form zitadel-introspect "$BASE/oauth/v2/introspect" \
+      "token=$cc_token&client_id=$INTROSPECT_CLIENT_ID&client_secret=$INTROSPECT_CLIENT_SECRET" >/dev/null
+  else
+    echo "[seed/smoke/zitadel] no introspection client provisioned — skipping introspect smoke check"
+  fi
+
+  cc_refresh=$(echo "$cc_body" | jq -r '.refresh_token // empty')
+  if [ -n "$cc_refresh" ]; then
+    echo "[seed/smoke/zitadel] refresh"
+    smoke_form zitadel-refresh "$BASE/oauth/v2/token" \
+      "grant_type=refresh_token&refresh_token=$cc_refresh&client_id=$CLIENT_ID&client_secret=$CLIENT_SECRET" >/dev/null
+  else
+    echo "[seed/smoke/zitadel] no refresh_token issued — skipping refresh smoke check (token_refresh.js tags this comparability: fallback-op)"
+  fi
+
+  echo "[seed/smoke/zitadel] userinfo"
+  smoke_get zitadel-userinfo "$BASE/oidc/v1/userinfo" "Authorization: Bearer $cc_token" >/dev/null
+
+  echo "[seed/smoke/zitadel] all smoke checks passed"
+}
+
 case "$TARGET" in
-  axiam)    seed_axiam ;;
-  keycloak) seed_keycloak ;;
-  zitadel)  seed_zitadel ;;
+  axiam)    seed_axiam;    smoke_axiam ;;
+  keycloak) seed_keycloak; smoke_keycloak ;;
+  zitadel)  seed_zitadel;  smoke_zitadel ;;
   *) echo "unknown target: $TARGET" >&2; exit 1 ;;
 esac
+
+touch "$SEED_OK_MARKER"
+echo "[seed] target=$TARGET seeded and smoke-checked OK ($SEED_OK_MARKER)"

--- a/benchmarks/runner/seed.sh
+++ b/benchmarks/runner/seed.sh
@@ -39,6 +39,21 @@ BENCH_PASSWORD="${BENCH_PASSWORD:-Bench@User123!}"
 # exercised during the measured run, not during provisioning.
 BASE="${2:-http://localhost:${BENCH_APP_PORT:-8090}}"
 
+# D3 native mTLS: under p3-mtls, AXIAM terminates client-cert auth in-process and
+# REQUIRES a verified client certificate on EVERY TLS connection — including the
+# ones this script makes to bootstrap/seed/smoke-check the target. When the p3
+# profile env is sourced (bench-seed does this for the native mTLS target), it
+# exports BENCH_CLIENT_CERT/KEY (the same cert k6 presents via tlsAuth). Wrap
+# curl transparently to present them so seeding succeeds against the mTLS
+# listener. Unset otherwise (server-auth profiles) → the wrapper is not defined
+# and curl behaves normally. seed.sh seeds one target per invocation, so this
+# only affects the native mTLS run.
+if [ -n "${BENCH_CLIENT_CERT:-}" ] && [ -n "${BENCH_CLIENT_KEY:-}" ]; then
+  _CURL_MTLS=(--cert "$BENCH_CLIENT_CERT" --key "$BENCH_CLIENT_KEY")
+  echo "[seed] native mTLS: presenting client cert on all requests ($BENCH_CLIENT_CERT)"
+  curl() { command curl "${_CURL_MTLS[@]}" "$@"; }
+fi
+
 # A fresh seed invalidates any prior "this target is known-good" marker until
 # the smoke checks pass again below.
 rm -f "$SEED_OK_MARKER"

--- a/benchmarks/runner/seed.sh
+++ b/benchmarks/runner/seed.sh
@@ -63,6 +63,15 @@ export BENCH_RESOURCE_ID=${BENCH_RESOURCE_ID:-}
 export BENCH_PROJECT_ID=${PROJECT_ID:-}
 export BENCH_INTROSPECT_CLIENT_ID=${INTROSPECT_CLIENT_ID:-}
 export BENCH_INTROSPECT_CLIENT_SECRET='${INTROSPECT_CLIENT_SECRET:-}'
+# Zitadel-only (D5): the seeded human user's id + a bearer credential for the
+# session API v2 (POST /v2/sessions), used by zitadel.login() in targets.js to
+# perform a REAL password check instead of the old client_credentials
+# fallback. Empty for axiam/keycloak, and empty for zitadel configurations
+# that couldn't provision a human user (manual client-only seeding, or
+# BENCH_ZITADEL_ALLOW_UNSEEDED) — targets.js falls back to client_credentials
+# (tagged fallback: true) whenever either is empty.
+export BENCH_ZITADEL_USER_ID=${ZITADEL_USER_ID:-}
+export BENCH_ZITADEL_SESSION_PAT='${ZITADEL_SESSION_PAT:-}'
 EOF
   chmod 600 "$SEED_ENV"
   echo "[seed] wrote $SEED_ENV"
@@ -408,6 +417,48 @@ seed_zitadel() {
     && [ -n "$INTROSPECT_CLIENT_ID" ] && [ -n "$INTROSPECT_CLIENT_SECRET" ] \
     || { echo "[seed/zitadel] provisioning returned an empty id/secret" >&2; exit 1; }
   echo "[seed/zitadel] provisioned client_id=$CLIENT_ID project=$PROJECT_ID"
+
+  # --- D5: human bench user + password, for a REAL password check via the
+  # session API v2 (see targets.js zitadel.login()). Deliberately soft-fail
+  # here (warn + continue with the machine-user-only fixture) rather than
+  # exit 1 like the rest of this function: the D5 spec calls for a graceful
+  # A3-style fallback to client_credentials when the session flow can't be
+  # provisioned/exercised, not a hard seed failure over what is otherwise a
+  # perfectly usable fixture for every other scenario. If a human user IS
+  # reported created, the smoke check below (smoke_zitadel) verifies the
+  # session-create flow end-to-end and DOES fail closed (A2) — a seed that
+  # looks complete but can't actually log in must not pass silently.
+  #
+  # Uses management v1 (POST /management/v1/users/human), the human-user
+  # counterpart of the /management/v1/users/machine call above, for
+  # consistency with the rest of this function. Like the machine
+  # user/project/app above, this assumes a fresh instance per seed run (the
+  # FIRSTINSTANCE PAT comment above already documents that re-seeding without
+  # wiping the volume is unsupported for zitadel), so no create-or-find
+  # idempotency handling is attempted — a 409 here is treated the same as any
+  # other failure: warn and fall back.
+  echo "[seed/zitadel] creating benchmark human user (password login, D5)"
+  local hu_resp hu_code hu_body
+  hu_resp=$(curl -sSk -H "Authorization: Bearer $PAT" -H "Content-Type: application/json" \
+    -X POST "$BASE/management/v1/users/human" \
+    --data "{\"userName\":\"$BENCH_USERNAME\",\"profile\":{\"firstName\":\"Bench\",\"lastName\":\"User\"},\"email\":{\"email\":\"bench@bench.dev\",\"isEmailVerified\":true},\"password\":\"$BENCH_PASSWORD\",\"passwordChangeRequired\":false}" \
+    -w $'\n%{http_code}') || hu_resp=$'\n000'
+  hu_code="${hu_resp##*$'\n'}"; hu_body="${hu_resp%$'\n'*}"
+  if [ "$hu_code" -ge 200 ] 2>/dev/null && [ "$hu_code" -lt 300 ] 2>/dev/null; then
+    ZITADEL_USER_ID=$(echo "$hu_body" | jq -r '.userId // empty' 2>/dev/null || true)
+  fi
+  if [ -n "${ZITADEL_USER_ID:-}" ]; then
+    # Session-create is an admin/management-style call, so it needs its own
+    # bearer credential at k6-request time — reuse the instance PAT read
+    # above (already proven against the management API by every zapi() call
+    # in this function) rather than minting a separate one.
+    ZITADEL_SESSION_PAT="$PAT"
+    echo "[seed/zitadel] provisioned human user id=$ZITADEL_USER_ID (session-login enabled)"
+  else
+    echo "[seed/zitadel] WARNING: human user creation failed (HTTP $hu_code): $hu_body" >&2
+    echo "[seed/zitadel] WARNING: zitadel.login() will fall back to client_credentials (tagged fallback: true — see D5 guard in targets.js)" >&2
+  fi
+
   write_seed
 }
 
@@ -568,6 +619,39 @@ smoke_zitadel() {
 
   echo "[seed/smoke/zitadel] userinfo"
   smoke_get zitadel-userinfo "$BASE/oidc/v1/userinfo" "Authorization: Bearer $cc_token" >/dev/null
+
+  # D5: real password login via the session API v2. Only exercised when
+  # seed_zitadel() reports a provisioned human user + session PAT; when it
+  # doesn't (see the soft-fail there), zitadel.login() falls back to
+  # client_credentials (A3) and there is nothing session-specific to smoke
+  # here — that fallback path is already covered by the client_credentials
+  # check above. When a human user WAS reported provisioned, this check is
+  # fail-closed (A2): a seed that claims a working session-login fixture but
+  # can't actually create a session must not pass silently.
+  if [ -n "${ZITADEL_USER_ID:-}" ] && [ -n "${ZITADEL_SESSION_PAT:-}" ]; then
+    echo "[seed/smoke/zitadel] session create (password check) — real password verification"
+    local sess_resp sess_code sess_body sess_token
+    sess_resp=$(curl -sSk -X POST "$BASE/v2/sessions" \
+      -H "Authorization: Bearer $ZITADEL_SESSION_PAT" -H "Content-Type: application/json" \
+      -d "{\"checks\":{\"user\":{\"userId\":\"$ZITADEL_USER_ID\"},\"password\":{\"password\":\"$BENCH_PASSWORD\"}}}" \
+      -w $'\n%{http_code}') || smoke_fail zitadel-session-create "curl request failed"
+    sess_code="${sess_resp##*$'\n'}"; sess_body="${sess_resp%$'\n'*}"
+    # Accept 200 or 201: Zitadel v2 create-endpoints are documented/observed
+    # returning 201 (what targets.js expects — see the comment there), but
+    # this has not been confirmed against a live instance in this sandbox, so
+    # the smoke check tolerates either rather than false-failing a seed that
+    # actually works. If 200 turns out to be correct, update targets.js's
+    # `expect: 201` to match — the acceptance criterion is a real password
+    # check happening at all, not the exact status code.
+    case "$sess_code" in
+      200|201) : ;;
+      *) smoke_fail "zitadel-session-create (HTTP $sess_code)" "$sess_body" ;;
+    esac
+    sess_token=$(echo "$sess_body" | jq -r '.sessionToken // empty')
+    [ -n "$sess_token" ] || smoke_fail zitadel-session-create-no-token "$sess_body"
+  else
+    echo "[seed/smoke/zitadel] no human user/session-PAT provisioned — password-login scenario will use the A3 client_credentials fallback (see D5 guard in targets.js)"
+  fi
 
   echo "[seed/smoke/zitadel] all smoke checks passed"
 }

--- a/benchmarks/scenarios/authz_batch_grpc.js
+++ b/benchmarks/scenarios/authz_batch_grpc.js
@@ -5,7 +5,7 @@
 // batch authz) in isolation and is reported separately, never as a head-to-head number.
 import grpc from 'k6/net/grpc';
 import { check } from 'k6';
-import { cfg, loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
+import { cfg, loadStages, thresholds, tlsOptions, grpcConnectParams, requireSeed } from './lib/config.js';
 import { m } from './lib/metrics.js';
 import { loginSession, jwtClaims } from './lib/auth.js';
 
@@ -14,8 +14,9 @@ const client = new grpc.Client();
 // --include-system-env-vars with BENCH_PROTO_ROOT.
 client.load([__ENV.BENCH_PROTO_ROOT || '../proto'], 'axiam/v1/authorization.proto');
 
-// tlsOptions() supplies insecureSkipTLSVerify (private-CA edge) + tlsAuth (mTLS);
-// merged in so the setup() HTTPS login — and the gRPC TLS dial — honor the profile.
+// tlsOptions() supplies insecureSkipTLSVerify (private-CA edge) + tlsAuth (mTLS)
+// for the setup() HTTPS login. The gRPC dial itself is separately TLS-gated via
+// grpcConnectParams() (D2) — see cfg.grpcPlaintext in lib/config.js.
 export const options = Object.assign(
   {
     scenarios: {
@@ -61,7 +62,7 @@ export function setup() {
 
 export default function (data) {
   if (__ITER === 0) {
-    client.connect(cfg.grpcAddr, { plaintext: cfg.grpcPlaintext });
+    client.connect(cfg.grpcAddr, grpcConnectParams());
   }
   const start = Date.now();
   const res = client.invoke(

--- a/benchmarks/scenarios/authz_check_grpc.js
+++ b/benchmarks/scenarios/authz_check_grpc.js
@@ -5,7 +5,7 @@
 // in isolation and is reported separately, never as a head-to-head number.
 import grpc from 'k6/net/grpc';
 import { check } from 'k6';
-import { cfg, loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
+import { cfg, loadStages, thresholds, tlsOptions, grpcConnectParams, requireSeed } from './lib/config.js';
 import { m } from './lib/metrics.js';
 import { loginSession, jwtClaims } from './lib/auth.js';
 
@@ -14,8 +14,9 @@ const client = new grpc.Client();
 // --include-system-env-vars with BENCH_PROTO_ROOT.
 client.load([__ENV.BENCH_PROTO_ROOT || '../proto'], 'axiam/v1/authorization.proto');
 
-// tlsOptions() supplies insecureSkipTLSVerify (private-CA edge) + tlsAuth (mTLS);
-// merged in so the setup() HTTPS login — and the gRPC TLS dial — honor the profile.
+// tlsOptions() supplies insecureSkipTLSVerify (private-CA edge) + tlsAuth (mTLS)
+// for the setup() HTTPS login. The gRPC dial itself is separately TLS-gated via
+// grpcConnectParams() (D2) — see cfg.grpcPlaintext in lib/config.js.
 export const options = Object.assign(
   {
     scenarios: {
@@ -48,7 +49,7 @@ export function setup() {
 
 export default function (data) {
   if (__ITER === 0) {
-    client.connect(cfg.grpcAddr, { plaintext: cfg.grpcPlaintext });
+    client.connect(cfg.grpcAddr, grpcConnectParams());
   }
   const start = Date.now();
   const res = client.invoke(

--- a/benchmarks/scenarios/lib/auth.js
+++ b/benchmarks/scenarios/lib/auth.js
@@ -23,8 +23,8 @@ export function mintToken() {
   throw new Error('auth.mintToken: could not obtain a token for setup (check seeding + profile)');
 }
 
-// Log in as the seeded *user* (never client_credentials) and return the session
-// credentials the authz scenarios need. Two AXIAM specifics drive this:
+// Shared cookie-jar extraction for `login()` responses. Two AXIAM specifics
+// drive this:
 //   1. `/api/v1/auth/login` delivers tokens ONLY via Set-Cookie (axiam_access,
 //      axiam_csrf, axiam_refresh) — the JSON body carries no token — so we read
 //      them back out of k6's cookie jar (HttpOnly is irrelevant to the jar).
@@ -34,9 +34,25 @@ export function mintToken() {
 //      T-27-12). A client-credentials service-account subject would neither match
 //      the seeded grant nor the required subject_id, so authz scenarios log in as
 //      the user.
-// The access token doubles as the gRPC bearer metadata; the CSRF token is
-// required as an X-CSRF-Token header (double-submit) on non-GET REST calls under
-// /api/v1.
+// Falls back to a body token for targets/profiles that return one there instead
+// of (or in addition to) cookies (e.g. Keycloak's ROPC "login").
+// Used by both `loginSession()` (authz scenarios) and `mintUserToken()`
+// (token-holding scenarios like userinfo) so the cookie-reading logic lives in
+// exactly one place.
+export function readAccessFromLogin(built, res, jar) {
+  const cookies = jar.cookiesForURL(built.url);
+  let body = null;
+  try { body = res.json(); } catch (_e) { /* cookie-only response, no JSON body */ }
+  const access = (cookies.axiam_access && cookies.axiam_access[0]) || (body && (body.access_token || body.token));
+  const refresh = (cookies.axiam_refresh && cookies.axiam_refresh[0]) || (body && body.refresh_token);
+  const csrf = cookies.axiam_csrf && cookies.axiam_csrf[0];
+  return { access_token: access, refresh_token: refresh, csrf_token: csrf };
+}
+
+// Log in as the seeded *user* (never client_credentials) and return the session
+// credentials the authz scenarios need. The access token doubles as the gRPC
+// bearer metadata; the CSRF token is required as an X-CSRF-Token header
+// (double-submit) on non-GET REST calls under /api/v1.
 export function loginSession() {
   const jar = http.cookieJar();
   const built = adapter().login();
@@ -44,15 +60,47 @@ export function loginSession() {
   if (res.status !== (built.expect || 200)) {
     throw new Error(`auth.loginSession: login failed (status ${res.status}) — check seeding + profile`);
   }
-  const cookies = jar.cookiesForURL(built.url);
-  let access = cookies.axiam_access && cookies.axiam_access[0];
-  if (!access) {
-    // Fall back to a body token in case a target/profile returns one there.
-    try { const b = res.json(); access = b.access_token || b.token; } catch (_e) { /* none */ }
+  const { access_token, csrf_token } = readAccessFromLogin(built, res, jar);
+  if (!access_token) throw new Error('auth.loginSession: no axiam_access cookie (or body token) in login response');
+  return { access_token, csrf_token };
+}
+
+// Obtain a token that represents the seeded *user* (not a service account),
+// for scenarios that need a genuine OIDC subject (e.g. userinfo). Tries the
+// target's `login()` op first; falls back to `clientCredentials()` only if
+// login isn't available/successful (e.g. a target with ROPC disabled) or
+// returns no usable token. `is_user_token` tells the caller (and the report,
+// via `bench_fallback`) whether the fallback was used, so a client-credentials
+// subject reading /userinfo isn't silently mistaken for the real op.
+export function mintUserToken() {
+  const a = adapter();
+  const jar = http.cookieJar();
+  const built = a.login();
+  // Some adapters' login() IS client_credentials in disguise, tagged
+  // `fallback: true` (see zitadel in targets.js) — skip straight to the
+  // explicit client_credentials branch below rather than "succeeding" here
+  // and mislabelling it is_user_token: true.
+  if (!built.fallback) {
+    const res = http.request(built.method, built.url, built.body || null, built.params || {});
+    if (res.status === (built.expect || 200)) {
+      const { access_token, refresh_token } = readAccessFromLogin(built, res, jar);
+      if (access_token) {
+        return { access_token, refresh_token, is_user_token: true };
+      }
+    }
   }
-  const csrf = cookies.axiam_csrf && cookies.axiam_csrf[0];
-  if (!access) throw new Error('auth.loginSession: no axiam_access cookie (or body token) in login response');
-  return { access_token: access, csrf_token: csrf };
+  // Fall back to client_credentials (e.g. a target whose login() already IS
+  // client_credentials — see zitadel in targets.js — or a login that failed).
+  const cc = a.clientCredentials();
+  const ccRes = http.request(cc.method, cc.url, cc.body || null, cc.params || {});
+  if (ccRes.status !== (cc.expect || 200)) {
+    throw new Error(`auth.mintUserToken: could not obtain a token for setup (status ${ccRes.status})`);
+  }
+  let body;
+  try { body = ccRes.json(); } catch (_e) { body = {}; }
+  const access = body.access_token || body.token;
+  if (!access) throw new Error('auth.mintUserToken: client_credentials fallback returned no token');
+  return { access_token: access, refresh_token: body.refresh_token, is_user_token: false };
 }
 
 // Decode the (unverified) claims from a JWT payload segment. Used only to read

--- a/benchmarks/scenarios/lib/config.js
+++ b/benchmarks/scenarios/lib/config.js
@@ -21,13 +21,19 @@ export const cfg = {
   host: str('BENCH_HOST', 'localhost'),
   port: num('BENCH_PORT', 8090),
   grpcAddr: str('BENCH_GRPC_ADDR', 'localhost:50051'),
-  // gRPC transport security is INDEPENDENT of the HTTP edge's TLS profile. The
-  // bench never TLS-terminates gRPC: the nginx edge (targets/axiam/tls/*.conf)
-  // proxies HTTP only, and the axiam-server gRPC port is published plaintext on
-  // :50051 for every profile (p0-p3). So the connect plaintext flag must NOT be
-  // derived from BENCH_SCHEME (https there is only the REST edge). Default
-  // plaintext; set BENCH_GRPC_PLAINTEXT=false only if you front gRPC with a TLS
-  // terminator.
+  // gRPC transport security is INDEPENDENT of the HTTP edge's TLS profile — the
+  // nginx edge (targets/axiam/tls/*.conf) proxies HTTP only, so a p1/p3 nginx-
+  // fronted profile still leaves :50051 plaintext. The connect plaintext flag
+  // must NOT be derived from BENCH_SCHEME. Default plaintext for every profile.
+  //
+  // D2: AXIAM's own gRPC server (crates/axiam-api-grpc/src/server.rs) natively
+  // terminates TLS on :50051 when AXIAM__GRPC_TLS_CERT_PATH/KEY_PATH are set
+  // (no proxy involved) — the p2-tls13 native overlay
+  // (targets/axiam/docker-compose.native-tls.yml) enables it and
+  // profiles/p2-tls13.env sets BENCH_GRPC_PLAINTEXT=false to match, so the k6
+  // gRPC dial and the server's listener agree. Any other profile that wants a
+  // TLS gRPC dial (e.g. a custom nginx grpc_pass front) can also set
+  // BENCH_GRPC_PLAINTEXT=false by hand.
   grpcPlaintext: str('BENCH_GRPC_PLAINTEXT', 'true') === 'true',
 
   // --- tenancy / credentials provisioned by runner/seed.sh ---
@@ -90,6 +96,21 @@ export function tlsOptions() {
     }];
   }
   return o;
+}
+
+// k6 net/grpc `Client.connect(addr, params)` params for AXIAM's dedicated gRPC
+// port (D2). Mirrors scenarios/zitadel_userinfo_grpc.js's connectParams(): when
+// not plaintext, k6's grpc client takes its own `tls: { insecureSkipVerify }`
+// key (distinct from tlsOptions()'s top-level `insecureSkipTLSVerify`, which
+// only covers k6's http/websocket clients) — required here because the p2
+// native-TLS overlay's server cert is signed by the same throwaway private CA
+// as the REST edge (see tlsOptions() above), which k6 cannot verify.
+export function grpcConnectParams() {
+  const params = { plaintext: cfg.grpcPlaintext };
+  if (!cfg.grpcPlaintext) {
+    params.tls = cfg.verifyTls ? {} : { insecureSkipVerify: true };
+  }
+  return params;
 }
 
 // Standard three-stage closed-loop model: warm-up (uncounted) → measure → cooldown.

--- a/benchmarks/scenarios/lib/metrics.js
+++ b/benchmarks/scenarios/lib/metrics.js
@@ -9,6 +9,12 @@ export const m = {
   failed: new Counter('bench_failed'),       // failed logical operations
   errorRate: new Rate('bench_error_rate'),   // fraction failed (validity gate)
   latency: new Trend('bench_op_latency_ms', true), // end-to-end op latency
+  // Count of iterations that measured a fallback operation instead of the
+  // labelled logical op (e.g. Zitadel's login() falling back to
+  // client_credentials, or a userinfo setup() that couldn't mint a real user
+  // token). report.py annotates any cell with bench_fallback > 0 as
+  // comparability: fallback-op and excludes it from head-to-head tables.
+  fallback: new Counter('bench_fallback'),
 };
 
 // Execute one built request (from targets.js) and record uniform metrics.
@@ -16,6 +22,8 @@ export const m = {
 export function doOp(built, params) {
   const reqParams = Object.assign({}, built.params || {}, params || {});
   const res = http.request(built.method, built.url, built.body || null, reqParams);
+
+  if (built.fallback) m.fallback.add(1);
 
   const expected = built.expect || 200;
   const passed = check(res, {

--- a/benchmarks/scenarios/lib/targets.js
+++ b/benchmarks/scenarios/lib/targets.js
@@ -125,6 +125,10 @@ const keycloak = {
         grant_type: 'client_credentials',
         client_id: cfg.clientId,
         client_secret: cfg.clientSecret,
+        // Without an explicit scope Keycloak still issues a token, but it is
+        // not OIDC-capable (no 'openid' in the granted scope), so /userinfo
+        // rejects it. Request it explicitly, matching the login() ROPC grant.
+        scope: 'openid',
       }),
       params: FORM,
       expect: 200,
@@ -170,8 +174,13 @@ const keycloak = {
 // OIDC endpoints at well-known paths; ROPC is generally disabled, so `login`
 // falls back to client_credentials for the comparative token-issuance number.
 const zitadel = {
+  // ROPC is generally disabled on Zitadel, so "login" falls back to
+  // client_credentials for the comparative token-issuance number — this is NOT
+  // a password verification, so tag the built request `fallback: true` and
+  // doOp()/report.py surface it (bench_fallback counter, "fallback-op"
+  // annotation, excluded from head-to-head winner tables).
   login() {
-    return zitadel.clientCredentials();
+    return Object.assign({}, zitadel.clientCredentials(), { fallback: true });
   },
   clientCredentials() {
     // Add the bench project's reserved audience scope so the issued token is

--- a/benchmarks/scenarios/lib/targets.js
+++ b/benchmarks/scenarios/lib/targets.js
@@ -172,15 +172,73 @@ const keycloak = {
 
 // --- Zitadel --------------------------------------------------------------
 // OIDC endpoints at well-known paths; ROPC is generally disabled, so `login`
-// falls back to client_credentials for the comparative token-issuance number.
+// used to fall back to client_credentials for the comparative token-issuance
+// number. D5 replaces that with a real password check via Zitadel's session
+// API v2 (`POST /v2/sessions`, `checks.password`) so oauth2_password_login
+// measures an actual Argon2/bcrypt-class password verification on Zitadel,
+// same as axiam/keycloak.
 const zitadel = {
-  // ROPC is generally disabled on Zitadel, so "login" falls back to
-  // client_credentials for the comparative token-issuance number — this is NOT
-  // a password verification, so tag the built request `fallback: true` and
-  // doOp()/report.py surface it (bench_fallback counter, "fallback-op"
-  // annotation, excluded from head-to-head winner tables).
+  // Real password verification via the session API v2: create a session with
+  // a `password` check factor over the seeded human bench user. This is NOT
+  // client_credentials — it drives Zitadel's actual password-hash comparison
+  // — so the built request is tagged `fallback: true` ONLY in the degraded
+  // path below (no seeded human user / session credential available); the
+  // normal-path request is untagged, so doOp()/report.py stop flagging this
+  // cell as a fallback op (D5 acceptance criterion).
+  //
+  // Session-create is an admin/management-style call (not a user-facing OIDC
+  // endpoint), so it needs its own bearer credential — seed.sh mints/derives
+  // one (the Zitadel instance PAT — see seed_zitadel()) and exports it as
+  // BENCH_ZITADEL_SESSION_PAT, alongside the seeded human user's id as
+  // BENCH_ZITADEL_USER_ID. Read directly via `__ENV` (a k6 global available
+  // to every module, same mechanism config.js's str()/num() use) rather than
+  // adding fields to `cfg` — config.js is out of scope for this change.
+  //
+  // IMPORTANT interaction with auth.js `mintUserToken()` (used by the
+  // userinfo scenario): a session-create response returns a `sessionToken`,
+  // NOT an OIDC access token — it is useless as a `/userinfo` bearer.
+  // `mintUserToken()` only accepts login()'s response as a real user token
+  // when `readAccessFromLogin()` finds an `access_token`/`token` JSON field
+  // or an `axiam_access` cookie (see auth.js). The v2 CreateSession body has
+  // neither (its field is literally named `sessionToken`, which does not
+  // match `access_token`/`token`), so `mintUserToken()` naturally falls
+  // through to its own `clientCredentials()` fallback for userinfo — exactly
+  // the previous behavior — WITHOUT needing this function to tag its result
+  // `fallback: true`. That tag is reserved for the "session API unavailable"
+  // guard below, per the D5 spec. No change to auth.js was required or made;
+  // this is a deliberate design choice, not an oversight.
   login() {
-    return Object.assign({}, zitadel.clientCredentials(), { fallback: true });
+    const userId = __ENV.BENCH_ZITADEL_USER_ID;
+    const sessionPat = __ENV.BENCH_ZITADEL_SESSION_PAT;
+    if (!userId || !sessionPat) {
+      // No seeded human user / session-creation credential (e.g. manual
+      // client-only seeding via BENCH_CLIENT_ID/SECRET, or the
+      // BENCH_ZITADEL_ALLOW_UNSEEDED jwks-only mode — see seed.sh) — the
+      // session API can't be exercised, so fall back to the old comparative
+      // token-issuance number and tag it accordingly (A3 fallback).
+      return Object.assign({}, zitadel.clientCredentials(), { fallback: true });
+    }
+    return {
+      method: 'POST',
+      url: `${baseUrl()}/v2/sessions`,
+      body: JSON.stringify({
+        checks: {
+          user: { userId },
+          password: { password: cfg.password },
+        },
+      }),
+      params: {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${sessionPat}`,
+        },
+      },
+      // Zitadel's v2 resource-creation endpoints return 201 in the docs/
+      // examples this was modeled on; unconfirmed against a live instance
+      // (no Zitadel available in this sandbox — see D5 report). If a live
+      // run shows 200 instead, this is the only line to change.
+      expect: 201,
+    };
   },
   clientCredentials() {
     // Add the bench project's reserved audience scope so the issued token is

--- a/benchmarks/scenarios/proto/zitadel/README.md
+++ b/benchmarks/scenarios/proto/zitadel/README.md
@@ -1,0 +1,133 @@
+# Vendored Zitadel proto (minimal, D4)
+
+Pinned source version: **Zitadel `v4.15.2`** — matches the image tag benched in
+`benchmarks/targets/zitadel/docker-compose.yml`
+(`ghcr.io/zitadel/zitadel:v4.15.2`, see that file's `services.zitadel.image`).
+If the benched Zitadel tag ever changes, re-fetch and re-diff these files
+against the new tag before trusting the gRPC scenario's numbers.
+
+Upstream repo: https://github.com/zitadel/zitadel — Apache License 2.0. These
+files are a **derived, trimmed** copy of upstream `.proto` sources, not a
+verbatim vendor drop.
+
+## What's here and why
+
+```
+zitadel/
+├── auth.proto     -- AuthService.GetMyUser only  (upstream: 1653 lines, ~90 RPCs)
+├── user.proto      -- User envelope + UserState   (upstream: 1021 lines)
+└── object.proto    -- ObjectDetails                (upstream: 105 lines, kept ~whole)
+```
+
+This benchmark needs exactly one RPC: `zitadel.auth.v1.AuthService/GetMyUser`,
+the gRPC counterpart to the REST `/oidc/v1/userinfo` scenario already covered
+by `scenarios/userinfo.js` (see `scenarios/zitadel_userinfo_grpc.js`). Rather
+than vendor the full upstream files — which would transitively require
+`google/api/annotations.proto`, `google/api/field_behavior.proto`,
+`zitadel/options.proto` (for `(zitadel.v1.auth_option)`),
+`protoc-gen-openapiv2/options/annotations.proto` (for the swagger/operation
+options), and, for `auth.proto`'s other ~89 RPCs, `zitadel/org.proto`,
+`zitadel/change.proto`, `zitadel/policy.proto`, `zitadel/idp.proto`,
+`zitadel/metadata.proto`, and `validate/validate.proto` — this vendors a
+**hand-trimmed subset**:
+
+1. **Fetched the real upstream files** at the `v4.15.2` tag (raw GitHub
+   content was reachable from this environment) to read the authoritative
+   RPC signature and message shapes rather than guessing them:
+   - `proto/zitadel/auth.proto` → `AuthService.GetMyUser`,
+     `GetMyUserRequest {}`, `GetMyUserResponse { User user = 1;
+     google.protobuf.Timestamp last_login = 2; }`
+   - `proto/zitadel/user.proto` → `User { string id = 1; ObjectDetails
+     details = 2; UserState state = 3; string user_name = 4; repeated
+     string login_names = 5; string preferred_login_name = 6; oneof type {
+     Human human = 7; Machine machine = 8; } }` + the 7-value `UserState`
+     enum.
+   - `proto/zitadel/object.proto` → `ObjectDetails { uint64 sequence = 1;
+     Timestamp creation_date = 2; Timestamp change_date = 3; string
+     resource_owner = 4; }`
+2. **Copied every field number verbatim** for every field kept below — this
+   matters because k6's gRPC client needs exact field numbers for wire
+   compatibility (a mismatched number silently decodes the wrong field).
+3. **Cut everything not required to call and decode `GetMyUser`:**
+   - `auth.proto`: dropped all ~89 other RPCs and every custom option
+     (`google.api.http`, `zitadel.v1.auth_option`, the
+     `protoc-gen-openapiv2` swagger/operation blocks). These select REST
+     gateway routing and generated docs, never the gRPC wire format — the
+     k6 scenario calls `AuthService/GetMyUser` directly over gRPC, never
+     through Zitadel's REST/JSON gateway, so none of this affects what's
+     being benchmarked.
+   - `user.proto`: dropped the `human`/`machine` oneof (upstream fields 7/8)
+     entirely, along with the `Human`/`Machine`/`Profile`/`Email`/`Phone`
+     message definitions those fields pull in. This is *safe*, not lossy in
+     a way that matters here: protobuf decoders silently skip unknown field
+     numbers on the wire, so a real Zitadel response carrying a populated
+     `human` payload still decodes cleanly against this trimmed message —
+     those bytes are just never surfaced to the k6 script. The benchmark
+     only asserts the RPC succeeds and the identity envelope
+     (`id`/`state`/`user_name`) decodes; it does not assert on profile
+     contents, so there is no need to vendor the profile sub-messages.
+   - Every remaining field-level `protoc-gen-openapiv2` annotation across
+     all three files was stripped for the same reason as the RPC options —
+     documentation metadata, not wire shape.
+4. **`google.protobuf.Timestamp` is referenced but not vendored.** k6's
+   `k6/net/grpc` client bundles the standard protobuf well-known types
+   (`google/protobuf/{any,duration,empty,struct,timestamp,wrappers}.proto`)
+   internally, so `import "google/protobuf/timestamp.proto";` resolves
+   without a file on disk — nothing to vendor there.
+
+Net result: 3 files, ~90 lines total, vs. ~2700 lines and 9+ additional
+transitive proto files upstream — everything needed for
+`AuthService/GetMyUser` to encode/decode correctly on the wire, nothing else.
+
+## Session service — not vendored
+
+The plan for this task (`claude_dev/benchmark-improvement-plan.md`, D4) also
+asks for "auth + session services" and an optional
+`zitadel_introspect_equivalent` scenario "only if a comparable RPC genuinely
+exists." `proto/zitadel/session/v2/session_service.proto` was fetched and
+inspected at the same `v4.15.2` tag; `SessionService` exposes
+`ListSessions`/`GetSession`/`CreateSession`/`SetSession`/`DeleteSession`.
+None of these are a comparable RPC to either of this repo's existing
+REST session/token operations:
+
+* `GetSession` takes a **session ID + session token** (Zitadel's own
+  session-object identity), not a bearer OAuth2 access/refresh token — it
+  cannot serve as an "introspect this token" equivalent to RFC 7662
+  `token_introspection.js`, which checks whether a given *token* is active.
+* `CreateSession` is the gRPC counterpart to the **login** flow, not
+  introspection or userinfo — out of scope for D4, and it is task D5's
+  concern (`benchmarks/scenarios/lib/targets.js`'s `zitadel.login()`), not
+  this one's.
+
+So no `session_service.proto` is vendored and no
+`zitadel_introspect_equivalent.js` scenario was added — forcing one would
+mean benchmarking a different logical operation under a misleading label,
+which is exactly what `docs/methodology.md`'s comparability rules (and this
+plan item) say not to do.
+
+## Comparability labeling
+
+`AuthService/GetMyUser` over gRPC is the **protocol-efficiency** pairing for
+Zitadel's own REST `/oidc/v1/userinfo` (`scenarios/userinfo.js`) — same
+logical operation (return the authenticated user's identity claims), two
+wire protocols, same vendor. It is **not** compared head-to-head against
+AXIAM's or Keycloak's REST `userinfo.js` cells in the cross-vendor winner
+tables (neither of those targets exposes this RPC at all), and it is not
+compared against AXIAM's `authz_check_grpc.js`/`authz_batch_grpc.js` either
+(those measure a service-mesh authorization decision, a different logical
+operation). See `docs/methodology.md` §3 and `runner/report.py`'s
+`NON_COMPARATIVE_SCENARIOS` handling for how this is enforced in the
+generated report.
+
+## Regenerating / re-verifying
+
+```bash
+# Re-fetch upstream at the pinned tag to diff against this trimmed copy:
+curl -sS https://raw.githubusercontent.com/zitadel/zitadel/v4.15.2/proto/zitadel/auth.proto
+curl -sS https://raw.githubusercontent.com/zitadel/zitadel/v4.15.2/proto/zitadel/user.proto
+curl -sS https://raw.githubusercontent.com/zitadel/zitadel/v4.15.2/proto/zitadel/object.proto
+
+# If buf or protoc is available, lint/compile-check this vendored set:
+buf lint scenarios/proto/zitadel
+protoc --proto_path=scenarios/proto/zitadel --descriptor_set_out=/dev/null zitadel/auth.proto
+```

--- a/benchmarks/scenarios/proto/zitadel/zitadel/auth.proto
+++ b/benchmarks/scenarios/proto/zitadel/zitadel/auth.proto
@@ -1,0 +1,43 @@
+// Trimmed vendor copy — see ../README.md for provenance and what was cut.
+//
+// Source: https://github.com/zitadel/zitadel/blob/v4.15.2/proto/zitadel/auth.proto
+// (1653 lines upstream, ~90 RPCs covering the full "operations on the
+// currently authenticated user" surface: profile/email/phone management,
+// OTP/U2F/passwordless factors, refresh-token listing/revocation, policies,
+// metadata, org/grant listings, etc.) This file keeps ONLY the
+// `AuthService.GetMyUser` RPC and its request/response messages, copied
+// verbatim (including field numbers) from upstream. Every `rpc` other than
+// GetMyUser, and every `google.api.http` / `zitadel.v1.auth_option` /
+// `protoc-gen-openapiv2` swagger option, was dropped — those options select
+// REST-gateway routing and generated docs, not the gRPC wire format, and
+// keeping them would have pulled in `google/api/annotations.proto`,
+// `zitadel/options.proto`, and `protoc-gen-openapiv2/options/annotations.proto`
+// as further transitive imports for a benchmark harness that only calls this
+// one RPC directly over gRPC (never through the REST/JSON gateway).
+syntax = "proto3";
+
+package zitadel.auth.v1;
+
+option go_package = "github.com/zitadel/zitadel/pkg/grpc/auth";
+
+import "zitadel/user.proto";
+import "google/protobuf/timestamp.proto";
+
+// AuthService is used for operations on the currently authenticated user.
+// Base path upstream: /auth/v1. This vendor copy exposes only GetMyUser.
+service AuthService {
+  // GetMyUser returns the full user object of the authenticated user
+  // (profile/email/phone/etc. in the upstream response — trimmed here to the
+  // identity envelope, see user.proto). Identity is derived entirely from
+  // the request's bearer token; the request message is empty upstream.
+  rpc GetMyUser(GetMyUserRequest) returns (GetMyUserResponse);
+}
+
+// This is an empty request — upstream reads all parameters from the
+// authorization bearer token, not from request fields.
+message GetMyUserRequest {}
+
+message GetMyUserResponse {
+  zitadel.user.v1.User user = 1;
+  google.protobuf.Timestamp last_login = 2;
+}

--- a/benchmarks/scenarios/proto/zitadel/zitadel/object.proto
+++ b/benchmarks/scenarios/proto/zitadel/zitadel/object.proto
@@ -1,0 +1,27 @@
+// Trimmed vendor copy — see ../README.md for provenance and what was cut.
+//
+// Source: https://github.com/zitadel/zitadel/blob/v4.15.2/proto/zitadel/object.proto
+// Only `ObjectDetails` is kept (the one message `User` embeds); field numbers
+// are copied verbatim from the upstream file. All `protoc-gen-openapiv2`
+// field-option annotations were stripped — they only affect generated Swagger
+// docs, never the wire format, and stripping them avoids vendoring the
+// `protoc-gen-openapiv2/options/annotations.proto` dependency for a benchmark
+// harness that only needs to encode/decode the gRPC wire bytes.
+syntax = "proto3";
+
+package zitadel.v1;
+
+option go_package = "github.com/zitadel/zitadel/pkg/grpc/object";
+
+import "google/protobuf/timestamp.proto";
+
+message ObjectDetails {
+  // sequence represents the order of events (last-event sequence on read).
+  uint64 sequence = 1;
+  // creation_date is the timestamp of the object's first event.
+  google.protobuf.Timestamp creation_date = 2;
+  // change_date is the timestamp of the object's last event.
+  google.protobuf.Timestamp change_date = 3;
+  // resource_owner is the organization the object belongs to.
+  string resource_owner = 4;
+}

--- a/benchmarks/scenarios/proto/zitadel/zitadel/user.proto
+++ b/benchmarks/scenarios/proto/zitadel/zitadel/user.proto
@@ -1,0 +1,47 @@
+// Trimmed vendor copy — see ../README.md for provenance and what was cut.
+//
+// Source: https://github.com/zitadel/zitadel/blob/v4.15.2/proto/zitadel/user.proto
+// (1021 lines upstream — Human/Machine profile/email/phone/IdP-link detail,
+// U2F/passwordless factors, etc.) Only the top-level `User` envelope and the
+// `UserState` enum it embeds are kept, with field numbers copied verbatim
+// from upstream. The `human`/`machine` oneof (upstream fields 7/8, each
+// pulling in Profile/Email/Phone/Machine sub-messages and their own nested
+// options) is deliberately OMITTED: this benchmark only asserts the RPC
+// completes and decodes the user's identity envelope (id/state/user_name),
+// it does not assert on profile contents. Dropping fields 7/8 from this
+// trimmed .proto does not break wire compatibility — protobuf decoders
+// silently skip unknown field numbers, so a real `GetMyUserResponse`
+// carrying a `human` or `machine` payload still decodes cleanly here; those
+// bytes are simply not surfaced to the k6 script. All
+// `protoc-gen-openapiv2` field-option annotations were stripped for the same
+// reason as in object.proto.
+syntax = "proto3";
+
+package zitadel.user.v1;
+
+option go_package = "github.com/zitadel/zitadel/pkg/grpc/user";
+
+import "zitadel/object.proto";
+
+enum UserState {
+  USER_STATE_UNSPECIFIED = 0;
+  USER_STATE_ACTIVE = 1;
+  USER_STATE_INACTIVE = 2;
+  USER_STATE_DELETED = 3;
+  USER_STATE_LOCKED = 4;
+  USER_STATE_SUSPEND = 5;
+  USER_STATE_INITIAL = 6;
+}
+
+message User {
+  string id = 1;
+  zitadel.v1.ObjectDetails details = 2;
+  UserState state = 3;
+  string user_name = 4;
+  repeated string login_names = 5;
+  string preferred_login_name = 6;
+  // Upstream fields 7 (human) / 8 (machine) intentionally omitted — see the
+  // file-level comment above. Reserved so nothing here ever redefines them.
+  reserved 7, 8;
+  reserved "human", "machine";
+}

--- a/benchmarks/scenarios/token_refresh.js
+++ b/benchmarks/scenarios/token_refresh.js
@@ -46,7 +46,9 @@ export default function () {
     vuRefresh = tok.refresh_token;
     if (!vuRefresh) {
       // Target issued no refresh token (e.g. pure client_credentials) — nothing to
-      // measure; mint again as the closest comparable token-issuance op.
+      // measure; mint again as the closest comparable token-issuance op. This is
+      // not a refresh, so tag + count it as a fallback (comparability: fallback-op).
+      m.fallback.add(1);
       doOp(a.clientCredentials());
       return;
     }

--- a/benchmarks/scenarios/userinfo.js
+++ b/benchmarks/scenarios/userinfo.js
@@ -2,8 +2,8 @@
 // bearer-token verification + a profile read on every request.
 import { loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
 import { adapter } from './lib/targets.js';
-import { doOp } from './lib/metrics.js';
-import { mintToken } from './lib/auth.js';
+import { doOp, m } from './lib/metrics.js';
+import { mintUserToken } from './lib/auth.js';
 
 export const options = Object.assign(
   {
@@ -18,7 +18,14 @@ export const options = Object.assign(
 
 export function setup() {
   requireSeed();
-  return mintToken();
+  // userinfo returns identity claims for the bearer's *subject* — a
+  // client_credentials service-account token is not the comparable op, so
+  // mint a real user token (via login()) and only fall back if that fails.
+  // k6 allows metric emission in setup(), so a fallback is recorded once here
+  // (not per-iteration) and shows up as bench_fallback in the summary.
+  const tok = mintUserToken();
+  if (!tok.is_user_token) m.fallback.add(1);
+  return tok;
 }
 
 export default function (data) {

--- a/benchmarks/scenarios/zitadel_userinfo_grpc.js
+++ b/benchmarks/scenarios/zitadel_userinfo_grpc.js
@@ -1,0 +1,93 @@
+// Scenario: gRPC identity read — zitadel.auth.v1.AuthService/GetMyUser.
+//
+// This is Zitadel's gRPC counterpart to its own REST `/oidc/v1/userinfo`
+// (scenarios/userinfo.js): same logical operation (return the authenticated
+// user's identity from a bearer token), two wire protocols, same vendor. It
+// is a PROTOCOL-EFFICIENCY pairing (REST vs gRPC within Zitadel), NOT a
+// cross-vendor head-to-head — AXIAM and Keycloak expose no equivalent gRPC
+// identity RPC, so this scenario is Zitadel-only (see
+// runner/run-benchmark.sh's ZITADEL_ONLY_SCENARIOS) and report.py never
+// places it in a cross-vendor winner table (docs/methodology.md §3,
+// runner/report.py's NON_COMPARATIVE_SCENARIOS). Mirrors the structure of
+// scenarios/authz_check_grpc.js.
+import grpc from 'k6/net/grpc';
+import { check } from 'k6';
+import { cfg, loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
+import { m } from './lib/metrics.js';
+import { mintUserToken } from './lib/auth.js';
+
+const client = new grpc.Client();
+// Vendored, hand-trimmed proto (scenarios/proto/zitadel/README.md documents
+// exactly what was kept/cut and why) — only AuthService/GetMyUser and the
+// message shapes it needs. Import root defaults to this repo's
+// scenarios/proto/zitadel (k6 is run with cwd=benchmarks/scenarios, see
+// runner/run-benchmark.sh); override with BENCH_ZITADEL_PROTO_ROOT if
+// invoking k6 from elsewhere.
+client.load([__ENV.BENCH_ZITADEL_PROTO_ROOT || 'proto/zitadel'], 'zitadel/auth.proto');
+
+// tlsOptions() supplies insecureSkipTLSVerify (private-CA edge) + tlsAuth
+// (mTLS) for the setup() HTTPS token mint. Unlike AXIAM (whose gRPC service
+// runs on a dedicated always-plaintext :50051 port, independent of the REST
+// edge's TLS profile — see config.js's grpcPlaintext comment), Zitadel
+// serves gRPC and REST multiplexed on the SAME port, so the gRPC dial's
+// TLS-ness must follow the security profile's scheme, not a fixed flag —
+// see connectParams() below.
+export const options = Object.assign(
+  {
+    scenarios: {
+      zitadel_userinfo_grpc: {
+        executor: 'ramping-vus', startVUs: 0, stages: loadStages(), gracefulRampDown: '5s',
+      },
+    },
+    thresholds: thresholds('bench_op_latency_ms'),
+    summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  },
+  tlsOptions(),
+);
+
+// GetMyUser resolves identity purely from the bearer token — same rule as
+// userinfo.js: a client_credentials service-account token is not the
+// comparable op, so mint a real user token and record the fallback (once,
+// in setup()) if that wasn't possible.
+export function setup() {
+  requireSeed();
+  const tok = mintUserToken();
+  if (!tok.is_user_token) m.fallback.add(1);
+  return tok;
+}
+
+// Zitadel multiplexes gRPC and REST on cfg.port (no separate gRPC port like
+// AXIAM's :50051), so dial the same host:port the REST scenarios use, and
+// derive plaintext/TLS from the active security profile's scheme.
+function grpcTarget() {
+  return `${cfg.host}:${cfg.port}`;
+}
+
+function connectParams() {
+  const plaintext = cfg.scheme !== 'https';
+  const params = { plaintext };
+  if (!plaintext) {
+    // k6 has no "trust this CA" option (see config.js's tlsOptions() note);
+    // the bench TLS edge uses a throwaway private-CA cert, so verification
+    // must be skipped unless BENCH_VERIFY_TLS points at a publicly-trusted
+    // cert.
+    params.tls = cfg.verifyTls ? {} : { insecureSkipVerify: true };
+  }
+  return params;
+}
+
+export default function (data) {
+  if (__ITER === 0) {
+    client.connect(grpcTarget(), connectParams());
+  }
+  const start = Date.now();
+  const res = client.invoke(
+    'zitadel.auth.v1.AuthService/GetMyUser',
+    {},
+    { metadata: { authorization: `Bearer ${data.access_token}` } },
+  );
+  const ok = check(res, { 'grpc status OK': (r) => r && r.status === grpc.StatusOK });
+  m.latency.add(Date.now() - start);
+  m.errorRate.add(!ok);
+  if (ok) m.ok.add(1); else m.failed.add(1);
+}

--- a/benchmarks/sdk/run-all.sh
+++ b/benchmarks/sdk/run-all.sh
@@ -8,9 +8,17 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 RESULTS="${BENCH_RESULTS_DIR:-$HERE/../results}/sdk"
 mkdir -p "$RESULTS"
 
-# Source the seed env so SDK benches hit a provisioned tenant/client.
-SEED_ENV="${BENCH_RESULTS_DIR:-$HERE/../results}/${BENCH_TARGET:-axiam}.seed.env"
-[ -f "$SEED_ENV" ] && source "$SEED_ENV"
+# Source the seed env so SDK benches hit a provisioned tenant/client. Lives
+# under .seed/ (client secrets kept out of the shareable results/ tree — see
+# A7 in claude_dev/benchmark-improvement-plan.md); fall back to the old
+# results/ location for a seed written before that move.
+SEED_ENV="${BENCH_SEED_DIR:-$HERE/../.seed}/${BENCH_TARGET:-axiam}.seed.env"
+LEGACY_SEED_ENV="${BENCH_RESULTS_DIR:-$HERE/../results}/${BENCH_TARGET:-axiam}.seed.env"
+if [ -f "$SEED_ENV" ]; then
+  source "$SEED_ENV"
+elif [ -f "$LEGACY_SEED_ENV" ]; then
+  source "$LEGACY_SEED_ENV"
+fi
 
 if [ "$#" -gt 0 ]; then
   SDKS=("$@")

--- a/benchmarks/targets/axiam/docker-compose.native-mtls.yml
+++ b/benchmarks/targets/axiam/docker-compose.native-mtls.yml
@@ -1,0 +1,30 @@
+# Overlay for AXIAM native (in-process) mutual TLS — used ONLY for the p3-mtls
+# profile via `just target=axiam profile=p3-mtls bench-up`, layered ON TOP of
+# docker-compose.native-tls.yml (which already enables the TLS 1.3 listener,
+# mounts profiles/certs at /certs, republishes the TLS port and disables the
+# https self-probe healthcheck). This overlay only adds the client-certificate
+# verifier configuration (D3), so the two files compose together:
+#
+#   -f docker-compose.yml \
+#   -f docker-compose.native-tls.yml \
+#   -f docker-compose.native-mtls.yml
+#
+# Why native for p3: AXIAM now terminates client-certificate auth in-process
+# (crates/axiam-server/src/tls.rs builds a rustls WebPkiClientVerifier over the
+# client-CA bundle). Fronting with nginx for mTLS would keep proxy-header
+# identity assertion (a spoofing surface) in the trusted path and measure
+# nginx's TLS work outside AXIAM's CPU cap. Native mTLS makes the VERIFIED peer
+# certificate — surfaced to handlers via on_connect / conn extensions — the sole
+# identity source, and keeps the measurement inside AXIAM's cap (comparable to
+# how p2 was moved native in 649798e). No nginx edge runs for p3 anymore.
+#
+# The client CA is the same throwaway private CA k6 presents its client cert
+# against: profiles/certs/ca.crt, already mounted read-only at /certs by the
+# native-tls overlay. k6 sends its client cert via tlsAuth (BENCH_CLIENT_CERT/
+# KEY from profiles/p3-mtls.env); the server requires + verifies it.
+services:
+  axiam-server:
+    environment:
+      # Require a client certificate, verified against the mounted CA bundle.
+      AXIAM__SERVER__TLS__CLIENT_AUTH: "required"
+      AXIAM__SERVER__TLS__CLIENT_CA_PATH: /certs/ca.crt

--- a/benchmarks/targets/axiam/docker-compose.native-tls.yml
+++ b/benchmarks/targets/axiam/docker-compose.native-tls.yml
@@ -11,6 +11,17 @@
 #
 # Because the rustls listener is TLS-only (no plaintext side port), seeding also
 # goes over https — `just bench-seed` handles that (curl -k).
+#
+# D2 (native gRPC TLS): the tonic gRPC server (crates/axiam-api-grpc/src/server.rs)
+# independently supports in-process TLS via ServerTlsConfig, env-gated on
+# AXIAM__GRPC_TLS_CERT_PATH/AXIAM__GRPC_TLS_KEY_PATH (REQ-15 AC-1 / CQ-B20;
+# unrelated to this file's REST AXIAM__SERVER__TLS__* keys — separate listener,
+# separate config surface). Reuses the SAME throwaway server cert/key already
+# mounted at /certs for the REST listener, so p2 exercises AXIAM's real TLS
+# stack on both protocols instead of leaving gRPC an internally-inconsistent
+# plaintext outlier. profiles/p2-tls13.env sets BENCH_GRPC_PLAINTEXT=false so
+# the k6 gRPC scenarios (authz_check_grpc.js / authz_batch_grpc.js) dial with
+# TLS to match. Default (this var unset) stays plaintext for every other profile.
 services:
   axiam-server:
     environment:
@@ -27,6 +38,9 @@ services:
       # cell uses the nginx tls13-h1.conf edge instead (see that file). The
       # newer published image reads this key; older images ignore it harmlessly.
       AXIAM__SERVER__TLS__HTTP2: "${BENCH_AXIAM_TLS_HTTP2:-true}"
+      # D2: native gRPC TLS termination on :50051, same cert/key as REST above.
+      AXIAM__GRPC_TLS_CERT_PATH: /certs/server.crt
+      AXIAM__GRPC_TLS_KEY_PATH: /certs/server.key
     volumes:
       - ../../profiles/certs:/certs:ro
     # Publish the server's now-TLS port as the TLS host port (default 8443). The

--- a/benchmarks/targets/axiam/docker-compose.native-tls.yml
+++ b/benchmarks/targets/axiam/docker-compose.native-tls.yml
@@ -20,6 +20,13 @@ services:
       AXIAM__SERVER__TLS__ENABLED: "true"
       AXIAM__SERVER__TLS__CERT_PATH: /certs/server.crt
       AXIAM__SERVER__TLS__KEY_PATH: /certs/server.key
+      # B2: ALPN h2 toggle. Default "true" keeps the backward-compatible
+      # h2+http/1.1 offer. Set "false" to build the rustls config advertising
+      # http/1.1 only. NOTE: on the actix-web rustls bind this is an intent
+      # signal only — actix re-adds h2 to ALPN, so a *true* http/1.1-only p2
+      # cell uses the nginx tls13-h1.conf edge instead (see that file). The
+      # newer published image reads this key; older images ignore it harmlessly.
+      AXIAM__SERVER__TLS__HTTP2: "${BENCH_AXIAM_TLS_HTTP2:-true}"
     volumes:
       - ../../profiles/certs:/certs:ro
     # Publish the server's now-TLS port as the TLS host port (default 8443). The

--- a/benchmarks/targets/axiam/docker-compose.yml
+++ b/benchmarks/targets/axiam/docker-compose.yml
@@ -56,6 +56,13 @@ services:
       AXIAM__GDPR_PSEUDONYM_PEPPER: "${AXIAM__GDPR_PSEUDONYM_PEPPER:?run via 'just bench-up'}"
       AXIAM__AUTH__PEPPER: "${AXIAM__AUTH__PEPPER:-}"
       AXIAM__AUTH__OAUTH2_ISSUER_URL: "${AXIAM__AUTH__OAUTH2_ISSUER_URL:-}"
+      # --- Argon2id hash gate (B1) ------------------------------------------------
+      # Bounds concurrent Argon2id hash/verify ops (each ~19 MiB arena) to cap peak
+      # RSS and shed load past capacity, closing an unauthenticated memory-DoS on the
+      # login path. Pass-through-or-default so a plain `docker compose up` still runs.
+      # 0 = auto → min(cores, 4). Set explicitly to exercise a specific value under load.
+      AXIAM__AUTH__MAX_CONCURRENT_HASHES: "${AXIAM__AUTH__MAX_CONCURRENT_HASHES:-0}"
+      AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS: "${AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS:-5}"
       AXIAM__SERVER__HOST: "0.0.0.0"
       AXIAM__GRPC__HOST: "0.0.0.0"
       # First-run bootstrap gate (D-03a): satisfies the fail-closed admin gate so

--- a/benchmarks/targets/axiam/tls/tls13-h1.conf
+++ b/benchmarks/targets/axiam/tls/tls13-h1.conf
@@ -1,0 +1,30 @@
+# p2-tls13 h2-isolation variant (B2): TLS 1.3 only, server-auth, HTTP/1.1 only.
+#
+# Identical to tls13.conf but WITHOUT `http2 on;`, so the edge negotiates
+# `http/1.1` over ALPN. Use this to run the p2 token-endpoint cells
+# apples-to-apples with the plaintext p0 listener (also HTTP/1.1) and isolate
+# the h2-vs-h1.1 throughput effect measured in the 2026-07-19 run
+# (client_credentials -55%, refresh -58%). Select it with:
+#
+#     just target=axiam profile=p2-tls13 BENCH_NGINX_CONF=tls13-h1.conf bench-up
+#
+# (i.e. the non-native nginx-fronted p2 path — NOT the native-tls overlay).
+# Confirm the effect via k6's `http_version` tag: this cell reports "1.1",
+# the native/h2 cell reports "2".
+server {
+    listen 8443 ssl;
+    server_name localhost;
+    # http2 intentionally omitted -> HTTP/1.1 only over TLS 1.3.
+
+    ssl_certificate     /certs/server.crt;
+    ssl_certificate_key /certs/server.key;
+    ssl_protocols TLSv1.3;
+
+    location / {
+        proxy_pass http://axiam-server:8090;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}

--- a/benchmarks/targets/keycloak/docker-compose.yml
+++ b/benchmarks/targets/keycloak/docker-compose.yml
@@ -91,6 +91,19 @@ services:
     container_name: bench-keycloak-postgres
     cpus: ${BENCH_DB_CPUS:-2}
     mem_limit: ${BENCH_DB_MEM:-1024m}
+    # Minimal, uniform tuning applied identically to Zitadel's postgres (C2) —
+    # sized for the standard 1 GiB cap, not a durability change (see the
+    # durability-parity note in docs/methodology.md §7). Defaults left
+    # otherwise stock so the comparison stays "same DB, sane settings", not
+    # "tuned for AXIAM's benefit".
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=256MB"
+      - "-c"
+      - "effective_cache_size=512MB"
+      - "-c"
+      - "max_connections=200"
     environment:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak

--- a/benchmarks/targets/zitadel/docker-compose.yml
+++ b/benchmarks/targets/zitadel/docker-compose.yml
@@ -89,6 +89,19 @@ services:
     container_name: bench-zitadel-postgres
     cpus: ${BENCH_DB_CPUS:-2}
     mem_limit: ${BENCH_DB_MEM:-1024m}
+    # Minimal, uniform tuning applied identically to Keycloak's postgres (C2) —
+    # sized for the standard 1 GiB cap, not a durability change (see the
+    # durability-parity note in docs/methodology.md §7). Defaults left
+    # otherwise stock so the comparison stays "same DB, sane settings", not
+    # "tuned for AXIAM's benefit".
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=256MB"
+      - "-c"
+      - "effective_cache_size=512MB"
+      - "-c"
+      - "max_connections=200"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/claude_dev/benchmark-improvement-plan.md
+++ b/claude_dev/benchmark-improvement-plan.md
@@ -611,3 +611,61 @@ everything in Phase A and C, B3, D2, D4, D5, D8, D9, E1, E4 (well-specified
 edits with acceptance criteria above). Every Opus task should end by
 recording its findings in `claude_dev/` so the next agent inherits the
 evidence, not just the diff.
+
+---
+
+## Implementation status (updated 2026-07-19)
+
+Implemented on branch `claude/benchmark-improvement-plan-9yxx7g`. **Every task
+was implemented with the model the plan assigns to it** (Opus tasks via Opus
+agents, Sonnet tasks via Sonnet agents). All code compiles and all unit/
+integration tests written for these changes pass in the dev sandbox.
+
+**One environment caveat governs the whole table:** the sandbox is **not** the
+benchmark laptop — it has `cargo`/`docker`/`node`/`python` but **no `k6` and no
+live target stacks**. So acceptance criteria that are a *measured benchmark
+number* (throughput/RSS/p95/latency-signature) are implemented and unit-tested
+here but their **measured confirmation is done by the maintainer's laptop
+re-run** — marked "⏳ pending re-run" below. No benchmark number was fabricated.
+
+Legend: ✅ done & verified in-sandbox · ⏳ code done, measured acceptance pending
+the laptop re-run · ⛔ blocked on external resources (documented).
+
+| Task | Model | Status | Notes |
+|------|-------|--------|-------|
+| A1 userinfo scenario fix | Sonnet | ✅ | `mintUserToken` (login-first), KC `scope=openid`; smoke-run ⏳ |
+| A2 seed hardening + smoke checks | Sonnet | ✅ | fail-closed provisioning, `seed.ok` gate |
+| A3 fallback tagging | Sonnet | ✅ | `bench_fallback` counter; report excludes fallback cells |
+| A4 complete `meta.json` | Sonnet | ✅ | image+digest, sha256, governor, k6 cores, etc. |
+| A5 `report.py` improvements | Sonnet | ✅ | p50, blank invalid cells, bottleneck column, server-only efficiency |
+| A6 host telemetry (mhz/temp/k6) | Sonnet | ✅ | `host-sampler.sh` + clock/gen-saturation flags |
+| A7 secrets out of results | Sonnet | ✅ | `.seed/` relocation, `just bench-pack` |
+| B1 bound Argon2id concurrency | Opus | ✅ / ⏳ | configurable semaphore + acquire-timeout backpressure; RSS/p95 ⏳ |
+| B2 TLS 1.3 throughput fix | Opus | ✅ / ⏳ | root-caused h2-vs-h1 ALPN; resumption+ticketer, HTTP2 knob, 0-RTT declined; ±15% ⏳ |
+| B3 JWKS caching + headers | Sonnet | ✅ / ⏳ | in-proc cache, ETag/304, Cache-Control; curl-loop ⏳ |
+| C1 median-of-N runs | Sonnet | ✅ | `repeat`, run-*/ aggregation, ±% spread |
+| C2 DB sensitivity + fair pg tuning | Sonnet | ✅ | `dbcaps=uncapped`, uniform pg flags; durability parity flagged unverified |
+| C3 laptop variance runbook | Sonnet | ✅ | governor warn + `BENCH_CELL_PAUSE`, docs |
+| C4 prod rate-limit posture | Sonnet | ✅ | non-comparable section; posture-mix guard verified |
+| D1 authz batch coalescing | Opus | ✅ / ⏳ | same-subject coalescing (REST+gRPC) + tracing + round-trip test; cell re-run ⏳ |
+| D2 gRPC TLS termination | Sonnet | ✅ / ⏳ | bench wiring (server support pre-existed); live p2 ⏳ |
+| D3 native mTLS | Opus | ✅ / ⏳ | client-auth verifier + verified-cert via `on_connect`; in-proc handshake tests pass; full p3 no-nginx run ⏳ |
+| D4 Zitadel gRPC coverage | Sonnet | ✅ / ⏳ | vendored proto + `GetMyUser` scenario; live round-trip ⏳ |
+| D5 real Zitadel login (session API) | Sonnet | ✅ / ⏳ | `/v2/sessions` password check; shapes confirmed on live Zitadel ⏳ |
+| D6 SurrealDB tuning investigation | Opus | ✅ / ⏳ | static query-pattern + pool analysis (report exists); quantified runtime findings need uncapped-DB data ⏳ |
+| D7 authz decision cache | Opus | ✅ / ⏳ | flagged (default off), event-driven invalidation; revocation proven in tests; throughput ⏳ |
+| D8 rate-limiter key config | Sonnet | ✅ | `ip\|client_id\|ip_client_id`; login stays per-IP; tests pass |
+| D9 allocator experiment | Sonnet | ✅ / ⏳ | opt-in `jemalloc` feature + experiment note; RSS A/B ⏳ |
+| E2 AMQP async-authz harness | Opus | ✅ | design doc landed (`claude_dev/`); build-out deferred per plan |
+| E1.1 validate 7 SDK benches | Sonnet | ⛔ | needs sibling `axiam-<lang>-sdk` checkouts + a live seeded target + per-language toolchains — absent in this container |
+| E1.2 implement 4 stub benches | Sonnet | ⛔ | plan's own guardrail: stop-and-report when the SDK isn't usable; SDK repos not present |
+| E1.3 cross-SDK run + report table | Sonnet | ⛔ | depends on E1.1 |
+| E3 server-class hardware re-run | — | ⛔ | blocked on hardware/budget (explicitly out of scope in the plan) |
+| E4 public doc refresh | Sonnet | ⛔ | needs the fresh median-of-3 numbers from the laptop re-run |
+
+**Summary:** Phases **A, B, C, D fully implemented** (23/23 tasks) + **E2**.
+The remaining Phase E items (E1.\*, E3, E4) are blocked on resources this
+sandbox cannot provide (live target, sibling SDK repos + toolchains, server-
+class hardware, fresh re-run numbers) and are the natural follow-ups after the
+maintainer's re-run. Measured-number acceptance across A–D is validated by that
+re-run; every logic/security change is already covered by passing tests here.

--- a/claude_dev/memory-retention-experiment.md
+++ b/claude_dev/memory-retention-experiment.md
@@ -1,0 +1,246 @@
+# D9 — Memory-Retention Allocator Experiment
+
+Status: **implementation landed (opt-in, default-off); measurement PENDING
+laptop hardware.** This note documents the hypothesis, the reproduction
+procedure, the A/B method, and the decay-tuning rationale so the maintainer
+(or a future agent) can run the actual comparison and fill in numbers without
+re-deriving the plan.
+
+Related: [`benchmark-improvement-plan.md`](benchmark-improvement-plan.md) §D9.
+Depends conceptually on B1 (`crates/axiam-auth` Argon2 concurrency semaphore,
+already landed) — B1 caps the concurrent-hashing **peak**; this task is about
+the **retention** after the peak subsides.
+
+## 1. Hypothesis
+
+Evidence from the first benchmark run: server RSS never returns to baseline
+after a login burst.
+
+- Baseline (idle, post-boot): ~93 MiB RSS
+- Post-burst steady state (observed, did not decay over the observation
+  window): ~646 MiB RSS
+
+This is consistent with a well-known glibc `malloc` behavior: freed large
+allocations from a burst of concurrent work (here, Argon2id hashing arenas —
+~19 MiB each, per B1's analysis) get returned to glibc's internal free lists
+per-arena, but the **arenas themselves are not unmapped / `madvise`d back to
+the OS** unless a full arena happens to be entirely free and glibc's trimming
+heuristics decide to release it. Under bursty, multi-threaded load (many
+threads each getting their own arena via `spawn_blocking`'s blocking pool),
+this is a known pathological case for glibc's allocator — high peak
+concurrency permanently inflates the number of live arenas even after load
+drops back to near-zero.
+
+**Hypothesis:** replacing the global allocator with jemalloc — which
+purges freed "dirty" pages back to the OS on a decay timer rather than
+relying on glibc's arena-trim heuristics — will make retained RSS after a
+burst converge back toward baseline within the decay window, with no
+material throughput cost.
+
+**Null hypothesis / alternative explanation to rule out:** the retention
+could instead (or additionally) be caused by growth in long-lived
+server-owned structures that scale with request volume (e.g. the D7 authz
+decision cache if enabled, the B3 JWKS response cache, connection pool
+buffers, or SurrealDB client-side buffering) rather than allocator
+fragmentation. The A/B test below is designed to distinguish these: if
+retained RSS is nearly identical between the default allocator and jemalloc,
+the leak/growth is in-process (a real bug to chase, not an allocator
+artifact); if jemalloc's retained RSS is materially lower, the glibc-arena
+hypothesis is confirmed and the fix is legitimate.
+
+## 2. What's implemented (this task's deliverable)
+
+Because this sandbox cannot run the server or the bench stack (no live
+process, and the full `axiam-server` release binary link risks OOMing the
+container), the actual RSS measurement is **not done here**. What ships
+instead:
+
+1. **`crates/axiam-server/Cargo.toml`** — `tikv-jemallocator = { version =
+   "0.7", optional = true }` as an optional dependency, plus a `jemalloc`
+   Cargo feature (`jemalloc = ["dep:tikv-jemallocator"]`). **Not** part of
+   `default = ["saml"]` — a default build (`cargo build -p axiam-server`,
+   and therefore every existing CI/Docker build) pulls in and links exactly
+   what it did before this change. `tikv-jemallocator` 0.7.0 was the current
+   crates.io release at the time of writing and resolved cleanly against the
+   workspace's `edition = "2024"` / `rust-version = "1.93"` toolchain
+   (verified via `cargo check`, see §5).
+2. **`crates/axiam-server/src/main.rs`** — behind `#[cfg(feature =
+   "jemalloc")]`:
+   ```rust
+   #[global_allocator]
+   static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+   ```
+   With the feature off (default), this line does not exist in the compiled
+   binary at all — zero behavior change, zero new transitive dependency in
+   the default dependency graph or lockfile resolution used by a default
+   build.
+3. This note.
+
+No changes were made to `docker/Dockerfile.server` or the bench compose
+files: the plan explicitly allows documenting the invocation instead of
+wiring a build variant "only if it's clean," and doing so untested (this
+sandbox cannot build/link the release binary) would risk landing an unverified
+Docker/compose change. The exact commands to build and run the jemalloc
+variant are below (§4) — wiring them into `docker-compose.yml` as a labeled,
+opt-in override is a small follow-up once the laptop measurement confirms the
+allocator is worth shipping.
+
+## 3. Reproduction procedure (to run on the laptop)
+
+Uses the existing bench harness; no new tooling needed.
+
+```bash
+just target=axiam bench-up bench-seed      # bring up + seed the AXIAM target
+source benchmarks/.seed/axiam.seed.env      # or wherever A7 relocated it
+```
+
+1. **Record baseline RSS.** Let the server sit idle ~30s post-seed, then:
+   ```bash
+   docker stats --no-stream bench-axiam-server --format '{{.MemUsage}}'
+   ```
+   Expect ~90-100 MiB (matches the ~93 MiB baseline from the original run).
+2. **Drive the login burst.** Run the existing password-login scenario at the
+   same concurrency used in the original benchmark (50 VUs):
+   ```bash
+   k6 run benchmarks/scenarios/oauth2_password_login.js
+   ```
+3. **Watch RSS for 10 minutes post-burst.** Sample every 10-15s for at least
+   10 minutes after the k6 run exits:
+   ```bash
+   for i in $(seq 1 60); do
+     docker stats --no-stream bench-axiam-server --format '{{.MemUsage}}'
+     sleep 10
+   done
+   ```
+   Record the RSS trajectory: peak-during-burst, immediately-post-burst, and
+   the value at each subsequent minute out to 10 minutes. The original
+   evidence is that this value plateaus around ~646 MiB and does not
+   decay further — confirm this reproduces before attributing anything to
+   the allocator.
+
+## 4. A/B method
+
+Run the reproduction procedure (§3) twice — **same load, same seed data,
+same host state** (governor, AC power, background apps quiesced per the C3
+runbook) — once per binary variant:
+
+### Variant A — default (control)
+
+```bash
+just target=axiam build=1 bench-up   # forces a local image build
+# (or, without docker): 
+cargo build --release -p axiam-server
+```
+No feature flags. This is today's shipped behavior.
+
+### Variant B — jemalloc
+
+```bash
+cargo build --release -p axiam-server --features jemalloc
+```
+For a containerized A/B, add a temporary build-arg override to
+`docker/Dockerfile.server`'s final `cargo build --release -p axiam-server`
+line (`--features jemalloc`) or build the binary locally and mount it over
+the image's `/usr/local/bin/axiam-server` — either is fine for a one-off
+laptop comparison; don't commit either hack without re-verifying it against
+a real Docker build first.
+
+### What to compare
+
+- **Retained RSS**: steady-state `docker stats` RSS at the 10-minute mark
+  post-burst, variant B vs variant A. This is the primary metric — jemalloc
+  is "worth it" only if this drops materially (propose a threshold of ≥30%
+  reduction toward baseline, i.e. closing at least 30% of the ~550 MiB gap
+  between the ~93 MiB baseline and the ~646 MiB plateau).
+- **Throughput / latency, no regression check**: rerun
+  `oauth2_password_login`'s req/s and p50/p95 under variant B and confirm it
+  is within noise (~±5%, consistent with the plan's other A/B acceptance
+  bars) of variant A. jemalloc swapping the global allocator can move
+  allocation-heavy hot-path latency in either direction; a retention win that
+  costs throughput is not an unambiguous win and should be reported as a
+  trade-off, not a straightforward fix.
+- Record both variants' `meta.json`/`res.csv` under separate result dirs
+  (e.g. `results/d9-jemalloc-off/`, `results/d9-jemalloc-on/`) so the
+  comparison is reproducible and reviewable, mirroring the existing bench
+  result layout.
+
+## 5. Decay tuning
+
+jemalloc's default behavior already purges freed "dirty" pages back to the
+OS via `madvise(MADV_DONTNEED)`/`MADV_FREE` on a **decay timer** (default:
+dirty pages decay over ~10s, "muzzy" pages — a middle state between dirty and
+fully purged — over another ~10s), rather than glibc's arena-trim
+heuristics. This alone should improve on the retention baseline. Whether to
+tune the decay times *more aggressively* than the default is an orthogonal
+knob, controlled entirely at **runtime via environment variable** — not
+hardcoded in `main.rs` — so it can be tuned per-deployment without a
+rebuild:
+
+```bash
+# tikv-jemallocator reads _RJEM_MALLOC_CONF first, falling back to
+# MALLOC_CONF if unset (the "_RJEM_" prefix avoids colliding with a
+# system glibc/other-jemalloc build that also honors MALLOC_CONF).
+export _RJEM_MALLOC_CONF="dirty_decay_ms:1000,muzzy_decay_ms:0"
+# or, if only one jemalloc is in play on the host:
+export MALLOC_CONF="dirty_decay_ms:1000,muzzy_decay_ms:0"
+```
+
+Rationale for the specific example values (not committed as a default —
+illustrative only, to be validated against the A/B data):
+
+- `dirty_decay_ms:1000` — purge freed-but-still-mapped ("dirty") pages back
+  to the OS ~1s after they go idle, instead of jemalloc's default ~10s. For
+  a bursty workload (login spikes, then quiet), a short decay converts idle
+  memory back into free OS pages quickly, which is exactly the behavior the
+  retention bug needs.
+- `muzzy_decay_ms:0` — skip the intermediate "muzzy" state entirely (pages
+  go straight from dirty to fully purged); muzzy exists as a cheaper
+  halfway point for allocator-churn-heavy workloads that will likely reuse
+  the memory soon, which is not this workload's profile during the 10-minute
+  post-burst observation window.
+
+**Caution:** more aggressive decay trades retained-RSS improvement for more
+frequent `madvise` syscalls and potential page-fault cost on the *next*
+burst (pages have to be faulted back in / re-zeroed). This is exactly what
+the throughput side of the A/B comparison (§4) is meant to catch — if p95
+regresses under variant B with aggressive decay, try the jemalloc defaults
+(no `MALLOC_CONF` override) before concluding jemalloc doesn't help.
+
+`tikv-jemallocator` also exposes a `stats` Cargo feature (not enabled here)
+that adds `jemalloc_ctl`-based introspection (`stats.resident`,
+`stats.retained`, arena counts) if finer-grained diagnosis is needed beyond
+`docker stats`' whole-process RSS — worth enabling temporarily during the
+laptop investigation if the plain RSS numbers are ambiguous, but not proposed
+as a permanent addition.
+
+## 6. Conclusion
+
+**Measurement PENDING laptop.** This sandbox has no live server process and
+no bench stack, so no RSS numbers exist yet for either variant. What *is*
+verified here:
+
+- The `jemalloc` feature compiles cleanly, both with and without itself
+  enabled (`cargo check -p axiam-server` and `cargo check -p axiam-server
+  --features jemalloc` both pass — see the PR/task report for the exact
+  output).
+- The feature is **strictly opt-in and default-off**: `default = ["saml"]`
+  in `crates/axiam-server/Cargo.toml` does not include `jemalloc`, so every
+  existing build path (CI, `docker/Dockerfile.server`, `just build`, the
+  bench compose's image build) is byte-for-byte unaffected — no new
+  dependency is even downloaded, let alone linked, unless someone explicitly
+  passes `--features jemalloc`.
+
+Because the change is default-off and additive, **it is safe to land
+un-measured**: it carries zero risk to the shipped binary, and gives the
+maintainer a zero-setup way to run the A/B in §4 on the laptop whenever
+convenient. Once that data exists, this section should be replaced with:
+
+- The actual retained-RSS numbers (baseline / variant A plateau / variant B
+  plateau) and the throughput comparison, and
+- Either (a) a follow-up PR proposing `jemalloc` become part of `default`
+  (with the chosen `MALLOC_CONF`, if any, documented in the deploy configs —
+  `docker/docker-compose.prod.yml` / k8s manifests — as an `environment:`
+  entry, never hardcoded in source), or (b) a documented negative result
+  ("jemalloc did not materially reduce retained RSS on this workload;
+  closing D9") if the hypothesis doesn't pan out, per the plan's acceptance
+  criteria ("a PR or a documented 'not worth it'").

--- a/claude_dev/surrealdb-tuning-report.md
+++ b/claude_dev/surrealdb-tuning-report.md
@@ -251,3 +251,132 @@ No timing assertion was added, on purpose.
   authz_batch_rest/grpc) before/after, and reading the new trace to confirm
   the 15→3 round-trip drop and to chase the single-check p99 tail toward the
   H1/D6 connection fix.
+
+---
+
+## 8. D7 — Authorization decision cache (design + implemented behind a flag)
+
+D7 builds *on top of* D1 (round-trip coalescing) and D6 (this report): D1
+removed the redundant per-item queries in a batch, and this report established
+that the authz wall is the shared-connection serialization, not CPU. The
+decision cache attacks the remaining cost — the DB round-trips themselves — by
+memoizing decisions so a repeated check does **zero** DB work. It is
+feature-flagged and **defaults off**, so it changes nothing until an operator
+opts in.
+
+### 8.1 What is cached and where
+
+- **Module:** `crates/axiam-authz/src/decision_cache.rs` (`DecisionCache`,
+  `DecisionCacheConfig`).
+- **Key:** `(tenant_id, subject, resource, action, scope)`. Organised as
+  per-tenant shards under one mutex, so a per-tenant flush is O(1) (drop the
+  shard) and one tenant's churn can't evict another's entries.
+- **Value:** the **full** `AccessDecision` — `Allow`, or `Deny(reason)` with the
+  exact deny string — plus an `Instant` stamp. A hit is therefore byte-identical
+  to a miss (allow and deny alike; deny reasons preserved verbatim).
+- **Eviction:** TTL on read (expired entry is dropped and treated as a miss) +
+  a per-tenant FIFO size cap (`max_entries_per_tenant`).
+
+### 8.2 Engine integration (zero-cost when off)
+
+`AuthorizationEngine` gained an `Option<Arc<DecisionCache>>` field, `None` by
+default. `new(..)` is unchanged (all existing call sites, tests, benches
+untouched); a builder `with_decision_cache(Arc<DecisionCache>)` attaches one.
+
+- `check_access`: consult cache → on hit return; on miss run the *unchanged*
+  `evaluate` body, then insert. The evaluation logic was moved verbatim into a
+  private `evaluate`, so a hit returns exactly what a miss would.
+- `check_access_batch`: when no cache is attached it calls the D1 coalesced
+  `evaluate_batch` directly — **byte-for-byte the current behaviour**. When a
+  cache is attached, it serves per-item hits from the cache and evaluates only
+  the misses through the same coalesced path, preserving input order.
+
+`axiam-server` builds **one** shared `Arc<DecisionCache>` (via
+`AuthzConfig::build_decision_cache`, `None` unless enabled) and clones it into
+the REST, gRPC and AMQP engines, so an invalidation triggered by a REST mutation
+is observed on every read path.
+
+### 8.3 Invalidation — the security-critical half
+
+AXIAM's RBAC is additive allow-wins / default-deny, so the only dangerous
+staleness is a **stale allow surviving a revocation**. Invalidation is wired
+into the REST mutation handlers through two new `AuthzChecker` trait methods
+(`invalidate_tenant`, `invalidate_subject`; default no-ops, forwarded to the
+cache by the engine impl). Granularity, and why no revocation can leave a stale
+allow:
+
+| Mutation path (REST handler) | Invalidation | Why it's safe |
+| --- | --- | --- |
+| `roles::unassign_from_user` | `invalidate_subject(t, user)` | Only that subject's roles change. |
+| `groups::remove_member` | `invalidate_subject(t, user)` | Only that subject's inherited roles change. |
+| `roles::assign_to_user`, `groups::add_member` | `invalidate_subject(t, user)` | Widening (safe direction); flushed for prompt visibility. |
+| `roles::unassign_from_group` | `invalidate_tenant(t)` | Affects every group member — set unknown without a query → flush. |
+| `permissions::revoke_from_role` | `invalidate_tenant(t)` | Affects every subject holding the role → flush. |
+| `roles::delete`, `roles::update` | `invalidate_tenant(t)` | Role removal / `is_global` change can narrow access for an unknown subject set → flush. |
+| `permissions::delete`, `permissions::update` | `invalidate_tenant(t)` | Permission removal / `action` change narrows access → flush. |
+| `permissions::grant_to_role`, `roles::assign_to_group` | `invalidate_tenant(t)` | Widening; flushed for prompt visibility. |
+| `resources::update`, `resources::delete` | `invalidate_tenant(t)` | Re-parent/delete changes which ancestor-scoped roles cascade → can narrow → flush. |
+| `scopes::update`, `scopes::delete` | `invalidate_tenant(t)` | Decisions are cached by scope *name*; rename/delete narrows scoped access → flush. |
+| `groups::delete` | `invalidate_tenant(t)` | Drops inherited roles for all members → flush. |
+
+Targeted subject invalidation is used only where exactly one subject is
+provably affected; every other (coarse) mutation uses a per-tenant flush. A
+flush is always sound — it cannot leave *any* stale entry for the tenant. The
+invalidation happens **in the same request that performs the mutation, before
+its response returns.**
+
+### 8.4 Bounded-staleness trade-off (documented explicitly)
+
+The TTL (default 5 s) is a *backstop*, not the primary safety mechanism. Even if
+an invalidation event were missed (a bug, or an out-of-band write straight to
+SurrealDB that bypasses the handlers), a stale allow self-heals within
+`AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` when the entry expires and is
+re-evaluated. So worst-case revocation latency ≤ TTL, always.
+
+### 8.5 Config keys (all default to the no-op / off state)
+
+- `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` — default **`false`**.
+- `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` — default `5`.
+- `AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES` — default `10000` (per tenant).
+
+Documented for operators in `docs/admin/README.md` and
+`docs/deployment/README.md`.
+
+### 8.6 Tests (sandbox — logic + invalidation correctness)
+
+- `src/decision_cache.rs` unit tests: hit==insert, deny-reason preserved
+  verbatim, action/scope key distinctness, TTL expiry, targeted-subject vs
+  whole-tenant invalidation, per-tenant FIFO cap, re-insert doesn't double-grow.
+- `src/config.rs`: defaults are off/conservative; `build_decision_cache`
+  returns `None` when disabled / `Some` when enabled; overrides deserialize.
+- `tests/decision_cache_integration_test.rs` (8 engine-level tests via mutable
+  counting mock repos):
+  - cache hit == miss for allow **and** deny, and the hit issues **no** DB
+    round-trips (counter proof);
+  - TTL expiry forces re-evaluation (DB queried again);
+  - **`revocation_invalidation_denies_immediately`** — grant → check (allow,
+    cached) → revoke via the mutation path (store change +
+    `invalidate_subject`, exactly what `unassign_from_user`/`remove_member`
+    call) → next check denies **immediately**, under a 60 s TTL, proving
+    event-driven (not TTL-driven) enforcement;
+  - a control (`without_invalidation_stale_allow_persists_until_ttl`) that
+    isolates invalidation as the mechanism — with the store changed but the
+    hook skipped, the cache does serve a stale allow within the TTL;
+  - `tenant_flush_enforces_revocation_immediately` (the coarse path);
+  - **feature-flag-off** path: every check hits the DB, decisions unchanged,
+    invalidation calls are harmless no-ops;
+  - the batch path caches and invalidates identically.
+
+### 8.7 Acceptance status
+
+- Code + unit/integration tests: **complete** in the sandbox.
+  `cargo test -p axiam-authz --lib` (config + cache unit tests) and
+  `--test decision_cache_integration_test` pass; `axiam-authz` and
+  `axiam-api-rest` (lib) build clean; `cargo fmt`/`clippy` clean for
+  `axiam-authz`.
+- **Pending laptop re-run (throughput acceptance):** "authz_check_rest/grpc
+  throughput materially increases with SurrealDB no longer pegged" requires the
+  benchmark laptop and is out of scope for the CI sandbox (no live SurrealDB).
+  The security-critical half — immediate revocation enforcement via
+  invalidation — **is** proven here by the integration tests above. Enable with
+  `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true` for the before/after cells.

--- a/claude_dev/surrealdb-tuning-report.md
+++ b/claude_dev/surrealdb-tuning-report.md
@@ -1,0 +1,122 @@
+# SurrealDB Tuning & Connection-Pool Investigation (D6)
+
+**Status:** PRELIMINARY — static source analysis complete; runtime profiling
+(query traces, pool wait-time, uncapped-DB delta, engine-mode sensitivity)
+is **pending a live run on the benchmark laptop** and must be filled in
+after D1's tracing lands and C2's uncapped-DB pass is available. Numbers are
+deliberately absent where they would require a measured run — do not treat
+any figure here as measured until this banner is removed.
+
+This document is the D6 deliverable required by
+`claude_dev/benchmark-improvement-plan.md`. It records what can be
+established from the code alone, states the leading hypothesis, and lists the
+exact runtime measurements needed to confirm or refute it.
+
+## 1. Connection architecture (established from source)
+
+`crates/axiam-db/src/connection.rs`:
+
+- AXIAM talks to SurrealDB over the **stateless HTTP engine**
+  (`surrealdb::engine::remote::http`), not the WebSocket engine. The choice is
+  deliberate (SDK issue #5750: Ws reconnect silently drops `use_ns`/`use_db`).
+- There is **no connection pool**. `DbManager` holds a single
+  `Arc<RwLock<Surreal<Client>>>`. Each of the ~30 repositories is handed a
+  `client_cloned()` handle at composition time. Cloning a `Surreal<Client>`
+  is cheap and **shares the same underlying connection lineage/router** — it
+  does not open an independent connection.
+- Consequence: every concurrent request in the process (all authz checks,
+  token introspections, refreshes, logins) is routed through **one** shared
+  SurrealDB client handle.
+
+## 2. Authz hot-path query pattern (established from source)
+
+`crates/axiam-authz/src/engine.rs::check_access` issues, per single check,
+these **sequential** awaited DB operations:
+
+1. `role_repo.get_user_role_assignments(tenant, subject)` — round-trip 1
+2. `resource_repo.get_ancestors(tenant, resource)` — round-trip 2
+3. *(only when a scope is requested)* `scope_repo.list_by_resource(...)` — round-trip 3
+4. `permission_repo.get_role_permission_grants_for_roles(tenant, role_ids)` —
+   round-trip 4 (already batched across roles — CQ-B13 N+1 fix; good)
+
+So a single check is **3–4 serial HTTP round-trips** over the shared
+connection. The REST/gRPC batch handler
+(`axiam-api-rest::handlers::authz_check::batch_check_access`) already runs
+items concurrently via `buffer_unordered(batch_max_concurrency)` — so a
+5-item batch fans out to as many as **~20 round-trips** that all contend for
+the **one** shared client handle.
+
+## 3. Leading hypothesis
+
+The benchmark evidence (batch-of-5 delivers *fewer* checks/s than single
+calls; server idles at 0.07–0.11 cores while SurrealDB sits at ~1.2–2 cores
+"waiting, not computing"; single-check gRPC p99 850 ms vs p95 173 ms) is
+consistent with **serialization at the shared client handle / SurrealDB HTTP
+router**, not with CPU-bound evaluation. Two independent contributors:
+
+- **H1 — connection/router serialization.** If the SDK router or the single
+  HTTP keep-alive connection serializes in-flight queries, concurrency at the
+  `buffer_unordered` layer cannot translate into concurrent DB work. This
+  would make batching *lose* to single calls (batch adds coordination
+  overhead but cannot parallelize the DB).
+- **H2 — redundant per-item queries in a batch.** Every item in the bench's
+  batch shares the **same subject** (and usually the same resource), so
+  round-trip 1 (`get_user_role_assignments`) and round-trip 2
+  (`get_ancestors`) are **identical** across all 5 items and are being
+  executed 5×. Coalescing same-subject/same-resource items into one set of
+  lookups (the D1 fast path) removes ~80% of the round-trips for this shape.
+
+H1 and H2 are additive: fix H2 (fewer round-trips) and H1 (parallelize the
+remaining ones) together.
+
+## 4. Measurements required to confirm (pending laptop run)
+
+Wire these before drawing conclusions — this is the D1/D6 instrumentation
+step and cannot be done in the CI sandbox (no live stack):
+
+1. **Query trace.** Run one 5-item batch against the bench stack with
+   `RUST_LOG=surrealdb=debug` (and per-item / per-query tracing spans added in
+   D1). Record: number of DB round-trips, whether they overlap in time or
+   serialize, and per-query latency.
+2. **Pool / connection wait-time.** Since there is no pool, instrument the
+   time each `check_access` spends between issuing a query and its first byte
+   of response under 50 VUs; a growing wait with flat CPU confirms H1.
+3. **Uncapped-DB delta (needs C2).** Re-run authz cells with
+   `dbcaps=uncapped` (BENCH_DB_CPUS=4 / BENCH_DB_MEM=2048). If throughput
+   barely moves while the server stays idle, the wall is the connection, not
+   DB capacity — pointing to a pool, not DB tuning.
+4. **Engine-mode sensitivity (labeled, respecting C2 durability parity).**
+   Compare SurrealKV-on-NVMe vs in-memory for the bench DB container as a
+   **sensitivity data point only** — never as the published headline, and
+   documented alongside the durability-parity caveat from methodology §9.
+
+## 5. Candidate changes (to be PR'd separately with before/after numbers)
+
+Do **not** land these until §4 confirms the hypothesis — each ships as its own
+PR carrying measured before/after authz-cell numbers, per the D6 acceptance
+criterion:
+
+- **CP-1: real connection pool.** Replace the single shared handle with a
+  small pool of N independent `Surreal<Client>` connections (round-robin or
+  checkout), sized to the authz concurrency (start N≈`batch_max_concurrency`
+  or a small multiple of CPUs). This is the direct fix for H1 if confirmed.
+  Must preserve the reconnect/re-signin machinery per-connection.
+- **CP-2: same-subject coalescing in the batch path (owned by D1).** Group
+  batch items by `(tenant, subject)` and resolve role assignments +
+  ancestors once per group. Belongs to D1; noted here for traceability.
+- **CP-3: DB container tuning.** Only if §4.3 shows DB capacity (not the
+  connection) is the wall.
+
+## 6. Interaction with other tasks
+
+- **D1** consumes §2/§3-H2 directly (the coalescing fast path) and shares the
+  tracing instrumentation from §4.1.
+- **D7 (decision cache)** must only be built *after* D1 + D6 remove the
+  fixable inefficiency — otherwise the cache would paper over a connection
+  bottleneck rather than a genuine evaluation cost.
+
+---
+
+*Prepared from static analysis of `axiam-db` and `axiam-authz` at branch
+`claude/benchmark-improvement-plan-9yxx7g`. Runtime sections to be completed
+after the laptop re-run with D1 tracing in place.*

--- a/claude_dev/surrealdb-tuning-report.md
+++ b/claude_dev/surrealdb-tuning-report.md
@@ -117,6 +117,137 @@ criterion:
 
 ---
 
-*Prepared from static analysis of `axiam-db` and `axiam-authz` at branch
-`claude/benchmark-improvement-plan-9yxx7g`. Runtime sections to be completed
-after the laptop re-run with D1 tracing in place.*
+## 7. D1 findings — batch-path coalescing landed (code complete; live cells pending)
+
+This section records the D1 work that consumes §2/§3-H2. It covers the code
+changes made to `axiam-authz`, `axiam-api-rest`, and `axiam-api-grpc`; the
+tracing added so the maintainer can read a single batch run on the laptop; and
+the round-trip reduction proven by a deterministic mock-repo test. The live
+"re-run the four authz cells" acceptance remains **pending a laptop re-run**
+(no live SurrealDB in the CI sandbox).
+
+### 7.1 Serialization point (confirmed from source; magnitude pending trace)
+
+The wall is the **single shared SurrealDB HTTP client handle** (§1): every
+concurrent authz check in the process funnels through one connection, so the
+pre-D1 batch handlers' `buffer_unordered` fan-out could not turn item-level
+concurrency into concurrent DB work — it only multiplied the number of
+serialized round-trips contending for that one handle. Fixing the connection
+serialization itself (H1) is D6/CP-1 (a real pool) and is deliberately out of
+D1 scope. D1 attacks the other half — H2, the **redundant per-item queries** —
+which is a pure round-trip-count reduction and needs no pool.
+
+### 7.2 What was coalesced (H2 fix)
+
+The bench's batch is 5 checks that all share one subject and (usually) one
+resource. Per the §2 query pattern, the pre-D1 path issued, per item:
+`get_user_role_assignments` (RT1), `get_ancestors` (RT2), optional
+`list_by_resource` (RT3), and the batched `get_role_permission_grants_for_roles`
+(RT4). For the 5-item same-subject/same-resource shape (no scope) that is
+**5 × 3 = 15 round-trips**, of which RT1 and RT2 were byte-for-byte identical
+across all five items.
+
+New `AuthorizationEngine::check_access_batch(&[AccessRequest])` groups the batch:
+
+- **RT1** resolved **once per `(tenant_id, subject_id)`** group.
+- **RT2** resolved **once per `(tenant_id, resource_id)`** group (only for
+  items whose subject actually has role assignments — so an early "no roles
+  assigned" deny walks no ancestors, exactly as single-check does).
+- **RT3** (scope list) resolved once per `(tenant_id, resource_id)` targeted by
+  a scoped, role-bearing item.
+- **RT4** the applicable role IDs across the *whole batch* are unioned and
+  de-duplicated, and grants are fetched in **one** batched query (per tenant).
+
+**Round-trip reduction for the bench shape (batch of 5, one subject, one
+resource, no scope): 15 → 3** — one `get_user_role_assignments`, one
+`get_ancestors`, one `get_role_permission_grants_for_roles`. That is the same
+3 round-trips a *single* check issues, so a batch of N same-subject/resource
+items costs the same DB round-trips as one check (the intended point of
+batching, which the bench showed was previously inverted).
+
+Exact input order, the `authz:check_as` subject-override gate + per-item audit
+(kept in the REST handler), the four deny reasons, and scope/wildcard handling
+are all preserved. The single-check and batch paths share two pure helpers
+(`applicable_role_ids`, `grants_allow`) plus `resolve_scope`, so their
+decision/deny-reason semantics cannot diverge.
+
+### 7.3 New engine method + how REST and gRPC share it
+
+- `axiam-authz::engine::AuthorizationEngine::check_access_batch` is the coalesced
+  path.
+- `axiam-api-rest`: the `AuthzChecker` trait gained a `check_access_batch`
+  method (default impl loops `check_access`; `AuthorizationEngine`'s impl
+  delegates to the coalesced method). `batch_check_access` now builds the
+  ordered `Vec<AccessRequest>` (running the check_as gate + per-item audit) and
+  issues **one** `checker.check_access_batch(&reqs)` call instead of a
+  `buffer_unordered` fan-out of per-item `check_access`.
+- `axiam-api-grpc`: `AuthorizationServiceImpl::batch_check_access` builds its
+  validated `access_requests` (unchanged identity cross-checks) and calls
+  `engine.check_access_batch(&access_requests)`. The old `buffer_unordered`
+  block and its `batch_max_concurrency` application are removed; the field is
+  retained on the struct (and in `new`) for config/call-site compatibility.
+
+Both API surfaces therefore share the exact same fast path.
+
+### 7.4 Single-check p99 tail
+
+No accidental extra round-trips exist on the single-check hot path: `check_access`
+issues RT1, RT2, optional RT3, RT4 and nothing else, and the refactor into
+shared helpers did not add any query. The p99 tail described in the plan
+(gRPC single-check p99 850 ms vs p95 173 ms) is therefore expected to be a
+property of the **shared-connection contention / SurrealKV compaction** (H1),
+not of the evaluation code — consistent with "server idle, DB waiting". The D1
+tracing (below) is what lets the maintainer confirm this on the laptop; the
+structural fix for H1 is D6/CP-1.
+
+### 7.5 Tracing added (read one batch on the laptop)
+
+`tracing` spans, matching the repo's macro style, now cover the authz path:
+
+- `authz.check_access` span (fields: tenant/subject/resource/action/scope) on the
+  single check, with a child `debug_span` per DB query
+  (`db.get_user_role_assignments`, `db.get_ancestors`, `db.list_by_resource`,
+  `db.get_role_permission_grants_for_roles`), attached via `tracing::Instrument`.
+- `authz.check_access_batch` span (field: `batch_size`) with the same per-query
+  child spans (carrying tenant/subject/resource fields), plus a per-item
+  `authz.batch.item` span (fields: `index`, `resource_id`, `action`).
+
+Running one bench batch with `RUST_LOG=axiam_authz=debug` (and
+`surrealdb=debug` per §4.1) will now show exactly how many DB spans a batch
+opens — the direct confirmation that a same-subject batch-of-5 emits 3 query
+spans, not 15 — and their timing/overlap.
+
+### 7.6 Test — round-trip count over wall-clock (and why)
+
+`crates/axiam-authz/tests/batch_coalescing_test.rs` uses **counting mock
+repositories** (each seam increments an `AtomicUsize`) rather than the real
+in-memory SurrealDB repos, so it can assert the *number* of round-trips
+directly:
+
+- `same_subject_batch_of_5_coalesces_round_trips`: the sequential per-item
+  baseline issues 5 role-assignment + 5 ancestor + 5 grant lookups; the batch
+  issues **1 + 1 + 1**, and the decisions are byte-identical and in order.
+- `distinct_groups_coalesce_per_group_and_preserve_order`: 2 subjects × 2
+  resources across 4 items → 2 role-assignment + 2 ancestor + 1 grant lookups
+  (not 4/4/4), order preserved with a deny in the middle, decisions match
+  per-item `check_access`.
+- `empty_subject_denies_without_extra_round_trips`: a no-roles subject denies
+  with the identical reason and walks **no** ancestors/grants.
+
+**Why round-trip counts, not a wall-clock ratio:** the plan's "batch < 3×
+single" is a latency target, but a timing assertion against sub-microsecond
+in-memory mocks is dominated by scheduler/allocator noise — it would flake or
+need a bound so loose it proves nothing. The round-trip *count* is the
+mechanism that produces the latency win and is exact and deterministic. Since
+each round-trip is one serialized call over the single shared connection on the
+real stack, 3 round-trips for a batch of 5 vs 3 for a single check is
+inherently sub-3×; the end-to-end ratio is confirmed on the laptop (pending).
+No timing assertion was added, on purpose.
+
+### 7.7 Acceptance status
+
+- Code + tests: complete, run against mock/in-memory repos in the sandbox.
+- **Pending laptop re-run:** the four authz cells (authz_check_rest/grpc,
+  authz_batch_rest/grpc) before/after, and reading the new trace to confirm
+  the 15→3 round-trip drop and to chase the single-check p99 tail toward the
+  H1/D6 connection fix.

--- a/crates/axiam-api-grpc/src/config.rs
+++ b/crates/axiam-api-grpc/src/config.rs
@@ -4,6 +4,42 @@ use std::net::SocketAddr;
 
 use serde::Deserialize;
 
+/// gRPC rate-limit bucket-key mode (D8 parity with
+/// `axiam_api_rest::config::rate_limit::RateLimitKeyMode`).
+///
+/// **Currently a no-op / reserved for forward compatibility.** The only
+/// gRPC surface wrapped by the rate-limit layers today
+/// (`middleware::rate_limit::{build_grpc_governor_layer,
+/// GrpcSharedRateLimitLayer}`) is the low-latency, service-mesh-wide authz
+/// check (`AuthorizationService`) — those layers are `Server::builder()`-
+/// wide `tower::Layer`s that run BEFORE tonic resolves any per-RPC
+/// authenticated identity (`ValidatedClaims`, inserted by each service's
+/// own `with_interceptor(...)` auth interceptor — see `server.rs`). There is
+/// therefore no client identity available at the point these layers key a
+/// request, structurally identical to why REST's `/auth/login` always stays
+/// per-IP (see `axiam_api_rest::config::rate_limit::RateLimitKeyMode`
+/// docs). Setting this to anything other than `Ip` has no observable effect
+/// yet; it exists so `AXIAM__GRPC__KEY` round-trips through config the same
+/// way `AXIAM__RATE_LIMIT__KEY` does on the REST side, and so a future
+/// per-RPC client-identity-aware interceptor (re-ordering the auth
+/// interceptor ahead of the rate-limit layer for `TokenService`'s
+/// `introspect_token`/`validate_token`, which DO have a caller identity via
+/// `ValidatedClaims.sub`) has a config surface to land on without another
+/// env var rename.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GrpcRateLimitKeyMode {
+    /// Key on source IP only (current and only implemented behavior).
+    #[default]
+    Ip,
+    /// Reserved (D8 parity) — not yet wired to any gRPC surface; behaves
+    /// identically to `Ip` today.
+    ClientId,
+    /// Reserved (D8 parity) — not yet wired to any gRPC surface; behaves
+    /// identically to `Ip` today.
+    IpClientId,
+}
+
 /// Configuration for the gRPC server.
 #[derive(Debug, Clone, Deserialize)]
 pub struct GrpcConfig {
@@ -16,6 +52,11 @@ pub struct GrpcConfig {
     /// Configure via AXIAM__GRPC__GRPC_AUTHZ_PER_SEC env var.
     #[serde(default = "default_grpc_authz_per_sec")]
     pub grpc_authz_per_sec: u32,
+    /// D8 parity field — see [`GrpcRateLimitKeyMode`]. Currently always
+    /// behaves as `Ip` regardless of value; reserved for a future per-RPC
+    /// client-identity-aware rate limiter. Configure via `AXIAM__GRPC__KEY`.
+    #[serde(default)]
+    pub key: GrpcRateLimitKeyMode,
 }
 
 impl Default for GrpcConfig {
@@ -24,6 +65,7 @@ impl Default for GrpcConfig {
             host: default_host(),
             port: default_port(),
             grpc_authz_per_sec: default_grpc_authz_per_sec(),
+            key: GrpcRateLimitKeyMode::Ip,
         }
     }
 }
@@ -51,4 +93,31 @@ fn default_port() -> u16 {
 
 fn default_grpc_authz_per_sec() -> u32 {
     100
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_key_mode_is_ip() {
+        assert_eq!(GrpcConfig::default().key, GrpcRateLimitKeyMode::Ip);
+        assert_eq!(GrpcRateLimitKeyMode::default(), GrpcRateLimitKeyMode::Ip);
+    }
+
+    #[test]
+    fn key_mode_deserializes_from_documented_env_values() {
+        assert_eq!(
+            serde_json::from_str::<GrpcRateLimitKeyMode>("\"ip\"").unwrap(),
+            GrpcRateLimitKeyMode::Ip
+        );
+        assert_eq!(
+            serde_json::from_str::<GrpcRateLimitKeyMode>("\"client_id\"").unwrap(),
+            GrpcRateLimitKeyMode::ClientId
+        );
+        assert_eq!(
+            serde_json::from_str::<GrpcRateLimitKeyMode>("\"ip_client_id\"").unwrap(),
+            GrpcRateLimitKeyMode::IpClientId
+        );
+    }
 }

--- a/crates/axiam-api-grpc/src/server.rs
+++ b/crates/axiam-api-grpc/src/server.rs
@@ -6,6 +6,28 @@
 //! `AXIAM__GRPC_TLS_KEY_PATH` env vars are set, the server is configured with
 //! `ServerTlsConfig`; otherwise plaintext mode is used (suitable for in-mesh
 //! mutual-TLS handled at the sidecar/service-mesh layer).
+//!
+//! D2 (benchmark plan — native gRPC TLS termination): this is the same
+//! mechanism the p2-tls13 native-TLS bench overlay
+//! (`benchmarks/targets/axiam/docker-compose.native-tls.yml`) turns on,
+//! pointed at the SAME server cert/key files the REST listener uses
+//! (`crates/axiam-server/src/tls.rs` / `AXIAM__SERVER__TLS__CERT_PATH`+
+//! `KEY_PATH`) so the two protocols present identical PKI material. No new
+//! `TlsConfig`-style struct was introduced here — the existing flat
+//! `AXIAM__GRPC_TLS_CERT_PATH`/`KEY_PATH` env-var pair (already shipped in
+//! phase 11) is reused as-is per D2's "least invasive" guidance, rather than
+//! adding a parallel `AXIAM__GRPC__TLS__*` nested config surface.
+//!
+//! Caveat vs. the REST listener: `crates/axiam-server/src/tls.rs` builds a
+//! custom rustls `ServerConfig` restricted to TLS 1.3 only
+//! (`with_protocol_versions(&[&rustls::version::TLS13])`). Tonic 0.14's
+//! `ServerTlsConfig` (see `tonic::transport::server::tls`) does not expose a
+//! protocol-version knob — it always builds `rustls::ServerConfig::builder()`
+//! with the crate's default versions (TLS 1.2 negotiable in addition to 1.3).
+//! There is no way to force TLS-1.3-only through tonic's public API without
+//! hand-rolling the accept loop, which is out of scope here; the gRPC
+//! listener is TLS 1.3-*capable* (matching REST posture) but not TLS
+//! 1.3-*exclusive*.
 
 use std::net::SocketAddr;
 use std::time::Duration;

--- a/crates/axiam-api-grpc/src/services/authorization.rs
+++ b/crates/axiam-api-grpc/src/services/authorization.rs
@@ -6,7 +6,6 @@ use axiam_authz::types::{AccessDecision, AccessRequest};
 use axiam_core::repository::{
     GroupRepository, PermissionRepository, ResourceRepository, RoleRepository, ScopeRepository,
 };
-use futures::stream::{self, StreamExt};
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
@@ -24,9 +23,12 @@ where
     G: GroupRepository,
 {
     engine: AuthorizationEngine<R, P, Res, S, G>,
-    /// Bound on concurrent `check_access` evaluations within a single
-    /// `BatchCheckAccess` call (D-06/D-07). Sourced from
-    /// `AuthzConfig::batch_max_concurrency` (default 16).
+    /// Retained from the pre-D1 concurrent-fan-out design and still accepted by
+    /// [`Self::new`] for call-site/config compatibility (`AuthzConfig::
+    /// batch_max_concurrency`, default 16). The D1 coalesced batch path issues
+    /// a small fixed number of DB round-trips per batch rather than one
+    /// per-item future, so the concurrency bound is no longer applied here.
+    #[allow(dead_code)]
     batch_max_concurrency: usize,
 }
 
@@ -168,34 +170,17 @@ where
             });
         }
 
-        // T-27-10/T-27-11: evaluate concurrently, bounded by
-        // batch_max_concurrency (D-07), preserving input order via
-        // sort_by_key after collection (D-06). `&self`-borrowing futures
-        // need no 'static/Clone bound for buffer_unordered.
-        let mut indexed: Vec<(usize, AccessDecision)> =
-            stream::iter(access_requests.into_iter().enumerate())
-                .map(|(i, access_req)| {
-                    let engine = &self.engine;
-                    async move {
-                        let decision = engine
-                            .check_access(&access_req)
-                            .await
-                            .map_err(|e| Status::internal(e.to_string()))?;
-                        Ok::<_, Status>((i, decision))
-                    }
-                })
-                .buffer_unordered(self.batch_max_concurrency)
-                .collect::<Vec<Result<_, Status>>>()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, Status>>()?;
+        // D1: route the whole batch through the engine's coalesced path. Items
+        // sharing a subject/resource (every item in the bench's batch shares
+        // both) resolve their role-assignment + ancestor + grant lookups ONCE
+        // instead of once per item, and input order is preserved by the engine.
+        let decisions = self
+            .engine
+            .check_access_batch(&access_requests)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
 
-        indexed.sort_by_key(|&(i, _)| i);
-
-        let results = indexed
-            .into_iter()
-            .map(|(_, decision)| to_check_response(decision))
-            .collect();
+        let results = decisions.into_iter().map(to_check_response).collect();
 
         Ok(Response::new(BatchCheckAccessResponse { results }))
     }

--- a/crates/axiam-api-grpc/tests/grpc_auth_test.rs
+++ b/crates/axiam-api-grpc/tests/grpc_auth_test.rs
@@ -99,6 +99,8 @@ fn test_auth_config() -> AuthConfig {
         jwt_decoding_key: None,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,
+        max_concurrent_hashes: 0,
+        hash_acquire_timeout_secs: 5,
     }
 }
 

--- a/crates/axiam-api-grpc/tests/grpc_authz_test.rs
+++ b/crates/axiam-api-grpc/tests/grpc_authz_test.rs
@@ -84,6 +84,8 @@ fn test_auth_config() -> AuthConfig {
         jwt_decoding_key: None,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,
+        max_concurrent_hashes: 0,
+        hash_acquire_timeout_secs: 5,
     }
 }
 

--- a/crates/axiam-api-grpc/tests/grpc_server_test.rs
+++ b/crates/axiam-api-grpc/tests/grpc_server_test.rs
@@ -109,6 +109,7 @@ async fn start_grpc_server_boots_in_plaintext_mode() {
         host: "127.0.0.1".into(),
         port: 0,
         grpc_authz_per_sec: 100,
+        ..GrpcConfig::default()
     };
     // Ensure the TLS branch is NOT taken.
     unsafe {

--- a/crates/axiam-api-grpc/tests/grpc_units.rs
+++ b/crates/axiam-api-grpc/tests/grpc_units.rs
@@ -76,6 +76,7 @@ fn grpc_config_bind_address_panics_on_bad_host() {
         host: "not a host".into(),
         port: 1,
         grpc_authz_per_sec: 1,
+        ..GrpcConfig::default()
     };
     let _ = c.bind_address();
 }

--- a/crates/axiam-api-rest/Cargo.toml
+++ b/crates/axiam-api-rest/Cargo.toml
@@ -43,6 +43,8 @@ reqwest = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+# D3: parse SAN/SPKI from the rustls-verified client certificate (native mTLS).
+x509-parser = { workspace = true }
 url = { workspace = true }
 subtle = { workspace = true }
 rand = { workspace = true }

--- a/crates/axiam-api-rest/src/authz.rs
+++ b/crates/axiam-api-rest/src/authz.rs
@@ -50,6 +50,25 @@ pub trait AuthzChecker: Send + Sync {
             Ok(out)
         })
     }
+
+    /// Invalidate **all** cached authorization decisions for a tenant (D7).
+    ///
+    /// The default implementation is a no-op — checkers without a decision
+    /// cache (the test doubles, and the engine when the cache feature flag is
+    /// off) simply ignore it. The real [`AuthorizationEngine`] forwards to its
+    /// cache. Mutation handlers call this after an access-*narrowing* change
+    /// whose affected-subject set isn't cheaply known (grant revoke,
+    /// role/permission delete or update, group-role unassignment, resource
+    /// reparent/delete) so that **no revocation can leave a stale allow**.
+    fn invalidate_tenant(&self, _tenant_id: Uuid) {}
+
+    /// Invalidate cached decisions for a single subject within a tenant (D7).
+    ///
+    /// Default no-op (see [`Self::invalidate_tenant`]). Mutation handlers call
+    /// this when exactly one subject's effective permissions change (user role
+    /// unassign/assign, group membership add/remove) — the targeted, cheaper
+    /// alternative to a full tenant flush.
+    fn invalidate_subject(&self, _tenant_id: Uuid, _subject_id: Uuid) {}
 }
 
 impl<R, P, Res, S, G> AuthzChecker for AuthorizationEngine<R, P, Res, S, G>
@@ -72,6 +91,14 @@ where
         requests: &'a [AccessRequest],
     ) -> Pin<Box<dyn Future<Output = AxiamResult<Vec<AccessDecision>>> + Send + 'a>> {
         Box::pin(AuthorizationEngine::check_access_batch(self, requests))
+    }
+
+    fn invalidate_tenant(&self, tenant_id: Uuid) {
+        AuthorizationEngine::invalidate_tenant(self, tenant_id);
+    }
+
+    fn invalidate_subject(&self, tenant_id: Uuid, subject_id: Uuid) {
+        AuthorizationEngine::invalidate_subject(self, tenant_id, subject_id);
     }
 }
 

--- a/crates/axiam-api-rest/src/authz.rs
+++ b/crates/axiam-api-rest/src/authz.rs
@@ -29,6 +29,27 @@ pub trait AuthzChecker: Send + Sync {
         &'a self,
         request: &'a AccessRequest,
     ) -> Pin<Box<dyn Future<Output = AxiamResult<AccessDecision>> + Send + 'a>>;
+
+    /// Evaluate an ordered batch of checks, returning decisions in input order
+    /// (result `i` ↔ `requests[i]`).
+    ///
+    /// The default implementation simply calls [`Self::check_access`] per item;
+    /// the real [`AuthorizationEngine`] overrides it with a **coalesced** path
+    /// that resolves the shared role-assignment / ancestor / scope lookups once
+    /// per `(tenant, subject)` / `(tenant, resource)` group instead of once per
+    /// item (D1). Both the REST and gRPC batch handlers route through this.
+    fn check_access_batch<'a>(
+        &'a self,
+        requests: &'a [AccessRequest],
+    ) -> Pin<Box<dyn Future<Output = AxiamResult<Vec<AccessDecision>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut out = Vec::with_capacity(requests.len());
+            for req in requests {
+                out.push(self.check_access(req).await?);
+            }
+            Ok(out)
+        })
+    }
 }
 
 impl<R, P, Res, S, G> AuthzChecker for AuthorizationEngine<R, P, Res, S, G>
@@ -44,6 +65,13 @@ where
         request: &'a AccessRequest,
     ) -> Pin<Box<dyn Future<Output = AxiamResult<AccessDecision>> + Send + 'a>> {
         Box::pin(AuthorizationEngine::check_access(self, request))
+    }
+
+    fn check_access_batch<'a>(
+        &'a self,
+        requests: &'a [AccessRequest],
+    ) -> Pin<Box<dyn Future<Output = AxiamResult<Vec<AccessDecision>>> + Send + 'a>> {
+        Box::pin(AuthorizationEngine::check_access_batch(self, requests))
     }
 }
 

--- a/crates/axiam-api-rest/src/config/mod.rs
+++ b/crates/axiam-api-rest/src/config/mod.rs
@@ -43,7 +43,7 @@ impl Default for ServerConfig {
 /// `cert_path` and `key_path` must point at readable PEM files; the server
 /// negotiates TLS 1.3 only (ASVS V9.1.2), whose cipher suites are all
 /// ASVS-approved (V9.1.3).
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
 pub struct TlsConfig {
     /// Enable direct TLS termination in the server process.
@@ -52,6 +52,26 @@ pub struct TlsConfig {
     pub cert_path: Option<PathBuf>,
     /// Path to the PEM-encoded private key (PKCS#8, PKCS#1, or SEC1).
     pub key_path: Option<PathBuf>,
+    /// Offer HTTP/2 (`h2`) over ALPN alongside `http/1.1`. Default `true`
+    /// (backward-compatible; matches what the actix-web rustls bind advertises).
+    ///
+    /// Set `false` to build the rustls listener advertising `http/1.1` only —
+    /// used to run the p2 benchmark apples-to-apples with the plaintext p0
+    /// listener (which is HTTP/1.1), isolating the h2-vs-h1.1 throughput effect
+    /// (B2). See `axiam-server`'s `tls` module for the important caveat that the
+    /// actix-web `HttpServer` bind re-adds `h2` to ALPN regardless.
+    pub http2: bool,
+}
+
+impl Default for TlsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            cert_path: None,
+            key_path: None,
+            http2: true,
+        }
+    }
 }
 
 impl ServerConfig {

--- a/crates/axiam-api-rest/src/config/mod.rs
+++ b/crates/axiam-api-rest/src/config/mod.rs
@@ -36,6 +36,31 @@ impl Default for ServerConfig {
     }
 }
 
+/// Native client-certificate (mTLS) authentication policy for the direct-TLS
+/// listener (D3).
+///
+/// When client auth is enabled, rustls verifies the presented client
+/// certificate against the CA bundle at [`TlsConfig::client_ca_path`] during
+/// the TLS handshake, and the *verified* leaf certificate is exposed to request
+/// handlers via the connection extensions — the certificate-auth flow then
+/// consumes that verified cert rather than a spoofable proxy header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClientAuth {
+    /// No client certificate requested (server-auth only). Backward-compatible
+    /// default — the rustls config is built with `with_no_client_auth()`.
+    #[default]
+    Off,
+    /// Request a client certificate but allow anonymous clients. A presented
+    /// certificate is still verified against the CA bundle; connections without
+    /// one are accepted (`WebPkiClientVerifier::builder(..).allow_unauthenticated()`).
+    Optional,
+    /// Require a client certificate verified against the CA bundle. The TLS
+    /// handshake is rejected if the client presents no certificate or an
+    /// unverifiable one (`WebPkiClientVerifier::builder(..).build()`).
+    Required,
+}
+
 /// Direct-TLS configuration for the REST API listener.
 ///
 /// TLS is **opt-in**: the default (`enabled = false`) preserves the plaintext
@@ -61,6 +86,14 @@ pub struct TlsConfig {
     /// (B2). See `axiam-server`'s `tls` module for the important caveat that the
     /// actix-web `HttpServer` bind re-adds `h2` to ALPN regardless.
     pub http2: bool,
+    /// Native client-certificate (mTLS) policy (D3). Default `off` keeps the
+    /// server-auth-only behaviour. `optional`/`required` build the rustls config
+    /// with a `WebPkiClientVerifier` over [`Self::client_ca_path`].
+    pub client_auth: ClientAuth,
+    /// Path to the PEM CA bundle used to verify client certificates. Required
+    /// (and must be readable) when `client_auth` is `optional` or `required`;
+    /// ignored when `off`.
+    pub client_ca_path: Option<PathBuf>,
 }
 
 impl Default for TlsConfig {
@@ -70,6 +103,8 @@ impl Default for TlsConfig {
             cert_path: None,
             key_path: None,
             http2: true,
+            client_auth: ClientAuth::Off,
+            client_ca_path: None,
         }
     }
 }
@@ -78,5 +113,53 @@ impl ServerConfig {
     /// Returns the socket bind address as "host:port".
     pub fn bind_address(&self) -> String {
         format!("{}:{}", self.host, self.port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_auth_defaults_to_off() {
+        assert_eq!(ClientAuth::default(), ClientAuth::Off);
+        assert_eq!(TlsConfig::default().client_auth, ClientAuth::Off);
+        assert!(TlsConfig::default().client_ca_path.is_none());
+    }
+
+    #[test]
+    fn client_auth_parses_all_three_values() {
+        for (raw, expected) in [
+            ("\"off\"", ClientAuth::Off),
+            ("\"optional\"", ClientAuth::Optional),
+            ("\"required\"", ClientAuth::Required),
+        ] {
+            let parsed: ClientAuth =
+                serde_json::from_str(raw).unwrap_or_else(|e| panic!("{raw} must parse: {e}"));
+            assert_eq!(parsed, expected, "{raw}");
+        }
+    }
+
+    #[test]
+    fn client_auth_rejects_invalid_value() {
+        let err = serde_json::from_str::<ClientAuth>("\"enabled\"");
+        assert!(err.is_err(), "unknown client_auth value must be rejected");
+    }
+
+    #[test]
+    fn tls_config_deserializes_client_auth_fields() {
+        let cfg: TlsConfig = serde_json::from_value(serde_json::json!({
+            "enabled": true,
+            "cert_path": "/etc/axiam/server.crt",
+            "key_path": "/etc/axiam/server.key",
+            "client_auth": "required",
+            "client_ca_path": "/etc/axiam/ca.crt",
+        }))
+        .expect("TlsConfig with client-auth fields must deserialize");
+        assert_eq!(cfg.client_auth, ClientAuth::Required);
+        assert_eq!(
+            cfg.client_ca_path.as_deref(),
+            Some(std::path::Path::new("/etc/axiam/ca.crt"))
+        );
     }
 }

--- a/crates/axiam-api-rest/src/config/rate_limit.rs
+++ b/crates/axiam-api-rest/src/config/rate_limit.rs
@@ -2,6 +2,55 @@
 
 use serde::Deserialize;
 
+/// Rate-limit bucket-key derivation mode (D8).
+///
+/// Environment variable: `AXIAM__RATE_LIMIT__KEY` = `ip` | `client_id` |
+/// `ip_client_id` (default `ip`).
+///
+/// **Why this exists (NAT'd-fleet lesson):** the bucket key was
+/// unconditionally `"{endpoint}:{ip}"` (see
+/// `middleware::rate_limit_shared::RateLimitShared` and
+/// `extractors::rate_limit::XForwardedForKeyExtractor`). Behind a NAT/proxy
+/// fleet (many distinct OAuth2 clients — e.g. IoT devices or microservices —
+/// egressing through one shared IP), every client sharing that IP collided
+/// into a SINGLE bucket, so one noisy/misbehaving client could exhaust the
+/// `/oauth2/token`, `/oauth2/revoke`, or `/oauth2/introspect` quota for every
+/// other client behind the same NAT gateway. `client_id` and `ip_client_id`
+/// give each OAuth2 client its own bucket (optionally still scoped per-IP)
+/// on the endpoints where a client identity is actually known.
+///
+/// **Scope — where this setting applies:** ONLY the three endpoints where an
+/// OAuth2 client authenticates itself via a form-encoded `client_id`
+/// (`client_secret_post`, RFC 6749 §2.3.1): `/oauth2/token`,
+/// `/oauth2/revoke`, `/oauth2/introspect` (see `handlers::oauth2` and
+/// `server.rs`'s wiring of `RateLimitShared::new_client_identity_aware` /
+/// the client-aware governor for exactly those three resources).
+///
+/// **`/auth/login` (and every other rate-limited endpoint) ALWAYS keys
+/// per-IP, regardless of this setting.** Login authenticates a *user* via
+/// username/password — there is no OAuth2 client identity anywhere in that
+/// request, so there is nothing meaningful to key on besides the source IP.
+/// This is intentional and NOT a bug: switching this config value never
+/// changes login's (or MFA's, or password-reset's, etc.) rate-limit
+/// behavior. See `server.rs` — those resources are wired with the plain
+/// `build_governor`/`RateLimitShared::new` constructors, which never read
+/// this field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RateLimitKeyMode {
+    /// Key on source IP only (current/default behavior, unchanged).
+    #[default]
+    Ip,
+    /// Key on the OAuth2 `client_id` alone — independent buckets per client,
+    /// regardless of which IP(s) it connects from.
+    ClientId,
+    /// Key on the `(ip, client_id)` pair — independent buckets per client
+    /// AND per IP, so a compromised/leaked client credential rate-limited
+    /// from one IP doesn't automatically throttle the same client_id
+    /// operating legitimately from a different IP.
+    IpClientId,
+}
+
 /// Rate limit configuration.
 /// Environment variables: AXIAM__RATE_LIMIT__LOGIN_PER_MIN, etc.
 #[derive(Debug, Clone, Deserialize)]
@@ -28,6 +77,12 @@ pub struct RateLimitConfig {
     /// Authz checks are read-only and high-frequency — used by UI permission gating.
     /// Kept in a dedicated bucket so heavy UI use does not consume the login/token limit (D-07).
     pub authz_check_per_min: u32,
+    /// Rate-limit bucket-key derivation mode (D8, default: `Ip` — current
+    /// behavior, unchanged). See [`RateLimitKeyMode`] for the full
+    /// rationale and scope (only `/oauth2/token`, `/oauth2/revoke`,
+    /// `/oauth2/introspect` honor this; `/auth/login` and every other
+    /// endpoint always stay per-IP).
+    pub key: RateLimitKeyMode,
 }
 
 impl Default for RateLimitConfig {
@@ -41,6 +96,7 @@ impl Default for RateLimitConfig {
             introspect_per_min: 10,
             revoke_per_min: 10,
             authz_check_per_min: 300,
+            key: RateLimitKeyMode::Ip,
         }
     }
 }
@@ -64,6 +120,40 @@ impl RateLimitConfig {
         assert!(
             self.authz_check_per_min >= 1,
             "authz_check_per_min must be >= 1"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// D8 acceptance: default behavior (`ip`) is unchanged — a
+    /// freshly-defaulted config must key exactly the way it did before this
+    /// field existed.
+    #[test]
+    fn default_key_mode_is_ip() {
+        assert_eq!(RateLimitConfig::default().key, RateLimitKeyMode::Ip);
+        assert_eq!(RateLimitKeyMode::default(), RateLimitKeyMode::Ip);
+    }
+
+    /// `AXIAM__RATE_LIMIT__KEY` values must map onto exactly `ip`,
+    /// `client_id`, `ip_client_id` via serde `snake_case` — this is what the
+    /// `config` crate's `Environment` source (see `axiam-server::main`)
+    /// deserializes the raw env var string against.
+    #[test]
+    fn key_mode_deserializes_from_documented_env_values() {
+        assert_eq!(
+            serde_json::from_str::<RateLimitKeyMode>("\"ip\"").unwrap(),
+            RateLimitKeyMode::Ip
+        );
+        assert_eq!(
+            serde_json::from_str::<RateLimitKeyMode>("\"client_id\"").unwrap(),
+            RateLimitKeyMode::ClientId
+        );
+        assert_eq!(
+            serde_json::from_str::<RateLimitKeyMode>("\"ip_client_id\"").unwrap(),
+            RateLimitKeyMode::IpClientId
         );
     }
 }

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -387,6 +387,8 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=\n\
             jwt_decoding_key: None,
             hibp_breaker_threshold: 5,
             hibp_breaker_cooldown_secs: 30,
+            max_concurrent_hashes: 0,
+            hash_acquire_timeout_secs: 5,
         }
     }
 

--- a/crates/axiam-api-rest/src/extractors/cert_auth.rs
+++ b/crates/axiam-api-rest/src/extractors/cert_auth.rs
@@ -1,18 +1,103 @@
 //! Certificate-based authentication extractor for mTLS device auth.
 //!
-//! Reads the `X-Client-Certificate` header (URL-encoded PEM forwarded
-//! by the TLS-terminating reverse proxy) and validates it via
-//! [`DeviceAuthService`].
+//! Two identity sources are supported, in order of trust:
+//!
+//! 1. **Native mTLS (D3):** when the server terminates TLS in-process with
+//!    client-cert auth enabled (`AXIAM__SERVER__TLS__CLIENT_AUTH`), rustls
+//!    cryptographically verifies the client certificate against the configured
+//!    CA bundle *during the handshake*. `axiam-server`'s `on_connect` hook then
+//!    stores the verified leaf certificate as a [`VerifiedClientCert`] in the
+//!    connection extensions. This extractor consumes that verified certificate —
+//!    it cannot be forged by a request header.
+//! 2. **Legacy proxy path:** the `X-Client-Certificate` header (URL-encoded PEM
+//!    forwarded by a TLS-terminating reverse proxy). Used only when no verified
+//!    certificate is present on the connection (i.e. TLS terminated upstream).
+//!
+//! Both paths validate the certificate via [`DeviceAuthService`].
 
 use actix_web::HttpRequest;
 use actix_web::web;
 use axiam_core::error::AxiamError;
 use axiam_core::models::certificate::DeviceIdentity;
+use sha2::{Digest, Sha256};
 use surrealdb::Connection;
 use uuid::Uuid;
+use x509_parser::extensions::GeneralName;
+use x509_parser::prelude::parse_x509_certificate;
 
 use crate::error::AxiamApiError;
 use crate::state::AppState;
+
+/// A client certificate that rustls **verified** against the configured client
+/// CA bundle during the TLS 1.3 handshake (D3).
+///
+/// `axiam-server`'s `HttpServer::on_connect` hook builds this from the rustls
+/// connection's `peer_certificates()` and inserts it into the per-connection
+/// [`actix_web::dev::Extensions`]; handlers read it back with
+/// `HttpRequest::conn_data::<VerifiedClientCert>()`. Because it originates from
+/// the verified peer chain — not a header — it is a trusted identity assertion.
+#[derive(Debug, Clone)]
+pub struct VerifiedClientCert {
+    /// DER encoding of the verified leaf certificate.
+    pub der: Vec<u8>,
+    /// Subject Alternative Names (DNS/URI/RFC822/IP) parsed from the leaf, in
+    /// certificate order. Empty if the leaf carries no SAN extension.
+    pub sans: Vec<String>,
+    /// Lowercase hex SHA-256 of the leaf's SubjectPublicKeyInfo (the SPKI
+    /// fingerprint) — a stable key-identity handle for cert-mapped identities.
+    pub spki_sha256: String,
+}
+
+impl VerifiedClientCert {
+    /// Parse SAN entries and the SPKI fingerprint from a DER-encoded leaf
+    /// certificate. Returns an error string only if the DER cannot be parsed as
+    /// an X.509 certificate (rustls has already verified the chain by this
+    /// point, so this parse is expected to succeed).
+    pub fn from_der(der: &[u8]) -> Result<Self, String> {
+        let (_, cert) =
+            parse_x509_certificate(der).map_err(|e| format!("parse client cert DER: {e}"))?;
+
+        let mut sans = Vec::new();
+        if let Ok(Some(ext)) = cert.subject_alternative_name() {
+            for name in &ext.value.general_names {
+                match name {
+                    GeneralName::DNSName(s) => sans.push(format!("DNS:{s}")),
+                    GeneralName::RFC822Name(s) => sans.push(format!("email:{s}")),
+                    GeneralName::URI(s) => sans.push(format!("URI:{s}")),
+                    GeneralName::IPAddress(b) => sans.push(format!("IP:{}", fmt_ip(b))),
+                    _ => {}
+                }
+            }
+        }
+
+        // The `.raw` field of SubjectPublicKeyInfo is the DER of the full SPKI
+        // structure (RFC 5280 §4.1) — the standard input for an SPKI fingerprint.
+        let spki_sha256 = hex::encode(Sha256::digest(cert.public_key().raw));
+
+        Ok(Self {
+            der: der.to_vec(),
+            sans,
+            spki_sha256,
+        })
+    }
+}
+
+/// Best-effort textual rendering of a SAN IP address (4-byte v4 / 16-byte v6).
+fn fmt_ip(bytes: &[u8]) -> String {
+    match bytes.len() {
+        4 => bytes
+            .iter()
+            .map(|b| b.to_string())
+            .collect::<Vec<_>>()
+            .join("."),
+        16 => bytes
+            .chunks(2)
+            .map(|c| format!("{:02x}{:02x}", c[0], c[1]))
+            .collect::<Vec<_>>()
+            .join(":"),
+        _ => hex::encode(bytes),
+    }
+}
 
 /// Authenticated device context extracted from a client certificate.
 ///
@@ -36,20 +121,33 @@ impl CertificateAuthenticated {
             .ok_or(AxiamError::Internal("missing AppState".into()))?;
         let service = &state.device_auth_service;
 
-        let header = req
-            .headers()
-            .get("X-Client-Certificate")
-            .and_then(|v| v.to_str().ok())
-            .ok_or(AxiamError::AuthenticationFailed {
-                reason: "missing X-Client-Certificate header".into(),
+        // Prefer the VERIFIED client certificate captured at TLS handshake time
+        // (D3 native mTLS): rustls has already checked it against the client-CA
+        // bundle, so it is authoritative and cannot be spoofed by a header. Only
+        // fall back to the `X-Client-Certificate` proxy header when TLS was
+        // terminated upstream (no verified cert on this connection).
+        let identity_result = if let Some(verified) = req.conn_data::<VerifiedClientCert>() {
+            service.authenticate_der(&verified.der).await
+        } else {
+            let header = req
+                .headers()
+                .get("X-Client-Certificate")
+                .and_then(|v| v.to_str().ok())
+                .ok_or(AxiamError::AuthenticationFailed {
+                    reason: "missing client certificate (no native mTLS peer cert and no \
+                             X-Client-Certificate header)"
+                        .into(),
+                })?;
+
+            // URL-decode the PEM (reverse proxy URL-encodes it)
+            let pem = urldecode(header).map_err(|_| AxiamError::AuthenticationFailed {
+                reason: "invalid URL encoding in X-Client-Certificate".into(),
             })?;
 
-        // URL-decode the PEM (reverse proxy URL-encodes it)
-        let pem = urldecode(header).map_err(|_| AxiamError::AuthenticationFailed {
-            reason: "invalid URL encoding in X-Client-Certificate".into(),
-        })?;
+            service.authenticate(&pem).await
+        };
 
-        let identity: DeviceIdentity = service.authenticate(&pem).await.map_err(|e| match &e {
+        let identity: DeviceIdentity = identity_result.map_err(|e| match &e {
             // Map certificate/NotFound errors to proper 401/403 status codes
             AxiamError::Certificate(msg) if msg.contains("not bound to a service account") => {
                 AxiamError::AuthorizationDenied {

--- a/crates/axiam-api-rest/src/extractors/rate_limit.rs
+++ b/crates/axiam-api-rest/src/extractors/rate_limit.rs
@@ -23,10 +23,13 @@
 use actix_governor::governor::NotUntil;
 use actix_governor::governor::clock::{Clock, DefaultClock, QuantaInstant};
 use actix_governor::{KeyExtractor, SimpleKeyExtractionError};
+use actix_web::HttpMessage;
 use actix_web::HttpResponse;
 use actix_web::dev::ServiceRequest;
 use actix_web::http::header::{ContentType, RETRY_AFTER};
 use std::net::IpAddr;
+
+use crate::config::rate_limit::RateLimitKeyMode;
 
 /// Extracts client IP from X-Forwarded-For header, falls back to peer address.
 ///
@@ -107,5 +110,240 @@ impl KeyExtractor for XForwardedForKeyExtractor {
                 r#"{{"error":"rate_limit_exceeded","retry_after":{}}}"#,
                 wait_secs
             ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// D8 — client-identity-aware keying (token/introspect/revoke only)
+// ---------------------------------------------------------------------------
+
+/// Request-extension carrying the `client_id` (if any) parsed from the
+/// request body by
+/// [`crate::middleware::rate_limit_shared::RateLimitShared`]'s
+/// client-identity-aware constructor, so [`ClientAwareKeyExtractor`] (used
+/// by the in-memory `Governor` on the SAME resource) doesn't need to peek
+/// the body a second time.
+///
+/// Ordering guarantee this relies on: in `server.rs`, `RateLimitShared` is
+/// always the OUTER `.wrap()` (last one added — see the module docs on
+/// `RateLimitShared`), so it always runs BEFORE the `Governor` middleware
+/// and always inserts this extension (`None` when no `client_id` could be
+/// parsed, or when the configured key mode is `ip`) before delegating.
+/// `Governor`'s [`ClientAwareKeyExtractor`] treats a *missing* extension
+/// (e.g. if the two middlewares were ever mis-ordered) identically to
+/// `None` — it falls back to the IP key, never panics.
+#[derive(Debug, Clone, Default)]
+pub struct RateLimitClientId(pub Option<String>);
+
+/// Parses the `client_id` field out of an `application/x-www-form-urlencoded`
+/// body — the ONLY client-authentication style AXIAM's `/oauth2/token`,
+/// `/oauth2/revoke`, and `/oauth2/introspect` handlers accept
+/// (`client_secret_post`, RFC 6749 §2.3.1; see `handlers::oauth2` and
+/// `axiam_oauth2::token::{TokenRequest, RevokeRequest, IntrospectRequest}`,
+/// all form-decoded via `web::Form<..>`).
+///
+/// Returns `None` for a missing/empty/unparseable `client_id` — the caller
+/// (the rate limiter) must fail SAFE by falling back to the IP key rather
+/// than reject the request outright; rejecting a malformed body is the
+/// handler's job (it returns a proper RFC 6749 `invalid_request` error),
+/// not the rate limiter's.
+pub fn extract_form_client_id(body: &[u8]) -> Option<String> {
+    url::form_urlencoded::parse(body)
+        .find(|(k, _)| k == "client_id")
+        .map(|(_, v)| v.into_owned())
+        .filter(|v| !v.is_empty())
+}
+
+/// D8 key extractor for the token/introspect/revoke endpoints: honors
+/// `AXIAM__RATE_LIMIT__KEY` (`ip` | `client_id` | `ip_client_id`) to key the
+/// in-memory `Governor` bucket on the OAuth2 `client_id`, the `(ip,
+/// client_id)` pair, or (default, unchanged behavior) IP alone.
+///
+/// **Never wire this onto `/auth/login` or any other endpoint without a
+/// client identity** — see [`crate::config::rate_limit::RateLimitKeyMode`]
+/// for why login is structurally excluded (it authenticates a user, not an
+/// OAuth2 client; there is no `client_id` to key on at that point).
+#[derive(Debug, Clone)]
+pub struct ClientAwareKeyExtractor {
+    /// Always computed alongside the client_id — used verbatim in `Ip`
+    /// mode, and as a namespace-safety prefix in `IpClientId` mode.
+    pub ip_extractor: XForwardedForKeyExtractor,
+    pub key_mode: RateLimitKeyMode,
+}
+
+impl ClientAwareKeyExtractor {
+    pub fn new(ip_extractor: XForwardedForKeyExtractor, key_mode: RateLimitKeyMode) -> Self {
+        Self {
+            ip_extractor,
+            key_mode,
+        }
+    }
+}
+
+impl KeyExtractor for ClientAwareKeyExtractor {
+    type Key = String;
+    type KeyExtractionError = SimpleKeyExtractionError<&'static str>;
+
+    fn extract(&self, req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError> {
+        let ip = self.ip_extractor.extract(req)?;
+
+        let client_id = req
+            .extensions()
+            .get::<RateLimitClientId>()
+            .and_then(|c| c.0.clone());
+
+        Ok(match (self.key_mode, client_id) {
+            // `ip` mode, or no client_id available (fail-safe fallback):
+            // identical to the pre-D8 IP-only key.
+            (RateLimitKeyMode::Ip, _) | (_, None) => ip.to_string(),
+            (RateLimitKeyMode::ClientId, Some(cid)) => format!("client:{cid}"),
+            (RateLimitKeyMode::IpClientId, Some(cid)) => format!("{ip}:client:{cid}"),
+        })
+    }
+
+    /// Same 429 contract as [`XForwardedForKeyExtractor`] — clients must
+    /// see one consistent rate-limit response shape regardless of which key
+    /// mode rejected the request.
+    fn exceed_rate_limit_response(
+        &self,
+        negative: &NotUntil<QuantaInstant>,
+        mut response: actix_web::HttpResponseBuilder,
+    ) -> HttpResponse {
+        let wait_secs = negative
+            .wait_time_from(DefaultClock::default().now())
+            .as_secs();
+        response
+            .content_type(ContentType::json())
+            .insert_header((RETRY_AFTER, wait_secs.to_string()))
+            .body(format!(
+                r#"{{"error":"rate_limit_exceeded","retry_after":{}}}"#,
+                wait_secs
+            ))
+    }
+}
+
+#[cfg(test)]
+mod client_aware_tests {
+    use super::*;
+    use actix_web::test::TestRequest;
+    use std::net::SocketAddr;
+
+    const PEER_A: &str = "203.0.113.9:1";
+    const PEER_B: &str = "203.0.113.10:2";
+
+    fn req_with_client_id(peer: &str, client_id: Option<&str>) -> ServiceRequest {
+        let req = TestRequest::get()
+            .peer_addr(peer.parse::<SocketAddr>().unwrap())
+            .to_srv_request();
+        req.extensions_mut()
+            .insert(RateLimitClientId(client_id.map(str::to_owned)));
+        req
+    }
+
+    #[test]
+    fn ip_mode_ignores_client_id_and_matches_plain_ip_extractor() {
+        let extractor =
+            ClientAwareKeyExtractor::new(XForwardedForKeyExtractor::default(), RateLimitKeyMode::Ip);
+        let req = req_with_client_id(PEER_A, Some("client-a"));
+
+        let key = extractor.extract(&req).unwrap();
+        assert_eq!(key, "203.0.113.9");
+    }
+
+    #[test]
+    fn client_id_mode_gives_independent_buckets_per_client_under_one_ip() {
+        let extractor = ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::default(),
+            RateLimitKeyMode::ClientId,
+        );
+
+        let req_a = req_with_client_id(PEER_A, Some("client-a"));
+        let req_b = req_with_client_id(PEER_A, Some("client-b"));
+
+        let key_a = extractor.extract(&req_a).unwrap();
+        let key_b = extractor.extract(&req_b).unwrap();
+
+        assert_ne!(
+            key_a, key_b,
+            "distinct client_ids behind the SAME IP must get distinct buckets (D8 NAT fix)"
+        );
+        assert!(!key_a.contains("203.0.113.9"));
+    }
+
+    #[test]
+    fn client_id_mode_gives_same_bucket_for_same_client_from_different_ips() {
+        let extractor = ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::default(),
+            RateLimitKeyMode::ClientId,
+        );
+
+        let req_a = req_with_client_id(PEER_A, Some("client-a"));
+        let req_b = req_with_client_id(PEER_B, Some("client-a"));
+
+        assert_eq!(
+            extractor.extract(&req_a).unwrap(),
+            extractor.extract(&req_b).unwrap()
+        );
+    }
+
+    #[test]
+    fn ip_client_id_mode_distinguishes_both_dimensions() {
+        let extractor = ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::default(),
+            RateLimitKeyMode::IpClientId,
+        );
+
+        let same_client_diff_ip_a = req_with_client_id(PEER_A, Some("client-a"));
+        let same_client_diff_ip_b = req_with_client_id(PEER_B, Some("client-a"));
+        let diff_client_same_ip = req_with_client_id(PEER_A, Some("client-b"));
+
+        let key1 = extractor.extract(&same_client_diff_ip_a).unwrap();
+        let key2 = extractor.extract(&same_client_diff_ip_b).unwrap();
+        let key3 = extractor.extract(&diff_client_same_ip).unwrap();
+
+        assert_ne!(key1, key2, "same client_id from different IPs must differ in ip_client_id mode");
+        assert_ne!(key1, key3, "different client_id from same IP must differ in ip_client_id mode");
+    }
+
+    #[test]
+    fn missing_client_id_falls_back_to_ip_even_in_client_id_mode() {
+        // Fail-SAFE: malformed/no client_id must not disable rate limiting —
+        // it must still be limited, just by the coarser IP key.
+        let extractor = ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::default(),
+            RateLimitKeyMode::ClientId,
+        );
+        let req = req_with_client_id(PEER_A, None);
+
+        let key = extractor.extract(&req).unwrap();
+        assert_eq!(key, "203.0.113.9");
+    }
+
+    #[test]
+    fn missing_extension_entirely_falls_back_to_ip() {
+        // Defense in depth: if RateLimitShared never ran (mis-ordering bug),
+        // the extractor must not panic — it degrades to IP-only, matching
+        // pre-D8 behavior rather than failing open or crashing.
+        let extractor = ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::default(),
+            RateLimitKeyMode::ClientId,
+        );
+        let req = TestRequest::get()
+            .peer_addr(PEER_A.parse::<SocketAddr>().unwrap())
+            .to_srv_request();
+
+        let key = extractor.extract(&req).unwrap();
+        assert_eq!(key, "203.0.113.9");
+    }
+
+    #[test]
+    fn extract_form_client_id_parses_and_rejects_empty() {
+        assert_eq!(
+            extract_form_client_id(b"grant_type=client_credentials&client_id=abc123&client_secret=s"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(extract_form_client_id(b"client_id=&grant_type=x"), None);
+        assert_eq!(extract_form_client_id(b"grant_type=x"), None);
+        assert_eq!(extract_form_client_id(b""), None);
     }
 }

--- a/crates/axiam-api-rest/src/extractors/rate_limit.rs
+++ b/crates/axiam-api-rest/src/extractors/rate_limit.rs
@@ -242,8 +242,10 @@ mod client_aware_tests {
 
     #[test]
     fn ip_mode_ignores_client_id_and_matches_plain_ip_extractor() {
-        let extractor =
-            ClientAwareKeyExtractor::new(XForwardedForKeyExtractor::default(), RateLimitKeyMode::Ip);
+        let extractor = ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::default(),
+            RateLimitKeyMode::Ip,
+        );
         let req = req_with_client_id(PEER_A, Some("client-a"));
 
         let key = extractor.extract(&req).unwrap();
@@ -301,8 +303,14 @@ mod client_aware_tests {
         let key2 = extractor.extract(&same_client_diff_ip_b).unwrap();
         let key3 = extractor.extract(&diff_client_same_ip).unwrap();
 
-        assert_ne!(key1, key2, "same client_id from different IPs must differ in ip_client_id mode");
-        assert_ne!(key1, key3, "different client_id from same IP must differ in ip_client_id mode");
+        assert_ne!(
+            key1, key2,
+            "same client_id from different IPs must differ in ip_client_id mode"
+        );
+        assert_ne!(
+            key1, key3,
+            "different client_id from same IP must differ in ip_client_id mode"
+        );
     }
 
     #[test]
@@ -339,7 +347,9 @@ mod client_aware_tests {
     #[test]
     fn extract_form_client_id_parses_and_rejects_empty() {
         assert_eq!(
-            extract_form_client_id(b"grant_type=client_credentials&client_id=abc123&client_secret=s"),
+            extract_form_client_id(
+                b"grant_type=client_credentials&client_id=abc123&client_secret=s"
+            ),
             Some("abc123".to_string())
         );
         assert_eq!(extract_form_client_id(b"client_id=&grant_type=x"), None);

--- a/crates/axiam-api-rest/src/handlers/authz_check.rs
+++ b/crates/axiam-api-rest/src/handlers/authz_check.rs
@@ -19,7 +19,6 @@ use axiam_authz::types::{AccessDecision, AccessRequest};
 use axiam_core::models::audit::{ActorType, AuditOutcome, CreateAuditLogEntry};
 use axiam_core::repository::AuditLogRepository;
 use axiam_db::SurrealAuditLogRepository;
-use futures::stream::{self, StreamExt};
 use serde::{Deserialize, Serialize};
 use surrealdb::Connection;
 use uuid::Uuid;
@@ -231,53 +230,42 @@ pub async fn batch_check_access<C: Connection + Clone>(
             .await?;
     }
 
-    // T-27-10/T-27-11: evaluate concurrently, bounded by
-    // AuthzConfig::batch_max_concurrency (D-07), preserving input order via
-    // sort_by_key after collection (D-06). The per-item append_check_as_audit
-    // fire-and-forget call is preserved inside the same mapped future.
-    let batch_max_concurrency = state.authz_config.batch_max_concurrency;
+    // D1: build the ordered AccessRequest list (resolving each item's effective
+    // subject and writing the per-item check_as audit entry), then hand the
+    // WHOLE batch to the engine's coalesced path in a single call. Same-subject
+    // / same-resource items share their role-assignment + ancestor + grant
+    // lookups instead of re-issuing them per item (the bench's batch shape).
     let checker: &dyn AuthzChecker = authz.get_ref().as_ref();
     let audit_repo_ref: &SurrealAuditLogRepository<C> = &state.audit_repo;
     let tenant_id = user.tenant_id;
     let actor_id = user.user_id;
 
-    let mut indexed: Vec<(usize, Result<AccessDecision, AxiamApiError>)> =
-        stream::iter(body.checks.into_iter().enumerate())
-            .map(|(i, check)| async move {
-                let resource_id = check.resource_id;
-                let effective_subject = if let Some(sid) = check.subject_id {
-                    // T-15-04: audit each cross-subject item individually.
-                    append_check_as_audit(audit_repo_ref, tenant_id, actor_id, sid, resource_id)
-                        .await;
-                    sid
-                } else {
-                    actor_id
-                };
+    let mut access_requests = Vec::with_capacity(body.checks.len());
+    for check in body.checks {
+        let resource_id = check.resource_id;
+        let effective_subject = if let Some(sid) = check.subject_id {
+            // T-15-04: audit each cross-subject item individually.
+            append_check_as_audit(audit_repo_ref, tenant_id, actor_id, sid, resource_id).await;
+            sid
+        } else {
+            actor_id
+        };
 
-                let access_req = AccessRequest {
-                    tenant_id,
-                    subject_id: effective_subject,
-                    action: check.action,
-                    resource_id,
-                    scope: check.scope,
-                };
-
-                let decision = checker
-                    .check_access(&access_req)
-                    .await
-                    .map_err(AxiamApiError::from);
-                (i, decision)
-            })
-            .buffer_unordered(batch_max_concurrency)
-            .collect()
-            .await;
-
-    indexed.sort_by_key(|&(i, _)| i);
-
-    let mut results = Vec::with_capacity(indexed.len());
-    for (_, decision) in indexed {
-        results.push(decision_to_response(decision?));
+        access_requests.push(AccessRequest {
+            tenant_id,
+            subject_id: effective_subject,
+            action: check.action,
+            resource_id,
+            scope: check.scope,
+        });
     }
+
+    let decisions = checker
+        .check_access_batch(&access_requests)
+        .await
+        .map_err(AxiamApiError::from)?;
+
+    let results = decisions.into_iter().map(decision_to_response).collect();
 
     Ok(HttpResponse::Ok().json(BatchCheckAccessResponse { results }))
 }

--- a/crates/axiam-api-rest/src/handlers/groups.rs
+++ b/crates/axiam-api-rest/src/handlers/groups.rs
@@ -184,6 +184,9 @@ pub async fn delete<C: Connection + Clone>(
         .group_repo
         .delete(user.tenant_id, path.into_inner())
         .await?;
+    // D7 (REVOCATION — security critical): deleting a group removes its
+    // inherited roles from every member. Member set unknown here — flush tenant.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -213,10 +216,17 @@ pub async fn add_member<C: Connection + Clone>(
     RequirePermission::new("groups:add_member", Uuid::nil())
         .check(&user, authz.get_ref().as_ref())
         .await?;
+    let new_member = body.user_id;
     state
         .group_repo
         .add_member(user.tenant_id, body.user_id, path.into_inner())
         .await?;
+    // D7: adding a member widens that one subject's inherited access (safe
+    // direction) — targeted flush so it takes effect immediately.
+    authz
+        .get_ref()
+        .as_ref()
+        .invalidate_subject(user.tenant_id, new_member);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -285,5 +295,11 @@ pub async fn remove_member<C: Connection + Clone>(
         .group_repo
         .remove_member(user.tenant_id, p.user_id, p.group_id)
         .await?;
+    // D7 (REVOCATION — security critical): removing a member drops the group's
+    // inherited roles for exactly this subject — targeted flush, immediate.
+    authz
+        .get_ref()
+        .as_ref()
+        .invalidate_subject(user.tenant_id, p.user_id);
     Ok(HttpResponse::NoContent().finish())
 }

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -549,7 +549,10 @@ mod jwks_handler_tests {
             .to_http_request();
         let second_resp = jwks(second_req, state).await;
 
-        assert_eq!(second_resp.status(), actix_web::http::StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            second_resp.status(),
+            actix_web::http::StatusCode::NOT_MODIFIED
+        );
         assert_eq!(second_resp.headers().get(ETAG).unwrap(), etag.as_str());
         assert_eq!(
             second_resp.headers().get(CACHE_CONTROL).unwrap(),

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -1,12 +1,13 @@
 //! OAuth2 authorization and token endpoints.
 
-use actix_web::{HttpResponse, web};
+use actix_web::{HttpRequest, HttpResponse, web};
 use axiam_auth::config::AuthConfig;
 use axiam_core::repository::UserRepository;
 use axiam_oauth2::authorize::AuthorizeRequest;
 use axiam_oauth2::error::OAuth2Error;
+use axiam_oauth2::jwks_cache::JwksCacheResponse;
 use axiam_oauth2::oidc::{
-    JwksDocument, OidcDiscoveryDocument, UserInfoResponse, build_discovery_document, build_jwks,
+    JwksDocument, OidcDiscoveryDocument, UserInfoResponse, build_discovery_document,
 };
 use axiam_oauth2::token::{
     IntrospectRequest, IntrospectionResponse, RevokeRequest, TokenRequest, TokenResponse,
@@ -286,18 +287,50 @@ pub async fn discovery(auth_config: web::Data<AuthConfig>) -> HttpResponse {
 ///
 /// Returns the public signing keys used by the authorization server
 /// so that relying parties can verify JWTs without sharing a secret.
+///
+/// B3: served from an in-process cache (`state.oauth2_jwks_cache`) keyed by
+/// a hash of the source PEM, with a `Cache-Control: public, max-age=<n>`
+/// header (configurable, default 300s) and a strong `ETag`. Clients that
+/// send a matching `If-None-Match` get `304 Not Modified` with no body;
+/// clients that ignore caching headers entirely still get the identical
+/// `200 OK` + JWKS body they always did -- this is a pure additive change.
+/// See `axiam_oauth2::jwks_cache` module docs for the cache design and the
+/// documented limitations (no key-rotation mechanism exists yet; the
+/// endpoint serves one global, not per-tenant, key set).
 #[utoipa::path(
     get,
     path = "/oauth2/jwks",
     tag = "oidc",
     responses(
         (status = 200, description = "JWKS document", body = JwksDocument),
+        (status = 304, description = "Not Modified -- ETag matches If-None-Match"),
         (status = 500, description = "Key parsing error"),
     ),
 )]
-pub async fn jwks(auth_config: web::Data<AuthConfig>) -> HttpResponse {
-    match build_jwks(&auth_config.jwt_public_key_pem) {
-        Ok(doc) => HttpResponse::Ok().json(doc),
+pub async fn jwks<C: Connection + Clone>(
+    req: HttpRequest,
+    state: web::Data<AppState<C>>,
+) -> HttpResponse {
+    let if_none_match = req
+        .headers()
+        .get(actix_web::http::header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok());
+
+    let cache_control = state.oauth2_jwks_cache_config.cache_control_header();
+
+    match state
+        .oauth2_jwks_cache
+        .get(&state.auth_config.jwt_public_key_pem, if_none_match)
+    {
+        Ok(JwksCacheResponse::Fresh { body, etag }) => HttpResponse::Ok()
+            .content_type("application/json")
+            .insert_header(("Cache-Control", cache_control))
+            .insert_header(("ETag", etag))
+            .body(body),
+        Ok(JwksCacheResponse::NotModified { etag }) => HttpResponse::NotModified()
+            .insert_header(("Cache-Control", cache_control))
+            .insert_header(("ETag", etag))
+            .finish(),
         Err(e) => HttpResponse::InternalServerError().json(OAuth2ErrorResponse {
             error: "server_error".into(),
             error_description: e,
@@ -439,4 +472,100 @@ fn build_oauth2_error_response(e: &OAuth2Error) -> HttpResponse {
         error: e.error_code().to_string(),
         error_description: e.error_description(),
     })
+}
+
+// ---------------------------------------------------------------------------
+// Tests (B3: JWKS caching headers wired through the actix handler)
+// ---------------------------------------------------------------------------
+//
+// The full RFC-conformance/e2e coverage for `/oauth2/jwks` lives in
+// `tests/oauth2_*.rs`. These handler-level tests are deliberately narrow:
+// they call `jwks::<C>` directly against `AppState::for_test` (no DB
+// migrations, no running `App`/router) since the handler does not touch the
+// database at all -- just enough actix machinery (`HttpRequest`,
+// `web::Data`) to prove the `If-None-Match` -> 304 wiring and the
+// `Cache-Control`/`ETag` headers actually reach the HTTP response. The
+// cache/ETag/304 *logic itself* (RFC 7232 comparison, rotation, malformed
+// keys, etc.) is exhaustively covered by `axiam_oauth2::jwks_cache`'s own
+// unit tests -- this module does not re-test that logic, only the plumbing.
+#[cfg(test)]
+mod jwks_handler_tests {
+    use actix_web::http::header::{CACHE_CONTROL, ETAG, IF_NONE_MATCH};
+    use actix_web::test::TestRequest;
+    use surrealdb::Surreal;
+    use surrealdb::engine::local::Mem;
+
+    use super::*;
+
+    // Test-only Ed25519 keypair with no real-world value. nosemgrep
+    const TEST_PUBLIC_KEY_PEM: &str = concat!(
+        "-----BEGIN PUBLIC KEY-----\n",
+        "MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=\n",
+        "-----END PUBLIC KEY-----"
+    );
+
+    async fn test_state() -> AppState<surrealdb::engine::local::Db> {
+        let db = Surreal::new::<Mem>(()).await.expect("in-memory db");
+        let auth_config = AuthConfig {
+            jwt_public_key_pem: TEST_PUBLIC_KEY_PEM.into(),
+            ..AuthConfig::default()
+        };
+        AppState::for_test(db, auth_config)
+    }
+
+    #[actix_web::test]
+    async fn jwks_returns_200_with_cache_control_and_etag_when_no_if_none_match() {
+        let state = web::Data::new(test_state().await);
+        let req = TestRequest::default().to_http_request();
+
+        let resp = jwks(req, state).await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(CACHE_CONTROL).unwrap(),
+            "public, max-age=300"
+        );
+        assert!(resp.headers().get(ETAG).is_some());
+    }
+
+    #[actix_web::test]
+    async fn jwks_returns_304_when_if_none_match_echoes_current_etag() {
+        let state = web::Data::new(test_state().await);
+
+        // First request: discover the current ETag.
+        let first_req = TestRequest::default().to_http_request();
+        let first_resp = jwks(first_req, state.clone()).await;
+        let etag = first_resp
+            .headers()
+            .get(ETAG)
+            .expect("etag present")
+            .to_str()
+            .expect("etag is ascii")
+            .to_string();
+
+        // Second request: echo it back via If-None-Match.
+        let second_req = TestRequest::default()
+            .insert_header((IF_NONE_MATCH, etag.as_str()))
+            .to_http_request();
+        let second_resp = jwks(second_req, state).await;
+
+        assert_eq!(second_resp.status(), actix_web::http::StatusCode::NOT_MODIFIED);
+        assert_eq!(second_resp.headers().get(ETAG).unwrap(), etag.as_str());
+        assert_eq!(
+            second_resp.headers().get(CACHE_CONTROL).unwrap(),
+            "public, max-age=300"
+        );
+    }
+
+    #[actix_web::test]
+    async fn jwks_returns_200_when_if_none_match_does_not_match() {
+        let state = web::Data::new(test_state().await);
+        let req = TestRequest::default()
+            .insert_header((IF_NONE_MATCH, "\"stale-etag-from-before-rotation\""))
+            .to_http_request();
+
+        let resp = jwks(req, state).await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+    }
 }

--- a/crates/axiam-api-rest/src/handlers/permissions.rs
+++ b/crates/axiam-api-rest/src/handlers/permissions.rs
@@ -168,6 +168,10 @@ pub async fn update<C: Connection + Clone>(
         .permission_repo
         .update(user.tenant_id, path.into_inner(), input)
         .await?;
+    // D7 (REVOCATION — security critical): changing a permission's `action`
+    // narrows access (a subject allowed for the old action is now denied).
+    // Flush the tenant.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::Ok().json(permission))
 }
 
@@ -196,6 +200,9 @@ pub async fn delete<C: Connection + Clone>(
         .permission_repo
         .delete(user.tenant_id, path.into_inner())
         .await?;
+    // D7 (REVOCATION — security critical): deleting a permission removes it
+    // from every role/subject that was granted it. Flush the tenant.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -235,6 +242,10 @@ pub async fn grant_to_role<C: Connection + Clone>(
             req.scope_ids,
         )
         .await?;
+    // D7: granting widens access (safe direction) for every subject holding
+    // the role (set unknown here) — flush the tenant so the new grant is
+    // visible immediately.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -293,5 +304,9 @@ pub async fn revoke_from_role<C: Connection + Clone>(
         .permission_repo
         .revoke_from_role(user.tenant_id, p.role_id, p.permission_id)
         .await?;
+    // D7 (REVOCATION — security critical): revoking a grant removes access for
+    // every subject holding this role. The subject set isn't known here without
+    // a query, so flush the whole tenant — this must never leave a stale allow.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }

--- a/crates/axiam-api-rest/src/handlers/resources.rs
+++ b/crates/axiam-api-rest/src/handlers/resources.rs
@@ -157,6 +157,10 @@ pub async fn update<C: Connection + Clone>(
         .resource_repo
         .update(user.tenant_id, path.into_inner(), input)
         .await?;
+    // D7 (REVOCATION — security critical): a resource update can re-parent it,
+    // changing which ancestor-scoped roles cascade down and thereby NARROWING
+    // access for subjects targeting this subtree. Flush the tenant.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::Ok().json(resource))
 }
 
@@ -185,6 +189,9 @@ pub async fn delete<C: Connection + Clone>(
         .resource_repo
         .delete(user.tenant_id, path.into_inner())
         .await?;
+    // D7 (REVOCATION — security critical): deleting a resource removes it (and
+    // its subtree scoping) from the hierarchy, narrowing access. Flush tenant.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 

--- a/crates/axiam-api-rest/src/handlers/roles.rs
+++ b/crates/axiam-api-rest/src/handlers/roles.rs
@@ -181,6 +181,10 @@ pub async fn update<C: Connection + Clone>(
         .role_repo
         .update(user.tenant_id, path.into_inner(), body.into_inner())
         .await?;
+    // D7: a role change (e.g. is_global, name) can narrow effective access for
+    // an unknown set of subjects — flush the whole tenant so no stale allow
+    // can survive. No-op when the decision cache is disabled.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::Ok().json(role))
 }
 
@@ -209,6 +213,9 @@ pub async fn delete<C: Connection + Clone>(
         .role_repo
         .delete(user.tenant_id, path.into_inner())
         .await?;
+    // D7: deleting a role revokes it from every subject holding it — flush the
+    // tenant so no cached allow granted through this role can survive.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -239,6 +246,7 @@ pub async fn assign_to_user<C: Connection + Clone>(
         .check(&user, authz.get_ref().as_ref())
         .await?;
     let req = body.into_inner();
+    let target_user = req.user_id;
     state
         .role_repo
         .assign_to_user(
@@ -248,6 +256,13 @@ pub async fn assign_to_user<C: Connection + Clone>(
             req.resource_id,
         )
         .await?;
+    // D7: only this subject's effective permissions change — targeted flush.
+    // (Assignment widens access, the safe direction, but we invalidate anyway
+    // so the new grant is visible immediately rather than after the TTL.)
+    authz
+        .get_ref()
+        .as_ref()
+        .invalidate_subject(user.tenant_id, target_user);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -281,6 +296,14 @@ pub async fn unassign_from_user<C: Connection + Clone>(
         .role_repo
         .unassign_from_user(user.tenant_id, p.user_id, p.role_id, query.resource_id)
         .await?;
+    // D7 (REVOCATION — security critical): unassigning a role removes access
+    // for exactly this subject. Invalidate immediately so a cached allow cannot
+    // survive; the additive allow-wins model makes this stale-allow the only
+    // dangerous staleness direction.
+    authz
+        .get_ref()
+        .as_ref()
+        .invalidate_subject(user.tenant_id, p.user_id);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -320,6 +343,9 @@ pub async fn assign_to_group<C: Connection + Clone>(
             req.resource_id,
         )
         .await?;
+    // D7: the affected subjects are every member of the group (set unknown
+    // without a query) — conservative per-tenant flush.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 
@@ -353,6 +379,10 @@ pub async fn unassign_from_group<C: Connection + Clone>(
         .role_repo
         .unassign_from_group(user.tenant_id, p.group_id, p.role_id, query.resource_id)
         .await?;
+    // D7 (REVOCATION — security critical): unassigning a role from a group
+    // revokes it from every member. The member set isn't known here without a
+    // query, so flush the whole tenant — this must never leave a stale allow.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }
 

--- a/crates/axiam-api-rest/src/handlers/scopes.rs
+++ b/crates/axiam-api-rest/src/handlers/scopes.rs
@@ -192,6 +192,10 @@ pub async fn update<C: Connection + Clone>(
         .scope_repo
         .update(user.tenant_id, path.scope_id, input)
         .await?;
+    // D7 (REVOCATION — security critical): decisions are cached by scope *name*.
+    // Renaming a scope narrows access for requests using the old name — flush
+    // the tenant so no scoped allow can survive under the stale name.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::Ok().json(scope))
 }
 
@@ -234,5 +238,8 @@ pub async fn delete<C: Connection + Clone>(
         .scope_repo
         .delete(user.tenant_id, path.scope_id)
         .await?;
+    // D7 (REVOCATION — security critical): deleting a scope removes it from
+    // grants that referenced it, narrowing scoped access — flush the tenant.
+    authz.get_ref().as_ref().invalidate_tenant(user.tenant_id);
     Ok(HttpResponse::NoContent().finish())
 }

--- a/crates/axiam-api-rest/src/lib.rs
+++ b/crates/axiam-api-rest/src/lib.rs
@@ -19,7 +19,7 @@ pub use authz::{AuthzChecker, AuthzData, RequirePermission};
 pub use config::{RateLimitConfig, ServerConfig};
 pub use error::AxiamApiError;
 pub use extractors::auth::{AuthenticatedUser, SessionValidator};
-pub use extractors::cert_auth::CertificateAuthenticated;
+pub use extractors::cert_auth::{CertificateAuthenticated, VerifiedClientCert};
 pub use extractors::tenant::TenantContext;
 pub use health::HealthChecker;
 pub use openapi::ApiDoc;

--- a/crates/axiam-api-rest/src/middleware/rate_limit_shared.rs
+++ b/crates/axiam-api-rest/src/middleware/rate_limit_shared.rs
@@ -30,14 +30,17 @@ use std::rc::Rc;
 
 use actix_governor::KeyExtractor;
 use actix_web::body::EitherBody;
-use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::dev::{Payload, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::header::{ContentType, RETRY_AFTER};
-use actix_web::{Error, HttpResponse, web};
+use actix_web::{Error, HttpMessage, HttpResponse, web};
 use axiam_db::repository::SurrealRateLimitBucketRepository;
 use chrono::{DateTime, Utc};
 use surrealdb::Connection;
 
-use crate::extractors::rate_limit::XForwardedForKeyExtractor;
+use crate::config::rate_limit::RateLimitKeyMode;
+use crate::extractors::rate_limit::{
+    RateLimitClientId, XForwardedForKeyExtractor, extract_form_client_id,
+};
 use crate::state::AppState;
 
 /// Fixed-window duration (seconds) for the shared bucket. A simple
@@ -102,14 +105,64 @@ fn too_many_requests_response() -> HttpResponse {
 pub struct RateLimitShared<C: Connection + Clone> {
     endpoint: &'static str,
     limit: u32,
+    /// D8: bucket-key derivation mode. Always [`RateLimitKeyMode::Ip`] for
+    /// instances built via [`RateLimitShared::new`] — only
+    /// [`RateLimitShared::new_client_identity_aware`] ever sets this to
+    /// something else.
+    key_mode: RateLimitKeyMode,
+    /// D8: whether this resource has a form-encoded OAuth2 `client_id` to
+    /// peek at (`/oauth2/token`, `/oauth2/revoke`, `/oauth2/introspect`
+    /// ONLY — see [`RateLimitShared::new_client_identity_aware`]). `false`
+    /// for every other resource (including `/auth/login`), which never
+    /// touches the request body and always keys per-IP.
+    client_identity_aware: bool,
     _marker: PhantomData<C>,
 }
 
 impl<C: Connection + Clone> RateLimitShared<C> {
+    /// Plain IP-keyed constructor — unchanged since before D8. Use this for
+    /// every endpoint EXCEPT `/oauth2/token`, `/oauth2/revoke`, and
+    /// `/oauth2/introspect`. In particular, `/auth/login` MUST keep using
+    /// this constructor: it authenticates a user via username/password, so
+    /// there is no OAuth2 `client_id` in the request to key on, and this
+    /// type never reads `AXIAM__RATE_LIMIT__KEY` for it.
     pub fn new(endpoint: &'static str, limit: u32) -> Self {
         Self {
             endpoint,
             limit,
+            key_mode: RateLimitKeyMode::Ip,
+            client_identity_aware: false,
+            _marker: PhantomData,
+        }
+    }
+
+    /// D8 constructor for the three endpoints where an OAuth2 client
+    /// authenticates itself via a form-encoded `client_id`
+    /// (`client_secret_post`, RFC 6749 §2.3.1): `/oauth2/token`,
+    /// `/oauth2/revoke`, `/oauth2/introspect`.
+    ///
+    /// When `key_mode` is [`RateLimitKeyMode::ClientId`] or
+    /// [`RateLimitKeyMode::IpClientId`], this middleware peeks (and
+    /// restores) the request body to read `client_id`, and stashes it into
+    /// the request extensions (as [`RateLimitClientId`]) so the downstream
+    /// in-memory `Governor`'s `ClientAwareKeyExtractor` on the SAME
+    /// resource can reuse it without a second body read. When `key_mode` is
+    /// [`RateLimitKeyMode::Ip`] this is exactly as if `new()` had been
+    /// called — the body is never touched.
+    ///
+    /// **Do not use this constructor for `/auth/login` or any other
+    /// endpoint without a client identity** — see
+    /// [`crate::config::rate_limit::RateLimitKeyMode`] docs.
+    pub fn new_client_identity_aware(
+        endpoint: &'static str,
+        limit: u32,
+        key_mode: RateLimitKeyMode,
+    ) -> Self {
+        Self {
+            endpoint,
+            limit,
+            key_mode,
+            client_identity_aware: true,
             _marker: PhantomData,
         }
     }
@@ -120,6 +173,8 @@ impl<C: Connection + Clone> Clone for RateLimitShared<C> {
         Self {
             endpoint: self.endpoint,
             limit: self.limit,
+            key_mode: self.key_mode,
+            client_identity_aware: self.client_identity_aware,
             _marker: PhantomData,
         }
     }
@@ -142,6 +197,8 @@ where
             inner: Rc::new(service),
             endpoint: self.endpoint,
             limit: self.limit,
+            key_mode: self.key_mode,
+            client_identity_aware: self.client_identity_aware,
             _marker: PhantomData,
         }))
     }
@@ -155,6 +212,8 @@ pub struct RateLimitSharedService<S, C: Connection + Clone> {
     inner: Rc<S>,
     endpoint: &'static str,
     limit: u32,
+    key_mode: RateLimitKeyMode,
+    client_identity_aware: bool,
     _marker: PhantomData<C>,
 }
 
@@ -175,9 +234,11 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&self, req: ServiceRequest) -> Self::Future {
+    fn call(&self, mut req: ServiceRequest) -> Self::Future {
         let endpoint = self.endpoint;
         let limit = self.limit;
+        let key_mode = self.key_mode;
+        let client_identity_aware = self.client_identity_aware;
         let inner = Rc::clone(&self.inner);
 
         // Reuse the EXACT fixed IP-key extraction logic (D-01d) so the
@@ -194,18 +255,63 @@ where
             .map(|d| d.db.clone());
 
         Box::pin(async move {
-            let allow = match (ip, db) {
-                (Some(ip), Some(db)) => {
+            // D8: for the client-identity-aware endpoints only
+            // (`/oauth2/token`, `/oauth2/revoke`, `/oauth2/introspect` —
+            // never `/auth/login`), peek the form-encoded body for
+            // `client_id` and restore the payload so the handler's
+            // `web::Form<..>` extractor still sees the full body
+            // untouched. This ALSO stashes the result into request
+            // extensions for the downstream in-memory `Governor`'s
+            // `ClientAwareKeyExtractor` to reuse (see
+            // `extractors::rate_limit::RateLimitClientId`).
+            //
+            // Skipped entirely in `ip` mode (the default) — no body read,
+            // byte-for-byte the pre-D8 code path.
+            let client_id = if client_identity_aware {
+                let client_id = if key_mode != RateLimitKeyMode::Ip {
+                    let bytes = req.extract::<web::Bytes>().await.unwrap_or_default();
+                    let client_id = extract_form_client_id(&bytes);
+                    // Restore the body EXACTLY as read so the handler's
+                    // `web::Form<..>` extraction downstream is unaffected —
+                    // this middleware must be transparent to the request.
+                    req.set_payload(Payload::from(bytes));
+                    client_id
+                } else {
+                    None
+                };
+                req.extensions_mut()
+                    .insert(RateLimitClientId(client_id.clone()));
+                client_id
+            } else {
+                None
+            };
+
+            // The bucket-key "identity" part: IP alone (`ip` mode, or
+            // fail-safe fallback when no client_id was found), the
+            // client_id alone, or the `(ip, client_id)` pair. Mirrors
+            // `extractors::rate_limit::ClientAwareKeyExtractor` exactly so
+            // this shared-store pre-check and the in-memory governor never
+            // disagree about which bucket a request belongs to.
+            let key_part = match (key_mode, &client_id) {
+                (RateLimitKeyMode::Ip, _) | (_, None) => ip.map(|ip| ip.to_string()),
+                (RateLimitKeyMode::ClientId, Some(cid)) => Some(format!("client:{cid}")),
+                (RateLimitKeyMode::IpClientId, Some(cid)) => {
+                    ip.map(|ip| format!("{ip}:client:{cid}"))
+                }
+            };
+
+            let allow = match (key_part, db) {
+                (Some(key_part), Some(db)) => {
                     let repo = SurrealRateLimitBucketRepository::new(db);
-                    let key = format!("{endpoint}:{ip}");
+                    let key = format!("{endpoint}:{key_part}");
                     let window = window_start(Utc::now());
                     match repo.increment(&key, window).await {
                         Ok(count) => count <= limit as u64,
                         Err(err) => {
                             // Fail OPEN (D-01b): a counter-store outage must
                             // never hard-block auth traffic. T-24-43: do NOT
-                            // log the raw key (endpoint:ip) at info+ — this
-                            // warn-level alarm omits it.
+                            // log the raw key (endpoint:ip/client_id) at
+                            // info+ — this warn-level alarm omits it.
                             tracing::warn!(
                                 endpoint,
                                 error = %err,
@@ -216,8 +322,9 @@ where
                         }
                     }
                 }
-                // No client-IP key or no DB handle available — fail open;
-                // the in-memory governor still makes the real decision.
+                // No key part (IP unavailable) or no DB handle available —
+                // fail open; the in-memory governor still makes the real
+                // decision.
                 _ => true,
             };
 

--- a/crates/axiam-api-rest/src/server.rs
+++ b/crates/axiam-api-rest/src/server.rs
@@ -10,7 +10,8 @@ use axiam_db::DbClient;
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::RateLimitConfig;
-use crate::extractors::rate_limit::XForwardedForKeyExtractor;
+use crate::config::rate_limit::RateLimitKeyMode;
+use crate::extractors::rate_limit::{ClientAwareKeyExtractor, XForwardedForKeyExtractor};
 use crate::handlers;
 use crate::middleware::authz::AuthzMiddleware;
 use crate::middleware::csrf::CsrfMiddleware;
@@ -33,6 +34,41 @@ fn build_governor(requests_per_min: u32) -> Governor<XForwardedForKeyExtractor, 
         .requests_per_minute(requests_per_min as u64)
         .burst_size(requests_per_min)
         .key_extractor(XForwardedForKeyExtractor::with_trusted_hops(trusted_hops))
+        .finish()
+        .expect("valid governor config");
+    Governor::new(&config)
+}
+
+/// D8: build a per-endpoint Governor middleware instance for the three
+/// endpoints where an OAuth2 client identity (`client_id`) is available —
+/// `/oauth2/token`, `/oauth2/revoke`, `/oauth2/introspect` ONLY.
+///
+/// `key_mode` (`AXIAM__RATE_LIMIT__KEY`, from [`RateLimitConfig::key`])
+/// controls whether the bucket key is IP alone (default, unchanged
+/// behavior), the OAuth2 `client_id` alone, or the `(ip, client_id)` pair —
+/// see [`crate::config::rate_limit::RateLimitKeyMode`] for the full
+/// NAT'd-fleet rationale. The `client_id` itself is read from request
+/// extensions populated by `middleware::rate_limit_shared::RateLimitShared`
+/// (wired as the OUTER `.wrap()` on the same resource, so it always runs
+/// first — see that middleware's docs).
+///
+/// **Never call this for `/auth/login`** (or any other endpoint without a
+/// client identity) — use [`build_governor`] there instead, unconditionally.
+fn build_client_aware_governor(
+    requests_per_min: u32,
+    key_mode: RateLimitKeyMode,
+) -> Governor<ClientAwareKeyExtractor, NoOpMiddleware> {
+    let trusted_hops: usize = std::env::var("AXIAM__RATE_LIMIT__TRUSTED_HOPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let config = GovernorConfigBuilder::default()
+        .requests_per_minute(requests_per_min as u64)
+        .burst_size(requests_per_min)
+        .key_extractor(ClientAwareKeyExtractor::new(
+            XForwardedForKeyExtractor::with_trusted_hops(trusted_hops),
+            key_mode,
+        ))
         .finish()
         .expect("valid governor config");
     Governor::new(&config)
@@ -70,6 +106,14 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
             .wrap(CsrfMiddleware)
             .app_data(web::JsonConfig::default().limit(65_536))
             .service(
+                // D8: `/auth/login` ALWAYS keys per-IP, regardless of
+                // `AXIAM__RATE_LIMIT__KEY`. Login authenticates a *user* via
+                // username/password — there is no OAuth2 `client_id` (or any
+                // other client identity) anywhere in this request to key
+                // on, so `build_governor`/`RateLimitShared::new` (the
+                // IP-only constructors) are used unconditionally here, never
+                // the client-identity-aware variants. See
+                // `crate::config::rate_limit::RateLimitKeyMode` docs.
                 web::resource("/login")
                     .wrap(build_governor(rate_limit_cfg.login_per_min))
                     .wrap(RateLimitShared::<C>::new("login", rate_limit_cfg.login_per_min))
@@ -237,12 +281,24 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
                 "/authorize",
                 web::get().to(handlers::oauth2::authorize::<C>),
             )
+            // D8: `/token`, `/revoke`, `/introspect` are the ONLY three
+            // endpoints with a form-encoded OAuth2 `client_id`
+            // (`client_secret_post`, RFC 6749 §2.3.1) — the client-aware
+            // governor/`RateLimitShared` constructors honor
+            // `rate_limit_cfg.key` (`AXIAM__RATE_LIMIT__KEY`) here so a
+            // NAT'd fleet of distinct OAuth2 clients no longer collides into
+            // one shared per-IP bucket. `key` defaults to `ip`, which is
+            // byte-for-byte the pre-D8 behavior.
             .service(
                 web::resource("/token")
-                    .wrap(build_governor(rate_limit_cfg.token_per_min))
-                    .wrap(RateLimitShared::<C>::new(
+                    .wrap(build_client_aware_governor(
+                        rate_limit_cfg.token_per_min,
+                        rate_limit_cfg.key,
+                    ))
+                    .wrap(RateLimitShared::<C>::new_client_identity_aware(
                         "oauth2_token",
                         rate_limit_cfg.token_per_min,
+                        rate_limit_cfg.key,
                     ))
                     .route(web::post().to(handlers::oauth2::token::<C>)),
             )
@@ -250,19 +306,27 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
             // and token probing attacks.
             .service(
                 web::resource("/revoke")
-                    .wrap(build_governor(rate_limit_cfg.revoke_per_min))
-                    .wrap(RateLimitShared::<C>::new(
+                    .wrap(build_client_aware_governor(
+                        rate_limit_cfg.revoke_per_min,
+                        rate_limit_cfg.key,
+                    ))
+                    .wrap(RateLimitShared::<C>::new_client_identity_aware(
                         "oauth2_revoke",
                         rate_limit_cfg.revoke_per_min,
+                        rate_limit_cfg.key,
                     ))
                     .route(web::post().to(handlers::oauth2::revoke::<C>)),
             )
             .service(
                 web::resource("/introspect")
-                    .wrap(build_governor(rate_limit_cfg.introspect_per_min))
-                    .wrap(RateLimitShared::<C>::new(
+                    .wrap(build_client_aware_governor(
+                        rate_limit_cfg.introspect_per_min,
+                        rate_limit_cfg.key,
+                    ))
+                    .wrap(RateLimitShared::<C>::new_client_identity_aware(
                         "oauth2_introspect",
                         rate_limit_cfg.introspect_per_min,
+                        rate_limit_cfg.key,
                     ))
                     .route(web::post().to(handlers::oauth2::introspect::<C>)),
             )

--- a/crates/axiam-api-rest/src/server.rs
+++ b/crates/axiam-api-rest/src/server.rs
@@ -266,7 +266,7 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
                     ))
                     .route(web::post().to(handlers::oauth2::introspect::<C>)),
             )
-            .route("/jwks", web::get().to(handlers::oauth2::jwks))
+            .route("/jwks", web::get().to(handlers::oauth2::jwks::<C>))
             .route("/userinfo", web::get().to(handlers::oauth2::userinfo::<C>)),
     );
     let api_scope = web::scope("/api/v1")

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -69,6 +69,9 @@ use axiam_federation::oidc::OidcFederationService;
 #[cfg(feature = "saml")]
 use axiam_federation::saml::SamlFederationService;
 use axiam_oauth2::authorize::AuthorizeService;
+use axiam_oauth2::jwks_cache::{
+    JwksCache as Oauth2JwksCache, JwksCacheConfig as Oauth2JwksCacheConfig,
+};
 use axiam_oauth2::token::TokenService;
 use axiam_pki::{CaService, CertService, DeviceAuthService, PgpService};
 use surrealdb::{Connection, Surreal};
@@ -265,7 +268,20 @@ pub struct AppState<C: Connection + Clone> {
     pub assertion_replay_repo: SurrealAssertionReplayRepository<C>,
     pub federation_login_state_repo: SurrealFederationLoginStateRepository<C>,
     pub http_client: reqwest::Client,
+    /// Federation JWKS cache: caches REMOTE identity providers' JWKS
+    /// documents fetched during OIDC federation login. NOT related to
+    /// `oauth2_jwks_cache` below -- see `axiam_oauth2::jwks_cache` module
+    /// docs for the distinction.
     pub jwks_cache: Arc<JwksCache>,
+    /// B3: in-process cache + ETag for AXIAM's OWN `GET /oauth2/jwks`
+    /// response (the signing keys AXIAM serves to relying parties).
+    /// Constructed once at startup and shared via this `Arc` so all workers
+    /// hit the same cache instead of each maintaining its own.
+    pub oauth2_jwks_cache: Arc<Oauth2JwksCache>,
+    /// B3: `Cache-Control` max-age (and header rendering) for the
+    /// `GET /oauth2/jwks` response. Configured via
+    /// `AXIAM__OAUTH2__JWKS_CACHE_MAX_AGE_SECS` (default 300s).
+    pub oauth2_jwks_cache_config: Oauth2JwksCacheConfig,
     pub crypto_semaphore: Arc<Semaphore>,
     /// D-02: `None` when `AXIAM__EMAIL_ENCRYPTION_KEY` is unset — the six
     /// email-config routes fail closed rather than silently using a
@@ -461,6 +477,8 @@ impl<C: Connection + Clone> AppState<C> {
             federation_login_state_repo: SurrealFederationLoginStateRepository::new(db.clone()),
             http_client: reqwest::Client::new(),
             jwks_cache: Arc::new(JwksCache::new()),
+            oauth2_jwks_cache: Arc::new(Oauth2JwksCache::new()),
+            oauth2_jwks_cache_config: Oauth2JwksCacheConfig::default(),
             crypto_semaphore,
             email_config_repo: None,
             password_reset_service,

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -329,7 +329,9 @@ impl<C: Connection + Clone> AppState<C> {
     /// state.email_encryption_key = Some(TEST_KEY);
     /// ```
     pub fn for_test(db: Surreal<C>, auth_config: AuthConfig) -> Self {
-        let crypto_semaphore = Arc::new(Semaphore::new(4));
+        // B1: resolve the hash-gate permit count from config (0 = auto → min(cores, 4)).
+        let crypto_semaphore =
+            Arc::new(Semaphore::new(auth_config.resolved_max_concurrent_hashes()));
         let pki_config = axiam_pki::PkiConfig {
             encryption_key: None,
         };
@@ -404,6 +406,7 @@ impl<C: Connection + Clone> AppState<C> {
             session_repo.clone(),
             refresh_token_repo.clone(),
             Arc::clone(&crypto_semaphore),
+            auth_config.hash_acquire_timeout_secs,
         );
         let email_verification_service = EmailVerificationService::new(
             user_repo.clone(),

--- a/crates/axiam-api-rest/src/tests/authz_check_test.rs
+++ b/crates/axiam-api-rest/src/tests/authz_check_test.rs
@@ -395,6 +395,7 @@ async fn batch_check_access_matches_sequential_per_item_check_access() {
     let mut batch_state_inner = AppState::for_test(batch_db, AuthConfig::default());
     batch_state_inner.authz_config = axiam_authz::AuthzConfig {
         batch_max_concurrency: 2,
+        ..Default::default()
     };
     let batch_state = web::Data::new(batch_state_inner);
     let batch_authz = make_authz(PerResourceAuthzChecker { allowed });

--- a/crates/axiam-api-rest/tests/middleware_test.rs
+++ b/crates/axiam-api-rest/tests/middleware_test.rs
@@ -79,6 +79,8 @@ fn test_auth_config(lifetime: u64) -> AuthConfig {
         jwt_decoding_key: None,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,
+        max_concurrent_hashes: 0,
+        hash_acquire_timeout_secs: 5,
     }
 }
 

--- a/crates/axiam-api-rest/tests/rate_limit_client_identity_test.rs
+++ b/crates/axiam-api-rest/tests/rate_limit_client_identity_test.rs
@@ -159,7 +159,10 @@ async fn client_id_mode_gives_independent_buckets_per_client_under_one_ip() {
             "bob request {i} must succeed independently of alice's exhausted bucket"
         );
         let body = test::read_body(resp).await;
-        assert_eq!(body, "bob", "handler must still see the correct client_id after body restore");
+        assert_eq!(
+            body, "bob",
+            "handler must still see the correct client_id after body restore"
+        );
     }
 }
 

--- a/crates/axiam-api-rest/tests/rate_limit_client_identity_test.rs
+++ b/crates/axiam-api-rest/tests/rate_limit_client_identity_test.rs
@@ -73,12 +73,14 @@ fn build_client_aware_app(
     db: Surreal<TestDb>,
     key_mode: RateLimitKeyMode,
     endpoint: &'static str,
-) -> impl actix_web::dev::ServiceFactory<
-    actix_web::dev::ServiceRequest,
-    Config = (),
-    Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
-    Error = actix_web::Error,
-    InitError = (),
+) -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
 > {
     App::new()
         .app_data(web::Data::new(AppState::for_test(
@@ -102,12 +104,14 @@ fn build_client_aware_app(
 fn build_login_like_app(
     db: Surreal<TestDb>,
     endpoint: &'static str,
-) -> impl actix_web::dev::ServiceFactory<
-    actix_web::dev::ServiceRequest,
-    Config = (),
-    Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
-    Error = actix_web::Error,
-    InitError = (),
+) -> App<
+    impl actix_web::dev::ServiceFactory<
+        actix_web::dev::ServiceRequest,
+        Config = (),
+        Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
 > {
     App::new()
         .app_data(web::Data::new(AppState::for_test(

--- a/crates/axiam-api-rest/tests/rate_limit_client_identity_test.rs
+++ b/crates/axiam-api-rest/tests/rate_limit_client_identity_test.rs
@@ -1,0 +1,286 @@
+//! D8 — rate-limiter key configurability (`AXIAM__RATE_LIMIT__KEY`).
+//!
+//! End-to-end proof (real `RateLimitShared` middleware + a Mem SurrealDB,
+//! mirroring `rate_limit_shared_store_test.rs`'s pattern) that:
+//! - `client_id` mode gives independent buckets per `client_id` under ONE
+//!   shared IP — the NAT'd-fleet collision this task fixes.
+//! - `client_id` mode still gives the SAME bucket to the SAME client_id
+//!   connecting from different IPs.
+//! - `ip_client_id` mode distinguishes both dimensions.
+//! - `ip` mode (the default) is byte-for-byte unchanged: two different
+//!   client_ids behind one IP still share ONE bucket, exactly like before
+//!   this field existed.
+//! - The body is transparently restored: the downstream `web::Form<..>`
+//!   handler still sees the full, correct form body after the middleware
+//!   peeked it for `client_id`.
+//! - A `RateLimitShared::new(...)`-wired resource (standing in for
+//!   `/auth/login`) NEVER keys on `client_id`, regardless of what's in the
+//!   body — proving login-stays-per-IP is structural, not merely
+//!   configuration-default.
+
+use actix_web::{App, HttpResponse, test, web};
+use axiam_api_rest::config::rate_limit::RateLimitKeyMode;
+use axiam_api_rest::middleware::rate_limit_shared::RateLimitShared;
+use axiam_api_rest::state::AppState;
+use axiam_auth::config::AuthConfig;
+use serde::Deserialize;
+use surrealdb::Surreal;
+use surrealdb::engine::local::{Db, Mem};
+
+type TestDb = Db;
+
+/// Per-bucket limit shared by every scenario below.
+const LIMIT: u32 = 2;
+
+#[derive(Debug, Deserialize)]
+struct FormLikeTokenRequest {
+    client_id: String,
+}
+
+/// Echoes the parsed `client_id` back — proves the middleware's body
+/// peek-and-restore left the payload intact for the real `web::Form<..>`
+/// extractor downstream (the same extraction style `handlers::oauth2::token`
+/// / `revoke` / `introspect` use).
+async fn echo_client_id(form: web::Form<FormLikeTokenRequest>) -> HttpResponse {
+    HttpResponse::Ok().body(form.client_id.clone())
+}
+
+async fn ok_handler() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+fn form_body(client_id: &str) -> String {
+    format!("grant_type=client_credentials&client_id={client_id}&client_secret=s")
+}
+
+fn post_form(uri: &str, peer: std::net::SocketAddr, client_id: &str) -> actix_http::Request {
+    use actix_web::http::header::{CONTENT_TYPE, HeaderValue};
+    test::TestRequest::post()
+        .uri(uri)
+        .peer_addr(peer)
+        .insert_header((
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/x-www-form-urlencoded"),
+        ))
+        .set_payload(form_body(client_id))
+        .to_request()
+}
+
+/// Builds a single-resource app with a client-identity-aware
+/// `RateLimitShared` in the given key mode, wired exactly like
+/// `/oauth2/token` in `server.rs`.
+fn build_client_aware_app(
+    db: Surreal<TestDb>,
+    key_mode: RateLimitKeyMode,
+    endpoint: &'static str,
+) -> impl actix_web::dev::ServiceFactory<
+    actix_web::dev::ServiceRequest,
+    Config = (),
+    Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+    Error = actix_web::Error,
+    InitError = (),
+> {
+    App::new()
+        .app_data(web::Data::new(AppState::for_test(
+            db,
+            AuthConfig::default(),
+        )))
+        .service(
+            web::resource("/t")
+                .wrap(RateLimitShared::<TestDb>::new_client_identity_aware(
+                    endpoint, LIMIT, key_mode,
+                ))
+                .route(web::post().to(echo_client_id)),
+        )
+}
+
+/// Builds a single-resource app with the PLAIN (non-client-identity-aware)
+/// `RateLimitShared` — exactly how `/auth/login` is wired in `server.rs`.
+/// Uses the plain `ok_handler` (not `web::Form<..>`) since login's real
+/// request body is JSON, not form-encoded — the point of this test is that
+/// the rate limiter never even looks at it.
+fn build_login_like_app(
+    db: Surreal<TestDb>,
+    endpoint: &'static str,
+) -> impl actix_web::dev::ServiceFactory<
+    actix_web::dev::ServiceRequest,
+    Config = (),
+    Response = actix_web::dev::ServiceResponse<impl actix_web::body::MessageBody>,
+    Error = actix_web::Error,
+    InitError = (),
+> {
+    App::new()
+        .app_data(web::Data::new(AppState::for_test(
+            db,
+            AuthConfig::default(),
+        )))
+        .service(
+            web::resource("/t")
+                .wrap(RateLimitShared::<TestDb>::new(endpoint, LIMIT))
+                .route(web::post().to(ok_handler)),
+        )
+}
+
+async fn fresh_db() -> Surreal<TestDb> {
+    let db = Surreal::new::<Mem>(()).await.unwrap();
+    db.use_ns("test").use_db("test").await.unwrap();
+    axiam_db::run_migrations(&db).await.unwrap();
+    db
+}
+
+#[actix_rt::test]
+async fn client_id_mode_gives_independent_buckets_per_client_under_one_ip() {
+    let db = fresh_db().await;
+    let app = test::init_service(build_client_aware_app(
+        db,
+        RateLimitKeyMode::ClientId,
+        "client_id_mode_test",
+    ))
+    .await;
+
+    let peer: std::net::SocketAddr = "203.0.113.50:1".parse().unwrap();
+
+    // Exhaust client "alice"'s bucket (LIMIT requests all succeed).
+    for i in 0..LIMIT {
+        let resp = test::call_service(&app, post_form("/t", peer, "alice")).await;
+        assert_eq!(resp.status(), 200, "alice request {i} should succeed");
+    }
+    let resp = test::call_service(&app, post_form("/t", peer, "alice")).await;
+    assert_eq!(resp.status(), 429, "alice must now be rate-limited");
+
+    // Client "bob", SAME source IP, is COMPLETELY unaffected — this is the
+    // NAT'd-fleet collision fix: before D8 (or in `ip` mode) this request
+    // would already be 429 because it shares alice's IP-only bucket.
+    for i in 0..LIMIT {
+        let resp = test::call_service(&app, post_form("/t", peer, "bob")).await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "bob request {i} must succeed independently of alice's exhausted bucket"
+        );
+        let body = test::read_body(resp).await;
+        assert_eq!(body, "bob", "handler must still see the correct client_id after body restore");
+    }
+}
+
+#[actix_rt::test]
+async fn client_id_mode_shares_one_bucket_for_same_client_across_ips() {
+    let db = fresh_db().await;
+    let app = test::init_service(build_client_aware_app(
+        db,
+        RateLimitKeyMode::ClientId,
+        "client_id_mode_cross_ip_test",
+    ))
+    .await;
+
+    let peer_a: std::net::SocketAddr = "203.0.113.60:1".parse().unwrap();
+    let peer_b: std::net::SocketAddr = "203.0.113.61:1".parse().unwrap();
+
+    // Split the SAME client_id's LIMIT requests across two different IPs —
+    // the bucket must still be shared (client_id mode ignores IP entirely).
+    for i in 0..LIMIT {
+        let peer = if i % 2 == 0 { peer_a } else { peer_b };
+        let resp = test::call_service(&app, post_form("/t", peer, "carol")).await;
+        assert_eq!(resp.status(), 200);
+    }
+    let resp = test::call_service(&app, post_form("/t", peer_a, "carol")).await;
+    assert_eq!(
+        resp.status(),
+        429,
+        "same client_id from a third IP must still hit the shared per-client bucket"
+    );
+}
+
+#[actix_rt::test]
+async fn ip_client_id_mode_distinguishes_both_dimensions() {
+    let db = fresh_db().await;
+    let app = test::init_service(build_client_aware_app(
+        db,
+        RateLimitKeyMode::IpClientId,
+        "ip_client_id_mode_test",
+    ))
+    .await;
+
+    let peer_a: std::net::SocketAddr = "203.0.113.70:1".parse().unwrap();
+    let peer_b: std::net::SocketAddr = "203.0.113.71:1".parse().unwrap();
+
+    // Exhaust (peer_a, "dave").
+    for _ in 0..LIMIT {
+        let resp = test::call_service(&app, post_form("/t", peer_a, "dave")).await;
+        assert_eq!(resp.status(), 200);
+    }
+    let resp = test::call_service(&app, post_form("/t", peer_a, "dave")).await;
+    assert_eq!(resp.status(), 429, "(peer_a, dave) must be exhausted");
+
+    // Same client_id "dave" from a DIFFERENT IP: independent bucket.
+    let resp = test::call_service(&app, post_form("/t", peer_b, "dave")).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "(peer_b, dave) must be independent of (peer_a, dave) in ip_client_id mode"
+    );
+
+    // Different client_id "erin" from the SAME peer_a: also independent.
+    let resp = test::call_service(&app, post_form("/t", peer_a, "erin")).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "(peer_a, erin) must be independent of (peer_a, dave) in ip_client_id mode"
+    );
+}
+
+#[actix_rt::test]
+async fn ip_mode_is_unchanged_two_client_ids_share_one_ip_bucket() {
+    // D8 acceptance: default behavior (`ip`) is identical to today — two
+    // DIFFERENT client_ids behind the SAME IP must still collide into ONE
+    // bucket, exactly like the pre-D8 code path.
+    let db = fresh_db().await;
+    let app = test::init_service(build_client_aware_app(
+        db,
+        RateLimitKeyMode::Ip,
+        "ip_mode_unchanged_test",
+    ))
+    .await;
+
+    let peer: std::net::SocketAddr = "203.0.113.80:1".parse().unwrap();
+
+    for i in 0..LIMIT {
+        let client_id = if i % 2 == 0 { "frank" } else { "grace" };
+        let resp = test::call_service(&app, post_form("/t", peer, client_id)).await;
+        assert_eq!(resp.status(), 200);
+    }
+    // Third request, yet ANOTHER client_id, same IP: must already be 429 —
+    // `ip` mode never distinguishes clients.
+    let resp = test::call_service(&app, post_form("/t", peer, "henry")).await;
+    assert_eq!(
+        resp.status(),
+        429,
+        "ip mode must ignore client_id entirely and share one per-IP bucket"
+    );
+}
+
+#[actix_rt::test]
+async fn login_like_endpoint_stays_per_ip_and_never_reads_client_id_from_body() {
+    // Simulates `/auth/login`'s wiring: `RateLimitShared::new(...)` (NOT
+    // `new_client_identity_aware`). Even though the request bodies below
+    // carry distinct "client_id"-shaped form fields, the login-style
+    // resource must treat them as one shared per-IP bucket — proving the
+    // login-stays-per-IP guarantee holds regardless of body content, not
+    // just because the global key mode defaults to `ip`.
+    let db = fresh_db().await;
+    let app = test::init_service(build_login_like_app(db, "login_like_test")).await;
+
+    let peer: std::net::SocketAddr = "203.0.113.90:1".parse().unwrap();
+
+    for i in 0..LIMIT {
+        let client_id = if i % 2 == 0 { "alice" } else { "bob" };
+        let resp = test::call_service(&app, post_form("/t", peer, client_id)).await;
+        assert_eq!(resp.status(), 200, "login-like request {i} should succeed");
+    }
+    let resp = test::call_service(&app, post_form("/t", peer, "someone-else")).await;
+    assert_eq!(
+        resp.status(),
+        429,
+        "login-like endpoint must be rate-limited per-IP, ignoring any client_id-shaped body field"
+    );
+}

--- a/crates/axiam-api-rest/tests/rate_limit_keying_test.rs
+++ b/crates/axiam-api-rest/tests/rate_limit_keying_test.rs
@@ -8,8 +8,12 @@
 //! completely evading brute-force protection.
 
 use actix_governor::KeyExtractor;
+use actix_web::HttpMessage;
 use actix_web::test::TestRequest;
-use axiam_api_rest::extractors::rate_limit::XForwardedForKeyExtractor;
+use axiam_api_rest::config::rate_limit::RateLimitKeyMode;
+use axiam_api_rest::extractors::rate_limit::{
+    ClientAwareKeyExtractor, RateLimitClientId, XForwardedForKeyExtractor,
+};
 use std::net::{IpAddr, SocketAddr};
 
 /// Fixed loopback peer address representing the real (trusted) TCP peer —
@@ -116,4 +120,103 @@ async fn sufficient_hops_still_selects_right_indexed_hop() {
         "203.0.113.51".parse::<IpAddr>().unwrap(),
         "sufficient-hops path must still select the rightmost-untrusted hop"
     );
+}
+
+// ---------------------------------------------------------------------------
+// D8 — client-identity-aware keying (`ClientAwareKeyExtractor`)
+//
+// `ClientAwareKeyExtractor` is what the in-memory `Governor` uses on
+// `/oauth2/token`, `/oauth2/revoke`, and `/oauth2/introspect` (see
+// `server.rs::build_client_aware_governor`). It reads the `client_id`
+// stashed into request extensions by
+// `middleware::rate_limit_shared::RateLimitShared::new_client_identity_aware`
+// (which always runs first — it is wired as the OUTER `.wrap()`). These
+// tests exercise the extractor directly via that same extension contract.
+// End-to-end (real middleware + real 429 responses) coverage lives in
+// `rate_limit_client_identity_test.rs`.
+// ---------------------------------------------------------------------------
+
+fn req_with_stashed_client_id(
+    peer: &str,
+    client_id: Option<&str>,
+) -> actix_web::dev::ServiceRequest {
+    let req = TestRequest::get()
+        .peer_addr(peer.parse::<SocketAddr>().unwrap())
+        .to_srv_request();
+    req.extensions_mut()
+        .insert(RateLimitClientId(client_id.map(str::to_owned)));
+    req
+}
+
+#[test]
+fn client_aware_extractor_ip_mode_matches_plain_ip_extractor() {
+    // D8 acceptance: `ip` mode (the default) must be indistinguishable from
+    // the plain `XForwardedForKeyExtractor` used everywhere else.
+    let plain = XForwardedForKeyExtractor::default();
+    let client_aware = ClientAwareKeyExtractor::new(plain.clone(), RateLimitKeyMode::Ip);
+
+    let req = req_with_stashed_client_id(TEST_PEER, Some("some-client"));
+
+    let plain_key = plain.extract(&req).unwrap().to_string();
+    let aware_key = client_aware.extract(&req).unwrap();
+
+    assert_eq!(
+        aware_key, plain_key,
+        "ip mode must ignore any stashed client_id and match plain IP keying exactly"
+    );
+}
+
+#[test]
+fn client_aware_extractor_distinguishes_clients_under_one_ip_in_client_id_mode() {
+    let extractor = ClientAwareKeyExtractor::new(
+        XForwardedForKeyExtractor::default(),
+        RateLimitKeyMode::ClientId,
+    );
+
+    let req_a = req_with_stashed_client_id(TEST_PEER, Some("client-a"));
+    let req_b = req_with_stashed_client_id(TEST_PEER, Some("client-b"));
+
+    let key_a = extractor.extract(&req_a).unwrap();
+    let key_b = extractor.extract(&req_b).unwrap();
+
+    assert_ne!(
+        key_a, key_b,
+        "distinct client_ids behind the SAME peer IP must get distinct buckets"
+    );
+}
+
+#[test]
+fn client_aware_extractor_ip_client_id_mode_distinguishes_both() {
+    let extractor = ClientAwareKeyExtractor::new(
+        XForwardedForKeyExtractor::default(),
+        RateLimitKeyMode::IpClientId,
+    );
+
+    const OTHER_PEER: &str = "198.51.100.20:1";
+
+    let same_client_diff_ip_1 = req_with_stashed_client_id(TEST_PEER, Some("client-a"));
+    let same_client_diff_ip_2 = req_with_stashed_client_id(OTHER_PEER, Some("client-a"));
+    let diff_client_same_ip = req_with_stashed_client_id(TEST_PEER, Some("client-b"));
+
+    let k1 = extractor.extract(&same_client_diff_ip_1).unwrap();
+    let k2 = extractor.extract(&same_client_diff_ip_2).unwrap();
+    let k3 = extractor.extract(&diff_client_same_ip).unwrap();
+
+    assert_ne!(k1, k2, "same client_id from a different IP must differ");
+    assert_ne!(k1, k3, "different client_id from the same IP must differ");
+}
+
+#[test]
+fn client_aware_extractor_falls_back_to_ip_when_no_client_id_present() {
+    // Fail-SAFE: `client_id` mode with no resolvable client_id (malformed
+    // body, or the extension was never stashed) must still rate-limit — by
+    // falling back to the IP key, not by disabling the limiter.
+    let extractor = ClientAwareKeyExtractor::new(
+        XForwardedForKeyExtractor::default(),
+        RateLimitKeyMode::ClientId,
+    );
+
+    let with_no_client_id = req_with_stashed_client_id(TEST_PEER, None);
+    let key = extractor.extract(&with_no_client_id).unwrap();
+    assert_eq!(key, peer_ip().to_string());
 }

--- a/crates/axiam-audit/tests/service_and_middleware.rs
+++ b/crates/axiam-audit/tests/service_and_middleware.rs
@@ -330,6 +330,8 @@ fn test_auth_config() -> AuthConfig {
         jwt_decoding_key: None,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,
+        max_concurrent_hashes: 0,
+        hash_acquire_timeout_secs: 5,
     }
 }
 

--- a/crates/axiam-auth/src/config.rs
+++ b/crates/axiam-auth/src/config.rs
@@ -100,6 +100,26 @@ pub struct AuthConfig {
     /// allowing a half-open probe request (default: 30). Overridable via
     /// `AXIAM__AUTH__HIBP_BREAKER_COOLDOWN_SECS`.
     pub hibp_breaker_cooldown_secs: u64,
+    /// B1: Maximum number of Argon2id hash/verify operations allowed to run
+    /// concurrently, enforced by the process-wide `crypto_semaphore` shared
+    /// across the login, password-change, password-reset and PKI crypto paths.
+    ///
+    /// Each in-flight Argon2id operation allocates a ~19 MiB memory arena
+    /// (OWASP params m=19456), so unbounded concurrency is an unauthenticated
+    /// memory-DoS vector: the login benchmark pegged 2 cores and reached
+    /// ~970 MiB RSS ≈ 50 concurrent × 19 MiB arenas, against a 1024 MiB
+    /// container cap. This permit count bounds peak concurrent arenas.
+    ///
+    /// `0` means "auto" and resolves to `min(available_parallelism, 4)` at
+    /// semaphore-construction time (see [`AuthConfig::resolved_max_concurrent_hashes`]).
+    /// Override via `AXIAM__AUTH__MAX_CONCURRENT_HASHES`.
+    pub max_concurrent_hashes: usize,
+    /// B1: How long (in seconds) a request waits to acquire a crypto-hash
+    /// permit before giving up and returning a `ServiceUnavailable` (HTTP 503)
+    /// backpressure error, instead of queueing unboundedly and adding to
+    /// tail latency. Default: 5. Override via
+    /// `AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS`.
+    pub hash_acquire_timeout_secs: u64,
 }
 
 impl AuthConfig {
@@ -130,6 +150,24 @@ impl AuthConfig {
         self.jwt_encoding_key = Some(Arc::new(enc));
         self.jwt_decoding_key = Some(Arc::new(dec));
         Ok(())
+    }
+
+    /// B1: Resolve `max_concurrent_hashes` (0 = auto) to a concrete permit
+    /// count for the crypto semaphore.
+    ///
+    /// Auto (`0`) resolves to `min(available_parallelism, 4)`: bound by the
+    /// core count so Argon2id (a CPU-bound operation) does not oversubscribe
+    /// cores, and capped at 4 so peak concurrent ~19 MiB arenas stay well
+    /// under typical container memory caps. A non-zero value is used verbatim
+    /// (a `0` after resolution is impossible — it would be a zero-permit
+    /// semaphore that deadlocks all hashing, so it is clamped to 1).
+    pub fn resolved_max_concurrent_hashes(&self) -> usize {
+        match self.max_concurrent_hashes {
+            0 => std::thread::available_parallelism()
+                .map(|n| n.get().min(4))
+                .unwrap_or(4),
+            n => n.max(1),
+        }
     }
 }
 
@@ -164,6 +202,9 @@ impl Default for AuthConfig {
             jwt_decoding_key: None,
             hibp_breaker_threshold: 5,
             hibp_breaker_cooldown_secs: 30,
+            // B1: 0 = auto → min(available_parallelism, 4) at construction.
+            max_concurrent_hashes: 0,
+            hash_acquire_timeout_secs: 5,
         }
     }
 }

--- a/crates/axiam-auth/src/crypto_gate.rs
+++ b/crates/axiam-auth/src/crypto_gate.rs
@@ -1,0 +1,119 @@
+//! Backpressure gate for CPU-bound Argon2id operations (B1).
+//!
+//! A single process-wide `tokio::sync::Semaphore` bounds how many Argon2id
+//! hash/verify operations run at once. The permit *count* caps peak memory:
+//! each in-flight Argon2id operation allocates a ~19 MiB arena (OWASP params
+//! m=19456), so without a bound an unauthenticated login flood is a
+//! memory-DoS vector (the login benchmark reached ~970 MiB RSS ≈ 50
+//! concurrent × 19 MiB against a 1024 MiB cap).
+//!
+//! This module adds an *acquire timeout* on top of that bound so that, once
+//! every permit is held, further callers fail fast with a 503 backpressure
+//! error rather than queueing unboundedly (which turns a memory problem into
+//! a tail-latency problem).
+
+use std::time::Duration;
+
+use axiam_core::error::{AxiamError, AxiamResult};
+use tokio::sync::{Semaphore, SemaphorePermit};
+
+/// Acquire a permit from the crypto semaphore, bounded by `timeout`.
+///
+/// * On success, returns the held [`SemaphorePermit`] (drop it to release).
+/// * On timeout, returns [`AxiamError::ServiceUnavailable`], which the REST
+///   layer maps to **HTTP 503** — the existing "service unavailable /
+///   overloaded" variant, chosen because a saturated hash gate is a transient
+///   server-capacity condition, not a per-client rate-limit violation.
+/// * A closed semaphore (never happens in practice — the gate is never
+///   closed) maps to [`AxiamError::Internal`], matching the prior behaviour of
+///   the untimed `acquire()` call sites.
+pub(crate) async fn acquire_hash_permit(
+    semaphore: &Semaphore,
+    timeout: Duration,
+) -> AxiamResult<SemaphorePermit<'_>> {
+    match tokio::time::timeout(timeout, semaphore.acquire()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        Ok(Err(_closed)) => Err(AxiamError::Internal("crypto semaphore closed".into())),
+        Err(_elapsed) => Err(AxiamError::ServiceUnavailable(
+            "authentication service is at capacity; please retry shortly".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn returns_permit_when_capacity_available() {
+        let sem = Semaphore::new(2);
+        let permit = acquire_hash_permit(&sem, Duration::from_secs(5)).await;
+        assert!(permit.is_ok(), "should acquire when permits are free");
+        assert_eq!(sem.available_permits(), 1, "one permit taken");
+    }
+
+    #[tokio::test]
+    async fn times_out_to_service_unavailable_when_saturated() {
+        let sem = Semaphore::new(1);
+        // Saturate: hold the only permit for the duration of the test.
+        let _held = sem.acquire().await.unwrap();
+
+        // A second acquire with a tiny timeout must return the backpressure
+        // error (HTTP 503), not block forever.
+        let result = acquire_hash_permit(&sem, Duration::from_millis(20)).await;
+        match result {
+            Err(AxiamError::ServiceUnavailable(_)) => {}
+            other => panic!("expected ServiceUnavailable backpressure error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn permit_release_lets_a_waiter_through() {
+        let sem = Arc::new(Semaphore::new(1));
+        let permit = acquire_hash_permit(&sem, Duration::from_secs(5))
+            .await
+            .expect("first acquire");
+        drop(permit); // release
+        let second = acquire_hash_permit(&sem, Duration::from_millis(50)).await;
+        assert!(second.is_ok(), "released permit should be reusable");
+    }
+
+    /// With N permits, more than N concurrent hash-gated sections must never
+    /// run at once — the surplus callers serialize behind the semaphore. This
+    /// is the memory-DoS bound: peak concurrent Argon2id arenas ≤ N.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrency_is_bounded_to_permit_count() {
+        const PERMITS: usize = 2;
+        const TASKS: usize = 8;
+        let sem = Arc::new(Semaphore::new(PERMITS));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_observed = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..TASKS {
+            let sem = Arc::clone(&sem);
+            let in_flight = Arc::clone(&in_flight);
+            let max_observed = Arc::clone(&max_observed);
+            handles.push(tokio::spawn(async move {
+                let _permit = acquire_hash_permit(&sem, Duration::from_secs(5))
+                    .await
+                    .expect("permit acquired within timeout");
+                let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                max_observed.fetch_max(now, Ordering::SeqCst);
+                // Hold the permit briefly to force overlap between tasks.
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        assert!(
+            max_observed.load(Ordering::SeqCst) <= PERMITS,
+            "observed concurrency {} exceeded permit bound {PERMITS}",
+            max_observed.load(Ordering::SeqCst)
+        );
+    }
+}

--- a/crates/axiam-auth/src/lib.rs
+++ b/crates/axiam-auth/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod config;
 pub mod crypto;
+pub mod crypto_gate;
 pub mod error;
 pub mod hibp_breaker;
 pub mod lockout;

--- a/crates/axiam-auth/src/password_reset.rs
+++ b/crates/axiam-auth/src/password_reset.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use uuid::Uuid;
 
+use crate::crypto_gate::acquire_hash_permit;
 use crate::error::AuthError;
 use crate::password::{self, DUMMY_HASH, hash_password, verify_password};
 use crate::policy::{PolicyCheckResult, evaluate_password};
@@ -60,6 +61,9 @@ where
     /// equalization below and the T-24-92 current-password check) to
     /// prevent CPU-bound crypto from starving the Tokio async runtime.
     crypto_semaphore: Arc<Semaphore>,
+    /// B1: Seconds to wait for a `crypto_semaphore` permit before returning a
+    /// 503 backpressure error. Threaded from `AuthConfig::hash_acquire_timeout_secs`.
+    hash_acquire_timeout_secs: u64,
 }
 
 impl<U, R, F, H, S, T> PasswordResetService<U, R, F, H, S, T>
@@ -79,6 +83,7 @@ where
         session_repo: S,
         refresh_token_repo: T,
         crypto_semaphore: Arc<Semaphore>,
+        hash_acquire_timeout_secs: u64,
     ) -> Self {
         Self {
             user_repo,
@@ -88,6 +93,7 @@ where
             session_repo,
             refresh_token_repo,
             crypto_semaphore,
+            hash_acquire_timeout_secs,
         }
     }
 
@@ -101,12 +107,33 @@ where
     /// user) so those responses are time-indistinguishable from the
     /// valid-account branch — no hand-tuned fixed-duration sleep.
     async fn dummy_hash_wait(&self, pepper: Option<&str>) {
-        let _permit = self.crypto_semaphore.acquire().await.ok();
-        let pepper_owned = pepper.map(str::to_string);
-        let _ = tokio::task::spawn_blocking(move || {
-            password::verify_password("dummy", DUMMY_HASH, pepper_owned.as_deref())
-        })
+        // B1: bound this enumeration-defence dummy hash by the crypto
+        // semaphore (and its timeout) so it counts against the same
+        // concurrency budget as real verifies and cannot itself become an
+        // un-throttled arena allocator.
+        //
+        // Unlike the login not-found branch, we deliberately do NOT surface a
+        // backpressure error here: `initiate_reset`'s *valid-account* branch
+        // does no Argon2 work and never touches the semaphore, so if this path
+        // returned 503 under saturation while the valid path returned
+        // `Ok(None)`, that difference would itself be a user-enumeration oracle
+        // (D-15). Instead we bound the wait by the same timeout and, if it
+        // elapses, simply skip the dummy hash and return normally — the
+        // observable result (`Ok(None)`) is identical to the valid branch
+        // regardless of load. Memory stays bounded because the permit *count*
+        // still caps concurrent arenas even when this path skips hashing.
+        let acquired = tokio::time::timeout(
+            std::time::Duration::from_secs(self.hash_acquire_timeout_secs),
+            self.crypto_semaphore.acquire(),
+        )
         .await;
+        if let Ok(Ok(_permit)) = acquired {
+            let pepper_owned = pepper.map(str::to_string);
+            let _ = tokio::task::spawn_blocking(move || {
+                password::verify_password("dummy", DUMMY_HASH, pepper_owned.as_deref())
+            })
+            .await;
+        }
     }
 
     /// Initiate a password reset for the given email.
@@ -232,11 +259,14 @@ where
         // run under the crypto_semaphore-gated spawn_blocking path (A3)
         // consistent with every other Argon2 call site in this codebase.
         {
-            let _permit = self
-                .crypto_semaphore
-                .acquire()
-                .await
-                .map_err(|_| AxiamError::Internal("crypto semaphore closed".into()))?;
+            // B1: bounded acquire — 503 backpressure on timeout. Enumeration is
+            // not a concern here (the caller already holds a valid reset token),
+            // so surfacing the error is safe and correct.
+            let _permit = acquire_hash_permit(
+                &self.crypto_semaphore,
+                std::time::Duration::from_secs(self.hash_acquire_timeout_secs),
+            )
+            .await?;
             let new_pw_owned = new_password.to_string();
             let current_hash_owned = user.password_hash.clone();
             let pepper_owned = pepper.map(str::to_string);
@@ -260,11 +290,14 @@ where
         // call site (A3) — `confirm_reset` previously performed this work
         // fully ungated.
         let check: PolicyCheckResult = {
-            let _permit = self
-                .crypto_semaphore
-                .acquire()
-                .await
-                .map_err(|_| AxiamError::Internal("crypto semaphore closed".into()))?;
+            // B1: bounded acquire — held for the duration of the policy
+            // evaluation so the history check's Argon2 verifies run under one
+            // permit; 503 backpressure on timeout.
+            let _permit = acquire_hash_permit(
+                &self.crypto_semaphore,
+                std::time::Duration::from_secs(self.hash_acquire_timeout_secs),
+            )
+            .await?;
             evaluate_password(
                 new_password,
                 pepper,
@@ -465,6 +498,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let result = svc.initiate_reset(tid, &user.email, 1, None).await.unwrap();
@@ -496,6 +530,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let result = svc
@@ -561,6 +596,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let result = svc.initiate_reset(tid, &user.email, 1, None).await.unwrap();
@@ -588,6 +624,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         // First 3 requests should succeed.
@@ -624,6 +661,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         // Generate first token.
@@ -691,6 +729,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let (raw_token, _uid, _exp) = svc
@@ -731,6 +770,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
         let policy = relaxed_policy();
 
@@ -779,6 +819,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
         let policy = relaxed_policy();
 
@@ -809,6 +850,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let (raw_token, _uid, _exp) = svc
@@ -860,6 +902,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let (raw_token, _uid, _exp) = svc
@@ -914,6 +957,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         let (raw_token, _uid, _exp) = svc
@@ -999,6 +1043,7 @@ mod tests {
             session_repo,
             refresh_token_repo,
             Arc::new(Semaphore::new(4)),
+            5,
         );
 
         fn mean(samples: &[StdDuration]) -> StdDuration {

--- a/crates/axiam-auth/src/service.rs
+++ b/crates/axiam-auth/src/service.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 
 use crate::config::AuthConfig;
+use crate::crypto_gate::acquire_hash_permit;
 use crate::error::AuthError;
 use crate::token::AUD_USER;
 use crate::{password, token, totp};
@@ -212,7 +213,28 @@ impl<
                     Err(AxiamError::NotFound { .. }) => {
                         // SEC-026: timing equalization — run a dummy Argon2 verify so
                         // user-not-found takes the same time as wrong-password (ASVS V2).
-                        let _permit = self.crypto_semaphore.acquire().await.ok();
+                        //
+                        // B1: acquire the crypto permit with the SAME
+                        // acquire-with-timeout used by the real wrong-password
+                        // verify below (step 3), so the two branches stay
+                        // constant-time in BOTH regimes:
+                        //   * normal load — both acquire immediately and run
+                        //     exactly one Argon2id verify → 401;
+                        //   * saturation  — both hit the same timeout and return
+                        //     the same 503 backpressure error *before* hashing.
+                        // Making only the real path shed load (while this dummy
+                        // path waited unboundedly and always hashed) would make
+                        // "existing + wrong password → 503" distinguishable from
+                        // "no such user → 401" under load — reintroducing the very
+                        // enumeration oracle SEC-026 closes. Propagating the error
+                        // here keeps them indistinguishable, and also subjects the
+                        // enumeration/dummy path to the memory-DoS bound (an
+                        // attacker spamming unknown usernames is throttled too).
+                        let _permit = acquire_hash_permit(
+                            &self.crypto_semaphore,
+                            std::time::Duration::from_secs(self.config.hash_acquire_timeout_secs),
+                        )
+                        .await?;
                         let pepper_owned = self.config.pepper.clone();
                         let _ = tokio::task::spawn_blocking(move || {
                             password::verify_password(
@@ -239,11 +261,12 @@ impl<
         }
 
         // 3. Verify password — CPU-bound Argon2id runs in spawn_blocking behind semaphore (CQ-B02).
-        let _permit = self
-            .crypto_semaphore
-            .acquire()
-            .await
-            .map_err(|_| AxiamError::Internal("crypto semaphore closed".into()))?;
+        //    B1: bounded acquire — 503 backpressure on timeout instead of unbounded queueing.
+        let _permit = acquire_hash_permit(
+            &self.crypto_semaphore,
+            std::time::Duration::from_secs(self.config.hash_acquire_timeout_secs),
+        )
+        .await?;
         let pw_owned = input.password.clone();
         let hash_owned = user.password_hash.clone();
         let pepper_owned = self.config.pepper.clone();
@@ -710,11 +733,13 @@ impl<
         let user = self.user_repo.get_by_id(tenant_id, user_id).await?;
 
         // 1. Verify current password — CPU-bound, run in spawn_blocking behind semaphore (CQ-B02).
-        let _permit = self
-            .crypto_semaphore
-            .acquire()
-            .await
-            .map_err(|_| AxiamError::Internal("crypto semaphore closed".into()))?;
+        //    B1: bounded acquire — held for the whole change_password call so the SEC-028
+        //    same-password check and the history verify reuse this single permit.
+        let _permit = acquire_hash_permit(
+            &self.crypto_semaphore,
+            std::time::Duration::from_secs(self.config.hash_acquire_timeout_secs),
+        )
+        .await?;
         let pw_owned = current_password.to_string();
         let hash_owned = user.password_hash.clone();
         let pepper_owned = self.config.pepper.clone();

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -456,6 +456,8 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=
             jwt_decoding_key: None,
             hibp_breaker_threshold: 5,
             hibp_breaker_cooldown_secs: 30,
+            max_concurrent_hashes: 0,
+            hash_acquire_timeout_secs: 5,
         }
     }
 

--- a/crates/axiam-auth/tests/auth_service_test.rs
+++ b/crates/axiam-auth/tests/auth_service_test.rs
@@ -48,6 +48,8 @@ fn test_config() -> AuthConfig {
         min_password_length: 12,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,
+        max_concurrent_hashes: 0,
+        hash_acquire_timeout_secs: 5,
         mfa_encryption_key: Some(TEST_MFA_KEY),
         federation_encryption_key: None,
         allow_missing_aud_as_user: true,

--- a/crates/axiam-authz/Cargo.toml
+++ b/crates/axiam-authz/Cargo.toml
@@ -25,6 +25,9 @@ tokio-test = "0.4"
 serde_json = { workspace = true }
 criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 futures = "0.3.32"
+# chrono: build model timestamps in the counting-mock repositories used by the
+# D1 batch-coalescing round-trip-count test; verified by cargo test.
+chrono = { workspace = true }
 
 [[bench]]
 name = "authz_bench"

--- a/crates/axiam-authz/src/config.rs
+++ b/crates/axiam-authz/src/config.rs
@@ -1,6 +1,11 @@
 //! Authorization engine configuration.
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use serde::Deserialize;
+
+use crate::decision_cache::{DecisionCache, DecisionCacheConfig};
 
 /// Configuration for the authorization engine.
 #[derive(Debug, Clone, Deserialize)]
@@ -13,13 +18,67 @@ pub struct AuthzConfig {
     ///
     /// Configure via `AXIAM__AUTHZ__BATCH_MAX_CONCURRENCY` env var.
     pub batch_max_concurrency: usize,
+
+    /// Enable the per-tenant authorization **decision cache** (D7). When
+    /// `false` (the default) the engine issues its usual DB round-trips on
+    /// every check — behaviour is byte-for-byte identical to a build without
+    /// the cache. Only when `true` does `axiam-server` attach a
+    /// [`DecisionCache`] to the authorization engines.
+    ///
+    /// Configure via `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` (default `false`).
+    ///
+    /// SECURITY: the cache is safe under AXIAM's additive allow-wins /
+    /// default-deny model *only because* every access-narrowing mutation
+    /// invalidates the affected entries immediately (see
+    /// `decision_cache` module docs). A stale allow can outlive a revocation
+    /// by at most `decision_cache_ttl_secs` even if an invalidation is missed.
+    pub decision_cache_enabled: bool,
+
+    /// TTL, in seconds, for a cached decision (D7). Bounds worst-case
+    /// revocation latency if an invalidation event is ever missed. Short by
+    /// design.
+    ///
+    /// Configure via `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` (default `5`).
+    pub decision_cache_ttl_secs: u64,
+
+    /// Maximum cached decisions retained **per tenant** before FIFO eviction
+    /// (D7). Bounds memory.
+    ///
+    /// Configure via `AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES` (default
+    /// `10000`).
+    pub decision_cache_max_entries: usize,
 }
 
 impl Default for AuthzConfig {
     fn default() -> Self {
         Self {
             batch_max_concurrency: 16,
+            decision_cache_enabled: false,
+            decision_cache_ttl_secs: 5,
+            decision_cache_max_entries: 10_000,
         }
+    }
+}
+
+impl AuthzConfig {
+    /// Build the shared [`DecisionCache`] iff caching is enabled, returning it
+    /// as an `Arc` ready to attach to every authorization engine
+    /// (`AuthorizationEngine::with_decision_cache`). Returns `None` when the
+    /// feature flag is off — the caller then constructs engines exactly as
+    /// before (no cache, no behaviour change).
+    ///
+    /// The *same* `Arc<DecisionCache>` must be shared across the REST, gRPC and
+    /// AMQP engines so that an invalidation triggered from a REST mutation
+    /// handler is observed by every read path. (All role/permission/resource
+    /// mutations are REST endpoints today.)
+    pub fn build_decision_cache(&self) -> Option<Arc<DecisionCache>> {
+        if !self.decision_cache_enabled {
+            return None;
+        }
+        Some(Arc::new(DecisionCache::new(DecisionCacheConfig {
+            ttl: Duration::from_secs(self.decision_cache_ttl_secs),
+            max_entries_per_tenant: self.decision_cache_max_entries,
+        })))
     }
 }
 
@@ -44,5 +103,39 @@ mod tests {
         let cfg: AuthzConfig = serde_json::from_str(r#"{"batch_max_concurrency": 4}"#)
             .expect("explicit override must deserialize");
         assert_eq!(cfg.batch_max_concurrency, 4);
+    }
+
+    #[test]
+    fn decision_cache_defaults_are_off_and_conservative() {
+        let cfg = AuthzConfig::default();
+        assert!(!cfg.decision_cache_enabled, "cache must default OFF");
+        assert_eq!(cfg.decision_cache_ttl_secs, 5);
+        assert_eq!(cfg.decision_cache_max_entries, 10_000);
+    }
+
+    #[test]
+    fn build_decision_cache_none_when_disabled() {
+        let cfg = AuthzConfig::default();
+        assert!(cfg.build_decision_cache().is_none());
+    }
+
+    #[test]
+    fn build_decision_cache_some_when_enabled() {
+        let cfg = AuthzConfig {
+            decision_cache_enabled: true,
+            ..AuthzConfig::default()
+        };
+        assert!(cfg.build_decision_cache().is_some());
+    }
+
+    #[test]
+    fn deserializes_decision_cache_overrides() {
+        let cfg: AuthzConfig = serde_json::from_str(
+            r#"{"decision_cache_enabled": true, "decision_cache_ttl_secs": 10, "decision_cache_max_entries": 500}"#,
+        )
+        .expect("cache overrides must deserialize");
+        assert!(cfg.decision_cache_enabled);
+        assert_eq!(cfg.decision_cache_ttl_secs, 10);
+        assert_eq!(cfg.decision_cache_max_entries, 500);
     }
 }

--- a/crates/axiam-authz/src/decision_cache.rs
+++ b/crates/axiam-authz/src/decision_cache.rs
@@ -1,0 +1,392 @@
+//! Per-tenant cache of effective-permission evaluations (D7).
+//!
+//! # What this caches
+//!
+//! A [`DecisionCache`] memoizes the full [`AccessDecision`] (Allow, or Deny
+//! *with its exact reason*) for a `(tenant_id, subject, resource, action,
+//! scope)` tuple, so a repeated check can skip the 3–4 sequential SurrealDB
+//! round-trips the engine would otherwise issue (see the D6 tuning report).
+//!
+//! The cache is **opt-in** and feature-flagged: [`AuthorizationEngine`] only
+//! consults it when one has been attached via
+//! [`AuthorizationEngine::with_decision_cache`], which `axiam-server` does only
+//! when `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true`. When absent, the engine's
+//! code path is byte-for-byte identical to today (zero behaviour change).
+//!
+//! [`AuthorizationEngine`]: crate::engine::AuthorizationEngine
+//! [`AuthorizationEngine::with_decision_cache`]: crate::engine::AuthorizationEngine::with_decision_cache
+//!
+//! # Security property (CRITICAL — read before changing invalidation)
+//!
+//! AXIAM's RBAC is **additive, allow-wins, default-deny** (CLAUDE.md /
+//! SEC-040). There is no deny-override. That asymmetry means the two staleness
+//! directions are NOT equally dangerous:
+//!
+//! - A **stale DENY** is *safe*: it only costs a redundant re-evaluation; the
+//!   subject is momentarily under-privileged, never over-privileged.
+//! - A **stale ALLOW after a revocation** is *dangerous*: a subject keeps
+//!   access they no longer have. This is the only direction we must protect
+//!   against, and TTL alone is not enough.
+//!
+//! Therefore every mutation that can *narrow* access (role unassignment, grant
+//! removal, role/permission deletion, group membership removal, resource
+//! reparent/delete) MUST invalidate the affected entries **immediately** via
+//! [`DecisionCache::invalidate_subject`] or [`DecisionCache::invalidate_tenant`]
+//! — wired to the mutation path, not left to TTL. The REST handlers in
+//! `axiam-api-rest` do exactly this through the `AuthzChecker` trait.
+//!
+//! # Bounded staleness fallback
+//!
+//! Even if an invalidation event were somehow missed (a bug, a mutation path
+//! that forgot to call invalidate, an out-of-band DB write), the damage is
+//! **bounded by the TTL**: a stale allow can persist at most
+//! `decision_cache_ttl_secs` (default 5 s) before TTL eviction forces a fresh
+//! evaluation. The short default TTL is the belt to the invalidation hooks'
+//! braces.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use uuid::Uuid;
+
+use crate::types::{AccessDecision, AccessRequest};
+
+/// Runtime configuration for the decision cache.
+#[derive(Debug, Clone)]
+pub struct DecisionCacheConfig {
+    /// Time-to-live for a cached decision. After this elapses the entry is
+    /// treated as a miss and re-evaluated. Bounds worst-case revocation
+    /// latency if an invalidation event is ever missed.
+    pub ttl: Duration,
+    /// Maximum number of live entries retained **per tenant**. When exceeded,
+    /// the oldest entry (FIFO) for that tenant is evicted. Bounds memory so a
+    /// hot tenant cannot grow the map without limit.
+    pub max_entries_per_tenant: usize,
+}
+
+impl Default for DecisionCacheConfig {
+    fn default() -> Self {
+        Self {
+            ttl: Duration::from_secs(5),
+            max_entries_per_tenant: 10_000,
+        }
+    }
+}
+
+/// The intra-tenant portion of the cache key: everything except `tenant_id`
+/// (which selects the shard). Ordering mirrors the design-doc key
+/// `(subject, resource, action, scope)`.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct SubKey {
+    subject_id: Uuid,
+    resource_id: Uuid,
+    action: String,
+    scope: Option<String>,
+}
+
+impl SubKey {
+    fn from_request(request: &AccessRequest) -> Self {
+        Self {
+            subject_id: request.subject_id,
+            resource_id: request.resource_id,
+            action: request.action.clone(),
+            scope: request.scope.clone(),
+        }
+    }
+}
+
+/// Per-tenant shard: the entry map plus a FIFO order queue used only for
+/// the size-cap eviction. Keeping tenants in separate shards makes a
+/// per-tenant flush O(1) (drop the shard) and keeps one tenant's churn from
+/// evicting another tenant's entries.
+#[derive(Default)]
+struct TenantShard {
+    entries: HashMap<SubKey, (AccessDecision, Instant)>,
+    /// Insertion order of *new* keys, for the bounded-size FIFO eviction. May
+    /// contain keys already removed by TTL/invalidation; such stragglers are
+    /// skipped when popping (they're simply absent from `entries`).
+    order: VecDeque<SubKey>,
+}
+
+/// A concurrent, per-tenant, TTL + size-bounded cache of authorization
+/// decisions. Cheap to clone-share behind an `Arc`.
+///
+/// See the [module docs](self) for the security rationale.
+pub struct DecisionCache {
+    config: DecisionCacheConfig,
+    shards: Mutex<HashMap<Uuid, TenantShard>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+}
+
+impl DecisionCache {
+    /// Build a cache with the given configuration.
+    pub fn new(config: DecisionCacheConfig) -> Self {
+        Self {
+            config,
+            shards: Mutex::new(HashMap::new()),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+        }
+    }
+
+    /// Look up a cached decision for `request`. Returns `None` on a miss or an
+    /// expired entry (which is evicted in passing). Records a hit/miss.
+    pub fn get(&self, request: &AccessRequest) -> Option<AccessDecision> {
+        let key = SubKey::from_request(request);
+        let now = Instant::now();
+        let mut shards = self.shards.lock().unwrap_or_else(|p| p.into_inner());
+        let decision = shards.get_mut(&request.tenant_id).and_then(|shard| {
+            match shard.entries.get(&key) {
+                Some((decision, inserted_at)) => {
+                    if now.duration_since(*inserted_at) >= self.config.ttl {
+                        // Expired: evict now so we don't keep returning it.
+                        shard.entries.remove(&key);
+                        None
+                    } else {
+                        Some(decision.clone())
+                    }
+                }
+                None => None,
+            }
+        });
+        if decision.is_some() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+        }
+        decision
+    }
+
+    /// Insert (or refresh) the decision for `request`, stamping it `now`.
+    pub fn insert(&self, request: &AccessRequest, decision: AccessDecision) {
+        let key = SubKey::from_request(request);
+        let now = Instant::now();
+        let mut shards = self.shards.lock().unwrap_or_else(|p| p.into_inner());
+        let shard = shards.entry(request.tenant_id).or_default();
+        let is_new = !shard.entries.contains_key(&key);
+        shard.entries.insert(key.clone(), (decision, now));
+        if is_new {
+            shard.order.push_back(key);
+            // Enforce the per-tenant size cap. Pop FIFO, skipping keys already
+            // gone (expired/invalidated), until we've dropped one live entry
+            // or the queue drains.
+            while shard.entries.len() > self.config.max_entries_per_tenant {
+                match shard.order.pop_front() {
+                    Some(old) => {
+                        if shard.entries.remove(&old).is_some() {
+                            break;
+                        }
+                        // else: stale order entry, keep popping.
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+
+    /// Drop **every** cached decision for a tenant. The conservative,
+    /// always-correct invalidation: after this, no decision for `tenant_id`
+    /// can be served stale. Used for coarse mutations whose affected-subject
+    /// set is not known without a DB query (grant revoke, role/permission
+    /// delete, role/permission update, group-role unassignment, resource
+    /// reparent/delete).
+    pub fn invalidate_tenant(&self, tenant_id: Uuid) {
+        let mut shards = self.shards.lock().unwrap_or_else(|p| p.into_inner());
+        shards.remove(&tenant_id);
+    }
+
+    /// Drop every cached decision for a single subject within a tenant. The
+    /// targeted invalidation used when a mutation changes exactly one
+    /// subject's effective permissions (user role unassignment, group
+    /// membership removal) — see the module security note.
+    pub fn invalidate_subject(&self, tenant_id: Uuid, subject_id: Uuid) {
+        let mut shards = self.shards.lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(shard) = shards.get_mut(&tenant_id) {
+            shard.entries.retain(|k, _| k.subject_id != subject_id);
+            // `order` may now hold stragglers; they're skipped on pop.
+        }
+    }
+
+    /// Drop the entire cache (all tenants). Provided for completeness /
+    /// administrative flush; not on any hot path.
+    pub fn invalidate_all(&self) {
+        let mut shards = self.shards.lock().unwrap_or_else(|p| p.into_inner());
+        shards.clear();
+    }
+
+    /// Cumulative (hits, misses) since construction — for observability/tests.
+    pub fn stats(&self) -> (u64, u64) {
+        (
+            self.hits.load(Ordering::Relaxed),
+            self.misses.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Total live entries across all tenants (test/observability helper; also
+    /// counts not-yet-evicted expired entries).
+    pub fn len(&self) -> usize {
+        let shards = self.shards.lock().unwrap_or_else(|p| p.into_inner());
+        shards.values().map(|s| s.entries.len()).sum()
+    }
+
+    /// Whether the cache holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(tenant: Uuid, subject: Uuid, resource: Uuid, action: &str) -> AccessRequest {
+        AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject,
+            action: action.to_string(),
+            resource_id: resource,
+            scope: None,
+        }
+    }
+
+    #[test]
+    fn hit_returns_inserted_decision() {
+        let cache = DecisionCache::new(DecisionCacheConfig::default());
+        let t = Uuid::new_v4();
+        let s = Uuid::new_v4();
+        let r = Uuid::new_v4();
+        let request = req(t, s, r, "read");
+
+        assert!(cache.get(&request).is_none());
+        cache.insert(&request, AccessDecision::Allow);
+        assert_eq!(cache.get(&request), Some(AccessDecision::Allow));
+
+        let (hits, misses) = cache.stats();
+        assert_eq!(hits, 1);
+        assert_eq!(misses, 1);
+    }
+
+    #[test]
+    fn deny_reason_is_preserved_verbatim() {
+        let cache = DecisionCache::new(DecisionCacheConfig::default());
+        let request = req(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), "read");
+        let deny = AccessDecision::Deny("no permission grants action 'read'".into());
+        cache.insert(&request, deny.clone());
+        assert_eq!(cache.get(&request), Some(deny));
+    }
+
+    #[test]
+    fn distinct_actions_and_scopes_are_distinct_keys() {
+        let cache = DecisionCache::new(DecisionCacheConfig::default());
+        let t = Uuid::new_v4();
+        let s = Uuid::new_v4();
+        let r = Uuid::new_v4();
+        let read = req(t, s, r, "read");
+        let write = req(t, s, r, "write");
+        let mut scoped = read.clone();
+        scoped.scope = Some("field:email".into());
+
+        cache.insert(&read, AccessDecision::Allow);
+        cache.insert(&write, AccessDecision::Deny("nope".into()));
+        assert_eq!(cache.get(&read), Some(AccessDecision::Allow));
+        assert_eq!(cache.get(&write), Some(AccessDecision::Deny("nope".into())));
+        // A scoped variant of the same action/resource is a different key.
+        assert!(cache.get(&scoped).is_none());
+    }
+
+    #[test]
+    fn ttl_expiry_forces_miss() {
+        let cache = DecisionCache::new(DecisionCacheConfig {
+            ttl: Duration::from_millis(30),
+            max_entries_per_tenant: 100,
+        });
+        let request = req(Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4(), "read");
+        cache.insert(&request, AccessDecision::Allow);
+        assert_eq!(cache.get(&request), Some(AccessDecision::Allow));
+        std::thread::sleep(Duration::from_millis(45));
+        assert!(cache.get(&request).is_none(), "entry must expire after TTL");
+    }
+
+    #[test]
+    fn invalidate_subject_drops_only_that_subject() {
+        let cache = DecisionCache::new(DecisionCacheConfig::default());
+        let t = Uuid::new_v4();
+        let s1 = Uuid::new_v4();
+        let s2 = Uuid::new_v4();
+        let r = Uuid::new_v4();
+        let r1 = req(t, s1, r, "read");
+        let r2 = req(t, s2, r, "read");
+        cache.insert(&r1, AccessDecision::Allow);
+        cache.insert(&r2, AccessDecision::Allow);
+
+        cache.invalidate_subject(t, s1);
+        assert!(cache.get(&r1).is_none(), "revoked subject must miss");
+        assert_eq!(
+            cache.get(&r2),
+            Some(AccessDecision::Allow),
+            "other subject must be untouched"
+        );
+    }
+
+    #[test]
+    fn invalidate_tenant_drops_whole_tenant_only() {
+        let cache = DecisionCache::new(DecisionCacheConfig::default());
+        let t1 = Uuid::new_v4();
+        let t2 = Uuid::new_v4();
+        let a = req(t1, Uuid::new_v4(), Uuid::new_v4(), "read");
+        let b = req(t1, Uuid::new_v4(), Uuid::new_v4(), "read");
+        let c = req(t2, Uuid::new_v4(), Uuid::new_v4(), "read");
+        cache.insert(&a, AccessDecision::Allow);
+        cache.insert(&b, AccessDecision::Allow);
+        cache.insert(&c, AccessDecision::Allow);
+
+        cache.invalidate_tenant(t1);
+        assert!(cache.get(&a).is_none());
+        assert!(cache.get(&b).is_none());
+        assert_eq!(cache.get(&c), Some(AccessDecision::Allow));
+    }
+
+    #[test]
+    fn per_tenant_size_cap_evicts_fifo() {
+        let cache = DecisionCache::new(DecisionCacheConfig {
+            ttl: Duration::from_secs(60),
+            max_entries_per_tenant: 2,
+        });
+        let t = Uuid::new_v4();
+        let s = Uuid::new_v4();
+        let r1 = req(t, s, Uuid::new_v4(), "read");
+        let r2 = req(t, s, Uuid::new_v4(), "read");
+        let r3 = req(t, s, Uuid::new_v4(), "read");
+        cache.insert(&r1, AccessDecision::Allow);
+        cache.insert(&r2, AccessDecision::Allow);
+        cache.insert(&r3, AccessDecision::Allow); // evicts r1 (oldest)
+
+        assert!(cache.get(&r1).is_none(), "oldest entry evicted by cap");
+        assert_eq!(cache.get(&r2), Some(AccessDecision::Allow));
+        assert_eq!(cache.get(&r3), Some(AccessDecision::Allow));
+        assert!(cache.len() <= 2);
+    }
+
+    #[test]
+    fn reinsert_same_key_does_not_grow_or_double_count_fifo() {
+        let cache = DecisionCache::new(DecisionCacheConfig {
+            ttl: Duration::from_secs(60),
+            max_entries_per_tenant: 2,
+        });
+        let t = Uuid::new_v4();
+        let s = Uuid::new_v4();
+        let r1 = req(t, s, Uuid::new_v4(), "read");
+        let r2 = req(t, s, Uuid::new_v4(), "read");
+        cache.insert(&r1, AccessDecision::Allow);
+        cache.insert(&r1, AccessDecision::Deny("changed".into())); // update in place
+        cache.insert(&r2, AccessDecision::Allow);
+
+        // r1 refreshed, r2 present, cap respected, r1 not evicted by its own re-insert.
+        assert_eq!(cache.get(&r1), Some(AccessDecision::Deny("changed".into())));
+        assert_eq!(cache.get(&r2), Some(AccessDecision::Allow));
+        assert!(cache.len() <= 2);
+    }
+}

--- a/crates/axiam-authz/src/engine.rs
+++ b/crates/axiam-authz/src/engine.rs
@@ -1,6 +1,7 @@
 //! Core authorization engine implementing RBAC with resource hierarchy.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use axiam_core::error::AxiamResult;
 use axiam_core::models::permission::PermissionGrant;
@@ -11,6 +12,7 @@ use axiam_core::repository::{
 use tracing::Instrument;
 use uuid::Uuid;
 
+use crate::decision_cache::DecisionCache;
 use crate::types::{AccessDecision, AccessRequest};
 
 /// Permission evaluation engine.
@@ -36,6 +38,11 @@ where
     scope_repo: S,
     #[allow(dead_code)]
     group_repo: G,
+    /// Optional per-tenant decision cache (D7). `None` unless
+    /// `with_decision_cache` was called (feature-flagged in `axiam-server`).
+    /// When `None`, `check_access` / `check_access_batch` behave exactly as a
+    /// build without the cache.
+    decision_cache: Option<Arc<DecisionCache>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +130,39 @@ where
             resource_repo,
             scope_repo,
             group_repo,
+            decision_cache: None,
+        }
+    }
+
+    /// Attach a shared [`DecisionCache`] to this engine (D7). Consumed builder
+    /// style so existing `new(..)` call sites are unaffected. `axiam-server`
+    /// calls this only when `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true`, and
+    /// passes the **same** `Arc<DecisionCache>` to every engine (REST, gRPC,
+    /// AMQP) so a REST-triggered invalidation is seen by all read paths.
+    #[must_use]
+    pub fn with_decision_cache(mut self, cache: Arc<DecisionCache>) -> Self {
+        self.decision_cache = Some(cache);
+        self
+    }
+
+    /// Immediately drop every cached decision for `tenant_id`. No-op when no
+    /// cache is attached. Called by the REST mutation handlers for coarse,
+    /// access-narrowing changes whose affected-subject set isn't known without
+    /// a query (grant revoke, role/permission delete or update, group-role
+    /// unassignment, resource reparent/delete).
+    pub fn invalidate_tenant(&self, tenant_id: Uuid) {
+        if let Some(cache) = self.decision_cache.as_ref() {
+            cache.invalidate_tenant(tenant_id);
+        }
+    }
+
+    /// Immediately drop every cached decision for a single `subject_id` within
+    /// `tenant_id`. No-op when no cache is attached. Called by the REST mutation
+    /// handlers when exactly one subject's effective permissions change (user
+    /// role unassign/assign, group membership add/remove).
+    pub fn invalidate_subject(&self, tenant_id: Uuid, subject_id: Uuid) {
+        if let Some(cache) = self.decision_cache.as_ref() {
+            cache.invalidate_subject(tenant_id, subject_id);
         }
     }
 
@@ -144,6 +184,29 @@ where
         )
     )]
     pub async fn check_access(&self, request: &AccessRequest) -> AxiamResult<AccessDecision> {
+        // D7 fast path: when a decision cache is attached (feature-flagged),
+        // a fresh cached decision skips the DB round-trips entirely. When no
+        // cache is attached this whole block is absent and the call is
+        // identical to a build without the cache.
+        if let Some(cache) = self.decision_cache.as_ref()
+            && let Some(decision) = cache.get(request)
+        {
+            return Ok(decision);
+        }
+        let decision = self.evaluate(request).await?;
+        if let Some(cache) = self.decision_cache.as_ref() {
+            // Cache the FULL decision (allow *or* deny-with-reason), so a hit
+            // is byte-identical to a miss.
+            cache.insert(request, decision.clone());
+        }
+        Ok(decision)
+    }
+
+    /// Uncached RBAC evaluation — the actual algorithm (3–4 sequential DB
+    /// round-trips). Kept as a separate method so the [`Self::check_access`]
+    /// cache wrapper can never alter decision or deny-reason semantics: a cache
+    /// hit returns exactly what this would have produced.
+    async fn evaluate(&self, request: &AccessRequest) -> AxiamResult<AccessDecision> {
         // 1. Fetch all role assignments (direct + group) with resource scope.
         let assignments = self
             .role_repo
@@ -185,7 +248,9 @@ where
         let grants_by_role = self
             .permission_repo
             .get_role_permission_grants_for_roles(request.tenant_id, &unique_role_ids)
-            .instrument(tracing::debug_span!("db.get_role_permission_grants_for_roles"))
+            .instrument(tracing::debug_span!(
+                "db.get_role_permission_grants_for_roles"
+            ))
             .await?;
 
         if grants_allow(
@@ -236,15 +301,52 @@ where
     /// `get_user_role_assignments`, one `get_ancestors`, and one batched
     /// `get_role_permission_grants_for_roles` across every applicable role in
     /// the batch.
+    pub async fn check_access_batch(
+        &self,
+        requests: &[AccessRequest],
+    ) -> AxiamResult<Vec<AccessDecision>> {
+        // D7: with no cache attached, this is exactly the D1 coalesced path —
+        // zero behaviour change.
+        let Some(cache) = self.decision_cache.as_ref() else {
+            return self.evaluate_batch(requests).await;
+        };
+
+        // Cache-enabled path: serve hits from the cache, evaluate only the
+        // misses (still via the coalesced batch path so shared lookups are
+        // resolved once), then backfill the cache. Input order is preserved.
+        let mut results: Vec<Option<AccessDecision>> =
+            requests.iter().map(|r| cache.get(r)).collect();
+
+        let miss_indices: Vec<usize> = results
+            .iter()
+            .enumerate()
+            .filter_map(|(i, slot)| slot.is_none().then_some(i))
+            .collect();
+
+        if !miss_indices.is_empty() {
+            let miss_requests: Vec<AccessRequest> =
+                miss_indices.iter().map(|&i| requests[i].clone()).collect();
+            let miss_decisions = self.evaluate_batch(&miss_requests).await?;
+            for (slot, &i) in miss_indices.iter().enumerate() {
+                let decision = miss_decisions[slot].clone();
+                cache.insert(&requests[i], decision.clone());
+                results[i] = Some(decision);
+            }
+        }
+
+        // Every slot is now filled (hit or freshly evaluated).
+        Ok(results.into_iter().map(|d| d.expect("filled")).collect())
+    }
+
+    /// Uncached coalesced batch evaluation (the D1 fast path). Separated from
+    /// [`Self::check_access_batch`] so the D7 cache wrapper cannot alter
+    /// decision/deny-reason semantics.
     #[tracing::instrument(
         name = "authz.check_access_batch",
         skip(self, requests),
         fields(batch_size = requests.len())
     )]
-    pub async fn check_access_batch(
-        &self,
-        requests: &[AccessRequest],
-    ) -> AxiamResult<Vec<AccessDecision>> {
+    async fn evaluate_batch(&self, requests: &[AccessRequest]) -> AxiamResult<Vec<AccessDecision>> {
         if requests.is_empty() {
             return Ok(Vec::new());
         }
@@ -305,7 +407,10 @@ where
         //     that any scoped, role-bearing item targets.
         let mut scopes_by_resource: HashMap<(Uuid, Uuid), Vec<axiam_core::models::scope::Scope>> =
             HashMap::new();
-        for req in requests.iter().filter(|r| r.scope.is_some() && has_roles(r)) {
+        for req in requests
+            .iter()
+            .filter(|r| r.scope.is_some() && has_roles(r))
+        {
             let key = (req.tenant_id, req.resource_id);
             if let std::collections::hash_map::Entry::Vacant(slot) = scopes_by_resource.entry(key) {
                 let scopes = self
@@ -328,7 +433,6 @@ where
         enum PreDecision {
             Decided(AccessDecision),
             NeedsGrants {
-                tenant_id: Uuid,
                 unique_role_ids: Vec<Uuid>,
                 requested_scope_id: Option<Uuid>,
             },
@@ -399,7 +503,6 @@ where
             }
 
             pre.push(PreDecision::NeedsGrants {
-                tenant_id: req.tenant_id,
                 unique_role_ids,
                 requested_scope_id,
             });
@@ -428,7 +531,6 @@ where
             match item {
                 PreDecision::Decided(d) => decisions.push(d),
                 PreDecision::NeedsGrants {
-                    tenant_id: _,
                     unique_role_ids,
                     requested_scope_id,
                 } => {

--- a/crates/axiam-authz/src/engine.rs
+++ b/crates/axiam-authz/src/engine.rs
@@ -1,11 +1,14 @@
 //! Core authorization engine implementing RBAC with resource hierarchy.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use axiam_core::error::AxiamResult;
+use axiam_core::models::permission::PermissionGrant;
+use axiam_core::models::role::RoleAssignment;
 use axiam_core::repository::{
     GroupRepository, PermissionRepository, ResourceRepository, RoleRepository, ScopeRepository,
 };
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::types::{AccessDecision, AccessRequest};
@@ -35,6 +38,70 @@ where
     group_repo: G,
 }
 
+// ---------------------------------------------------------------------------
+// Pure evaluation helpers (no I/O) — shared by the single-check and coalesced
+// batch paths so their decision/deny-reason semantics can never diverge.
+// ---------------------------------------------------------------------------
+
+/// Filter a subject's role assignments down to those applicable to
+/// `resource_id`, returning the deduplicated list of applicable role IDs in
+/// first-seen order.
+///
+/// A role applies when it is global, scoped directly to the target resource,
+/// or scoped to any ancestor of the target resource (hierarchy inheritance).
+fn applicable_role_ids(
+    assignments: &[RoleAssignment],
+    resource_id: Uuid,
+    ancestor_ids: &HashSet<Uuid>,
+) -> Vec<Uuid> {
+    let mut seen = HashSet::new();
+    assignments
+        .iter()
+        .filter(|a| {
+            a.role.is_global
+                || a.resource_id == Some(resource_id)
+                || a.resource_id
+                    .map(|rid| ancestor_ids.contains(&rid))
+                    .unwrap_or(false)
+        })
+        .map(|a| a.role.id)
+        .filter(|role_id| seen.insert(*role_id))
+        .collect()
+}
+
+/// Given the applicable role IDs and the (shared) grants-by-role map, decide
+/// whether any grant matches `action` under the optional `requested_scope_id`.
+///
+/// Wildcard grants (empty `scope_ids`) match any requested scope; otherwise the
+/// requested scope must be present in the grant's scope list. When no scope is
+/// requested, an action match is sufficient.
+fn grants_allow(
+    unique_role_ids: &[Uuid],
+    grants_by_role: &HashMap<Uuid, Vec<PermissionGrant>>,
+    action: &str,
+    requested_scope_id: Option<Uuid>,
+) -> bool {
+    for role_id in unique_role_ids {
+        let Some(grants) = grants_by_role.get(role_id) else {
+            continue;
+        };
+        for grant in grants {
+            if grant.permission.action != action {
+                continue;
+            }
+            match requested_scope_id {
+                Some(scope_id) => {
+                    if grant.scope_ids.is_empty() || grant.scope_ids.contains(&scope_id) {
+                        return true;
+                    }
+                }
+                None => return true,
+            }
+        }
+    }
+    false
+}
+
 impl<R, P, Res, S, G> AuthorizationEngine<R, P, Res, S, G>
 where
     R: RoleRepository,
@@ -60,11 +127,28 @@ where
     }
 
     /// Evaluate whether the subject can perform the requested action.
+    ///
+    /// Issues 3–4 sequential DB round-trips (role assignments, ancestors,
+    /// optional scope lookup, batched grants). For batches that repeat the same
+    /// subject/resource, prefer [`Self::check_access_batch`], which resolves the
+    /// shared lookups once.
+    #[tracing::instrument(
+        name = "authz.check_access",
+        skip(self, request),
+        fields(
+            tenant_id = %request.tenant_id,
+            subject_id = %request.subject_id,
+            resource_id = %request.resource_id,
+            action = %request.action,
+            scope = request.scope.as_deref().unwrap_or("")
+        )
+    )]
     pub async fn check_access(&self, request: &AccessRequest) -> AxiamResult<AccessDecision> {
         // 1. Fetch all role assignments (direct + group) with resource scope.
         let assignments = self
             .role_repo
             .get_user_role_assignments(request.tenant_id, request.subject_id)
+            .instrument(tracing::debug_span!("db.get_user_role_assignments"))
             .await?;
 
         if assignments.is_empty() {
@@ -75,106 +159,307 @@ where
         let ancestors = self
             .resource_repo
             .get_ancestors(request.tenant_id, request.resource_id)
+            .instrument(tracing::debug_span!("db.get_ancestors"))
             .await?;
         let ancestor_ids: HashSet<Uuid> = ancestors.iter().map(|r| r.id).collect();
 
-        // 3. Filter applicable roles:
-        //    - Global roles always apply
-        //    - Roles scoped to the target resource
-        //    - Roles scoped to any ancestor of the target resource
-        let applicable_role_ids: Vec<Uuid> = assignments
-            .iter()
-            .filter(|a| {
-                a.role.is_global
-                    || a.resource_id == Some(request.resource_id)
-                    || a.resource_id
-                        .map(|rid| ancestor_ids.contains(&rid))
-                        .unwrap_or(false)
-            })
-            .map(|a| a.role.id)
-            .collect();
+        // 3. Filter applicable roles (global / target-scoped / ancestor-scoped),
+        //    deduplicated in first-seen order.
+        let unique_role_ids = applicable_role_ids(&assignments, request.resource_id, &ancestor_ids);
 
-        if applicable_role_ids.is_empty() {
+        if unique_role_ids.is_empty() {
             return Ok(AccessDecision::Deny(
                 "no applicable roles for this resource".into(),
             ));
         }
 
         // 4. Resolve the requested scope to an ID (if specified).
-        let requested_scope_id = if let Some(ref scope_name) = request.scope {
-            let scopes = self
-                .scope_repo
-                .list_by_resource(request.tenant_id, request.resource_id)
-                .await?;
-
-            let scope = scopes.iter().find(|s| s.name == *scope_name);
-            match scope {
-                Some(s) => Some(s.id),
-                None => {
-                    return Ok(AccessDecision::Deny(format!(
-                        "scope '{}' not found on resource",
-                        scope_name
-                    )));
-                }
-            }
-        } else {
-            None
+        let requested_scope_id = match self.resolve_scope(request).await? {
+            ScopeResolution::None => None,
+            ScopeResolution::Resolved(id) => Some(id),
+            ScopeResolution::NotFound(deny) => return Ok(deny),
         };
 
-        // 5. Collect permission grants from all applicable roles and check
-        //    action + scope constraints.
-        //
-        // Dedupe applicable roles first (preserving the previous per-role
-        // `seen_roles` semantics), then fetch every role's grants in a SINGLE
-        // batched query instead of one query per role (CQ-B13 N+1 fix).
-        let mut seen_roles = HashSet::new();
-        let unique_role_ids: Vec<Uuid> = applicable_role_ids
-            .iter()
-            .copied()
-            .filter(|role_id| seen_roles.insert(*role_id))
-            .collect();
-
+        // 5. Fetch every applicable role's grants in a SINGLE batched query
+        //    (CQ-B13 N+1 fix), then evaluate action + scope constraints.
         let grants_by_role = self
             .permission_repo
             .get_role_permission_grants_for_roles(request.tenant_id, &unique_role_ids)
+            .instrument(tracing::debug_span!("db.get_role_permission_grants_for_roles"))
             .await?;
 
-        let mut has_matching_grant = false;
+        if grants_allow(
+            &unique_role_ids,
+            &grants_by_role,
+            &request.action,
+            requested_scope_id,
+        ) {
+            Ok(AccessDecision::Allow)
+        } else {
+            Ok(AccessDecision::Deny(format!(
+                "no permission grants action '{}'",
+                request.action
+            )))
+        }
+    }
 
-        'roles: for role_id in &unique_role_ids {
-            let Some(grants) = grants_by_role.get(role_id) else {
+    /// Resolve the request's optional scope name to a scope ID on the target
+    /// resource. Shared by [`Self::check_access`] and the batch path.
+    async fn resolve_scope(&self, request: &AccessRequest) -> AxiamResult<ScopeResolution> {
+        let Some(ref scope_name) = request.scope else {
+            return Ok(ScopeResolution::None);
+        };
+        let scopes = self
+            .scope_repo
+            .list_by_resource(request.tenant_id, request.resource_id)
+            .instrument(tracing::debug_span!("db.list_by_resource"))
+            .await?;
+        match scopes.iter().find(|s| s.name == *scope_name) {
+            Some(s) => Ok(ScopeResolution::Resolved(s.id)),
+            None => Ok(ScopeResolution::NotFound(AccessDecision::Deny(format!(
+                "scope '{}' not found on resource",
+                scope_name
+            )))),
+        }
+    }
+
+    /// Evaluate an ordered batch of authorization checks, coalescing the shared
+    /// DB lookups so that items repeating the same subject or resource resolve
+    /// each lookup **once** instead of once per item.
+    ///
+    /// The returned `Vec` has the same length and order as `requests`; result
+    /// `i` is the decision for `requests[i]` and is byte-identical to what
+    /// [`Self::check_access`] would return for that request in isolation.
+    ///
+    /// Round-trip reduction for the benchmark shape (5 items, one shared subject
+    /// and resource, no scope): **15 round-trips → 3** — one
+    /// `get_user_role_assignments`, one `get_ancestors`, and one batched
+    /// `get_role_permission_grants_for_roles` across every applicable role in
+    /// the batch.
+    #[tracing::instrument(
+        name = "authz.check_access_batch",
+        skip(self, requests),
+        fields(batch_size = requests.len())
+    )]
+    pub async fn check_access_batch(
+        &self,
+        requests: &[AccessRequest],
+    ) -> AxiamResult<Vec<AccessDecision>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // --- Coalesce round-trip 1: role assignments, once per (tenant, subject).
+        let mut assignments_by_subject: HashMap<(Uuid, Uuid), Vec<RoleAssignment>> = HashMap::new();
+        for req in requests {
+            let key = (req.tenant_id, req.subject_id);
+            if let std::collections::hash_map::Entry::Vacant(slot) =
+                assignments_by_subject.entry(key)
+            {
+                let assignments = self
+                    .role_repo
+                    .get_user_role_assignments(req.tenant_id, req.subject_id)
+                    .instrument(tracing::debug_span!(
+                        "db.get_user_role_assignments",
+                        tenant_id = %req.tenant_id,
+                        subject_id = %req.subject_id
+                    ))
+                    .await?;
+                slot.insert(assignments);
+            }
+        }
+
+        // Only items whose subject actually has role assignments proceed past
+        // the first gate — so ancestors/scopes/grants are fetched ONLY for
+        // resources those items target. This keeps the batch's round-trip
+        // profile identical to per-item `check_access` (no wasted ancestor walk
+        // for a subject that would deny at "no roles assigned").
+        let has_roles = |req: &AccessRequest| {
+            assignments_by_subject
+                .get(&(req.tenant_id, req.subject_id))
+                .map(|a| !a.is_empty())
+                .unwrap_or(false)
+        };
+
+        // --- Coalesce round-trip 2: ancestors, once per (tenant, resource).
+        let mut ancestors_by_resource: HashMap<(Uuid, Uuid), HashSet<Uuid>> = HashMap::new();
+        for req in requests.iter().filter(|r| has_roles(r)) {
+            let key = (req.tenant_id, req.resource_id);
+            if let std::collections::hash_map::Entry::Vacant(slot) =
+                ancestors_by_resource.entry(key)
+            {
+                let ancestors = self
+                    .resource_repo
+                    .get_ancestors(req.tenant_id, req.resource_id)
+                    .instrument(tracing::debug_span!(
+                        "db.get_ancestors",
+                        tenant_id = %req.tenant_id,
+                        resource_id = %req.resource_id
+                    ))
+                    .await?;
+                slot.insert(ancestors.iter().map(|r| r.id).collect());
+            }
+        }
+
+        // --- Coalesce round-trip 3: scope lists, once per (tenant, resource)
+        //     that any scoped, role-bearing item targets.
+        let mut scopes_by_resource: HashMap<(Uuid, Uuid), Vec<axiam_core::models::scope::Scope>> =
+            HashMap::new();
+        for req in requests.iter().filter(|r| r.scope.is_some() && has_roles(r)) {
+            let key = (req.tenant_id, req.resource_id);
+            if let std::collections::hash_map::Entry::Vacant(slot) = scopes_by_resource.entry(key) {
+                let scopes = self
+                    .scope_repo
+                    .list_by_resource(req.tenant_id, req.resource_id)
+                    .instrument(tracing::debug_span!(
+                        "db.list_by_resource",
+                        tenant_id = %req.tenant_id,
+                        resource_id = %req.resource_id
+                    ))
+                    .await?;
+                slot.insert(scopes);
+            }
+        }
+
+        // --- Per-item: compute applicable roles from the shared lookups, and
+        //     accumulate the union of role IDs so grants can be fetched ONCE.
+        //     `PreDecision` short-circuits (deny) are recorded here so the final
+        //     pass need not re-derive them.
+        enum PreDecision {
+            Decided(AccessDecision),
+            NeedsGrants {
+                tenant_id: Uuid,
+                unique_role_ids: Vec<Uuid>,
+                requested_scope_id: Option<Uuid>,
+            },
+        }
+
+        let mut pre: Vec<PreDecision> = Vec::with_capacity(requests.len());
+        // Union of (tenant, role_id) that we must fetch grants for, deduped.
+        let mut grant_role_ids: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+        let mut grant_role_seen: HashSet<(Uuid, Uuid)> = HashSet::new();
+
+        for (i, req) in requests.iter().enumerate() {
+            let _item_span = tracing::debug_span!(
+                "authz.batch.item",
+                index = i,
+                resource_id = %req.resource_id,
+                action = %req.action
+            )
+            .entered();
+
+            let assignments = assignments_by_subject
+                .get(&(req.tenant_id, req.subject_id))
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            if assignments.is_empty() {
+                pre.push(PreDecision::Decided(AccessDecision::Deny(
+                    "no roles assigned".into(),
+                )));
                 continue;
+            }
+
+            let empty_ancestors = HashSet::new();
+            let ancestor_ids = ancestors_by_resource
+                .get(&(req.tenant_id, req.resource_id))
+                .unwrap_or(&empty_ancestors);
+
+            let unique_role_ids = applicable_role_ids(assignments, req.resource_id, ancestor_ids);
+            if unique_role_ids.is_empty() {
+                pre.push(PreDecision::Decided(AccessDecision::Deny(
+                    "no applicable roles for this resource".into(),
+                )));
+                continue;
+            }
+
+            // Resolve scope against the coalesced scope list (no I/O here).
+            let requested_scope_id = if let Some(ref scope_name) = req.scope {
+                let scopes = scopes_by_resource
+                    .get(&(req.tenant_id, req.resource_id))
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]);
+                match scopes.iter().find(|s| s.name == *scope_name) {
+                    Some(s) => Some(s.id),
+                    None => {
+                        pre.push(PreDecision::Decided(AccessDecision::Deny(format!(
+                            "scope '{}' not found on resource",
+                            scope_name
+                        ))));
+                        continue;
+                    }
+                }
+            } else {
+                None
             };
 
-            for grant in grants {
-                if grant.permission.action != request.action {
-                    continue;
+            for rid in &unique_role_ids {
+                if grant_role_seen.insert((req.tenant_id, *rid)) {
+                    grant_role_ids.entry(req.tenant_id).or_default().push(*rid);
                 }
+            }
 
-                // Action matches — now check scope constraint.
-                if let Some(scope_id) = requested_scope_id {
-                    // If grant has no scope constraints (wildcard), it
-                    // matches any scope. Otherwise the scope must be in
-                    // the grant's list.
-                    if grant.scope_ids.is_empty() || grant.scope_ids.contains(&scope_id) {
-                        has_matching_grant = true;
-                        break 'roles;
+            pre.push(PreDecision::NeedsGrants {
+                tenant_id: req.tenant_id,
+                unique_role_ids,
+                requested_scope_id,
+            });
+        }
+
+        // --- Coalesce round-trip 4: fetch grants for every applicable role in
+        //     the batch, one batched query per tenant.
+        let mut grants_by_role: HashMap<Uuid, Vec<PermissionGrant>> = HashMap::new();
+        for (tenant_id, role_ids) in &grant_role_ids {
+            let map = self
+                .permission_repo
+                .get_role_permission_grants_for_roles(*tenant_id, role_ids)
+                .instrument(tracing::debug_span!(
+                    "db.get_role_permission_grants_for_roles",
+                    tenant_id = %tenant_id,
+                    role_count = role_ids.len()
+                ))
+                .await?;
+            grants_by_role.extend(map);
+        }
+
+        // --- Final pass: evaluate each item against the shared grants map,
+        //     preserving input order.
+        let mut decisions = Vec::with_capacity(requests.len());
+        for (item, req) in pre.into_iter().zip(requests.iter()) {
+            match item {
+                PreDecision::Decided(d) => decisions.push(d),
+                PreDecision::NeedsGrants {
+                    tenant_id: _,
+                    unique_role_ids,
+                    requested_scope_id,
+                } => {
+                    if grants_allow(
+                        &unique_role_ids,
+                        &grants_by_role,
+                        &req.action,
+                        requested_scope_id,
+                    ) {
+                        decisions.push(AccessDecision::Allow);
+                    } else {
+                        decisions.push(AccessDecision::Deny(format!(
+                            "no permission grants action '{}'",
+                            req.action
+                        )));
                     }
-                } else {
-                    // No scope requested — action match is sufficient.
-                    has_matching_grant = true;
-                    break 'roles;
                 }
             }
         }
 
-        if !has_matching_grant {
-            return Ok(AccessDecision::Deny(format!(
-                "no permission grants action '{}'",
-                request.action
-            )));
-        }
-
-        Ok(AccessDecision::Allow)
+        Ok(decisions)
     }
+}
+
+/// Outcome of resolving an optional scope name to a scope ID.
+enum ScopeResolution {
+    /// No scope was requested.
+    None,
+    /// Scope name resolved to this ID.
+    Resolved(Uuid),
+    /// Scope name was requested but does not exist on the resource — carries
+    /// the ready-made deny decision.
+    NotFound(AccessDecision),
 }

--- a/crates/axiam-authz/src/lib.rs
+++ b/crates/axiam-authz/src/lib.rs
@@ -1,9 +1,11 @@
 //! AXIAM AuthZ — Permission evaluation engine with resource hierarchy inheritance.
 
 pub mod config;
+pub mod decision_cache;
 pub mod engine;
 pub mod types;
 
 pub use config::AuthzConfig;
+pub use decision_cache::{DecisionCache, DecisionCacheConfig};
 pub use engine::AuthorizationEngine;
 pub use types::{AccessDecision, AccessRequest};

--- a/crates/axiam-authz/tests/batch_coalescing_test.rs
+++ b/crates/axiam-authz/tests/batch_coalescing_test.rs
@@ -26,8 +26,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use axiam_authz::types::{AccessDecision, AccessRequest};
 use axiam_authz::AuthorizationEngine;
+use axiam_authz::types::{AccessDecision, AccessRequest};
 use axiam_core::error::AxiamResult;
 use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
 use axiam_core::models::permission::{
@@ -306,7 +306,11 @@ impl ScopeRepository for MockScopeRepo {
         resource_id: Uuid,
     ) -> AxiamResult<Vec<Scope>> {
         self.counter.fetch_add(1, Ordering::SeqCst);
-        Ok(self.by_resource.get(&resource_id).cloned().unwrap_or_default())
+        Ok(self
+            .by_resource
+            .get(&resource_id)
+            .cloned()
+            .unwrap_or_default())
     }
 
     // --- unused ---
@@ -363,8 +367,13 @@ impl GroupRepository for MockGroupRepo {
     }
 }
 
-type MockEngine =
-    AuthorizationEngine<MockRoleRepo, MockPermissionRepo, MockResourceRepo, MockScopeRepo, MockGroupRepo>;
+type MockEngine = AuthorizationEngine<
+    MockRoleRepo,
+    MockPermissionRepo,
+    MockResourceRepo,
+    MockScopeRepo,
+    MockGroupRepo,
+>;
 
 /// Build an engine where `subject` has a role granting `action` on `resource`.
 fn build_engine(
@@ -636,8 +645,5 @@ async fn empty_subject_denies_without_extra_round_trips() {
     // No applicable subject -> engine must not walk ancestors or fetch grants.
     assert_eq!(Counters::get(&counters.ancestors), 0);
     assert_eq!(Counters::get(&counters.grants), 0);
-    assert_eq!(
-        batched[0],
-        AccessDecision::Deny("no roles assigned".into())
-    );
+    assert_eq!(batched[0], AccessDecision::Deny("no roles assigned".into()));
 }

--- a/crates/axiam-authz/tests/batch_coalescing_test.rs
+++ b/crates/axiam-authz/tests/batch_coalescing_test.rs
@@ -1,0 +1,643 @@
+//! D1: round-trip-count tests for the coalesced batch authorization path.
+//!
+//! These tests use **counting mock repositories** rather than the real
+//! SurrealDB in-memory repos so we can assert *how many* DB round-trips the
+//! engine issues — the core D1 win. The benchmark's batch shape is 5 checks
+//! that all share one subject and one resource; the pre-D1 path issued the
+//! role-assignment and ancestor lookups once **per item** (5× each), while the
+//! coalesced [`AuthorizationEngine::check_access_batch`] resolves each shared
+//! lookup exactly **once**.
+//!
+//! ## Why round-trip counts, not wall-clock ratios
+//!
+//! The plan's acceptance target ("batch < 3× single") is a *latency* ratio, but
+//! a wall-clock assertion in CI is flaky: against an in-memory mock every query
+//! is sub-microsecond, so the ratio is dominated by scheduler/allocator noise
+//! and would either false-fail or need such a loose bound it proves nothing.
+//! The *mechanism* that produces the latency win is the round-trip reduction,
+//! and that is exactly and deterministically countable. We therefore assert the
+//! round-trip counts directly (robust, precise) and derive the latency claim
+//! from them: on the real stack each round-trip is one serialized HTTP call
+//! over the single shared SurrealDB connection, so 3 round-trips for a batch of
+//! 5 vs 3 for a single check is inherently sub-3×. The end-to-end latency ratio
+//! is confirmed on the benchmark laptop (pending laptop re-run).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use axiam_authz::types::{AccessDecision, AccessRequest};
+use axiam_authz::AuthorizationEngine;
+use axiam_core::error::AxiamResult;
+use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
+use axiam_core::models::permission::{
+    CreatePermission, Permission, PermissionGrant, UpdatePermission,
+};
+use axiam_core::models::resource::{CreateResource, Resource, UpdateResource};
+use axiam_core::models::role::{CreateRole, Role, RoleAssignment, UpdateRole};
+use axiam_core::models::scope::{CreateScope, Scope, UpdateScope};
+use axiam_core::models::user::User;
+use axiam_core::repository::{
+    GroupRepository, PaginatedResult, Pagination, PermissionRepository, ResourceRepository,
+    RoleRepository, ScopeRepository,
+};
+use chrono::Utc;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Model builders
+// ---------------------------------------------------------------------------
+
+fn role(id: Uuid, tenant: Uuid, is_global: bool) -> Role {
+    Role {
+        id,
+        tenant_id: tenant,
+        name: "r".into(),
+        description: String::new(),
+        is_global,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn permission(action: &str, tenant: Uuid) -> Permission {
+    Permission {
+        id: Uuid::new_v4(),
+        tenant_id: tenant,
+        action: action.into(),
+        description: String::new(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn resource(id: Uuid, tenant: Uuid) -> Resource {
+    Resource {
+        id,
+        tenant_id: tenant,
+        name: "res".into(),
+        resource_type: "service".into(),
+        parent_id: None,
+        metadata: serde_json::Value::Null,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Counting mock repositories
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Default)]
+struct Counters {
+    role_assignments: Arc<AtomicUsize>,
+    ancestors: Arc<AtomicUsize>,
+    grants: Arc<AtomicUsize>,
+    scopes: Arc<AtomicUsize>,
+}
+
+impl Counters {
+    fn reset(&self) {
+        self.role_assignments.store(0, Ordering::SeqCst);
+        self.ancestors.store(0, Ordering::SeqCst);
+        self.grants.store(0, Ordering::SeqCst);
+        self.scopes.store(0, Ordering::SeqCst);
+    }
+    fn get(a: &Arc<AtomicUsize>) -> usize {
+        a.load(Ordering::SeqCst)
+    }
+}
+
+/// Role repo: returns seeded assignments per subject, counting each lookup.
+struct MockRoleRepo {
+    counter: Arc<AtomicUsize>,
+    by_subject: HashMap<Uuid, Vec<RoleAssignment>>,
+}
+
+impl RoleRepository for MockRoleRepo {
+    async fn get_user_role_assignments(
+        &self,
+        _tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> AxiamResult<Vec<RoleAssignment>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        Ok(self.by_subject.get(&user_id).cloned().unwrap_or_default())
+    }
+
+    // --- unused by the engine hot path ---
+    async fn create(&self, _input: CreateRole) -> AxiamResult<Role> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Role> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateRole) -> AxiamResult<Role> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Role>> {
+        unimplemented!()
+    }
+    async fn assign_to_user(
+        &self,
+        _t: Uuid,
+        _u: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn unassign_from_user(
+        &self,
+        _t: Uuid,
+        _u: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_user_roles(&self, _t: Uuid, _u: Uuid) -> AxiamResult<Vec<Role>> {
+        unimplemented!()
+    }
+    async fn assign_to_group(
+        &self,
+        _t: Uuid,
+        _g: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn unassign_from_group(
+        &self,
+        _t: Uuid,
+        _g: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_group_roles(&self, _t: Uuid, _g: Uuid) -> AxiamResult<Vec<Role>> {
+        unimplemented!()
+    }
+    async fn get_role_user_ids(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Uuid>> {
+        unimplemented!()
+    }
+    async fn get_role_group_ids(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Uuid>> {
+        unimplemented!()
+    }
+}
+
+/// Permission repo: returns seeded grants per role, counting the batched lookup.
+struct MockPermissionRepo {
+    counter: Arc<AtomicUsize>,
+    by_role: HashMap<Uuid, Vec<PermissionGrant>>,
+}
+
+impl PermissionRepository for MockPermissionRepo {
+    async fn get_role_permission_grants_for_roles(
+        &self,
+        _tenant_id: Uuid,
+        role_ids: &[Uuid],
+    ) -> AxiamResult<HashMap<Uuid, Vec<PermissionGrant>>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        let mut out = HashMap::new();
+        for rid in role_ids {
+            if let Some(grants) = self.by_role.get(rid) {
+                out.insert(*rid, grants.clone());
+            }
+        }
+        Ok(out)
+    }
+
+    // --- unused ---
+    async fn create(&self, _input: CreatePermission) -> AxiamResult<Permission> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Permission> {
+        unimplemented!()
+    }
+    async fn update(
+        &self,
+        _t: Uuid,
+        _id: Uuid,
+        _input: UpdatePermission,
+    ) -> AxiamResult<Permission> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Permission>> {
+        unimplemented!()
+    }
+    async fn grant_to_role(&self, _t: Uuid, _r: Uuid, _p: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn revoke_from_role(&self, _t: Uuid, _r: Uuid, _p: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_role_permissions(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Permission>> {
+        unimplemented!()
+    }
+    async fn grant_to_role_with_scopes(
+        &self,
+        _t: Uuid,
+        _r: Uuid,
+        _p: Uuid,
+        _s: Vec<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_role_permission_grants(
+        &self,
+        _t: Uuid,
+        _r: Uuid,
+    ) -> AxiamResult<Vec<PermissionGrant>> {
+        unimplemented!()
+    }
+}
+
+/// Resource repo: returns seeded ancestors per resource, counting each lookup.
+struct MockResourceRepo {
+    counter: Arc<AtomicUsize>,
+    ancestors: HashMap<Uuid, Vec<Resource>>,
+}
+
+impl ResourceRepository for MockResourceRepo {
+    async fn get_ancestors(&self, _tenant_id: Uuid, id: Uuid) -> AxiamResult<Vec<Resource>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        Ok(self.ancestors.get(&id).cloned().unwrap_or_default())
+    }
+
+    // --- unused ---
+    async fn create(&self, _input: CreateResource) -> AxiamResult<Resource> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Resource> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateResource) -> AxiamResult<Resource> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Resource>> {
+        unimplemented!()
+    }
+    async fn get_children(&self, _t: Uuid, _parent: Uuid) -> AxiamResult<Vec<Resource>> {
+        unimplemented!()
+    }
+}
+
+/// Scope repo: returns seeded scopes per resource, counting each lookup.
+struct MockScopeRepo {
+    counter: Arc<AtomicUsize>,
+    by_resource: HashMap<Uuid, Vec<Scope>>,
+}
+
+impl ScopeRepository for MockScopeRepo {
+    async fn list_by_resource(
+        &self,
+        _tenant_id: Uuid,
+        resource_id: Uuid,
+    ) -> AxiamResult<Vec<Scope>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        Ok(self.by_resource.get(&resource_id).cloned().unwrap_or_default())
+    }
+
+    // --- unused ---
+    async fn create(&self, _input: CreateScope) -> AxiamResult<Scope> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Scope> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateScope) -> AxiamResult<Scope> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+}
+
+/// Group repo: never touched by the engine hot path (group expansion happens
+/// inside the role repo's `get_user_role_assignments`).
+struct MockGroupRepo;
+
+impl GroupRepository for MockGroupRepo {
+    async fn create(&self, _input: CreateGroup) -> AxiamResult<Group> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Group> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateGroup) -> AxiamResult<Group> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Group>> {
+        unimplemented!()
+    }
+    async fn add_member(&self, _t: Uuid, _u: Uuid, _g: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn remove_member(&self, _t: Uuid, _u: Uuid, _g: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_members(
+        &self,
+        _t: Uuid,
+        _g: Uuid,
+        _p: Pagination,
+    ) -> AxiamResult<PaginatedResult<User>> {
+        unimplemented!()
+    }
+    async fn get_user_groups(&self, _t: Uuid, _u: Uuid) -> AxiamResult<Vec<Group>> {
+        unimplemented!()
+    }
+}
+
+type MockEngine =
+    AuthorizationEngine<MockRoleRepo, MockPermissionRepo, MockResourceRepo, MockScopeRepo, MockGroupRepo>;
+
+/// Build an engine where `subject` has a role granting `action` on `resource`.
+fn build_engine(
+    tenant: Uuid,
+    subject: Uuid,
+    resource_id: Uuid,
+    action: &str,
+) -> (MockEngine, Counters) {
+    let counters = Counters::default();
+    let role_id = Uuid::new_v4();
+
+    let mut by_subject = HashMap::new();
+    by_subject.insert(
+        subject,
+        vec![RoleAssignment {
+            role: role(role_id, tenant, false),
+            resource_id: Some(resource_id),
+        }],
+    );
+
+    let mut by_role = HashMap::new();
+    by_role.insert(
+        role_id,
+        vec![PermissionGrant {
+            permission: permission(action, tenant),
+            scope_ids: vec![],
+        }],
+    );
+
+    let engine = AuthorizationEngine::new(
+        MockRoleRepo {
+            counter: counters.role_assignments.clone(),
+            by_subject,
+        },
+        MockPermissionRepo {
+            counter: counters.grants.clone(),
+            by_role,
+        },
+        MockResourceRepo {
+            counter: counters.ancestors.clone(),
+            ancestors: HashMap::new(),
+        },
+        MockScopeRepo {
+            counter: counters.scopes.clone(),
+            by_resource: HashMap::new(),
+        },
+        MockGroupRepo,
+    );
+
+    (engine, counters)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The core D1 assertion: a same-subject / same-resource batch of 5 must NOT
+/// issue 5× the role-assignment and ancestor lookups. It coalesces to exactly
+/// one of each (plus one batched grants query) — vs 5 of each for the
+/// sequential per-item path.
+#[tokio::test]
+async fn same_subject_batch_of_5_coalesces_round_trips() {
+    let tenant = Uuid::new_v4();
+    let subject = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let (engine, counters) = build_engine(tenant, subject, resource_id, "read");
+
+    let requests: Vec<AccessRequest> = (0..5)
+        .map(|_| AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject,
+            action: "read".into(),
+            resource_id,
+            scope: None,
+        })
+        .collect();
+
+    // --- Baseline: sequential per-item check_access issues 5× each lookup.
+    counters.reset();
+    let mut sequential = Vec::new();
+    for req in &requests {
+        sequential.push(engine.check_access(req).await.unwrap());
+    }
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        5,
+        "sequential path issues one role-assignment lookup per item"
+    );
+    assert_eq!(Counters::get(&counters.ancestors), 5);
+    assert_eq!(Counters::get(&counters.grants), 5);
+
+    // --- Coalesced batch: exactly ONE of each shared lookup.
+    counters.reset();
+    let batched = engine.check_access_batch(&requests).await.unwrap();
+
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        1,
+        "batch coalesces the role-assignment lookup to once per (tenant, subject)"
+    );
+    assert_eq!(
+        Counters::get(&counters.ancestors),
+        1,
+        "batch coalesces the ancestor lookup to once per (tenant, resource)"
+    );
+    assert_eq!(
+        Counters::get(&counters.grants),
+        1,
+        "batch fetches grants for the whole batch in a single query"
+    );
+
+    // --- Decisions must be byte-identical to the sequential path, in order.
+    assert_eq!(batched, sequential);
+    assert!(batched.iter().all(|d| *d == AccessDecision::Allow));
+}
+
+/// Distinct subjects/resources still coalesce per *group*: two subjects across
+/// four items issue two role-assignment lookups (one per subject), not four,
+/// and decisions match the per-item engine exactly (order preserved incl. a
+/// deny in the middle).
+#[tokio::test]
+async fn distinct_groups_coalesce_per_group_and_preserve_order() {
+    let tenant = Uuid::new_v4();
+    let subject_a = Uuid::new_v4();
+    let subject_b = Uuid::new_v4();
+    let resource_x = Uuid::new_v4();
+    let resource_y = Uuid::new_v4();
+    let counters = Counters::default();
+
+    let role_a = Uuid::new_v4();
+    let role_b = Uuid::new_v4();
+
+    // subject_a: read on resource_x. subject_b: write on resource_y.
+    let mut by_subject = HashMap::new();
+    by_subject.insert(
+        subject_a,
+        vec![RoleAssignment {
+            role: role(role_a, tenant, false),
+            resource_id: Some(resource_x),
+        }],
+    );
+    by_subject.insert(
+        subject_b,
+        vec![RoleAssignment {
+            role: role(role_b, tenant, false),
+            resource_id: Some(resource_y),
+        }],
+    );
+
+    let mut by_role = HashMap::new();
+    by_role.insert(
+        role_a,
+        vec![PermissionGrant {
+            permission: permission("read", tenant),
+            scope_ids: vec![],
+        }],
+    );
+    by_role.insert(
+        role_b,
+        vec![PermissionGrant {
+            permission: permission("write", tenant),
+            scope_ids: vec![],
+        }],
+    );
+
+    let mut ancestors = HashMap::new();
+    ancestors.insert(resource_x, vec![resource(resource_x, tenant)]);
+    ancestors.insert(resource_y, vec![resource(resource_y, tenant)]);
+
+    let engine = AuthorizationEngine::new(
+        MockRoleRepo {
+            counter: counters.role_assignments.clone(),
+            by_subject,
+        },
+        MockPermissionRepo {
+            counter: counters.grants.clone(),
+            by_role,
+        },
+        MockResourceRepo {
+            counter: counters.ancestors.clone(),
+            ancestors,
+        },
+        MockScopeRepo {
+            counter: counters.scopes.clone(),
+            by_resource: HashMap::new(),
+        },
+        MockGroupRepo,
+    );
+
+    // Order: A/read/x (allow), A/write/x (deny — no grant), B/write/y (allow),
+    // A/read/x (allow again — same group as item 0).
+    let requests = vec![
+        AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject_a,
+            action: "read".into(),
+            resource_id: resource_x,
+            scope: None,
+        },
+        AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject_a,
+            action: "write".into(),
+            resource_id: resource_x,
+            scope: None,
+        },
+        AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject_b,
+            action: "write".into(),
+            resource_id: resource_y,
+            scope: None,
+        },
+        AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject_a,
+            action: "read".into(),
+            resource_id: resource_x,
+            scope: None,
+        },
+    ];
+
+    // Sequential per-item baseline for the decisions.
+    counters.reset();
+    let mut sequential = Vec::new();
+    for req in &requests {
+        sequential.push(engine.check_access(req).await.unwrap());
+    }
+
+    counters.reset();
+    let batched = engine.check_access_batch(&requests).await.unwrap();
+
+    // Two distinct subjects -> 2 role-assignment lookups (not 4).
+    assert_eq!(Counters::get(&counters.role_assignments), 2);
+    // Two distinct resources -> 2 ancestor lookups (not 4).
+    assert_eq!(Counters::get(&counters.ancestors), 2);
+    // One batched grants query for the whole batch.
+    assert_eq!(Counters::get(&counters.grants), 1);
+
+    assert_eq!(batched, sequential);
+    assert_eq!(batched[0], AccessDecision::Allow);
+    assert!(matches!(batched[1], AccessDecision::Deny(_)));
+    assert_eq!(batched[2], AccessDecision::Allow);
+    assert_eq!(batched[3], AccessDecision::Allow);
+}
+
+/// A subject with no roles short-circuits to the same deny reason as the
+/// single-check path, and issues no ancestor/grants lookups for that item.
+#[tokio::test]
+async fn empty_subject_denies_without_extra_round_trips() {
+    let tenant = Uuid::new_v4();
+    let known = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let (engine, counters) = build_engine(tenant, known, resource_id, "read");
+
+    let unknown = Uuid::new_v4(); // no assignments seeded
+    let requests = vec![AccessRequest {
+        tenant_id: tenant,
+        subject_id: unknown,
+        action: "read".into(),
+        resource_id,
+        scope: None,
+    }];
+
+    counters.reset();
+    let batched = engine.check_access_batch(&requests).await.unwrap();
+
+    assert_eq!(Counters::get(&counters.role_assignments), 1);
+    // No applicable subject -> engine must not walk ancestors or fetch grants.
+    assert_eq!(Counters::get(&counters.ancestors), 0);
+    assert_eq!(Counters::get(&counters.grants), 0);
+    assert_eq!(
+        batched[0],
+        AccessDecision::Deny("no roles assigned".into())
+    );
+}

--- a/crates/axiam-authz/tests/decision_cache_integration_test.rs
+++ b/crates/axiam-authz/tests/decision_cache_integration_test.rs
@@ -1,0 +1,663 @@
+//! D7: authorization decision cache — integration + security tests.
+//!
+//! These tests exercise the [`AuthorizationEngine`] with a [`DecisionCache`]
+//! attached (the feature-flagged fast path) against **mutable counting mock
+//! repositories**: the mocks both (a) count DB round-trips so we can prove a
+//! cache hit skips the DB, and (b) let a test mutate the seeded data at runtime
+//! to simulate a revocation landing in the store.
+//!
+//! The headline test is [`revocation_invalidation_denies_immediately`]: it
+//! proves that a removed grant is enforced **immediately** via the engine's
+//! event-driven invalidation hook (`invalidate_subject`, which is exactly what
+//! the REST `unassign_from_user` / group `remove_member` handlers call through
+//! the `AuthzChecker` trait) — NOT after waiting for the TTL. A control case
+//! (mutate the store but skip invalidation) shows the cache *would* otherwise
+//! serve a stale allow within the TTL, isolating invalidation as the mechanism
+//! that enforces the revocation.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axiam_authz::types::{AccessDecision, AccessRequest};
+use axiam_authz::{AuthorizationEngine, DecisionCache, DecisionCacheConfig};
+use axiam_core::error::AxiamResult;
+use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
+use axiam_core::models::permission::{
+    CreatePermission, Permission, PermissionGrant, UpdatePermission,
+};
+use axiam_core::models::resource::{CreateResource, Resource, UpdateResource};
+use axiam_core::models::role::{CreateRole, Role, RoleAssignment, UpdateRole};
+use axiam_core::models::scope::{CreateScope, Scope, UpdateScope};
+use axiam_core::models::user::User;
+use axiam_core::repository::{
+    GroupRepository, PaginatedResult, Pagination, PermissionRepository, ResourceRepository,
+    RoleRepository, ScopeRepository,
+};
+use chrono::Utc;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Model builders
+// ---------------------------------------------------------------------------
+
+fn role(id: Uuid, tenant: Uuid) -> Role {
+    Role {
+        id,
+        tenant_id: tenant,
+        name: "r".into(),
+        description: String::new(),
+        is_global: false,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn permission(action: &str, tenant: Uuid) -> Permission {
+    Permission {
+        id: Uuid::new_v4(),
+        tenant_id: tenant,
+        action: action.into(),
+        description: String::new(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mutable, counting mock repositories
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Default)]
+struct Counters {
+    role_assignments: Arc<AtomicUsize>,
+    ancestors: Arc<AtomicUsize>,
+    grants: Arc<AtomicUsize>,
+}
+
+impl Counters {
+    fn get(a: &Arc<AtomicUsize>) -> usize {
+        a.load(Ordering::SeqCst)
+    }
+}
+
+/// Role repo whose per-subject assignments can be mutated at runtime (to
+/// simulate a role unassignment landing in the store), counting each lookup.
+#[derive(Clone)]
+struct MockRoleRepo {
+    counter: Arc<AtomicUsize>,
+    by_subject: Arc<Mutex<HashMap<Uuid, Vec<RoleAssignment>>>>,
+}
+
+impl MockRoleRepo {
+    /// Simulate the DB effect of unassigning every role from `subject`.
+    fn revoke_all_roles(&self, subject: Uuid) {
+        self.by_subject.lock().unwrap().remove(&subject);
+    }
+}
+
+impl RoleRepository for MockRoleRepo {
+    async fn get_user_role_assignments(
+        &self,
+        _tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> AxiamResult<Vec<RoleAssignment>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .by_subject
+            .lock()
+            .unwrap()
+            .get(&user_id)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn create(&self, _input: CreateRole) -> AxiamResult<Role> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Role> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateRole) -> AxiamResult<Role> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Role>> {
+        unimplemented!()
+    }
+    async fn assign_to_user(
+        &self,
+        _t: Uuid,
+        _u: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn unassign_from_user(
+        &self,
+        _t: Uuid,
+        _u: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_user_roles(&self, _t: Uuid, _u: Uuid) -> AxiamResult<Vec<Role>> {
+        unimplemented!()
+    }
+    async fn assign_to_group(
+        &self,
+        _t: Uuid,
+        _g: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn unassign_from_group(
+        &self,
+        _t: Uuid,
+        _g: Uuid,
+        _r: Uuid,
+        _res: Option<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_group_roles(&self, _t: Uuid, _g: Uuid) -> AxiamResult<Vec<Role>> {
+        unimplemented!()
+    }
+    async fn get_role_user_ids(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Uuid>> {
+        unimplemented!()
+    }
+    async fn get_role_group_ids(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Uuid>> {
+        unimplemented!()
+    }
+}
+
+struct MockPermissionRepo {
+    counter: Arc<AtomicUsize>,
+    by_role: HashMap<Uuid, Vec<PermissionGrant>>,
+}
+
+impl PermissionRepository for MockPermissionRepo {
+    async fn get_role_permission_grants_for_roles(
+        &self,
+        _tenant_id: Uuid,
+        role_ids: &[Uuid],
+    ) -> AxiamResult<HashMap<Uuid, Vec<PermissionGrant>>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        let mut out = HashMap::new();
+        for rid in role_ids {
+            if let Some(grants) = self.by_role.get(rid) {
+                out.insert(*rid, grants.clone());
+            }
+        }
+        Ok(out)
+    }
+
+    async fn create(&self, _input: CreatePermission) -> AxiamResult<Permission> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Permission> {
+        unimplemented!()
+    }
+    async fn update(
+        &self,
+        _t: Uuid,
+        _id: Uuid,
+        _input: UpdatePermission,
+    ) -> AxiamResult<Permission> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Permission>> {
+        unimplemented!()
+    }
+    async fn grant_to_role(&self, _t: Uuid, _r: Uuid, _p: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn revoke_from_role(&self, _t: Uuid, _r: Uuid, _p: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_role_permissions(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Permission>> {
+        unimplemented!()
+    }
+    async fn grant_to_role_with_scopes(
+        &self,
+        _t: Uuid,
+        _r: Uuid,
+        _p: Uuid,
+        _s: Vec<Uuid>,
+    ) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_role_permission_grants(
+        &self,
+        _t: Uuid,
+        _r: Uuid,
+    ) -> AxiamResult<Vec<PermissionGrant>> {
+        unimplemented!()
+    }
+}
+
+struct MockResourceRepo {
+    counter: Arc<AtomicUsize>,
+}
+
+impl ResourceRepository for MockResourceRepo {
+    async fn get_ancestors(&self, _tenant_id: Uuid, _id: Uuid) -> AxiamResult<Vec<Resource>> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    }
+
+    async fn create(&self, _input: CreateResource) -> AxiamResult<Resource> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Resource> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateResource) -> AxiamResult<Resource> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Resource>> {
+        unimplemented!()
+    }
+    async fn get_children(&self, _t: Uuid, _parent: Uuid) -> AxiamResult<Vec<Resource>> {
+        unimplemented!()
+    }
+}
+
+struct MockScopeRepo;
+
+impl ScopeRepository for MockScopeRepo {
+    async fn list_by_resource(&self, _t: Uuid, _r: Uuid) -> AxiamResult<Vec<Scope>> {
+        Ok(Vec::new())
+    }
+    async fn create(&self, _input: CreateScope) -> AxiamResult<Scope> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Scope> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateScope) -> AxiamResult<Scope> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+}
+
+struct MockGroupRepo;
+
+impl GroupRepository for MockGroupRepo {
+    async fn create(&self, _input: CreateGroup) -> AxiamResult<Group> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _id: Uuid) -> AxiamResult<Group> {
+        unimplemented!()
+    }
+    async fn update(&self, _t: Uuid, _id: Uuid, _input: UpdateGroup) -> AxiamResult<Group> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _id: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<Group>> {
+        unimplemented!()
+    }
+    async fn add_member(&self, _t: Uuid, _u: Uuid, _g: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn remove_member(&self, _t: Uuid, _u: Uuid, _g: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn get_members(
+        &self,
+        _t: Uuid,
+        _g: Uuid,
+        _p: Pagination,
+    ) -> AxiamResult<PaginatedResult<User>> {
+        unimplemented!()
+    }
+    async fn get_user_groups(&self, _t: Uuid, _u: Uuid) -> AxiamResult<Vec<Group>> {
+        unimplemented!()
+    }
+}
+
+type MockEngine = AuthorizationEngine<
+    MockRoleRepo,
+    MockPermissionRepo,
+    MockResourceRepo,
+    MockScopeRepo,
+    MockGroupRepo,
+>;
+
+/// Build an engine (NO cache attached) where `subject` has a role granting
+/// `action` on `resource`. Returns the engine, the mutable role repo handle
+/// (to simulate revocation), and the DB counters.
+fn build_engine(
+    tenant: Uuid,
+    subject: Uuid,
+    resource_id: Uuid,
+    action: &str,
+) -> (MockEngine, MockRoleRepo, Counters) {
+    let counters = Counters::default();
+    let role_id = Uuid::new_v4();
+
+    let mut by_subject = HashMap::new();
+    by_subject.insert(
+        subject,
+        vec![RoleAssignment {
+            role: role(role_id, tenant),
+            resource_id: Some(resource_id),
+        }],
+    );
+
+    let role_repo = MockRoleRepo {
+        counter: counters.role_assignments.clone(),
+        by_subject: Arc::new(Mutex::new(by_subject)),
+    };
+
+    let mut by_role = HashMap::new();
+    by_role.insert(
+        role_id,
+        vec![PermissionGrant {
+            permission: permission(action, tenant),
+            scope_ids: vec![],
+        }],
+    );
+
+    let engine = AuthorizationEngine::new(
+        role_repo.clone(),
+        MockPermissionRepo {
+            counter: counters.grants.clone(),
+            by_role,
+        },
+        MockResourceRepo {
+            counter: counters.ancestors.clone(),
+        },
+        MockScopeRepo,
+        MockGroupRepo,
+    );
+
+    (engine, role_repo, counters)
+}
+
+fn cache(ttl: Duration) -> Arc<DecisionCache> {
+    Arc::new(DecisionCache::new(DecisionCacheConfig {
+        ttl,
+        max_entries_per_tenant: 10_000,
+    }))
+}
+
+fn req(tenant: Uuid, subject: Uuid, resource: Uuid, action: &str) -> AccessRequest {
+    AccessRequest {
+        tenant_id: tenant,
+        subject_id: subject,
+        action: action.into(),
+        resource_id: resource,
+        scope: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A cache hit returns the SAME decision as a miss, for an allow — and skips
+/// the DB round-trips on the second call.
+#[tokio::test]
+async fn cache_hit_matches_miss_allow_and_skips_db() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, _repo, counters) = build_engine(tenant, subject, resource, "read");
+    let engine = engine.with_decision_cache(cache(Duration::from_secs(60)));
+    let request = req(tenant, subject, resource, "read");
+
+    let miss = engine.check_access(&request).await.unwrap();
+    assert_eq!(miss, AccessDecision::Allow);
+    assert_eq!(Counters::get(&counters.role_assignments), 1, "miss hits DB");
+
+    let hit = engine.check_access(&request).await.unwrap();
+    assert_eq!(hit, miss, "hit must equal miss");
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        1,
+        "hit must NOT re-query the DB"
+    );
+}
+
+/// A cache hit returns the SAME decision as a miss, for a deny (with its exact
+/// reason preserved).
+#[tokio::test]
+async fn cache_hit_matches_miss_deny_with_reason() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, _repo, counters) = build_engine(tenant, subject, resource, "read");
+    let engine = engine.with_decision_cache(cache(Duration::from_secs(60)));
+    // Ask for an action the subject's role does NOT grant → deny.
+    let request = req(tenant, subject, resource, "delete");
+
+    let miss = engine.check_access(&request).await.unwrap();
+    assert_eq!(
+        miss,
+        AccessDecision::Deny("no permission grants action 'delete'".into())
+    );
+    let grants_after_miss = Counters::get(&counters.grants);
+
+    let hit = engine.check_access(&request).await.unwrap();
+    assert_eq!(hit, miss, "deny decision + reason must be cached verbatim");
+    assert_eq!(
+        Counters::get(&counters.grants),
+        grants_after_miss,
+        "deny hit must not re-query"
+    );
+}
+
+/// TTL expiry forces a re-evaluation (the DB is queried again after the TTL).
+#[tokio::test]
+async fn ttl_expiry_forces_reevaluation() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, _repo, counters) = build_engine(tenant, subject, resource, "read");
+    let engine = engine.with_decision_cache(cache(Duration::from_millis(40)));
+    let request = req(tenant, subject, resource, "read");
+
+    engine.check_access(&request).await.unwrap();
+    assert_eq!(Counters::get(&counters.role_assignments), 1);
+    // Immediate second call: served from cache.
+    engine.check_access(&request).await.unwrap();
+    assert_eq!(Counters::get(&counters.role_assignments), 1);
+
+    tokio::time::sleep(Duration::from_millis(60)).await;
+
+    engine.check_access(&request).await.unwrap();
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        2,
+        "after TTL the decision is re-evaluated against the DB"
+    );
+}
+
+/// THE KEY TEST. Grant → check (allow, cached) → revoke through the mutation
+/// path (store change + `invalidate_subject`) → check MUST deny immediately,
+/// even though the TTL is long (60 s). Proves event-driven invalidation, not
+/// TTL expiry.
+#[tokio::test]
+async fn revocation_invalidation_denies_immediately() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, repo, _counters) = build_engine(tenant, subject, resource, "read");
+    // Long TTL: if enforcement relied on TTL this test would (wrongly) still
+    // see an allow. Only event-driven invalidation can make it deny now.
+    let engine = engine.with_decision_cache(cache(Duration::from_secs(60)));
+    let request = req(tenant, subject, resource, "read");
+
+    // 1. Granted → allow, now cached.
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow
+    );
+    // Confirm it is genuinely cached (a second call would be served without DB).
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow
+    );
+
+    // 2. Revoke through the mutation path: the store now denies AND the handler
+    //    fires the invalidation hook (this is exactly what the REST
+    //    `unassign_from_user` handler calls via `AuthzChecker::invalidate_subject`).
+    repo.revoke_all_roles(subject);
+    engine.invalidate_subject(tenant, subject);
+
+    // 3. The very next check must be denied — immediately, not after the TTL.
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Deny("no roles assigned".into()),
+        "a revoked grant must be enforced immediately via invalidation"
+    );
+}
+
+/// Control for the test above: WITHOUT the invalidation hook, the cache serves
+/// a stale allow within the TTL. This isolates invalidation (not the store
+/// change alone) as the mechanism that enforces a revocation before TTL —
+/// exactly why the mutation-path hooks are security-critical.
+#[tokio::test]
+async fn without_invalidation_stale_allow_persists_until_ttl() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, repo, _counters) = build_engine(tenant, subject, resource, "read");
+    let engine = engine.with_decision_cache(cache(Duration::from_secs(60)));
+    let request = req(tenant, subject, resource, "read");
+
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow
+    );
+
+    // Store change only — NO invalidation call.
+    repo.revoke_all_roles(subject);
+
+    // The cache still (dangerously) returns the stale allow — demonstrating why
+    // the immediate invalidation hooks are required, and that a missed event is
+    // only bounded by the TTL.
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow,
+        "without invalidation the stale allow persists until TTL"
+    );
+}
+
+/// `invalidate_tenant` (the conservative flush used for coarse revocations like
+/// grant revoke / role delete) also enforces a revocation immediately.
+#[tokio::test]
+async fn tenant_flush_enforces_revocation_immediately() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, repo, _counters) = build_engine(tenant, subject, resource, "read");
+    let engine = engine.with_decision_cache(cache(Duration::from_secs(60)));
+    let request = req(tenant, subject, resource, "read");
+
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow
+    );
+
+    repo.revoke_all_roles(subject);
+    engine.invalidate_tenant(tenant); // e.g. revoke_from_role / role delete path
+
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Deny("no roles assigned".into())
+    );
+}
+
+/// Feature-flag-OFF path: with no cache attached, every check hits the DB
+/// (nothing is cached) and decisions are exactly as today. Also proves a
+/// revocation is enforced with zero invalidation calls (there's no cache to go
+/// stale).
+#[tokio::test]
+async fn cache_disabled_behaves_exactly_as_today() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, repo, counters) = build_engine(tenant, subject, resource, "read");
+    // NOTE: no `.with_decision_cache(..)` — this is the default-off path.
+    let request = req(tenant, subject, resource, "read");
+
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow
+    );
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Allow
+    );
+    // Both calls hit the DB — no caching happened.
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        2,
+        "with the flag off every check re-queries the DB"
+    );
+
+    // A revocation is enforced on the next call with NO invalidation call,
+    // because there is no cache.
+    repo.revoke_all_roles(subject);
+    assert_eq!(
+        engine.check_access(&request).await.unwrap(),
+        AccessDecision::Deny("no roles assigned".into())
+    );
+
+    // Invalidation calls are harmless no-ops when no cache is attached.
+    engine.invalidate_subject(tenant, subject);
+    engine.invalidate_tenant(tenant);
+}
+
+/// The batch path is cached too: identical decisions on a second batch, DB
+/// skipped, and a revocation via invalidation flips the cached allow to deny.
+#[tokio::test]
+async fn batch_path_caches_and_invalidates() {
+    let (tenant, subject, resource) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
+    let (engine, repo, counters) = build_engine(tenant, subject, resource, "read");
+    let engine = engine.with_decision_cache(cache(Duration::from_secs(60)));
+
+    let batch: Vec<AccessRequest> = vec![
+        req(tenant, subject, resource, "read"),
+        req(tenant, subject, resource, "read"),
+        req(tenant, subject, resource, "delete"), // deny
+    ];
+
+    let first = engine.check_access_batch(&batch).await.unwrap();
+    assert_eq!(
+        first,
+        vec![
+            AccessDecision::Allow,
+            AccessDecision::Allow,
+            AccessDecision::Deny("no permission grants action 'delete'".into()),
+        ]
+    );
+    let ra_after_first = Counters::get(&counters.role_assignments);
+
+    // Second identical batch: fully served from cache, no new DB round-trips.
+    let second = engine.check_access_batch(&batch).await.unwrap();
+    assert_eq!(second, first, "cached batch decisions identical + in order");
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        ra_after_first,
+        "a fully-cached batch issues no DB round-trips"
+    );
+
+    // Revoke + invalidate → the previously-allowed items now deny immediately.
+    repo.revoke_all_roles(subject);
+    engine.invalidate_subject(tenant, subject);
+    let third = engine.check_access_batch(&batch).await.unwrap();
+    assert_eq!(
+        third,
+        vec![
+            AccessDecision::Deny("no roles assigned".into()),
+            AccessDecision::Deny("no roles assigned".into()),
+            AccessDecision::Deny("no roles assigned".into()),
+        ]
+    );
+}

--- a/crates/axiam-oauth2/src/jwks_cache.rs
+++ b/crates/axiam-oauth2/src/jwks_cache.rs
@@ -1,0 +1,426 @@
+//! In-process JWKS cache with RFC 7232 conditional-GET (ETag) support (B3).
+//!
+//! ## Baseline finding this module addresses
+//!
+//! Before this module existed, `GET /oauth2/jwks` called
+//! [`crate::oidc::build_jwks`] fresh on every single request: PEM strip →
+//! base64 decode → SHA-256(kid) → JSON-serialize, with zero HTTP caching
+//! headers. The benchmark's low 0.062 cpu·ms/req for that endpoint is
+//! simply because that computation is cheap (a 44-byte Ed25519 SPKI, no
+//! I/O) — it was never evidence of caching. This module adds a real
+//! in-process cache plus `ETag`/`If-None-Match`/304 support so repeat
+//! requests (the overwhelming majority in practice — relying parties are
+//! expected to poll `jwks_uri` on an interval, not per-request) skip the
+//! recompute and the response body entirely.
+//!
+//! ## Not the same thing as `axiam_federation::jwks_cache::JwksCache`
+//!
+//! That cache stores REMOTE identity providers' JWKS documents fetched
+//! during OIDC federation login (keyed by `(tenant_id, federation_config_id)`,
+//! TTL-based, with stale-while-revalidate). This module caches AXIAM's OWN
+//! signing-key JWKS — the document AXIAM *serves* at `GET /oauth2/jwks` —
+//! and invalidates itself based on the input key material rather than a
+//! wall-clock TTL. The two are unrelated and live in different crates.
+//!
+//! ## Known limitations (documented per B3, not fixed here)
+//!
+//! - **No key-rotation mechanism exists today.** `AuthConfig` loads
+//!   `jwt_public_key_pem` once at process startup from config/env and it
+//!   never changes for the life of the process — there is no reachable
+//!   code path that swaps it at runtime. In practice this cache is
+//!   therefore built exactly once per process. It is still keyed by a hash
+//!   of the input PEM (rather than being unconditionally "build once and
+//!   never touch again") so that IF a future rotation mechanism starts
+//!   swapping the PEM string held by the caller between calls, this cache
+//!   picks the change up automatically on the very next [`JwksCache::get`]
+//!   call — no code in that future rotation path needs to know this cache
+//!   exists or call anything special. [`JwksCache::invalidate`] is also
+//!   provided for a caller that wants to force an eager rebuild instead of
+//!   waiting for the input hash to differ.
+//! - **The endpoint is not actually per-tenant.** `GET /oauth2/jwks` serves
+//!   ONE global key set sourced from the server-wide `AuthConfig`, despite
+//!   living under the tenant-aware API surface. Every tenant is served the
+//!   same signing key today; this cache mirrors that reality (it is a
+//!   single-slot cache, not a per-tenant map).
+
+use std::sync::RwLock;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::oidc::build_jwks;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+fn default_max_age_secs() -> u64 {
+    300
+}
+
+/// Configuration for the `GET /oauth2/jwks` HTTP caching headers (B3).
+///
+/// Mirrors the `#[serde(default)]` style used by `axiam_auth::config::AuthConfig`
+/// so it composes into the same `config`-crate-driven env var plumbing.
+///
+/// The field is named `max_age_secs` in Rust for readability at call sites
+/// (`config.max_age_secs`), but is deserialized under the key
+/// `jwks_cache_max_age_secs` so that, nested one level under the server's
+/// `oauth2` config section, it is reachable via the env var
+/// `AXIAM__OAUTH2__JWKS_CACHE_MAX_AGE_SECS`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct JwksCacheConfig {
+    /// `max-age` value (seconds) advertised in the `Cache-Control` header on
+    /// `GET /oauth2/jwks` responses. Default: 300 (5 minutes). Override via
+    /// `AXIAM__OAUTH2__JWKS_CACHE_MAX_AGE_SECS`.
+    #[serde(rename = "jwks_cache_max_age_secs")]
+    pub max_age_secs: u64,
+}
+
+impl Default for JwksCacheConfig {
+    fn default() -> Self {
+        Self {
+            max_age_secs: default_max_age_secs(),
+        }
+    }
+}
+
+impl JwksCacheConfig {
+    /// Render the `Cache-Control` header value for this config, e.g.
+    /// `"public, max-age=300"`.
+    pub fn cache_control_header(&self) -> String {
+        format!("public, max-age={}", self.max_age_secs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+/// A cached, pre-serialized JWKS response plus the hash of the PEM it was
+/// built from (the self-invalidation key).
+struct CacheEntry {
+    /// SHA-256 of the source PEM this entry was built from. When a `get()`
+    /// call is made with a PEM that hashes differently, the entry is stale
+    /// and gets rebuilt.
+    pem_hash: [u8; 32],
+    /// Pre-serialized JSON body of the `JwksDocument`, cached verbatim so
+    /// repeat requests skip `serde_json` re-serialization too.
+    body: String,
+    /// Strong, quoted ETag: `"` + hex(SHA-256(body))[..16 bytes as hex] + `"`.
+    etag: String,
+}
+
+/// Outcome of a [`JwksCache::get`] call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JwksCacheResponse {
+    /// No conditional match (or no `If-None-Match` sent): the caller should
+    /// respond `200 OK` with this body and this `ETag`.
+    Fresh { body: String, etag: String },
+    /// The client's `If-None-Match` matched the current ETag: the caller
+    /// should respond `304 Not Modified` with this `ETag` and an empty body.
+    NotModified { etag: String },
+}
+
+/// Thread-safe, single-slot, in-process cache for AXIAM's own JWKS
+/// response (see module docs for the distinction from
+/// `axiam_federation::jwks_cache::JwksCache`).
+///
+/// Self-invalidates when the input PEM changes (compared by SHA-256 hash,
+/// not by string equality, to keep the stored key small and avoid retaining
+/// PEM copies longer than necessary). [`JwksCache::invalidate`] forces an
+/// eager rebuild on the next `get()` regardless of whether the PEM changed.
+pub struct JwksCache {
+    inner: RwLock<Option<CacheEntry>>,
+}
+
+impl Default for JwksCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl JwksCache {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(None),
+        }
+    }
+
+    /// Drop the cached entry unconditionally. The next [`JwksCache::get`]
+    /// call will rebuild from scratch (still hitting the fast path again on
+    /// every subsequent call, as long as the PEM does not change).
+    pub fn invalidate(&self) {
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = None;
+    }
+
+    /// Get the (possibly cached) JWKS response for `pem`, honoring an
+    /// optional `If-None-Match` request header value.
+    ///
+    /// - Cache hit (PEM hash unchanged): served from the cached, already
+    ///   serialized body — no re-parsing, no re-serialization.
+    /// - Cache miss (first call, PEM changed, or after [`JwksCache::invalidate`]):
+    ///   rebuilds via [`build_jwks`], serializes once, computes the ETag,
+    ///   and stores the new entry. On a build error (malformed PEM), the
+    ///   error is returned and the existing cache entry (if any) is left
+    ///   untouched — a bad key never evicts a previously good one.
+    ///
+    /// `if_none_match` is compared per RFC 7232 §3.2: a `*` always matches;
+    /// a comma-separated list of (optionally `W/`-prefixed) entity-tags
+    /// matches if any entry equals the current strong ETag once its `W/`
+    /// prefix (if any) is stripped.
+    pub fn get(
+        &self,
+        pem: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<JwksCacheResponse, String> {
+        let pem_hash = sha256(pem.as_bytes());
+
+        // Fast path: an existing entry built from the same PEM.
+        {
+            let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
+            if let Some(entry) = guard.as_ref() {
+                if entry.pem_hash == pem_hash {
+                    return Ok(respond(entry, if_none_match));
+                }
+            }
+        }
+
+        // Slow path: (re)build. Do NOT touch the cache until this succeeds,
+        // so a malformed key never evicts a previously-good cached entry.
+        let doc = build_jwks(pem)?;
+        let body = serde_json::to_string(&doc).map_err(|e| format!("JWKS serialize: {e}"))?;
+        let etag = format!("\"{}\"", hex::encode(&sha256(body.as_bytes())[..16]));
+
+        let entry = CacheEntry {
+            pem_hash,
+            body,
+            etag,
+        };
+        let response = respond(&entry, if_none_match);
+
+        let mut guard = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(entry);
+
+        Ok(response)
+    }
+}
+
+fn respond(entry: &CacheEntry, if_none_match: Option<&str>) -> JwksCacheResponse {
+    if let Some(header) = if_none_match {
+        if if_none_match_matches(header, &entry.etag) {
+            return JwksCacheResponse::NotModified {
+                etag: entry.etag.clone(),
+            };
+        }
+    }
+    JwksCacheResponse::Fresh {
+        body: entry.body.clone(),
+        etag: entry.etag.clone(),
+    }
+}
+
+/// RFC 7232 §3.2 `If-None-Match` comparison (weak comparison, as required
+/// for use with `GET`): `*` matches unconditionally; otherwise the header
+/// is a comma-separated list of entity-tags, each optionally prefixed with
+/// `W/` for a weak validator. A match is found if any listed tag — with its
+/// `W/` prefix stripped, if present — equals `current_etag` exactly.
+fn if_none_match_matches(header: &str, current_etag: &str) -> bool {
+    let header = header.trim();
+    if header == "*" {
+        return true;
+    }
+    header.split(',').any(|raw| {
+        let candidate = raw.trim();
+        let stripped = candidate.strip_prefix("W/").unwrap_or(candidate);
+        stripped == current_etag
+    })
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PEM_A: &str = "\
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=
+-----END PUBLIC KEY-----";
+
+    // A second, distinct Ed25519 SubjectPublicKeyInfo (different 32-byte raw
+    // key), used to simulate key rotation.
+    const PEM_B: &str = "\
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAAGCxCNpcTHjOYiJ3r54SLgtpqvhkRvAcFNq0MrqpoMU=
+-----END PUBLIC KEY-----";
+
+    #[test]
+    fn default_max_age_is_300() {
+        let cfg = JwksCacheConfig::default();
+        assert_eq!(cfg.max_age_secs, 300);
+        assert_eq!(cfg.cache_control_header(), "public, max-age=300");
+    }
+
+    #[test]
+    fn custom_max_age_renders_header() {
+        let cfg = JwksCacheConfig {
+            max_age_secs: 60,
+        };
+        assert_eq!(cfg.cache_control_header(), "public, max-age=60");
+    }
+
+    #[test]
+    fn fresh_response_has_body_and_etag_with_no_if_none_match() {
+        let cache = JwksCache::new();
+        let resp = cache.get(PEM_A, None).unwrap();
+        match resp {
+            JwksCacheResponse::Fresh { body, etag } => {
+                assert!(body.contains("\"kty\":\"OKP\""));
+                assert!(etag.starts_with('"') && etag.ends_with('"'));
+                // 16 bytes of SHA-256 hex-encoded = 32 hex chars, plus 2 quotes.
+                assert_eq!(etag.len(), 34);
+            }
+            other => panic!("expected Fresh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fresh_response_on_non_matching_if_none_match() {
+        let cache = JwksCache::new();
+        let resp = cache.get(PEM_A, Some("\"not-the-etag\"")).unwrap();
+        assert!(matches!(resp, JwksCacheResponse::Fresh { .. }));
+    }
+
+    #[test]
+    fn not_modified_on_matching_etag() {
+        let cache = JwksCache::new();
+        let etag = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+        let resp = cache.get(PEM_A, Some(&etag)).unwrap();
+        assert_eq!(resp, JwksCacheResponse::NotModified { etag });
+    }
+
+    #[test]
+    fn not_modified_on_weak_prefixed_matching_etag() {
+        let cache = JwksCache::new();
+        let etag = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+        let weak = format!("W/{etag}");
+        let resp = cache.get(PEM_A, Some(&weak)).unwrap();
+        assert_eq!(resp, JwksCacheResponse::NotModified { etag });
+    }
+
+    #[test]
+    fn not_modified_on_wildcard() {
+        let cache = JwksCache::new();
+        cache.get(PEM_A, None).unwrap();
+        let resp = cache.get(PEM_A, Some("*")).unwrap();
+        assert!(matches!(resp, JwksCacheResponse::NotModified { .. }));
+    }
+
+    #[test]
+    fn not_modified_on_comma_separated_list_containing_the_etag() {
+        let cache = JwksCache::new();
+        let etag = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+        let header = format!("\"deadbeef\", {etag}, \"other\"");
+        let resp = cache.get(PEM_A, Some(&header)).unwrap();
+        assert_eq!(resp, JwksCacheResponse::NotModified { etag });
+    }
+
+    #[test]
+    fn etag_changes_on_key_rotation_and_stale_etag_no_longer_304s() {
+        let cache = JwksCache::new();
+        let etag_a = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+
+        // Simulate rotation: caller now passes a different PEM.
+        let etag_b = match cache.get(PEM_B, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+
+        assert_ne!(etag_a, etag_b, "ETag must change when the key material changes");
+
+        // The pre-rotation ETag must no longer produce a 304 against the
+        // now-current (post-rotation) cache state.
+        let resp = cache.get(PEM_B, Some(&etag_a)).unwrap();
+        assert!(matches!(resp, JwksCacheResponse::Fresh { .. }));
+
+        // But the fresh, post-rotation ETag still 304s.
+        let resp = cache.get(PEM_B, Some(&etag_b)).unwrap();
+        assert_eq!(resp, JwksCacheResponse::NotModified { etag: etag_b });
+    }
+
+    #[test]
+    fn invalidate_forces_rebuild_and_still_serves_correctly() {
+        let cache = JwksCache::new();
+        let etag_before = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+
+        cache.invalidate();
+
+        // Same PEM, same deterministic kid/etag — invalidation just forces
+        // a rebuild, it does not change the computed result.
+        let etag_after = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+        assert_eq!(etag_before, etag_after);
+
+        // And conditional requests against the rebuilt entry still work.
+        let resp = cache.get(PEM_A, Some(&etag_after)).unwrap();
+        assert_eq!(
+            resp,
+            JwksCacheResponse::NotModified {
+                etag: etag_after
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_key_errors_without_poisoning_the_cache() {
+        let cache = JwksCache::new();
+
+        // Seed the cache with a good entry.
+        let good_etag = match cache.get(PEM_A, None).unwrap() {
+            JwksCacheResponse::Fresh { etag, .. } => etag,
+            _ => unreachable!(),
+        };
+
+        // A malformed PEM (not valid base64 / wrong length) must error...
+        let err = cache.get("not a real pem", None);
+        assert!(err.is_err());
+
+        // ...and must NOT have evicted the previously-good entry: the same
+        // good PEM still round-trips through the cache correctly afterward.
+        let resp = cache.get(PEM_A, Some(&good_etag)).unwrap();
+        assert_eq!(
+            resp,
+            JwksCacheResponse::NotModified {
+                etag: good_etag
+            }
+        );
+    }
+}

--- a/crates/axiam-oauth2/src/jwks_cache.rs
+++ b/crates/axiam-oauth2/src/jwks_cache.rs
@@ -171,11 +171,7 @@ impl JwksCache {
     /// a comma-separated list of (optionally `W/`-prefixed) entity-tags
     /// matches if any entry equals the current strong ETag once its `W/`
     /// prefix (if any) is stripped.
-    pub fn get(
-        &self,
-        pem: &str,
-        if_none_match: Option<&str>,
-    ) -> Result<JwksCacheResponse, String> {
+    pub fn get(&self, pem: &str, if_none_match: Option<&str>) -> Result<JwksCacheResponse, String> {
         let pem_hash = sha256(pem.as_bytes());
 
         // Fast path: an existing entry built from the same PEM.
@@ -274,9 +270,7 @@ MCowBQYDK2VwAyEAAGCxCNpcTHjOYiJ3r54SLgtpqvhkRvAcFNq0MrqpoMU=
 
     #[test]
     fn custom_max_age_renders_header() {
-        let cfg = JwksCacheConfig {
-            max_age_secs: 60,
-        };
+        let cfg = JwksCacheConfig { max_age_secs: 60 };
         assert_eq!(cfg.cache_control_header(), "public, max-age=60");
     }
 
@@ -359,7 +353,10 @@ MCowBQYDK2VwAyEAAGCxCNpcTHjOYiJ3r54SLgtpqvhkRvAcFNq0MrqpoMU=
             _ => unreachable!(),
         };
 
-        assert_ne!(etag_a, etag_b, "ETag must change when the key material changes");
+        assert_ne!(
+            etag_a, etag_b,
+            "ETag must change when the key material changes"
+        );
 
         // The pre-rotation ETag must no longer produce a 304 against the
         // now-current (post-rotation) cache state.
@@ -391,12 +388,7 @@ MCowBQYDK2VwAyEAAGCxCNpcTHjOYiJ3r54SLgtpqvhkRvAcFNq0MrqpoMU=
 
         // And conditional requests against the rebuilt entry still work.
         let resp = cache.get(PEM_A, Some(&etag_after)).unwrap();
-        assert_eq!(
-            resp,
-            JwksCacheResponse::NotModified {
-                etag: etag_after
-            }
-        );
+        assert_eq!(resp, JwksCacheResponse::NotModified { etag: etag_after });
     }
 
     #[test]
@@ -416,11 +408,6 @@ MCowBQYDK2VwAyEAAGCxCNpcTHjOYiJ3r54SLgtpqvhkRvAcFNq0MrqpoMU=
         // ...and must NOT have evicted the previously-good entry: the same
         // good PEM still round-trips through the cache correctly afterward.
         let resp = cache.get(PEM_A, Some(&good_etag)).unwrap();
-        assert_eq!(
-            resp,
-            JwksCacheResponse::NotModified {
-                etag: good_etag
-            }
-        );
+        assert_eq!(resp, JwksCacheResponse::NotModified { etag: good_etag });
     }
 }

--- a/crates/axiam-oauth2/src/jwks_cache.rs
+++ b/crates/axiam-oauth2/src/jwks_cache.rs
@@ -177,10 +177,10 @@ impl JwksCache {
         // Fast path: an existing entry built from the same PEM.
         {
             let guard = self.inner.read().unwrap_or_else(|e| e.into_inner());
-            if let Some(entry) = guard.as_ref() {
-                if entry.pem_hash == pem_hash {
-                    return Ok(respond(entry, if_none_match));
-                }
+            if let Some(entry) = guard.as_ref()
+                && entry.pem_hash == pem_hash
+            {
+                return Ok(respond(entry, if_none_match));
             }
         }
 
@@ -205,12 +205,12 @@ impl JwksCache {
 }
 
 fn respond(entry: &CacheEntry, if_none_match: Option<&str>) -> JwksCacheResponse {
-    if let Some(header) = if_none_match {
-        if if_none_match_matches(header, &entry.etag) {
-            return JwksCacheResponse::NotModified {
-                etag: entry.etag.clone(),
-            };
-        }
+    if let Some(header) = if_none_match
+        && if_none_match_matches(header, &entry.etag)
+    {
+        return JwksCacheResponse::NotModified {
+            etag: entry.etag.clone(),
+        };
     }
     JwksCacheResponse::Fresh {
         body: entry.body.clone(),

--- a/crates/axiam-oauth2/src/lib.rs
+++ b/crates/axiam-oauth2/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod authorize;
 pub mod error;
+pub mod jwks_cache;
 pub mod oidc;
 pub mod pkce;
 pub mod token;

--- a/crates/axiam-oauth2/tests/token_service.rs
+++ b/crates/axiam-oauth2/tests/token_service.rs
@@ -71,6 +71,8 @@ fn test_config() -> AuthConfig {
         jwt_decoding_key: None,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,
+        max_concurrent_hashes: 0,
+        hash_acquire_timeout_secs: 5,
     }
 }
 

--- a/crates/axiam-pki/src/mtls.rs
+++ b/crates/axiam-pki/src/mtls.rs
@@ -43,12 +43,26 @@ impl<CR: CertificateRepository, CCR: CaCertificateRepository> DeviceAuthService<
     /// Returns a [`DeviceIdentity`] with the service account and tenant.
     /// The caller is responsible for resolving `org_id` from the tenant.
     pub async fn authenticate(&self, pem: &str) -> AxiamResult<DeviceIdentity> {
-        // Parse PEM
+        // Parse PEM, then delegate to the DER path so the PEM (proxy header) and
+        // native-mTLS (verified peer cert, D3) flows share one validation chain.
         let (_, pem_obj) = parse_x509_pem(pem.as_bytes())
             .map_err(|e| AxiamError::Certificate(format!("invalid client certificate PEM: {e}")))?;
+        self.authenticate_der(&pem_obj.contents).await
+    }
 
+    /// Authenticate a device from a DER-encoded client certificate.
+    ///
+    /// This is the shared core of [`Self::authenticate`]: it is called directly
+    /// by the REST layer with the certificate rustls **verified** during the
+    /// native-mTLS handshake (D3), so the verified peer certificate — not a
+    /// proxy header — drives certificate-based identity.
+    ///
+    /// Steps mirror [`Self::authenticate`]: fingerprint lookup, status/expiry
+    /// checks, chain verification to the tenant/org CA (SEC-024/SECHRD-05), and
+    /// service-account resolution.
+    pub async fn authenticate_der(&self, der: &[u8]) -> AxiamResult<DeviceIdentity> {
         // Compute SHA-256 fingerprint from DER
-        let fingerprint = hex::encode(Sha256::digest(&pem_obj.contents));
+        let fingerprint = hex::encode(Sha256::digest(der));
 
         // Look up by fingerprint globally
         let cert = self
@@ -102,8 +116,8 @@ impl<CR: CertificateRepository, CCR: CaCertificateRepository> DeviceAuthService<
         let (_, ca_x509) = parse_x509_certificate(&ca_pem_obj.contents)
             .map_err(|e| AxiamError::Certificate(format!("failed to parse CA certificate: {e}")))?;
 
-        // Parse the client cert DER (already extracted from PEM above).
-        let (_, client_x509) = parse_x509_certificate(&pem_obj.contents).map_err(|e| {
+        // Parse the client cert DER.
+        let (_, client_x509) = parse_x509_certificate(der).map_err(|e| {
             AxiamError::Certificate(format!("failed to parse client certificate: {e}"))
         })?;
 

--- a/crates/axiam-server/Cargo.toml
+++ b/crates/axiam-server/Cargo.toml
@@ -50,6 +50,13 @@ chrono = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 secrecy = { workspace = true }
+# D9 (memory-retention experiment): optional jemalloc global allocator, gated
+# behind the `jemalloc` feature below. NOT a default dependency — omitted
+# entirely from a default build's dependency graph. See
+# claude_dev/memory-retention-experiment.md for the A/B procedure and
+# rationale; measurement is pending laptop hardware, so this stays opt-in
+# until data justifies flipping the default.
+tikv-jemallocator = { version = "0.7", optional = true }
 
 [features]
 # SAML SP support, forwarded to the api-rest and federation crates (→ samael).
@@ -57,6 +64,14 @@ secrecy = { workspace = true }
 # so it compiles on hosts with an incompatible system libxml2 (e.g. Arch 2.15.x).
 default = ["saml"]
 saml = ["axiam-api-rest/saml", "axiam-federation/saml"]
+# D9: swap the process global allocator from the platform default (glibc
+# malloc in the release container image) to jemalloc via tikv-jemallocator.
+# Default-OFF — enabling this changes nothing else about the build; it exists
+# so the maintainer can A/B retained RSS after a login burst on real hardware
+# (`cargo build --release -p axiam-server --features jemalloc`). See
+# claude_dev/memory-retention-experiment.md for the full procedure and the
+# decay-tuning env vars (`MALLOC_CONF`/`_RJEM_MALLOC_CONF`).
+jemalloc = ["dep:tikv-jemallocator"]
 
 [dev-dependencies]
 axiam-core = { workspace = true }

--- a/crates/axiam-server/Cargo.toml
+++ b/crates/axiam-server/Cargo.toml
@@ -24,6 +24,11 @@ axiam-pki = { workspace = true }
 # `rustls-0_23` enables `HttpServer::bind_rustls_0_23` for the opt-in direct-TLS
 # path (F-04); TLS termination still defaults to the proxy layer.
 actix-web = { workspace = true, features = ["rustls-0_23"] }
+# D3: name the concrete accepted-connection type in `HttpServer::on_connect` so
+# the rustls-VERIFIED peer certificate can be lifted into the connection
+# extensions. actix-web already pulls actix-tls in transitively with the same
+# feature; this is a direct dep only so the `TlsStream` type path is nameable.
+actix-tls = { version = "3", features = ["rustls-0_23"] }
 # Explicit `ring` provider for the TLS 1.3-only server config (see src/tls.rs).
 # PEM parsing uses rustls-pki-types' `PemObject` (re-exported by rustls) rather
 # than the unmaintained rustls-pemfile (RUSTSEC-2025-0134).
@@ -67,6 +72,9 @@ wiremock = "0.6"
 rsa = { version = "0.9", features = ["sha2"] }
 actix-rt = { workspace = true }
 actix-http = { workspace = true }
+# D3: generate a throwaway CA + server/client leaf certs for the native-mTLS
+# verifier construction and in-process rustls handshake tests.
+rcgen = { workspace = true }
 # rsa 0.9 requires a rand_core 0.6 CryptoRng; the workspace `rand` (0.9) ThreadRng
 # does not satisfy it. Use rand_core 0.6 OsRng for RSA test-key generation.
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -42,6 +42,7 @@ use axiam_federation::oidc::OidcFederationService;
 #[cfg(feature = "saml")]
 use axiam_federation::saml::SamlFederationService;
 use axiam_oauth2::authorize::AuthorizeService;
+use axiam_oauth2::jwks_cache::JwksCache as Oauth2JwksCache;
 use axiam_oauth2::token::TokenService;
 use axiam_pki::{CaService, CertService, DeviceAuthService, PgpService, PkiConfig};
 use secrecy::ExposeSecret;
@@ -91,6 +92,11 @@ struct AppConfig {
     grpc: GrpcConfig,
     #[serde(default)]
     authz: axiam_authz::AuthzConfig,
+    /// B3: `GET /oauth2/jwks` HTTP caching config (currently just the
+    /// `Cache-Control` max-age). Configured via `AXIAM__OAUTH2__*` env vars,
+    /// e.g. `AXIAM__OAUTH2__JWKS_CACHE_MAX_AGE_SECS`.
+    #[serde(default)]
+    oauth2: axiam_oauth2::jwks_cache::JwksCacheConfig,
     #[serde(default)]
     amqp: AmqpConfig,
     #[serde(default)]
@@ -510,6 +516,10 @@ async fn main() -> std::io::Result<()> {
         SurrealFederationLoginStateRepository::new(db.client_cloned().await);
     // Process-wide JWKS cache shared by all OIDC federation handlers (D-01/D-02/D-03).
     let jwks_cache = Arc::new(JwksCache::new());
+    // B3: process-wide in-process cache for AXIAM's OWN `GET /oauth2/jwks`
+    // response (distinct from the federation JWKS cache above -- see
+    // `axiam_oauth2::jwks_cache` module docs).
+    let oauth2_jwks_cache = Arc::new(Oauth2JwksCache::new());
     // Disable automatic redirects to prevent SSRF bypass (an HTTPS URL
     // could redirect to http:// or an internal host). Apply a global
     // timeout for consistent outbound HTTP behaviour.
@@ -920,6 +930,8 @@ async fn main() -> std::io::Result<()> {
         federation_login_state_repo: federation_login_state_repo.clone(),
         http_client: http_client.clone(),
         jwks_cache: jwks_cache.clone(),
+        oauth2_jwks_cache: oauth2_jwks_cache.clone(),
+        oauth2_jwks_cache_config: config.oauth2.clone(),
         crypto_semaphore: Arc::clone(&crypto_semaphore),
         email_config_repo: email_config_repo.clone(),
         password_reset_service: password_reset_service.clone(),

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -630,15 +630,36 @@ async fn main() -> std::io::Result<()> {
 
     tracing::info!(bind = %bind_addr, "Starting REST API server");
 
+    // D7: build the shared authorization decision cache. `None` unless
+    // `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true` — when `None`, every engine
+    // below is constructed exactly as before (no cache, zero behaviour
+    // change). The SAME `Arc<DecisionCache>` is cloned into the REST, gRPC and
+    // AMQP engines so an invalidation triggered from a REST mutation handler is
+    // observed on every read path (all role/permission/resource mutations are
+    // REST endpoints).
+    let decision_cache = config.authz.build_decision_cache();
+    if decision_cache.is_some() {
+        tracing::info!(
+            ttl_secs = config.authz.decision_cache_ttl_secs,
+            max_entries = config.authz.decision_cache_max_entries,
+            "AuthZ decision cache ENABLED (D7)"
+        );
+    }
+
     // Build REST-facing authorization checker (D-01, D-02).
-    let rest_authz: Arc<dyn axiam_api_rest::authz::AuthzChecker> =
-        Arc::new(axiam_authz::AuthorizationEngine::new(
+    let rest_authz: Arc<dyn axiam_api_rest::authz::AuthzChecker> = {
+        let engine = axiam_authz::AuthorizationEngine::new(
             role_repo.clone(),
             permission_repo.clone(),
             resource_repo.clone(),
             scope_repo.clone(),
             group_repo.clone(),
-        ));
+        );
+        Arc::new(match decision_cache.as_ref() {
+            Some(cache) => engine.with_decision_cache(cache.clone()),
+            None => engine,
+        })
+    };
 
     // Spawn AMQP authorization consumer on a background task.
     // Uses a publisher channel because the consumer also publishes responses.
@@ -646,13 +667,19 @@ async fn main() -> std::io::Result<()> {
         .create_publisher_channel()
         .await
         .expect("Failed to create AMQP authz publisher channel");
-    let amqp_engine = axiam_authz::AuthorizationEngine::new(
-        role_repo.clone(),
-        permission_repo.clone(),
-        resource_repo.clone(),
-        scope_repo.clone(),
-        group_repo.clone(),
-    );
+    let amqp_engine = {
+        let engine = axiam_authz::AuthorizationEngine::new(
+            role_repo.clone(),
+            permission_repo.clone(),
+            resource_repo.clone(),
+            scope_repo.clone(),
+            group_repo.clone(),
+        );
+        match decision_cache.as_ref() {
+            Some(cache) => engine.with_decision_cache(cache.clone()),
+            None => engine,
+        }
+    };
     // SEC-022/SECHRD-08: Resolve the mandatory AMQP master signing key. In a
     // debug build this falls back to a documented dev-only default when
     // unset; in a release build (the production container image) an unset
@@ -802,13 +829,19 @@ async fn main() -> std::io::Result<()> {
 
     // Build gRPC services and spawn server on a background task.
     let grpc_addr = config.grpc.bind_address();
-    let grpc_engine = axiam_authz::AuthorizationEngine::new(
-        role_repo.clone(),
-        permission_repo.clone(),
-        resource_repo.clone(),
-        scope_repo.clone(),
-        group_repo.clone(),
-    );
+    let grpc_engine = {
+        let engine = axiam_authz::AuthorizationEngine::new(
+            role_repo.clone(),
+            permission_repo.clone(),
+            resource_repo.clone(),
+            scope_repo.clone(),
+            group_repo.clone(),
+        );
+        match decision_cache.as_ref() {
+            Some(cache) => engine.with_decision_cache(cache.clone()),
+            None => engine,
+        }
+    };
     let grpc_user_repo = user_repo.clone();
     let grpc_auth_config = config.auth.clone();
     let grpc_config = config.grpc.clone();

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -405,9 +405,17 @@ async fn main() -> std::io::Result<()> {
     // revoke_all_sessions / revoke_all_sessions_except on password change and reset).
     let auth_refresh_token_repo = SurrealRefreshTokenRepository::new(db.client_cloned().await);
     // Single shared bounding semaphore for all CPU-bound crypto operations (CQ-B02 / REQ-14 AC-2).
-    // Limits concurrent Argon2 and PKI keygen/sign operations to 4 to prevent DoS via
-    // runtime thread starvation. Constructed once, cloned (Arc) into each service.
-    let crypto_semaphore = Arc::new(tokio::sync::Semaphore::new(4));
+    // Limits concurrent Argon2 and PKI keygen/sign operations to prevent runtime-thread
+    // starvation AND an unauthenticated memory-DoS (each Argon2id arena is ~19 MiB; B1).
+    // Permit count is `AXIAM__AUTH__MAX_CONCURRENT_HASHES` (0 = auto → min(cores, 4)).
+    // Constructed once, cloned (Arc) into each service.
+    let crypto_hash_permits = config.auth.resolved_max_concurrent_hashes();
+    tracing::info!(
+        permits = crypto_hash_permits,
+        acquire_timeout_secs = config.auth.hash_acquire_timeout_secs,
+        "crypto hash gate configured (B1)"
+    );
+    let crypto_semaphore = Arc::new(tokio::sync::Semaphore::new(crypto_hash_permits));
 
     let auth_service = AuthService::new(
         user_repo.clone(),
@@ -556,6 +564,7 @@ async fn main() -> std::io::Result<()> {
         session_repo.clone(),
         handler_refresh_token_repo.clone(),
         Arc::clone(&crypto_semaphore),
+        config.auth.hash_acquire_timeout_secs,
     );
     let email_verification_service = EmailVerificationService::new(
         user_repo.clone(),

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -1043,19 +1043,19 @@ async fn main() -> std::io::Result<()> {
         use actix_web::rt::net::TcpStream;
         if let Some(tls) = conn.downcast_ref::<TlsStream<TcpStream>>() {
             let (_io, session) = tls.get_ref();
-            if let Some(certs) = session.peer_certificates() {
-                if let Some(leaf) = certs.first() {
-                    match axiam_api_rest::VerifiedClientCert::from_der(leaf.as_ref()) {
-                        Ok(vc) => {
-                            ext.insert(vc);
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                error = %e,
-                                "failed to parse verified client certificate; \
-                                 cert-mapped identity will be unavailable for this connection"
-                            );
-                        }
+            if let Some(certs) = session.peer_certificates()
+                && let Some(leaf) = certs.first()
+            {
+                match axiam_api_rest::VerifiedClientCert::from_der(leaf.as_ref()) {
+                    Ok(vc) => {
+                        ext.insert(vc);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "failed to parse verified client certificate; \
+                             cert-mapped identity will be unavailable for this connection"
+                        );
                     }
                 }
             }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -972,6 +972,35 @@ async fn main() -> std::io::Result<()> {
             .configure(health_routes::<axiam_db::DbClient>)
             .configure(|cfg| register_api_v1_routes::<axiam_db::DbClient>(cfg, &rl))
             .configure(openapi_routes)
+    })
+    // D3 native mTLS: lift the rustls-VERIFIED client certificate off the TLS
+    // connection into the per-connection extensions so cert-auth handlers read
+    // the verified peer cert (via `HttpRequest::conn_data`) instead of a
+    // spoofable proxy header. Only fires on the rustls bind with client-auth
+    // enabled; on plaintext / server-auth-only connections there is no peer cert
+    // and nothing is inserted (backward compatible).
+    .on_connect(|conn, ext| {
+        use actix_tls::accept::rustls_0_23::TlsStream;
+        use actix_web::rt::net::TcpStream;
+        if let Some(tls) = conn.downcast_ref::<TlsStream<TcpStream>>() {
+            let (_io, session) = tls.get_ref();
+            if let Some(certs) = session.peer_certificates() {
+                if let Some(leaf) = certs.first() {
+                    match axiam_api_rest::VerifiedClientCert::from_der(leaf.as_ref()) {
+                        Ok(vc) => {
+                            ext.insert(vc);
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "failed to parse verified client certificate; \
+                                 cert-mapped identity will be unavailable for this connection"
+                            );
+                        }
+                    }
+                }
+            }
+        }
     });
 
     // Bind plaintext (proxy-terminated TLS, the default) or, when

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -2,6 +2,32 @@
 
 use axiam_server::cleanup;
 
+// D9 (memory-retention experiment): opt-in jemalloc global allocator.
+//
+// Default build uses the platform allocator (glibc malloc in the release
+// container image) — unchanged. Enabling the `jemalloc` cargo feature
+// (`cargo build --release -p axiam-server --features jemalloc`) swaps the
+// process-wide allocator to jemalloc, which is a candidate fix for the
+// observed RSS-retention issue: server RSS never returns to baseline after a
+// login burst (~93 -> ~646 MiB permanently, see
+// claude_dev/memory-retention-experiment.md). B1 already bounds the
+// concurrency *peak* via the Argon2 semaphore; this experiment targets the
+// *retention* — glibc malloc is known to keep freed arenas mapped rather
+// than returning pages to the OS, while jemalloc's decay-based purging
+// actively `madvise`s freed dirty/muzzy pages back to the kernel.
+//
+// Decay tuning is deliberately NOT hardcoded here: jemalloc's dirty/muzzy
+// page decay times are configured at process startup via the `MALLOC_CONF`
+// (or tikv-jemallocator's `_RJEM_MALLOC_CONF`) environment variable, e.g.
+//   MALLOC_CONF=dirty_decay_ms:1000,muzzy_decay_ms:0
+// which returns freed pages to the OS within ~1s of a burst subsiding
+// instead of jemalloc's default ~10s decay. See the experiment note for the
+// full rationale and the A/B measurement procedure (pending laptop
+// hardware — this feature is default-off so it ships safely un-measured).
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -968,7 +968,26 @@ async fn main() -> std::io::Result<()> {
     // misconfiguration, so a misconfigured TLS server never starts insecurely.
     let http_server = if tls_config.enabled {
         let rustls_config = axiam_server::tls::build_rustls_server_config(&tls_config)?;
-        tracing::info!(bind = %bind_addr, "Direct TLS enabled — negotiating TLS 1.3 only");
+        tracing::info!(
+            bind = %bind_addr,
+            http2_offered = tls_config.http2,
+            resumption = "tls1.3-tickets",
+            early_data = false,
+            "Direct TLS enabled — negotiating TLS 1.3 only"
+        );
+        // B2 honesty: the http2=false knob narrows the rustls config's ALPN to
+        // http/1.1, but actix-web's rustls HttpService re-adds h2 to ALPN, so
+        // h2 still wins negotiation on this bind. Warn so an operator expecting
+        // a true http/1.1-only listener is not misled.
+        if !tls_config.http2 {
+            tracing::warn!(
+                "server.tls.http2=false requested: the rustls config advertises http/1.1 only, \
+                 but the actix-web rustls HttpServer bind unconditionally re-adds h2 to ALPN, so \
+                 h2 remains offered and preferred. For a genuine http/1.1-only TLS listener (e.g. \
+                 the p2 h2-isolation benchmark cell) front the server with the tls13-h1 nginx edge. \
+                 See docs/security-profiles.md."
+            );
+        }
         http_server.bind_rustls_0_23(&bind_addr, rustls_config)?
     } else {
         http_server.bind(&bind_addr)?

--- a/crates/axiam-server/src/tls.rs
+++ b/crates/axiam-server/src/tls.rs
@@ -19,6 +19,36 @@ use axiam_api_rest::config::TlsConfig;
 use rustls::ServerConfig;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::ServerSessionMemoryCache;
+
+/// Number of resumption entries kept in the in-process session cache.
+///
+/// TLS 1.3 resumption is ticket-based (stateless — the ticket travels with the
+/// client), so this cache mainly bounds any non-ticket session state; a small
+/// value is plenty for a benchmark/service workload and caps memory.
+const RESUMPTION_CACHE_SIZE: usize = 512;
+
+/// The ALPN protocol list the rustls listener is *built with*, given the
+/// `http2` knob.
+///
+/// **Important caveat (B2):** for the REST listener this list is only fully
+/// authoritative when the rustls `ServerConfig` is used directly. actix-web's
+/// `HttpServer::bind_rustls_0_23` path funnels through
+/// `actix_http::HttpService::rustls_0_23_with_config`, which unconditionally
+/// **prepends** `["h2", "http/1.1"]` to whatever `alpn_protocols` we set. So
+/// with the current actix bind, `http2 = false` narrows the config's list to
+/// `http/1.1` but h2 is re-added and still wins negotiation. A *true*
+/// http/1.1-only TLS listener therefore requires either fronting with the
+/// `tls13-h1` nginx edge (see the benchmarks) or an H1-only actix service.
+/// This helper is unit-tested and records operator intent; it is authoritative
+/// for any non-actix consumer of the config.
+fn alpn_protocols(http2: bool) -> Vec<Vec<u8>> {
+    if http2 {
+        vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+    } else {
+        vec![b"http/1.1".to_vec()]
+    }
+}
 
 /// Build a TLS 1.3-only rustls [`ServerConfig`] from the configured PEM files.
 ///
@@ -86,7 +116,7 @@ pub fn build_rustls_server_config(tls: &TlsConfig) -> io::Result<ServerConfig> {
 
     // TLS 1.3 only (ASVS V9.1.2). ring provider selected explicitly.
     let provider = Arc::new(rustls::crypto::ring::default_provider());
-    ServerConfig::builder_with_provider(provider)
+    let mut config = ServerConfig::builder_with_provider(provider)
         .with_protocol_versions(&[&rustls::version::TLS13])
         .map_err(|e| io::Error::other(format!("rustls TLS 1.3 configuration failed: {e}")))?
         .with_no_client_auth()
@@ -96,7 +126,32 @@ pub fn build_rustls_server_config(tls: &TlsConfig) -> io::Result<ServerConfig> {
                 io::ErrorKind::InvalidData,
                 format!("invalid TLS certificate/key pair: {e}"),
             )
-        })
+        })?;
+
+    // ALPN (B2): advertise h2+http/1.1 by default, or http/1.1-only when the
+    // operator disables h2. See `alpn_protocols` for the actix-bind caveat.
+    config.alpn_protocols = alpn_protocols(tls.http2);
+
+    // TLS 1.3 session resumption (B2). Without a ticketer + session store a
+    // rustls server does a *full* handshake on every connection; k6 opens many
+    // short-lived connections per VU, so a full ECDHE handshake per request is a
+    // per-request fixed cost that shows up as the ~2× p50 inflation on the token
+    // endpoints. Enabling stateless TLS 1.3 tickets lets repeat connections
+    // resume (PSK) instead. We deliberately do NOT enable 0-RTT/early-data:
+    // rustls' `max_early_data_size` stays at its default 0 because the token
+    // endpoints are non-idempotent POSTs and early data is replayable
+    // (see docs/security-profiles.md).
+    config.session_storage = ServerSessionMemoryCache::new(RESUMPTION_CACHE_SIZE);
+    match rustls::crypto::ring::Ticketer::new() {
+        Ok(ticketer) => config.ticketer = ticketer,
+        Err(e) => tracing::warn!(
+            error = %e,
+            "failed to construct a TLS ticketer; session resumption disabled \
+             (falling back to full handshakes)"
+        ),
+    }
+
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -112,11 +167,23 @@ mod tests {
     }
 
     #[test]
+    fn alpn_list_reflects_http2_knob() {
+        assert_eq!(alpn_protocols(true), vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
+        assert_eq!(alpn_protocols(false), vec![b"http/1.1".to_vec()]);
+    }
+
+    #[test]
+    fn default_offers_http2() {
+        assert!(TlsConfig::default().http2);
+    }
+
+    #[test]
     fn missing_cert_path_fails_fast() {
         let tls = TlsConfig {
             enabled: true,
             cert_path: None,
             key_path: Some("/tmp/does-not-matter.key".into()),
+            ..TlsConfig::default()
         };
         let err = build_rustls_server_config(&tls).expect_err("missing cert_path must error");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -128,6 +195,7 @@ mod tests {
             enabled: true,
             cert_path: Some("/tmp/does-not-matter.crt".into()),
             key_path: None,
+            ..TlsConfig::default()
         };
         let err = build_rustls_server_config(&tls).expect_err("missing key_path must error");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -139,6 +207,7 @@ mod tests {
             enabled: true,
             cert_path: Some("/nonexistent/axiam-test-cert.pem".into()),
             key_path: Some("/nonexistent/axiam-test-key.pem".into()),
+            ..TlsConfig::default()
         };
         let err = build_rustls_server_config(&tls).expect_err("unreadable cert file must error");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);

--- a/crates/axiam-server/src/tls.rs
+++ b/crates/axiam-server/src/tls.rs
@@ -15,11 +15,12 @@ use std::fs::File;
 use std::io;
 use std::sync::Arc;
 
-use axiam_api_rest::config::TlsConfig;
-use rustls::ServerConfig;
+use axiam_api_rest::config::{ClientAuth, TlsConfig};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::server::ServerSessionMemoryCache;
+use rustls::server::danger::ClientCertVerifier;
+use rustls::server::{ServerSessionMemoryCache, WebPkiClientVerifier};
+use rustls::{RootCertStore, ServerConfig};
 
 /// Number of resumption entries kept in the in-process session cache.
 ///
@@ -48,6 +49,83 @@ fn alpn_protocols(http2: bool) -> Vec<Vec<u8>> {
     } else {
         vec![b"http/1.1".to_vec()]
     }
+}
+
+/// Build a rustls [`ClientCertVerifier`] from the configured client-CA bundle
+/// (D3 native mTLS).
+///
+/// Loads the PEM bundle at `client_ca_path` into a [`RootCertStore`] and builds
+/// a [`WebPkiClientVerifier`] over it, using the same [`CryptoProvider`] as the
+/// server config. For [`ClientAuth::Optional`] the verifier still *offers* and
+/// *verifies* client certs but permits anonymous clients
+/// (`allow_unauthenticated`); for [`ClientAuth::Required`] a verified client
+/// cert is mandatory.
+///
+/// Fails fast (aborting startup) when the CA path is unset, missing/unreadable,
+/// empty, or malformed — matching this file's existing `io::Error` style so a
+/// misconfigured mTLS server never starts.
+fn build_client_cert_verifier(
+    tls: &TlsConfig,
+    provider: &Arc<rustls::crypto::CryptoProvider>,
+) -> io::Result<Arc<dyn ClientCertVerifier>> {
+    let ca_path = tls.client_ca_path.as_ref().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "server.tls.client_auth is optional/required but \
+             server.tls.client_ca_path is not set",
+        )
+    })?;
+
+    let ca_file = File::open(ca_path).map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!(
+                "failed to open TLS client CA bundle {}: {e}",
+                ca_path.display()
+            ),
+        )
+    })?;
+    let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_reader_iter(ca_file)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "failed to parse client CA certificates from {}: {e}",
+                    ca_path.display()
+                ),
+            )
+        })?;
+    if ca_certs.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("no client CA certificates found in {}", ca_path.display()),
+        ));
+    }
+
+    let mut roots = RootCertStore::empty();
+    for cert in ca_certs {
+        roots.add(cert).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "invalid client CA certificate in {}: {e}",
+                    ca_path.display()
+                ),
+            )
+        })?;
+    }
+
+    let builder = WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone());
+    let verifier = match tls.client_auth {
+        // Verify presented certs but accept anonymous clients.
+        ClientAuth::Optional => builder.allow_unauthenticated().build(),
+        // Require a verified client cert (Off is unreachable here).
+        _ => builder.build(),
+    }
+    .map_err(|e| io::Error::other(format!("failed to build client cert verifier: {e}")))?;
+
+    Ok(verifier)
 }
 
 /// Build a TLS 1.3-only rustls [`ServerConfig`] from the configured PEM files.
@@ -116,17 +194,29 @@ pub fn build_rustls_server_config(tls: &TlsConfig) -> io::Result<ServerConfig> {
 
     // TLS 1.3 only (ASVS V9.1.2). ring provider selected explicitly.
     let provider = Arc::new(rustls::crypto::ring::default_provider());
-    let mut config = ServerConfig::builder_with_provider(provider)
+    let builder = ServerConfig::builder_with_provider(provider.clone())
         .with_protocol_versions(&[&rustls::version::TLS13])
-        .map_err(|e| io::Error::other(format!("rustls TLS 1.3 configuration failed: {e}")))?
-        .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid TLS certificate/key pair: {e}"),
-            )
-        })?;
+        .map_err(|e| io::Error::other(format!("rustls TLS 1.3 configuration failed: {e}")))?;
+
+    // Client-certificate (mTLS) policy (D3). `off` keeps the server-auth-only
+    // behaviour (`with_no_client_auth`); `optional`/`required` install a
+    // WebPkiClientVerifier over the configured CA bundle so rustls verifies the
+    // client cert during the handshake and the *verified* cert (not a header)
+    // drives certificate-based identity.
+    let builder = match tls.client_auth {
+        ClientAuth::Off => builder.with_no_client_auth(),
+        ClientAuth::Optional | ClientAuth::Required => {
+            let verifier = build_client_cert_verifier(tls, &provider)?;
+            builder.with_client_cert_verifier(verifier)
+        }
+    };
+
+    let mut config = builder.with_single_cert(cert_chain, key).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid TLS certificate/key pair: {e}"),
+        )
+    })?;
 
     // ALPN (B2): advertise h2+http/1.1 by default, or http/1.1-only when the
     // operator disables h2. See `alpn_protocols` for the actix-bind caveat.
@@ -211,5 +301,274 @@ mod tests {
         };
         let err = build_rustls_server_config(&tls).expect_err("unreadable cert file must error");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    // ---------------------------------------------------------------------
+    // D3 — native client-certificate (mTLS) support
+    // ---------------------------------------------------------------------
+
+    use std::io::Write as _;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use rcgen::{
+        BasicConstraints, CertificateParams, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType,
+    };
+
+    static TMP_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    /// Write `contents` to a unique temp file and return its path.
+    fn write_tmp(tag: &str, contents: &str) -> PathBuf {
+        let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("axiam-d3-{}-{n}-{tag}.pem", std::process::id()));
+        let mut f = File::create(&path).expect("create temp pem");
+        f.write_all(contents.as_bytes()).expect("write temp pem");
+        path
+    }
+
+    struct TestPki {
+        ca_pem: String,
+        server_cert_pem: String,
+        server_key_pem: String,
+        client_cert_pem: String,
+        client_key_pem: String,
+    }
+
+    /// Generate a throwaway CA plus a server leaf (SAN `localhost`) and a client
+    /// leaf (SAN `URI:spiffe://axiam/device-01`), all signed by the CA.
+    fn gen_test_pki() -> TestPki {
+        let ca_key = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+        let issuer = Issuer::from_params(&ca_params, &ca_key);
+
+        // Server leaf: SAN localhost so the in-process client can verify it.
+        let server_key = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let mut server_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        server_params.is_ca = IsCa::NoCa;
+        let server_cert = server_params.signed_by(&server_key, &issuer).unwrap();
+
+        // Client leaf: carries a URI SAN we assert on after extraction.
+        let client_key = KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+        let mut client_params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        client_params.is_ca = IsCa::NoCa;
+        client_params
+            .subject_alt_names
+            .push(SanType::URI("spiffe://axiam/device-01".try_into().unwrap()));
+        let client_cert = client_params.signed_by(&client_key, &issuer).unwrap();
+
+        TestPki {
+            ca_pem: ca_cert.pem(),
+            server_cert_pem: server_cert.pem(),
+            server_key_pem: server_key.serialize_pem(),
+            client_cert_pem: client_cert.pem(),
+            client_key_pem: client_key.serialize_pem(),
+        }
+    }
+
+    #[test]
+    fn client_auth_off_is_the_default() {
+        assert_eq!(TlsConfig::default().client_auth, ClientAuth::Off);
+        assert!(TlsConfig::default().client_ca_path.is_none());
+    }
+
+    #[test]
+    fn verifier_builds_from_ca_bundle() {
+        let pki = gen_test_pki();
+        let ca_path = write_tmp("ca", &pki.ca_pem);
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        for mode in [ClientAuth::Optional, ClientAuth::Required] {
+            let tls = TlsConfig {
+                enabled: true,
+                client_auth: mode,
+                client_ca_path: Some(ca_path.clone()),
+                ..TlsConfig::default()
+            };
+            build_client_cert_verifier(&tls, &provider)
+                .unwrap_or_else(|e| panic!("verifier must build for {mode:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn required_without_ca_path_fails_fast() {
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let tls = TlsConfig {
+            enabled: true,
+            client_auth: ClientAuth::Required,
+            client_ca_path: None,
+            ..TlsConfig::default()
+        };
+        let err = build_client_cert_verifier(&tls, &provider)
+            .expect_err("required client-auth with no CA path must fail fast");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn missing_ca_bundle_file_fails_fast() {
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let tls = TlsConfig {
+            enabled: true,
+            client_auth: ClientAuth::Required,
+            client_ca_path: Some("/nonexistent/axiam-d3-ca.pem".into()),
+            ..TlsConfig::default()
+        };
+        let err = build_client_cert_verifier(&tls, &provider)
+            .expect_err("unreadable CA bundle must fail fast");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn empty_ca_bundle_fails_fast() {
+        let ca_path = write_tmp("empty-ca", "# no certificates here\n");
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let tls = TlsConfig {
+            enabled: true,
+            client_auth: ClientAuth::Required,
+            client_ca_path: Some(ca_path),
+            ..TlsConfig::default()
+        };
+        let err = build_client_cert_verifier(&tls, &provider)
+            .expect_err("empty CA bundle must fail fast");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn server_config_builds_with_required_client_auth() {
+        let pki = gen_test_pki();
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(write_tmp("srv-cert", &pki.server_cert_pem)),
+            key_path: Some(write_tmp("srv-key", &pki.server_key_pem)),
+            client_auth: ClientAuth::Required,
+            client_ca_path: Some(write_tmp("ca", &pki.ca_pem)),
+            ..TlsConfig::default()
+        };
+        build_rustls_server_config(&tls).expect("server config with mTLS must build");
+    }
+
+    // --- In-process rustls handshake tests (no live socket needed) ---------
+
+    /// Pump handshake records between two in-memory rustls connections until
+    /// both finish handshaking or one errors. Returns the first processing
+    /// error (e.g. the server rejecting a missing required client cert).
+    fn drive_handshake(
+        client: &mut rustls::Connection,
+        server: &mut rustls::Connection,
+    ) -> Result<(), rustls::Error> {
+        for _ in 0..16 {
+            let mut buf = Vec::new();
+            while client.wants_write() {
+                client.write_tls(&mut buf).unwrap();
+            }
+            let mut rd: &[u8] = &buf;
+            while !rd.is_empty() {
+                server.read_tls(&mut rd).unwrap();
+            }
+            server.process_new_packets()?;
+
+            let mut buf = Vec::new();
+            while server.wants_write() {
+                server.write_tls(&mut buf).unwrap();
+            }
+            let mut rd: &[u8] = &buf;
+            while !rd.is_empty() {
+                client.read_tls(&mut rd).unwrap();
+            }
+            client.process_new_packets()?;
+
+            if !client.is_handshaking() && !server.is_handshaking() {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
+    fn make_server(pki: &TestPki) -> rustls::ServerConnection {
+        let tls = TlsConfig {
+            enabled: true,
+            cert_path: Some(write_tmp("srv-cert", &pki.server_cert_pem)),
+            key_path: Some(write_tmp("srv-key", &pki.server_key_pem)),
+            client_auth: ClientAuth::Required,
+            client_ca_path: Some(write_tmp("ca", &pki.ca_pem)),
+            ..TlsConfig::default()
+        };
+        let config = build_rustls_server_config(&tls).expect("server config must build");
+        rustls::ServerConnection::new(Arc::new(config)).expect("server connection")
+    }
+
+    /// Client config trusting the CA; `client_cert` toggles whether it presents
+    /// its own certificate.
+    fn make_client(pki: &TestPki, present_cert: bool) -> rustls::ClientConnection {
+        use rustls::pki_types::pem::PemObject;
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
+
+        let mut roots = RootCertStore::empty();
+        roots
+            .add(CertificateDer::from_pem_slice(pki.ca_pem.as_bytes()).unwrap())
+            .unwrap();
+
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let builder = rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .unwrap()
+            .with_root_certificates(roots);
+
+        let config = if present_cert {
+            let chain = vec![CertificateDer::from_pem_slice(pki.client_cert_pem.as_bytes()).unwrap()];
+            let key = PrivateKeyDer::from_pem_slice(pki.client_key_pem.as_bytes()).unwrap();
+            builder.with_client_auth_cert(chain, key).unwrap()
+        } else {
+            builder.with_no_client_auth()
+        };
+
+        let name = ServerName::try_from("localhost").unwrap();
+        rustls::ClientConnection::new(Arc::new(config), name).expect("client connection")
+    }
+
+    #[test]
+    fn handshake_rejected_without_client_cert_when_required() {
+        let pki = gen_test_pki();
+        let mut server = rustls::Connection::Server(make_server(&pki));
+        let mut client = rustls::Connection::Client(make_client(&pki, false));
+        let result = drive_handshake(&mut client, &mut server);
+        assert!(
+            result.is_err(),
+            "required client-auth must reject a client presenting no certificate"
+        );
+    }
+
+    #[test]
+    fn handshake_accepts_bench_client_cert_and_exposes_verified_peer_cert() {
+        let pki = gen_test_pki();
+        let mut server = rustls::Connection::Server(make_server(&pki));
+        let mut client = rustls::Connection::Client(make_client(&pki, true));
+        drive_handshake(&mut client, &mut server)
+            .expect("handshake with a CA-signed client cert must succeed");
+        assert!(
+            !server.is_handshaking(),
+            "server handshake should complete with a valid client cert"
+        );
+
+        // The VERIFIED peer certificate is what handlers consume (never a header).
+        let peer = server
+            .peer_certificates()
+            .expect("verified client cert must be present after mTLS handshake");
+        let leaf = peer.first().expect("at least one peer cert");
+
+        // SAN extraction (the axiam-api-rest side of D3) must find the URI SAN.
+        let verified = axiam_api_rest::VerifiedClientCert::from_der(leaf.as_ref())
+            .expect("verified client cert must parse");
+        assert!(
+            verified
+                .sans
+                .iter()
+                .any(|s| s == "URI:spiffe://axiam/device-01"),
+            "expected the client URI SAN to be extracted, got {:?}",
+            verified.sans
+        );
+        assert_eq!(verified.spki_sha256.len(), 64, "SPKI fingerprint is hex-SHA256");
     }
 }

--- a/crates/axiam-server/src/tls.rs
+++ b/crates/axiam-server/src/tls.rs
@@ -258,7 +258,10 @@ mod tests {
 
     #[test]
     fn alpn_list_reflects_http2_knob() {
-        assert_eq!(alpn_protocols(true), vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
+        assert_eq!(
+            alpn_protocols(true),
+            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+        );
         assert_eq!(alpn_protocols(false), vec![b"http/1.1".to_vec()]);
     }
 
@@ -517,7 +520,8 @@ mod tests {
             .with_root_certificates(roots);
 
         let config = if present_cert {
-            let chain = vec![CertificateDer::from_pem_slice(pki.client_cert_pem.as_bytes()).unwrap()];
+            let chain =
+                vec![CertificateDer::from_pem_slice(pki.client_cert_pem.as_bytes()).unwrap()];
             let key = PrivateKeyDer::from_pem_slice(pki.client_key_pem.as_bytes()).unwrap();
             builder.with_client_auth_cert(chain, key).unwrap()
         } else {
@@ -569,6 +573,10 @@ mod tests {
             "expected the client URI SAN to be extracted, got {:?}",
             verified.sans
         );
-        assert_eq!(verified.spki_sha256.len(), 64, "SPKI fingerprint is hex-SHA256");
+        assert_eq!(
+            verified.spki_sha256.len(),
+            64,
+            "SPKI fingerprint is hex-SHA256"
+        );
     }
 }

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -169,3 +169,55 @@ Groups themselves are created via `POST /api/v1/groups` and populated via
 `POST /api/v1/groups/{group_id}/members`. Assigning a role to a group is the
 recommended pattern for managing access for a team rather than granting
 roles to individual users one at a time.
+
+## Authorization decision cache (optional, D7)
+
+AXIAM can cache effective-permission decisions per tenant to cut the 3–4
+SurrealDB round-trips each authorization check would otherwise make. It is
+**off by default** and controlled entirely by configuration — enabling it
+changes performance, never the decision an endpoint returns.
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` | `false` | Master switch. When `false`, the authorization path is byte-for-byte identical to a build without the cache. |
+| `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` | `5` | Time-to-live for a cached decision, in seconds. Also the **bound on worst-case revocation latency** if an invalidation event is ever missed (see below). Keep it short. |
+| `AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES` | `10000` | Maximum cached decisions retained **per tenant** before FIFO eviction (memory bound). |
+
+The cache key is `(tenant, subject, resource, action, scope)` and it stores the
+**full** decision — an allow, or a deny *with its exact reason* — so a cache
+hit is indistinguishable from a fresh evaluation.
+
+### Why it is safe: immediate invalidation on revocation
+
+AXIAM's RBAC is **additive, allow-wins, default-deny** (no deny-override). That
+makes the two staleness directions asymmetric:
+
+- A **stale deny** is harmless — it only forces a redundant re-check; the
+  subject is briefly under-privileged, never over-privileged.
+- A **stale allow after a revocation** is the *only* dangerous case — a subject
+  keeping access they no longer have.
+
+So the cache is not left to expire on its own for security. Every mutation that
+can narrow access **invalidates the affected cache entries immediately**, wired
+directly into the mutation handlers:
+
+| Mutation | Invalidation |
+| --- | --- |
+| Unassign role from user; remove user from group | Targeted — that one subject |
+| Assign role to user; add user to group (widening) | Targeted — that one subject |
+| Unassign role from group; revoke grant from role; delete/update role or permission; assign role to group or grant to role; create/update/delete resource; rename/delete scope; delete group | Per-tenant flush (affected-subject set not known without a query) |
+
+A per-tenant flush is the conservative fallback for coarse mutations; it can
+never leave a stale allow. **The security guarantee is: no revocation leaves a
+stale allow** — the cache entry is dropped in the same request that performs
+the revocation, before the response returns.
+
+### Bounded-staleness backstop
+
+The TTL is a second line of defence, not the primary one. Even if an
+invalidation were somehow missed (a bug, an out-of-band write straight to the
+database), a stale allow can persist for **at most
+`AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS`** before it is force-evicted and
+re-evaluated. The short default (5 s) keeps that worst case small. Operators who
+want a tighter bound can lower the TTL; those who never mutate roles out-of-band
+can safely raise it.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -157,6 +157,26 @@ The 503 path preserves the SEC-026 username-enumeration defence: the login
 as the real password-verify branch, so the two remain timing- and
 status-indistinguishable under both normal and saturated load.
 
+## Authorization decision cache (optional, D7)
+
+An optional per-tenant cache of authorization decisions that skips the 3–4
+SurrealDB round-trips per check. **Off by default**; enabling it changes
+performance only, never the decision an endpoint returns.
+
+| Key | Purpose |
+|---|---|
+| `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` | Master switch. Default `false` — the authorization path is then byte-for-byte identical to a build without the cache. Set `true` to enable. |
+| `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` | Cached-decision TTL in seconds (default `5`). Also the upper bound on revocation latency if an invalidation event is ever missed — keep it short. |
+| `AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES` | Max cached decisions **per tenant** before FIFO eviction (default `10000`). Memory bound. |
+
+**Security posture (safe under AXIAM's additive allow-wins / default-deny
+model):** every access-*narrowing* mutation (role/grant/group/resource change)
+invalidates the affected cache entries immediately, wired into the mutation
+handlers — so **no revocation can leave a stale allow**. The TTL is only a
+bounded-staleness backstop: even a missed invalidation self-heals within
+`AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS`. Full rationale and the per-mutation
+invalidation table are in the [Admin Guide](../admin/README.md#authorization-decision-cache-optional-d7).
+
 ## Rate limiting
 
 Every authentication/OAuth2 endpoint is rate-limited (see

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -130,6 +130,33 @@ from `RABBITMQ_DEFAULT_USER` / `RABBITMQ_DEFAULT_PASS` (see
 `AXIAM__AMQP__URL` at the deployment layer (see how
 `docker-compose.prod.yml` does this for the Compose path).
 
+## Argon2id hash concurrency (memory-DoS protection)
+
+Password hashing/verification uses Argon2id with OWASP-recommended parameters
+(`m=19456, t=2, p=1`). Each **in-flight** Argon2id operation allocates a
+~19 MiB memory arena. Unbounded concurrency is therefore an unauthenticated
+**memory-DoS** vector: a burst of concurrent logins multiplies that arena by
+the number of simultaneous hashes. In benchmarking, an unbounded login flood
+pegged 2 cores and drove server RSS to ~970 MiB (≈ 50 concurrent × 19 MiB),
+approaching the 1024 MiB container cap, while p95 latency ballooned to ~2.1 s.
+
+AXIAM bounds this with a process-wide semaphore shared across all CPU-bound
+crypto (login, password change, password reset, and PKI keygen/sign). The
+permit count caps peak concurrent arenas (and thus peak crypto RSS); a
+configurable acquire timeout sheds load with an HTTP **503** backpressure
+response instead of queueing unboundedly once every permit is held. The
+Argon2id cost parameters themselves are never weakened to gain throughput.
+
+| Key | Purpose |
+|---|---|
+| `AXIAM__AUTH__MAX_CONCURRENT_HASHES` | Max concurrent Argon2id hash/verify operations. `0` (default) = auto → `min(CPU cores, 4)`. Raise only if the host has spare memory headroom (peak crypto RSS ≈ this value × 19 MiB); lower to harden a tightly memory-capped container. |
+| `AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS` | Seconds a request waits for a hash permit before returning a `503 service_unavailable` backpressure error. Default `5`. Lower for faster load-shedding under attack; raise to tolerate longer queues before shedding. |
+
+The 503 path preserves the SEC-026 username-enumeration defence: the login
+"user not found" branch is subject to the same permit acquisition and timeout
+as the real password-verify branch, so the two remain timing- and
+status-indistinguishable under both normal and saturated load.
+
 ## TLS termination
 
 AXIAM supports two TLS patterns (ASVS V9.1.2/V9.1.3). Both enforce TLS 1.3 as

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -157,6 +157,66 @@ The 503 path preserves the SEC-026 username-enumeration defence: the login
 as the real password-verify branch, so the two remain timing- and
 status-indistinguishable under both normal and saturated load.
 
+## Rate limiting
+
+Every authentication/OAuth2 endpoint is rate-limited (see
+`crates/axiam-api-rest/src/config/rate_limit.rs`) by two cooperating layers:
+a per-replica in-memory `Governor` and a `SurrealDB`-backed shared counter
+that closes the multi-replica gap (`middleware::rate_limit_shared`). Both
+layers derive their bucket key the same way.
+
+| Key | Purpose |
+|---|---|
+| `AXIAM__RATE_LIMIT__LOGIN_PER_MIN` | Max `/auth/login` requests per minute per key (default `10`). |
+| `AXIAM__RATE_LIMIT__REGISTER_PER_MIN` | Max register requests per minute per key (default `5`). |
+| `AXIAM__RATE_LIMIT__TOKEN_PER_MIN` | Max `/oauth2/token` requests per minute per key (default `20`). |
+| `AXIAM__RATE_LIMIT__PASSWORD_RESET_PER_MIN` | Max password-reset requests per minute per key (default `3`). |
+| `AXIAM__RATE_LIMIT__MFA_PER_MIN` | Max MFA enroll/confirm/verify requests per minute per key (default `5`). |
+| `AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN` | Max `/oauth2/introspect` requests per minute per key (default `10`). |
+| `AXIAM__RATE_LIMIT__REVOKE_PER_MIN` | Max `/oauth2/revoke` requests per minute per key (default `10`). |
+| `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN` | Max authz-check requests per minute per key (default `300`). |
+| `AXIAM__RATE_LIMIT__TRUSTED_HOPS` | Number of trusted reverse-proxy hops to skip from the right of `X-Forwarded-For` when deriving the client IP (default `0` — set to `1` behind a single ingress/nginx). |
+| `AXIAM__RATE_LIMIT__KEY` | Bucket-key derivation mode: `ip` (default) \| `client_id` \| `ip_client_id`. See below. |
+
+### `AXIAM__RATE_LIMIT__KEY` — NAT'd-fleet key configurability (D8)
+
+By default (`ip`) every rate-limit bucket keys on the caller's source IP —
+this is the original, unchanged behavior for every endpoint.
+
+For `/oauth2/token`, `/oauth2/revoke`, and `/oauth2/introspect` **only**,
+`AXIAM__RATE_LIMIT__KEY` can instead key on the authenticating OAuth2
+`client_id` (parsed from the form-encoded `client_secret_post` body, RFC 6749
+§2.3.1):
+
+- **`ip`** (default) — key on source IP alone, exactly as before. Many
+  distinct OAuth2 clients egressing through one NAT gateway / corporate
+  proxy / load balancer share a single bucket, so one noisy or
+  misconfigured client can exhaust the token/introspect/revoke quota for
+  every other client behind the same IP.
+- **`client_id`** — key on the OAuth2 `client_id` alone. Each client gets an
+  independent bucket regardless of source IP, which fixes the NAT collision
+  above but means a client rotating IPs is still tracked as one bucket
+  (intentional — the identity that matters here is the client, not the
+  network path).
+- **`ip_client_id`** — key on the `(ip, client_id)` pair. Each client gets an
+  independent bucket **per IP it connects from**, so a compromised/leaked
+  client credential being hammered from one attacker IP doesn't throttle the
+  same client operating legitimately from its normal IP.
+
+**`/auth/login` (and every other rate-limited endpoint) always keys per-IP,
+regardless of this setting.** Login authenticates a *user* via
+username/password — there is no OAuth2 client identity anywhere in that
+request to key on. This is enforced in code (`server.rs` wires `/auth/login`
+with the plain, IP-only `build_governor`/`RateLimitShared::new`
+constructors, which never read `AXIAM__RATE_LIMIT__KEY`) and is not
+configurable — see `RateLimitKeyMode`'s doc comment in
+`crates/axiam-api-rest/src/config/rate_limit.rs` for the full rationale.
+
+When a `client_id`/`ip_client_id`-mode request has no parseable `client_id`
+(malformed body, wrong content type, etc.), the rate limiter fails **safe**
+by falling back to the IP key for that request — it never disables rate
+limiting outright.
+
 ## TLS termination
 
 AXIAM supports two TLS patterns (ASVS V9.1.2/V9.1.3). Both enforce TLS 1.3 as

--- a/docs/security-profiles.md
+++ b/docs/security-profiles.md
@@ -17,10 +17,49 @@ When `AXIAM__SERVER__TLS__ENABLED=true`, the server builds a rustls
   offered natively — every TLS 1.3 cipher suite is ASVS-approved, so no manual
   cipher filtering is needed (V9.1.3). Legacy TLS 1.2 clients must use an edge
   proxy; native AXIAM is **TLS 1.3-only by policy** (see p1 below).
-- **Server-auth only** (`with_no_client_auth`). Client-certificate / mTLS
-  verification is not yet native (tracked as roadmap D3); p3-mtls uses an nginx
-  edge today.
+- **Client-certificate / mTLS verification is native (D3).** See
+  [Native client-certificate auth](#native-client-certificate-auth-mtls) below.
+  Default is server-auth only (`with_no_client_auth`), backward compatible.
 - **`ring` crypto provider**, selected explicitly for determinism.
+
+### Native client-certificate auth (mTLS)
+
+Client-certificate authentication is terminated **in-process** — no nginx edge
+and, critically, **no proxy-header identity assertion** (`X-Client-Certificate`
+et al.) in the trusted path. Two new config keys control it:
+
+| Env var | Values | Default | Meaning |
+|---------|--------|---------|---------|
+| `AXIAM__SERVER__TLS__CLIENT_AUTH` | `off` \| `optional` \| `required` | `off` | client-cert policy |
+| `AXIAM__SERVER__TLS__CLIENT_CA_PATH` | PEM bundle path | — | trust anchors for client certs |
+
+- **`off`** — server-auth only (unchanged behaviour; the config is built with
+  `with_no_client_auth()`).
+- **`optional`** — a client certificate is requested and, if presented,
+  **verified** against the CA bundle, but anonymous clients are still accepted
+  (`WebPkiClientVerifier::builder(..).allow_unauthenticated().build()`).
+- **`required`** — the TLS handshake is **rejected** unless the client presents
+  a certificate that verifies against the CA bundle
+  (`WebPkiClientVerifier::builder(..).build()`).
+
+The verifier is a `rustls::server::WebPkiClientVerifier` (rustls 0.23) built from
+a `RootCertStore` loaded from `CLIENT_CA_PATH`, using the same explicit `ring`
+provider as the server config. Startup **fails fast** (an `io::Error` aborting
+the process) when client-auth is enabled but the CA path is unset,
+missing/unreadable, empty, or malformed — a misconfigured mTLS server never
+starts serving.
+
+**Identity comes from the verified certificate, not a header.** When a client
+cert verifies during the handshake, the server's `HttpServer::on_connect` hook
+lifts the rustls-verified leaf certificate (via the connection's
+`peer_certificates()`) into the per-connection extensions as a
+`VerifiedClientCert` (DER + parsed SAN + SPKI SHA-256). Certificate-auth
+handlers read it back with `HttpRequest::conn_data::<VerifiedClientCert>()` and
+feed the **verified DER** into `DeviceAuthService::authenticate_der`. The legacy
+`X-Client-Certificate` proxy header is consulted **only** as a fallback when no
+verified peer certificate is present on the connection (i.e. TLS was terminated
+upstream) — so with native mTLS enabled a spoofed header can never assert an
+identity.
 
 ### ALPN / HTTP-version (`AXIAM__SERVER__TLS__HTTP2`, default `true`)
 
@@ -79,6 +118,18 @@ override is applied.
 | Profile   | Transport                    | Native AXIAM? | Notes |
 |-----------|------------------------------|---------------|-------|
 | p0        | plaintext HTTP/1.1           | yes           | baseline |
-| p1-tls12  | TLS 1.2                      | **no**        | N/A-by-policy natively (TLS 1.3-only); nginx edge if run |
+| p1-tls12  | TLS 1.2                      | **no — N/A-by-policy** | AXIAM is **TLS 1.3-only natively** (per the security standards; ASVS V9.1.2). TLS 1.2 is never offered in-process; a legacy TLS 1.2 endpoint, if ever needed, is an nginx-edge concern outside AXIAM. This profile stays nginx-fronted when run. |
 | p2-tls13  | TLS 1.3 (h2 by default)      | yes (native overlay) | h1-isolation via `tls13-h1.conf` edge |
-| p3-mtls   | TLS 1.3 + client cert        | **no** (today)| nginx edge; native mTLS tracked as D3 |
+| p3-mtls   | TLS 1.3 + client cert        | **yes (native overlay, D3)** | native mTLS: `docker-compose.native-mtls.yml` sets `CLIENT_AUTH=required` + `CLIENT_CA_PATH=/certs/ca.crt`; no nginx edge. Identity from the verified cert, not a header. |
+
+### Why p1-tls12 is N/A-by-policy (not "not yet implemented")
+
+TLS 1.2 support is a **deliberate non-goal** for the native listener, not a
+missing feature. AXIAM's security standards mandate **TLS 1.3 minimum for all
+external communication**, and restricting to TLS 1.3 is also what lets the
+native config skip manual cipher-suite filtering (every TLS 1.3 suite is
+ASVS-approved, V9.1.3). Adding TLS 1.2 would regress that posture. Deployments
+that must terminate legacy TLS 1.2 for old clients do so at an edge proxy, which
+is that proxy's policy surface — AXIAM itself never negotiates below TLS 1.3.
+The p1-tls12 benchmark profile therefore stays nginx-fronted; there is no native
+overlay for it by design.

--- a/docs/security-profiles.md
+++ b/docs/security-profiles.md
@@ -1,0 +1,84 @@
+# AXIAM TLS & Security Profiles
+
+This document records the security-relevant decisions for AXIAM's native
+in-process TLS listener (`crates/axiam-server/src/tls.rs`), and how the
+benchmark TLS profiles (p0–p3) map onto them.
+
+TLS termination at a proxy/load balancer remains the **recommended default**
+(the server binds plaintext unless `server.tls.enabled` is set); the native
+listener is an opt-in alternative (ASVS V9.1.2/V9.1.3, D-06).
+
+## Native TLS listener
+
+When `AXIAM__SERVER__TLS__ENABLED=true`, the server builds a rustls
+`ServerConfig`:
+
+- **TLS 1.3 only** (`rustls::version::TLS13`). TLS 1.2 and earlier are not
+  offered natively — every TLS 1.3 cipher suite is ASVS-approved, so no manual
+  cipher filtering is needed (V9.1.3). Legacy TLS 1.2 clients must use an edge
+  proxy; native AXIAM is **TLS 1.3-only by policy** (see p1 below).
+- **Server-auth only** (`with_no_client_auth`). Client-certificate / mTLS
+  verification is not yet native (tracked as roadmap D3); p3-mtls uses an nginx
+  edge today.
+- **`ring` crypto provider**, selected explicitly for determinism.
+
+### ALPN / HTTP-version (`AXIAM__SERVER__TLS__HTTP2`, default `true`)
+
+The rustls config is built advertising `h2` + `http/1.1` by default. Setting
+`AXIAM__SERVER__TLS__HTTP2=false` narrows the config's ALPN list to
+`http/1.1` only.
+
+**Caveat — actix-web re-adds h2.** The REST listener is served through
+actix-web's `HttpServer::bind_rustls_0_23`, whose service factory
+(`actix_http::HttpService::rustls_0_23_with_config`) unconditionally
+**prepends** `["h2", "http/1.1"]` to whatever ALPN we configure. As a result,
+on the actix bind the `http2=false` knob is an *intent signal* — h2 is re-added
+and still wins negotiation. A genuinely `http/1.1`-only TLS 1.3 listener is
+obtained by fronting with the `tls13-h1` nginx edge
+(`benchmarks/targets/axiam/tls/tls13-h1.conf`). The rustls-level list is still
+authoritative for any non-actix consumer of the config and is unit-tested. See
+`benchmarks/PRIVATE_BENCH_ANALYSIS.md` §4.3 for why this matters (the p2 TLS
+throughput asymmetry is primarily an h2-vs-h1.1 effect).
+
+### Session resumption
+
+The native config enables **TLS 1.3 ticket-based (PSK) session resumption**:
+a `rustls::crypto::ring::Ticketer` is installed plus a bounded in-process
+`ServerSessionMemoryCache`. Without these, rustls performs a full ECDHE
+handshake on **every** connection — a per-request fixed cost that inflated p2
+token-endpoint latency in the 2026-07-19 benchmark. Resumption lets repeat
+connections from the same client resume instead.
+
+### 0-RTT / early data — **explicitly disabled** (decision)
+
+TLS 1.3 **0-RTT / early-data is deliberately NOT enabled.** rustls'
+`ServerConfig::max_early_data_size` is left at its default of `0`, so the
+server accepts no early data.
+
+Rationale: early data is **replayable** by a network attacker. The endpoints
+that dominate the TLS traffic — `/oauth2/token` (authorization_code, refresh,
+client_credentials), `/introspect`, `/revoke` — are **non-idempotent POSTs**.
+Replaying a refresh-token grant or a revocation as 0-RTT early data is an
+unacceptable correctness/security risk (token reuse, rotation races). The
+modest handshake latency saved by 0-RTT does not justify it for an IAM. If a
+future read-only, idempotent, safely-replayable endpoint ever wants 0-RTT, it
+must be gated separately and never on the token endpoints.
+
+This decision is enforced by omission (we never raise `max_early_data_size`)
+and recorded here so it is not "optimized in" later without review.
+
+### TCP_NODELAY
+
+actix-server enables `TCP_NODELAY` on accepted sockets by default, and the
+plaintext and rustls binds share the **same** `HttpServer` builder (only the
+bind method differs), so Nagle behaviour is identical across p0 and p2. No
+override is applied.
+
+## Benchmark profile mapping
+
+| Profile   | Transport                    | Native AXIAM? | Notes |
+|-----------|------------------------------|---------------|-------|
+| p0        | plaintext HTTP/1.1           | yes           | baseline |
+| p1-tls12  | TLS 1.2                      | **no**        | N/A-by-policy natively (TLS 1.3-only); nginx edge if run |
+| p2-tls13  | TLS 1.3 (h2 by default)      | yes (native overlay) | h1-isolation via `tls13-h1.conf` edge |
+| p3-mtls   | TLS 1.3 + client cert        | **no** (today)| nginx edge; native mTLS tracked as D3 |

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -7306,7 +7306,7 @@
           "oidc"
         ],
         "summary": "`GET /oauth2/jwks` -- JSON Web Key Set.",
-        "description": "Returns the public signing keys used by the authorization server\nso that relying parties can verify JWTs without sharing a secret.",
+        "description": "Returns the public signing keys used by the authorization server\nso that relying parties can verify JWTs without sharing a secret.\n\nB3: served from an in-process cache (`state.oauth2_jwks_cache`) keyed by\na hash of the source PEM, with a `Cache-Control: public, max-age=<n>`\nheader (configurable, default 300s) and a strong `ETag`. Clients that\nsend a matching `If-None-Match` get `304 Not Modified` with no body;\nclients that ignore caching headers entirely still get the identical\n`200 OK` + JWKS body they always did -- this is a pure additive change.\nSee `axiam_oauth2::jwks_cache` module docs for the cache design and the\ndocumented limitations (no key-rotation mechanism exists yet; the\nendpoint serves one global, not per-tenant, key set).",
         "operationId": "jwks",
         "responses": {
           "200": {
@@ -7318,6 +7318,9 @@
                 }
               }
             }
+          },
+          "304": {
+            "description": "Not Modified -- ETag matches If-None-Match"
           },
           "500": {
             "description": "Key parsing error"


### PR DESCRIPTION
Implements `claude_dev/benchmark-improvement-plan.md` — derived from the first full benchmark run (2026-07-19). **Phases A, B, C, D are fully implemented (23/23 tasks) plus E2.** Each task was implemented with the model the plan assigns it (Opus for security-sensitive server internals; Sonnet for well-specified harness/config work).

### Environment caveat (important for review)
The dev sandbox is **not** the benchmark laptop — no `k6`, no live target stacks. So acceptance criteria that are a *measured benchmark number* (throughput / RSS / p95 / latency signature) are implemented and unit-tested here, but their **measured confirmation is the maintainer's laptop re-run** (marked ⏳ below). No benchmark number was fabricated. Every logic/security change is covered by passing unit/integration tests in-sandbox.

### Phase A — harness correctness & honesty (Sonnet, benchmark-only)
- **A1** `userinfo` fix: `mintUserToken()` (login-first, client_credentials fallback, shared cookie-jar extraction); Keycloak `client_credentials` now requests `scope=openid`.
- **A2** fail-closed `seed.sh` provisioning + per-flow post-seed smoke checks gated by `results/<target>.seed.ok`; `run-benchmark.sh` refuses to start without it.
- **A3** `bench_fallback` counter; Zitadel login/refresh fallbacks tagged and excluded from head-to-head winner tables.
- **A4** complete `meta.json` (image+digest, `scenario_sha256`, governor, kernel, k6 cores…).
- **A5** `report.py`: p50 columns, blanked 100%-error cells, per-container bottleneck attribution, server-only efficiency variant.
- **A6** host telemetry sampler (CPU MHz / temp / host+k6 cores) + `clock_variance`/`generator_saturated` flags + methodology docs.
- **A7** secrets out of shareable results (`.seed/` relocation, `just bench-pack` with a secret grep).

### Phase B — server quick wins
- **B1** (Opus) bound concurrent Argon2id hashing: configurable `crypto_semaphore` (`AXIAM__AUTH__MAX_CONCURRENT_HASHES`, default `min(cpus,4)`) + acquire-timeout backpressure (existing overload error), SEC-026 timing equalization preserved. Fixes an unauthenticated memory-DoS vector. ⏳ RSS/p95.
- **B2** (Opus) TLS 1.3 throughput: root-caused the p2 halving to ALPN **h2-vs-h1.1** asymmetry (from actix-http source); enabled TLS 1.3 ticket resumption, added an HTTP2 knob + h1-only bench edge, declined 0-RTT (documented in new `docs/security-profiles.md`), wrote the root-cause note. ⏳ ±15%.
- **B3** (Sonnet) JWKS in-process cache + `Cache-Control`/strong `ETag`/`304` handling. ⏳ curl-loop.

### Phase C — re-run protocol (Sonnet, config/orchestration)
- **C1** median-of-N (`repeat`, `results/run-*/` aggregation, ±% spread, ≥2-valid-runs gate; single-run layout unchanged).
- **C2** DB sensitivity (`dbcaps=uncapped`) + uniform Postgres tuning on both competitors; durability-parity note (flagged unverified).
- **C3** laptop runbook: governor warning + `BENCH_CELL_PAUSE`, docs linked from README.
- **C4** prod rate-limit posture as a clearly non-comparable section; posture-mix guard verified.

### Phase D — deeper product work
- **D1** (Opus) authz batch coalescing: same-subject batches resolve the shared role/ancestor lookups once (REST + gRPC) + tracing spans + round-trip-count test. ⏳ cell re-run.
- **D2** (Sonnet) drive gRPC over TLS at p2 (server support pre-existed; added bench wiring). ⏳ live p2.
- **D3** (Opus) **native mTLS**: `WebPkiClientVerifier` (off/optional/required), verified peer cert reaches handlers via `on_connect` (not a header); in-process handshake tests pass. ⏳ full p3 no-nginx run.
- **D4** (Sonnet) Zitadel gRPC coverage (vendored minimal proto @v4.15.2, `GetMyUser` scenario, protocol-efficiency labeling). ⏳ live round-trip.
- **D5** (Sonnet) real Zitadel login via session API v2 (`/v2/sessions` password check); userinfo path preserved. ⏳ live shapes.
- **D6** (Opus) SurrealDB tuning investigation — static query-pattern + single-connection analysis (report in `claude_dev/`). ⏳ quantified runtime findings need uncapped-DB data.
- **D7** (Opus) authz **decision cache** behind a flag (default off), TTL + **event-driven invalidation** so a revocation can never leave a stale allow — proven by a revocation integration test. ⏳ throughput.
- **D8** (Sonnet) configurable rate-limiter key (`ip | client_id | ip_client_id`); login stays per-IP by design.
- **D9** (Sonnet) opt-in `jemalloc` feature (default off) + RSS-retention A/B experiment note. ⏳ RSS A/B.

### Phase E
- **E2** (Opus) AMQP async-authz load-harness **design doc** landed.
- **E1.1 / E1.2 / E1.3, E3, E4** — ⛔ blocked on resources this sandbox can't provide (sibling `axiam-<lang>-sdk` checkouts + per-language toolchains + a live seeded target; server-class hardware; the fresh median-of-3 numbers from the re-run). Natural follow-ups after the re-run.

### Verification
All changed crates compile; all unit/integration tests written for these changes pass (`axiam-auth`, `axiam-authz`, `axiam-oauth2`, `axiam-api-rest`, `axiam-server` lib + targeted integration tests), with the swagger-ui build workaround. Harness scripts validated with `node --check` / `py_compile` / `bash -n`. See the per-task status table at the end of `claude_dev/benchmark-improvement-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUMXSDuf3maCJR3PembLw7)_