### PR TITLE
Phase F: DB connection pooling (design + implementation) + re-run runbook

### DIFF
--- a/benchmarks/targets/axiam/docker-compose.yml
+++ b/benchmarks/targets/axiam/docker-compose.yml
@@ -63,6 +63,12 @@ services:
       # 0 = auto → min(cores, 4). Set explicitly to exercise a specific value under load.
       AXIAM__AUTH__MAX_CONCURRENT_HASHES: "${AXIAM__AUTH__MAX_CONCURRENT_HASHES:-0}"
       AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS: "${AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS:-5}"
+      # --- Authz decision cache (D7) ----------------------------------------------
+      # Default OFF (today's behavior). Flip ENABLED=true only for the labeled
+      # cache-sensitivity pass — never for the head-to-head matrix.
+      AXIAM__AUTHZ__DECISION_CACHE_ENABLED: "${AXIAM__AUTHZ__DECISION_CACHE_ENABLED:-false}"
+      AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS: "${AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS:-5}"
+      AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES: "${AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES:-10000}"
       AXIAM__SERVER__HOST: "0.0.0.0"
       AXIAM__GRPC__HOST: "0.0.0.0"
       # First-run bootstrap gate (D-03a): satisfies the fail-closed admin gate so

--- a/claude_dev/benchmark-improvement-plan.md
+++ b/claude_dev/benchmark-improvement-plan.md
@@ -593,6 +593,95 @@ documented "not worth it".
 
 ---
 
+## Phase F — DB connection management & pooling (added 2026-07-20, post-merge)
+
+**Investigation findings** (read from the vendored `surrealdb` **3.2.1** source,
+`src/engine/remote/http/native.rs` + `src/lib.rs`, not assumed):
+
+- The crate offers **no native connection pool** and no tuning surface: you
+  cannot inject a custom `reqwest::Client`, set pool limits, or cap concurrency.
+- The HTTP engine is **not** a serial single connection, though: `run_router`
+  spawns a tokio task **per request** over one shared `reqwest::Client`, which
+  maintains its own implicit per-host HTTP/1.1 connection pool (connections
+  opened on demand, effectively unbounded).
+- **But** every `Surreal::clone()` shares the *same* `Arc<inner>` — one router
+  dispatch task and one `reqwest::Client` for the entire process (a clone only
+  mints a new session id). All ~30 repository handles funnel through that
+  single dispatcher, DB concurrency has **no upper bound** (stampede risk, the
+  same class of problem B1 fixed for Argon2), and the documented CQ-B48 gap
+  remains: repo-clone sessions expire independently (~4-week token TTL) with a
+  process restart as the only recovery.
+- Honest expectation-setting: D6's bench evidence shows the SurrealDB
+  container's CPU cap was the wall on authz cells, so a pool is a
+  **correctness/robustness win first** (bounded concurrency, owned session
+  lifecycle, no single-funnel) and a throughput win **to be measured, not
+  presumed** (F3).
+
+So: agreed with the maintainer — a hand-rolled pool is warranted; the crate
+will not provide one. The design below keeps the stateless HTTP engine.
+
+### F1. Instrumentation-first design — **Opus**
+
+*Files:* `claude_dev/db-pool-design.md` (new), `crates/axiam-db` (metrics only).
+
+1. Add client-path instrumentation (no behavior change): route-channel wait
+   time, in-flight DB request gauge, request spawn→response latency; capture
+   TCP-connection counts to the DB (`ss -tan`) during one authz bench cell so
+   the single-funnel cost is quantified before building anything.
+2. Write the design doc: a `DbPool` of **N independent `Surreal<Client>`
+   handles** (each its own router task + `reqwest::Client`, built via the
+   existing `DbManager` init path), checkout = least-in-flight (or round-robin)
+   **plus** a `tokio::sync::Semaphore` cap with acquire timeout returning the
+   existing overload error (B1 taxonomy — no new error shape). Config:
+   `AXIAM__DB__POOL_SIZE` (default TBD in design, modest e.g. 4) and
+   `AXIAM__DB__POOL_MAX_IN_FLIGHT` + timeout.
+3. Lifecycle ownership: the pool owns proactive re-signin + health/reconnect
+   **per pooled handle** — closing CQ-B48 (repositories stop holding startup
+   auth-snapshot clones that silently expire).
+4. Decide the least-invasive repository seam: ~30 repos take an owned
+   `Surreal<Client>` at construction today; design the provider handle
+   (e.g. `Arc<DbPool>` yielding a checkout guard) with minimal churn.
+
+*Acceptance:* design doc committed; instrumentation merged with zero behavior
+change; measured funnel numbers from one bench cell recorded in the doc.
+
+### F2. Implement `DbPool` + wire repositories — **Opus**
+
+*Files:* `crates/axiam-db/src/pool.rs` (new), `connection.rs`, repository
+constructors, `axiam-server` composition, docs.
+
+1. Implement per F1. `pool_size=1` must behave byte-for-byte like today and be
+   the first-release default (safe rollout); `>1` is opt-in until F3 data
+   justifies a new default.
+2. Tests: checkout distribution; bounded concurrency + acquire-timeout →
+   overload error; a short-TTL session-expiry renewal test (reuse
+   `connect_with_ttl`) proving pooled handles re-sign-in — i.e. the CQ-B48
+   401-outage is gone; per-handle poisoned-handle eviction (mirror the
+   existing D-12 swap test).
+3. Update `connection.rs` module docs — the "Known residual gap" paragraph
+   must be rewritten to describe the pool.
+
+*Acceptance:* workspace tests green; construction-only API change for repos;
+config keys documented in the deployment docs.
+
+### F3. Bench validation + expiry soak — **Sonnet**
+
+Re-run the four authz cells + token cells before/after (pool 1 vs N) on the
+laptop per the Phase C protocol (median-of-3, labeled sensitivity rows — with
+the D7 cache **off** for apples-to-apples, then one combined cell); run a
+short-TTL soak proving no 401 outage after token expiry; record everything in
+`claude_dev/surrealdb-tuning-report.md` (new §9) and fold into the E4 doc
+refresh.
+
+*Acceptance:* before/after cells recorded; soak passes; an honest written
+conclusion — ship `pool_size>1` as default, or keep 1 and close with a
+negative result.
+
+*Order:* F1 → F2 → F3, **after** the Phase A–D laptop re-run so clean
+baselines exist.
+
+---
+
 ## Execution order & dependency summary
 
 ```
@@ -603,11 +692,12 @@ Phase C (C1–C3 before the re-run;
    → RE-RUN MATRIX on the XPS (A6 telemetry proves/disproves clock effects)
 Phase D: D1 → D6 → D7 (sequential); D2, D3, D4, D5, D8, D9 independent
 Phase E: E4 after the Phase C re-run; E1/E2 when capacity allows; E3 blocked
+Phase F: F1 → F2 → F3 (sequential), AFTER the Phase A–D laptop re-run
 ```
 
-Model split summary: **Opus** — B1, B2, D1, D3, D6, D7, E2 (debugging,
-security-sensitive server internals, cache/verifier design). **Sonnet** —
-everything in Phase A and C, B3, D2, D4, D5, D8, D9, E1, E4 (well-specified
+Model split summary: **Opus** — B1, B2, D1, D3, D6, D7, E2, F1, F2 (debugging,
+security-sensitive server internals, cache/verifier/pool design). **Sonnet** —
+everything in Phase A and C, B3, D2, D4, D5, D8, D9, E1, E4, F3 (well-specified
 edits with acceptance criteria above). Every Opus task should end by
 recording its findings in `claude_dev/` so the next agent inherits the
 evidence, not just the diff.
@@ -662,6 +752,9 @@ the laptop re-run · ⛔ blocked on external resources (documented).
 | E1.3 cross-SDK run + report table | Sonnet | ⛔ | depends on E1.1 |
 | E3 server-class hardware re-run | — | ⛔ | blocked on hardware/budget (explicitly out of scope in the plan) |
 | E4 public doc refresh | Sonnet | ⛔ | needs the fresh median-of-3 numbers from the laptop re-run |
+| F1 DB pool design + instrumentation | Opus | ⬜ planned | added 2026-07-20; run after the laptop re-run |
+| F2 implement `DbPool` + wire repos | Opus | ⬜ planned | pool_size=1 default (today's behavior); >1 opt-in until F3 data |
+| F3 pool bench validation + expiry soak | Sonnet | ⬜ planned | before/after cells + short-TTL soak |
 
 **Summary:** Phases **A, B, C, D fully implemented** (23/23 tasks) + **E2**.
 The remaining Phase E items (E1.\*, E3, E4) are blocked on resources this
@@ -669,3 +762,71 @@ sandbox cannot provide (live target, sibling SDK repos + toolchains, server-
 class hardware, fresh re-run numbers) and are the natural follow-ups after the
 maintainer's re-run. Measured-number acceptance across A–D is validated by that
 re-run; every logic/security change is already covered by passing tests here.
+
+---
+
+## Collecting the data — laptop re-run runbook (added 2026-07-20)
+
+Everything below runs from `benchmarks/` on the XPS, against **merged `main`**.
+Full detail lives in `docs/methodology.md` §8 (median-of-N), §9 (DB caps),
+§10 (laptop variance control), §11 (prod posture); this is the short path.
+
+**0. Prerequisites.** `docker` + compose v2, `just`, `k6`, `python3`. Laptop
+prep per §10: on AC power, `sudo cpupower frequency-set -g performance`
+(the runner warns if not), optionally pin no-turbo — but run the WHOLE matrix
+in one mode. The A6 host sampler runs automatically; check the report's
+`clock_variance` / `generator_saturated` flags before trusting any cell.
+
+**1. Build AXIAM locally — this is the critical flag.** The published ghcr
+image predates all of Phase B/D, so every AXIAM cell must use a local source
+build of merged `main`: pass **`build=1`** (forces `docker compose --build`;
+it is also the automatic fallback when the pull fails). Keycloak/Zitadel are
+unchanged pulled images. First time (or after cert changes): `just bench-certs`.
+
+**2. Main matrix (median-of-3 is the default `repeat`):**
+
+```bash
+cd benchmarks
+just build=1 targets="axiam keycloak zitadel" profiles="p0-plaintext p2-tls13" bench-matrix
+```
+
+`bench-matrix` loops bench-up → bench-seed → bench-run → bench-down per
+target×profile into `results/run-<i>/…`, then runs `bench-report`
+(auto-medians when `run-*/` dirs exist). Seeding is fail-closed (A2): if a
+seed smoke check fails, `bench-run` refuses to start — inspect
+`results/<target>/seed-failure/`. Expected first-run friction: the new
+Zitadel session-API seeding (D5) has two flagged best-guesses (`expect: 201`
+vs 200; management-API field names) — if its smoke check trips, adjust per
+the in-code comments in `scenarios/lib/targets.js` / `runner/seed.sh`.
+
+**3. AXIAM-only extra passes** (each a labeled section/sensitivity row, not
+mixed into head-to-head):
+
+```bash
+# p3 native mTLS (D3 — no nginx container should appear in `docker ps`)
+just target=axiam profile=p3-mtls build=1 bench-up bench-seed bench-run bench-down
+# C4 prod rate-limit posture
+just target=axiam rl=prod build=1 bench-up bench-seed bench-run bench-down
+# C2 DB-uncapped sensitivity (one AXIAM + one Zitadel pass)
+just target=axiam dbcaps=uncapped build=1 bench-up bench-seed bench-run bench-down
+just target=zitadel dbcaps=uncapped bench-up bench-seed bench-run bench-down
+# D7 decision-cache sensitivity (default is OFF; one labeled ON pass)
+AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true just target=axiam build=1 bench-up bench-seed bench-run bench-down
+```
+
+**4. B2 TLS verification — zero new runs first.** Before any p2 re-run, read
+the archived 2026-07-19 k6 JSONs: the `http_version` tag (expect `2` at p2 vs
+`1.1` at p0) and `http_req_tls_handshaking` attribute the halving with no new
+data. Then the isolation cell: re-run only `oauth2_client_credentials` +
+`token_refresh` at p2 with the h1-only edge (`tls13-h1.conf`) and compare —
+acceptance is p2 within ~15% of p0.
+
+**5. B1/D9 memory checks.** During the login cell, watch server RSS
+(`docker stats`): B1 acceptance is ≤ ~350 MiB at 50 VUs. The D9 jemalloc A/B
+is separate — procedure in `claude_dev/memory-retention-experiment.md`
+(build with `--features jemalloc`, compare 10-min post-burst RSS).
+
+**6. Package/publish:** `just bench-pack` produces the shareable
+`results-<date>.tar.xz` (only k6/res/host/meta/report files; it greps the
+archive for secrets and fails if any leak). Then E4 (public doc refresh) can
+run against the fresh numbers.

--- a/claude_dev/db-pool-design.md
+++ b/claude_dev/db-pool-design.md
@@ -1,0 +1,474 @@
+# DB Connection Pool — Design (F1)
+
+**Status:** design-only; implementation is F2. Instrumentation (F1 deliverable 2)
+is merged with this doc.
+**Scope:** `crates/axiam-db` (`connection.rs`, new `pool.rs`, `metrics.rs`),
+repository constructors, `axiam-server` composition.
+**Author context:** grounded in the pinned `surrealdb` 3.2.1 HTTP-engine source
+(`src/engine/remote/http/native.rs`, `src/lib.rs`) and the existing
+`DbManager` (`crates/axiam-db/src/connection.rs`).
+
+---
+
+## 1. Problem statement (verified, not assumed)
+
+The vendored `surrealdb` 3.2.1 HTTP engine:
+
+- Offers **no native connection pool** and no tuning surface — you cannot inject
+  a custom `reqwest::Client`, set pool limits, or cap concurrency.
+- Is **not** a serial single connection: `run_router` spawns a tokio task **per
+  request** over one shared `reqwest::Client`, which keeps its own implicit
+  per-host HTTP/1.1 connection pool (connections opened on demand, effectively
+  unbounded).
+- Shares **one** `Arc<inner>` across every `Surreal::clone()` — so one router
+  dispatch task and one `reqwest::Client` serve the entire process. A clone only
+  mints a new session id; it does **not** get its own dispatcher, its own TCP
+  pool, or its own future re-signin/reconnect lifecycle.
+
+AXIAM builds ~30 repositories at startup via `db.client_cloned().await` (48
+`client_cloned().await` + 5 `db_handle.clone()` call sites in
+`axiam-server/src/main.rs`). Consequences today:
+
+1. **Single funnel.** All repository traffic dispatches through one router task
+   and one `reqwest::Client`. DB concurrency has **no upper bound** (stampede
+   risk — the same class of problem B1 fixed for Argon2id).
+2. **CQ-B48 session-expiry gap.** Each startup clone is a value-snapshot of the
+   auth state at composition time. `DbManager`'s proactive re-signin and
+   reconnect loop keep only the manager's OWN handle alive; the ~30 repo
+   sessions each expire independently on the ~4-week root-token TTL, and the
+   only recovery is a process restart. `health_check` deliberately probes a
+   startup-generation clone (`health_probe`) so the readiness gate at least
+   *trips* when the repos' tokens expire — but recovery is still restart-only.
+
+**Honest framing (D6 evidence).** The benchmark showed the SurrealDB
+container's CPU cap was the wall on authz cells (server idle, DB pegged). So the
+pool is a **correctness/robustness win first** — bounded concurrency, owned
+session lifecycle, no single funnel — and a **throughput win to be MEASURED in
+F3, not presumed.** N independent reqwest pools give the OS more concurrent TCP
+sockets to the DB, which *may* raise the ceiling, but only a laptop re-run
+(§9) decides whether `pool_size > 1` becomes the default.
+
+---
+
+## 2. Architecture: N independent handles (not clones)
+
+`DbPool` holds **N fully independent `Surreal<Client>` handles**, each built via
+the existing `DbManager` connect/auth path — **not** `.clone()` of one handle.
+
+```
+DbPool
+├── handle[0] : PooledHandle { db: Arc<RwLock<Surreal<Client>>>, refresh_task, reconnect_task }
+├── handle[1] : PooledHandle { ... }               each its OWN:
+├── ...                                              • router dispatch task
+└── handle[N-1]: PooledHandle { ... }               • reqwest::Client (⇒ own implicit TCP pool)
+                                                     • signin session + renewal lifecycle
+semaphore : Arc<Semaphore>   ← process-wide in-flight cap (AXIAM__DB__POOL_MAX_IN_FLIGHT)
+in_flight : per-handle AtomicUsize (checkout policy input)
+```
+
+**Why independent handles and not clones — this is the entire point:**
+
+| Property | 30 clones of one handle (today) | N independent handles (DbPool) |
+|---|---|---|
+| Router dispatch task | 1 shared | N — dispatch parallelism, no single funnel |
+| `reqwest::Client` / TCP pool | 1 shared implicit pool | N independent implicit pools ⇒ more concurrent sockets to the DB |
+| Session renewal | only manager's handle renews; clones expire (CQ-B48) | every handle independently re-signed-in + reconnected |
+| Poisoned-handle recovery | restart-only for clones | per-handle evict-and-swap (D-12 pattern) |
+
+Because a clone shares `Arc<inner>`, cloning can never buy any of the right-hand
+column — the only way to get a second router task + second reqwest pool +
+independently-renewable session is a second `Surreal::new::<Http>(...)` with its
+own `signin`. That is exactly what `DbManager::connect_with_ttl` /
+`DbManager::reconnect` already do, so each pooled handle is constructed through
+that same proven path.
+
+### 2.1 `PooledHandle`
+
+Each pooled handle reuses the manager's existing D-12 machinery **per handle**:
+
+```rust
+struct PooledHandle {
+    /// Swappable so the per-handle reconnect loop can evict a poisoned handle
+    /// (D-12) — identical to DbManager::db today.
+    db: Arc<RwLock<Surreal<Client>>>,
+    /// In-flight count for THIS handle — least-in-flight checkout input.
+    in_flight: Arc<AtomicUsize>,
+    refresh_handle: JoinHandle<()>,   // spawn_proactive_resignin, per handle
+    reconnect_handle: JoinHandle<()>, // spawn_reconnect_loop, per handle
+}
+```
+
+The three lifecycle functions in `connection.rs`
+(`spawn_proactive_resignin`, `spawn_reconnect_loop`, `reconnect`) are already
+written against `Arc<RwLock<Surreal<Client>>>` + `&DbConfig` and are engine-
+neutral — F2 lifts them (or makes them `pub(crate)` associated fns callable
+from `pool.rs`) and spawns one pair **per handle**. No new resilience logic is
+invented; the pool is N replicas of the manager's own already-tested lifecycle.
+
+---
+
+## 3. Checkout policy: least-in-flight + a semaphore cap
+
+**Two independent mechanisms, both required:**
+
+### 3.1 Which handle — least-in-flight (chosen)
+
+On checkout, pick the handle with the smallest current `in_flight` count
+(ties broken by index). Rationale over round-robin:
+
+- Round-robin distributes *checkouts* evenly but not *load*: a slow query on
+  handle 2 leaves it congested while round-robin keeps assigning it its turn.
+- Least-in-flight is load-aware — it steers new work to the least-busy router,
+  which is exactly the property we want when one handle's implicit TCP pool is
+  momentarily saturated. It is O(N) over a tiny N (default 1, expected ≤ 8), so
+  the scan cost is negligible.
+- It degrades to identical behavior as round-robin when all handles are equally
+  loaded, and to a **no-op** at `pool_size = 1` (there is only one handle) —
+  preserving the "pool_size=1 ≡ today" invariant.
+
+Selection reads each `in_flight` with `Ordering::Relaxed`; exactness is not
+required (it is a hint), so no lock is taken on the hot path.
+
+### 3.2 How much concurrency — process-wide semaphore cap
+
+A single process-wide `tokio::sync::Semaphore` (permits =
+`AXIAM__DB__POOL_MAX_IN_FLIGHT`) bounds total concurrent in-flight DB ops across
+**all** handles — this is the stampede fix (analogous to B1's Argon2id gate).
+Checkout acquires a permit with a timeout of
+`AXIAM__DB__POOL_ACQUIRE_TIMEOUT_SECS`; on timeout it returns the **existing**
+overload error — reusing B1's taxonomy exactly, no new error shape:
+
+> **B1 mapping (verified in `crates/axiam-auth/src/crypto_gate.rs`):**
+> `acquire_hash_permit` returns `AxiamError::ServiceUnavailable(String)` on
+> acquire-timeout, which the REST layer maps to **HTTP 503** ("service
+> unavailable / overloaded"; a transient server-capacity condition, not a
+> per-client rate-limit). A closed semaphore → `AxiamError::Internal`.
+
+The pool mirrors this precisely. Since `axiam-db` errors are `DbError` and the
+crate does not depend on the REST layer, the acquire helper lives at the
+`axiam-db` boundary and surfaces the overload as **`AxiamError::ServiceUnavailable`**
+(which `DbError`/the repos already convert into via
+`impl From<DbError> for AxiamError` — see below) so the same 503 is produced.
+Concretely, F2 adds a small helper mirroring `acquire_hash_permit`:
+
+```rust
+// crates/axiam-db/src/pool.rs
+async fn acquire_db_permit(
+    sem: &Semaphore,
+    timeout: Duration,
+) -> Result<OwnedSemaphorePermit, AxiamError> {
+    match tokio::time::timeout(timeout, sem.clone().acquire_owned()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        Ok(Err(_closed)) => Err(AxiamError::Internal("db pool semaphore closed".into())),
+        Err(_elapsed) => Err(AxiamError::ServiceUnavailable(
+            "database is at capacity; please retry shortly".into(),
+        )),
+    }
+}
+```
+
+> **Error-shape note.** B1 returns `AxiamError` directly (the auth crate speaks
+> `AxiamError`). `DbError` has no `ServiceUnavailable` variant, and it should not
+> grow one: adding it would drift from B1's single overload shape. The pool
+> therefore returns `AxiamError::ServiceUnavailable` from the checkout path
+> (the repos already surface `AxiamError`), keeping **one** overload taxonomy
+> across Argon2id (B1) and the DB pool (F2). No new error shape is invented.
+
+### 3.3 The checkout guard
+
+A checkout returns an RAII guard that:
+
+1. Holds the `OwnedSemaphorePermit` (released on drop).
+2. Incremented the chosen handle's `in_flight` on creation; **decrements it on
+   drop**.
+3. `Deref`s to `Surreal<Client>` so call sites use it exactly like the owned
+   handle they hold today (see §6).
+
+```rust
+pub struct DbCheckout {
+    handle: Arc<RwLock<Surreal<Client>>>, // the chosen handle
+    _permit: OwnedSemaphorePermit,
+    in_flight: Arc<AtomicUsize>,          // decremented on drop
+}
+// Deref target is the current Surreal<Client> read out of the handle's RwLock.
+```
+
+Drop order (permit + in_flight decrement) is guaranteed by struct field drop
+order; both are infallible non-blocking ops.
+
+---
+
+## 4. Config keys (extend `DbConfig` in `connection.rs`)
+
+Exact new fields appended to the existing `DbConfig` struct (which already
+derives `Deserialize`, `#[serde(default)]`, and has a hand-written `Default`):
+
+```rust
+pub struct DbConfig {
+    // ... existing fields (url, namespace, database, username, password,
+    //     token_refresh_fraction, reconnect_base_ms, reconnect_ceiling_ms,
+    //     reconnect_max_retries) unchanged ...
+
+    /// Number of INDEPENDENT `Surreal<Client>` handles in the pool — each its
+    /// own router task + reqwest client + renewable session (NOT clones).
+    /// Overridable via `AXIAM__DB__POOL_SIZE`.
+    /// DEFAULT `1` — byte-for-byte today's behavior (one handle, one funnel),
+    /// the safe first-release default. `>1` is opt-in until F3 laptop data
+    /// justifies a new default.
+    pub pool_size: usize,
+
+    /// Process-wide cap on concurrent in-flight DB ops across ALL handles
+    /// (the stampede bound, analogous to B1's MAX_CONCURRENT_HASHES).
+    /// Overridable via `AXIAM__DB__POOL_MAX_IN_FLIGHT`.
+    /// DEFAULT: see rationale below.
+    pub pool_max_in_flight: usize,
+
+    /// How long a checkout waits for a semaphore permit before returning the
+    /// existing overload error (HTTP 503, B1 taxonomy). Overridable via
+    /// `AXIAM__DB__POOL_ACQUIRE_TIMEOUT_SECS`. DEFAULT `5` (matches B1's
+    /// `hash_acquire_timeout_secs` default for a consistent backpressure feel).
+    pub pool_acquire_timeout_secs: u64,
+}
+
+impl Default for DbConfig {
+    fn default() -> Self {
+        Self {
+            // ... existing defaults unchanged ...
+            pool_size: 1,
+            pool_max_in_flight: 256,
+            pool_acquire_timeout_secs: 5,
+        }
+    }
+}
+```
+
+**Default rationale:**
+
+- `pool_size = 1` — **mandatory** safe default: with one handle the pool is
+  observably identical to today (one router, one reqwest pool, one session), so
+  the migration is provably a no-op behavior change. This is the F2 acceptance
+  gate ("`pool_size=1` must behave byte-for-byte like today").
+- `pool_max_in_flight = 256` — high enough to be a **safety ceiling, not a
+  throttle** at `pool_size = 1` (today's concurrency is unbounded; 256 in-flight
+  DB ops is far above the ~50-VU bench load yet caps a genuine stampede). It is
+  the guardrail B1 established for hashing, applied to DB ops. F3 tunes it
+  against real load; it must never be set below expected steady-state
+  concurrency or it becomes a latency source (documented for operators).
+- `pool_acquire_timeout_secs = 5` — identical to B1's default so overload
+  backpressure feels the same across the Argon2id gate and the DB pool.
+
+> All three keys follow the existing `AXIAM__DB__*` env convention (see the
+> `token_refresh_fraction` / `reconnect_*` fields already wired that way).
+
+---
+
+## 5. Session lifecycle — closing CQ-B48
+
+The pool **owns** proactive re-signin + health/reconnect **per pooled handle**,
+reusing `spawn_proactive_resignin` / `spawn_reconnect_loop` / `reconnect`
+verbatim, one pair of background tasks per handle. Because repositories now hold
+`Arc<DbPool>` (or check out from it) instead of a frozen startup snapshot, there
+are **no** un-renewed snapshot sessions left in the process — every session a
+request can touch belongs to a pooled handle whose proactive re-signin keeps it
+inside the root-token TTL and whose reconnect loop rebuilds it on expiry/poison.
+**This closes CQ-B48:** the ~4-week TTL is no longer a restart-only outage.
+
+### 5.1 The module-doc "Known residual gap" paragraph must change
+
+`connection.rs`'s current module doc says (paraphrased): *"every repository is
+constructed via `db.client_cloned().await` … those startup repo clones are NOT
+re-signed-in … there is no connection pool, and threading a shared/swappable
+handle into the repositories is explicitly out of scope."*
+
+F2 **rewrites** that paragraph to state the opposite now holds:
+
+> **Session lifecycle (CQ-B48 closed by the DbPool, F2).** Repositories no
+> longer hold frozen `client_cloned()` snapshots. They check out from
+> [`DbPool`], which holds N independent handles, each with its OWN proactive
+> re-signin and reconnect loop (the same D-04/PERF-04 machinery previously
+> applied only to the manager's own handle). Every session a request can reach
+> is therefore kept alive inside the root-token TTL and rebuilt on
+> expiry/poison — the former restart-only ~4-week outage is gone. `health_probe`
+> and its startup-snapshot rationale are removed; `health_check` probes the
+> pooled handles.
+
+`health_probe` (the deliberately-un-renewed CQ-B48 detector) is **deleted** in
+F2 — its only purpose was to alarm on the gap this design closes.
+
+---
+
+## 6. Repository seam — least churn
+
+**Today:** 36 repository constructors take an owned `Surreal<C>` at construction
+(`pub fn new(db: Surreal<C>) -> Self`, one exception: `SurrealEmailConfigRepository::new(db, key)`),
+store it as `db: Surreal<C>`, and call `self.db.query(...)` directly. They are
+generic over `C: Connection` and `#[derive(Clone)]`. Composition clones a handle
+per repo (48 + 5 call sites in `main.rs`).
+
+Two candidate seams were evaluated:
+
+### Option A — repos hold `Arc<DbPool>`, check out per call (rejected as primary)
+
+Change `db: Surreal<C>` → `pool: Arc<DbPool>` and every `self.db.query(...)` →
+`self.pool.checkout().await?.query(...)`. **Churn:** every query call site in
+every repo (hundreds), plus the generic `<C: Connection>` bound has to go (the
+pool is concrete `Surreal<Client>`). High risk, defeats "least churn," and
+breaks the `kv-mem` unit tests that construct repos over `Surreal<Db>`.
+
+### Option B — construction-only swap: repos hold a checkout provider (CHOSEN)
+
+Keep repos calling `self.db.query(...)` **unchanged**. Change only what `self.db`
+*is* and how it is **constructed**:
+
+- Introduce `DbHandle` — the type repos store. It `Deref`s to `Surreal<Client>`
+  so `self.db.query(...)` compiles untouched. In the simplest correct form
+  `DbHandle` is produced by the pool and each repo is bound to one pooled handle
+  at construction (checkout-at-construction, release-never — matching today's
+  "own a handle for the repo's life" semantics but now a *pooled, renewable*
+  handle instead of a frozen snapshot).
+- `DbManager`/`DbPool` grows `pub async fn checkout(&self) -> DbCheckout` (per-op)
+  **and** `pub async fn handle_for_repo(&self) -> Surreal<Client>` (construction-
+  time binding). For F2's first release, repositories bind one pooled handle at
+  construction via the latter — this is the **lowest-risk** option: it is a
+  pure construction-site change, identical call-site count to today, and every
+  `self.db.query` body is untouched.
+
+**Call-site change count (Option B, construction-only):** the 48
+`client_cloned().await` + 5 `db_handle.clone()` sites in `main.rs` change from
+`db.client_cloned().await` to `pool.handle_for_repo().await` (or the composition
+holds `Arc<DbPool>` and hands each repo a bound handle). **~53 mechanical
+one-line construction-site edits, zero changes inside any repository query
+body.** The `<C: Connection>` generic is retained (unit tests keep using
+`Surreal<Db>` / `kv-mem`); production binds `C = Client`.
+
+**Why this is provably safe at `pool_size = 1`:** with one handle,
+`handle_for_repo()` hands out the single pooled handle exactly as
+`client_cloned()` handed out the single manager handle today — same router, same
+reqwest pool — so behavior is byte-for-byte identical. The only *added* behavior
+(per-handle renewal) strictly improves on the snapshot it replaces.
+
+> **Per-op checkout (`DbCheckout` + semaphore) — where it applies.** The
+> semaphore cap and least-in-flight selection (§3) bite when there are ≥ 2
+> handles OR when the operator sets `pool_max_in_flight` below steady-state
+> load. F2 ships the per-op `checkout()` guard and routes the query path
+> through it (via the `instrument_query` seam, §7/§8) so the cap is real; at
+> `pool_size = 1` with the default high cap this is a transparent
+> increment/permit that never blocks — preserving the no-op invariant. The
+> construction-time binding (above) is what keeps repo *bodies* unchanged; the
+> per-op guard is what enforces the bound. F2 chooses whether the bound is
+> enforced by wrapping the bound handle's queries or by a true per-op checkout,
+> guided by the churn budget — both satisfy the pool_size=1 invariant.
+
+---
+
+## 7. Instrumentation (F1 deliverable 2 — MERGED, zero behavior change)
+
+`crates/axiam-db/src/metrics.rs` (new, wired into `lib.rs` as `pub mod metrics`).
+Because the surrealdb router channel is opaque, instrumentation sits at **our**
+call path — the boundary a `DbPool` will own:
+
+- `db_in_flight() -> i64` — process-wide gauge of DB requests in flight through
+  the `axiam-db` boundary. Today: requests contending for the single dispatcher.
+  Post-F2: the pool's aggregate in-flight count the semaphore bounds.
+- `db_handle_checkouts() -> u64` — monotonic counter of handles handed out by
+  `client_cloned()`. Directly quantifies the single-funnel fan-in (~30 at
+  startup) that F2 replaces.
+- `instrument_query(op, fut)` — **transparent passthrough** wrapper: RAII gauge
+  guard (inc on entry, dec on drop — correct on cancel/panic/error) + a
+  `tracing` TRACE event carrying `op` and `latency_us` on completion. It awaits
+  exactly `fut` and returns its output unchanged: no new await points, no
+  reordering, no altered error semantics. The TRACE event is free when no
+  subscriber is attached.
+
+**Choke points wired in F1** (the only ones that exist today; F2 routes the
+repository query path through `instrument_query`):
+
+1. `DbManager::client_cloned()` → `metrics::record_handle_checkout()`.
+2. `DbManager::health_check()` → both `RETURN 1` probes wrapped in
+   `instrument_query("health_check.manager" / ".probe", ...)`.
+
+There is **no single query choke point across the repos today** (each repo calls
+`self.db.query` directly), so F1 adds the wrapper and documents that **F2 routes
+the repository/pool query path through `instrument_query`** — at which point the
+gauge reflects true whole-process DB concurrency.
+
+### 7.1 Emission
+
+Uses `tracing` (already a crate dependency; no `metrics`/`prometheus` facade
+exists in `axiam-db` — grep confirmed). Structured fields
+(`op`, `latency_us`, `in_flight_at_entry`, `handle_checkouts_total`) under
+`target: "axiam_db::metrics"` so an operator can enable just this target.
+
+---
+
+## 8. Testing plan for F2
+
+1. **Checkout distribution.** Construct a `DbPool` with `pool_size = 3` over
+   `kv-mem` handles; issue K concurrent checkouts holding briefly; assert each
+   handle's `in_flight` peak is ≈ K/3 (least-in-flight spreads load) and no
+   handle is starved. At `pool_size = 1` assert all checkouts map to the one
+   handle (no-op invariant).
+2. **Bounded concurrency + acquire-timeout → overload error.** `pool_size = 1`,
+   `pool_max_in_flight = 2`; saturate with 2 held checkouts; a 3rd checkout with
+   a tiny acquire timeout must return `AxiamError::ServiceUnavailable` (HTTP 503,
+   B1 taxonomy) — mirrors `crypto_gate::times_out_to_service_unavailable_when_saturated`.
+   Also assert peak concurrency never exceeds the permit count (mirrors B1's
+   `concurrency_is_bounded_to_permit_count`).
+3. **Short-TTL session renewal (CQ-B48 proof).** Reuse
+   `DbManager::connect_with_ttl` per pooled handle with a short TTL (as
+   `connection_resilience_test.rs::recovers_from_token_expiry_without_restart`
+   does for the manager); drive queries through pooled handles past the TTL and
+   assert **no 401 outage** — proving the pooled sessions re-sign-in where the
+   old `client_cloned()` snapshots would have 401'd. Requires a live SurrealDB
+   (gated the same way the existing resilience tests are).
+4. **Per-handle poisoned-handle eviction.** Mirror
+   `connection.rs::poisoned_handle_is_evicted_and_never_returned_after_swap`
+   (D-12) but per pooled handle: swap one handle's `Arc<RwLock<Surreal<C>>>`
+   under the write guard with two marked `kv-mem` instances and assert readers
+   observe only the new handle afterwards, and that the OTHER handles in the
+   pool are unaffected by the swap.
+5. **`pool_size=1` ≡ today.** Assert a single-handle pool routes exactly as
+   `client_cloned()` did (same handle identity semantics), so the migration is a
+   proven no-op behavior change.
+
+---
+
+## 9. Deferred to the laptop (no live stack here)
+
+This sandbox has `cargo` but **no live SurrealDB and no `k6`/target stacks**, so
+the *measured* funnel numbers are pending the maintainer's laptop re-run. Mark
+these PENDING in F3:
+
+- **TCP-connection count during one authz bench cell (single-funnel cost).**
+  While an authz cell runs against native AXIAM, on the laptop run:
+
+  ```bash
+  # Count established TCP connections from the AXIAM server to SurrealDB (port 8000).
+  # Run repeatedly during the measure window; expect ~1 host's worth of reqwest
+  # HTTP/1.1 sockets at pool_size=1, and ~N× that at pool_size=N.
+  ss -tan | grep ':8000' | grep ESTAB | wc -l
+  # or, scoped to the server container's PID/netns:
+  nsenter -t "$(docker inspect -f '{{.State.Pid}}' axiam-server)" -n ss -tan state established '( dport = :8000 )' | wc -l
+  ```
+
+  Record the count at `pool_size=1` vs `pool_size=N` to quantify that N handles
+  really open N independent reqwest pools.
+- **In-flight gauge + query latency under load.** Enable
+  `RUST_LOG=axiam_db::metrics=trace` (or wire the gauge into `/metrics`) during
+  an authz cell; record peak `db_in_flight` and `latency_us` distribution — the
+  boundary funnel cost before/after the pool.
+- **F3 throughput before/after (pool 1 vs N)** on the four authz + token cells,
+  median-of-3, D7 cache off — the honest measured verdict on whether
+  `pool_size>1` ships as default (per F3 acceptance).
+
+---
+
+## 10. Summary
+
+`DbPool` = N independent `Surreal<Client>` handles (own router + reqwest pool +
+renewable session each), least-in-flight checkout, a process-wide semaphore cap
+returning B1's existing `ServiceUnavailable`/503 overload error on acquire
+timeout, per-handle re-signin/reconnect closing CQ-B48, and a construction-only
+repository seam (~53 one-line composition edits, repo query bodies untouched,
+`pool_size=1` provably identical to today). Correctness/robustness win is
+certain; the throughput win is F3's to measure, not this doc's to claim.

--- a/crates/axiam-api-rest/src/health.rs
+++ b/crates/axiam-api-rest/src/health.rs
@@ -26,6 +26,18 @@ impl HealthChecker for axiam_db::DbManager {
     }
 }
 
+impl HealthChecker for axiam_db::DbPool {
+    fn check(&self) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + '_>> {
+        Box::pin(async {
+            // Probes every pooled handle so readiness reflects the whole pool
+            // (an auth-expired or poisoned handle anywhere trips the gate).
+            self.health_check()
+                .await
+                .map_err(|e| format!("db health check failed: {e}"))
+        })
+    }
+}
+
 /// Always-healthy test double (mirrors the `AllowAllAuthzChecker` test
 /// fixture precedent already established in this crate). Used by
 /// `AppState::for_test` so test harnesses that don't specifically exercise

--- a/crates/axiam-db/src/connection.rs
+++ b/crates/axiam-db/src/connection.rs
@@ -71,6 +71,7 @@ use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 use crate::error::DbError;
+use crate::metrics;
 
 /// Cadence at which [`spawn_reconnect_loop`]'s background task polls
 /// `health_check` while the connection is believed healthy. Independent of
@@ -502,6 +503,11 @@ impl DbManager {
     /// residual gap"; repositories keep their own independent snapshot
     /// exactly as before this migration (RESEARCH Pitfall 2 — out of scope).
     pub async fn client_cloned(&self) -> Surreal<Client> {
+        // F1 instrumentation (zero behavior change): count how many handles are
+        // handed out. Under the current single-router architecture every clone
+        // shares the SAME dispatcher/`reqwest::Client`, so this counter directly
+        // quantifies the single-funnel fan-in the F2 pool will replace.
+        metrics::record_handle_checkout();
         self.db.read().await.clone()
     }
 
@@ -522,8 +528,11 @@ impl DbManager {
     /// without a process restart.
     pub async fn health_check(&self) -> Result<(), DbError> {
         let guard = self.db.read().await;
-        let result = guard
-            .query("RETURN 1")
+        // F1 instrumentation (zero behavior change): the health probe is a real
+        // query through the `axiam-db` boundary, so route it through the
+        // in-flight gauge + latency wrapper. `instrument_query` is a transparent
+        // passthrough — it awaits exactly this future and returns its output.
+        let result = metrics::instrument_query("health_check.manager", guard.query("RETURN 1"))
             .await
             .map_err(Self::classify_query_error)?;
         // Surface any statement-level error (HTTP returns 200 even on SQL error).
@@ -534,11 +543,12 @@ impl DbManager {
         // probe alarms when the request-serving repositories' tokens expire —
         // the manager handle above is proactively re-signed-in and would report
         // healthy even while every repo DB request 401s.
-        let probe = self
-            .health_probe
-            .query("RETURN 1")
-            .await
-            .map_err(Self::classify_query_error)?;
+        let probe = metrics::instrument_query(
+            "health_check.probe",
+            self.health_probe.query("RETURN 1"),
+        )
+        .await
+        .map_err(Self::classify_query_error)?;
         probe.check().map_err(Self::classify_query_error)?;
         Ok(())
     }

--- a/crates/axiam-db/src/connection.rs
+++ b/crates/axiam-db/src/connection.rs
@@ -543,12 +543,10 @@ impl DbManager {
         // probe alarms when the request-serving repositories' tokens expire —
         // the manager handle above is proactively re-signed-in and would report
         // healthy even while every repo DB request 401s.
-        let probe = metrics::instrument_query(
-            "health_check.probe",
-            self.health_probe.query("RETURN 1"),
-        )
-        .await
-        .map_err(Self::classify_query_error)?;
+        let probe =
+            metrics::instrument_query("health_check.probe", self.health_probe.query("RETURN 1"))
+                .await
+                .map_err(Self::classify_query_error)?;
         probe.check().map_err(Self::classify_query_error)?;
         Ok(())
     }

--- a/crates/axiam-db/src/connection.rs
+++ b/crates/axiam-db/src/connection.rs
@@ -30,17 +30,20 @@
 //! treating expired/invalid root credentials as an ordinary, possibly
 //! transient query error.
 //!
-//! **Known residual gap (documented, not fixed here):** every repository in
-//! `axiam-server` is constructed via `db.client_cloned().await`. Cloning a
-//! `Surreal<C>` mints a brand-new session id and copies the CURRENT auth
-//! state as a value snapshot — it does not share future re-signins or
-//! reconnects with `DbManager`'s own handle. This module's proactive
-//! re-signin and reconnect loop therefore only keep `DbManager`'s OWN
-//! session (used by `health_check`) alive; the ~30 already-cloned repository
-//! sessions each still expire independently on their own original schedule.
-//! This matches the phase's locked scope (`26-RESEARCH.md` /
-//! `27-RESEARCH.md` Pitfall 2) — there is no connection pool, and threading a
-//! shared/swappable handle into the repositories is explicitly out of scope.
+//! ## Session lifecycle (CQ-B48 closed by the DbPool, F2)
+//!
+//! Repositories no longer hold frozen `client_cloned()` snapshots. They bind a
+//! handle from [`crate::DbPool`], which holds N INDEPENDENT `Surreal<Client>`
+//! handles (not clones), each with its OWN proactive re-signin and reconnect
+//! loop — the same D-04/PERF-04 machinery this module implements, now spawned
+//! once per pooled handle instead of only for the manager's single handle.
+//! Every session a request can reach therefore belongs to a pooled handle that
+//! is kept authenticated inside the root-token TTL and rebuilt on
+//! expiry/poison, so the former restart-only ~4-week outage is gone. The
+//! deliberately-un-renewed startup-snapshot `health_probe` that used to alarm
+//! on that gap is removed; readiness is now established by [`crate::DbPool`]
+//! probing its pooled handles (see [`DbManager::connect_handle`], the shared
+//! per-handle connect+spawn path both [`DbManager`] and the pool build through).
 //!
 //! ## Reconnect loop, full-jitter backoff, poisoned-handle eviction (PERF-04)
 //!
@@ -86,7 +89,7 @@ const HEALTH_POLL_INTERVAL: Duration = Duration::from_secs(5);
 /// truth and can never drift apart. Four weeks comfortably outlives any
 /// normal uptime even without renewal; the renewal mechanism above exists so
 /// that ceiling is never actually load-bearing.
-const ROOT_TOKEN_DURATION: Duration = Duration::from_secs(4 * 7 * 24 * 3600);
+pub(crate) const ROOT_TOKEN_DURATION: Duration = Duration::from_secs(4 * 7 * 24 * 3600);
 
 /// Configuration for connecting to SurrealDB.
 #[derive(Debug, Clone, Deserialize)]
@@ -123,6 +126,31 @@ pub struct DbConfig {
     /// interval forever (D-11) — it never exits the process. Overridable via
     /// `AXIAM__DB__RECONNECT_MAX_RETRIES`; default 10.
     pub reconnect_max_retries: u32,
+    /// Number of INDEPENDENT `Surreal<Client>` handles the [`crate::DbPool`]
+    /// builds — each with its OWN router task, `reqwest` client (hence its own
+    /// implicit TCP pool) and renewable signin session (NOT `.clone()`s of one
+    /// handle). Overridable via `AXIAM__DB__POOL_SIZE`. DEFAULT `1` —
+    /// byte-for-byte today's behavior (one handle, one funnel, one session):
+    /// the safe-rollout default. `>1` is opt-in until F3 laptop data justifies
+    /// a new default. A value of `0` is treated as `1`.
+    pub pool_size: usize,
+    /// Process-wide cap on concurrent in-flight DB ops across ALL pooled
+    /// handles — the stampede bound, analogous to B1's `MAX_CONCURRENT_HASHES`
+    /// Argon2id gate. Overridable via `AXIAM__DB__POOL_MAX_IN_FLIGHT`.
+    /// DEFAULT `0` = **disabled/unbounded** (no semaphore is built and the
+    /// checkout acquire-timeout path can never fire) — this preserves today's
+    /// unbounded DB concurrency so the default config is a no-op behavior
+    /// change. Set a positive value to enable the bound; F3 tunes it against
+    /// real load. It must never be set below expected steady-state concurrency
+    /// or it becomes a latency source.
+    pub pool_max_in_flight: usize,
+    /// How long [`crate::DbPool::checkout`] waits for a semaphore permit before
+    /// returning the existing overload error (`AxiamError::ServiceUnavailable`
+    /// → HTTP 503, B1's taxonomy). Only consulted when `pool_max_in_flight > 0`.
+    /// Overridable via `AXIAM__DB__POOL_ACQUIRE_TIMEOUT_SECS`. DEFAULT `5`
+    /// (matches B1's `hash_acquire_timeout_secs` so backpressure feels the same
+    /// across the Argon2id gate and the DB pool).
+    pub pool_acquire_timeout_secs: u64,
 }
 
 impl Default for DbConfig {
@@ -137,6 +165,11 @@ impl Default for DbConfig {
             reconnect_base_ms: 250,
             reconnect_ceiling_ms: 30_000,
             reconnect_max_retries: 10,
+            // pool_size=1 + disabled cap ⇒ the pool is byte-for-byte today's
+            // single-funnel, unbounded-concurrency behavior (the safe default).
+            pool_size: 1,
+            pool_max_in_flight: 0,
+            pool_acquire_timeout_secs: 5,
         }
     }
 }
@@ -186,17 +219,6 @@ pub struct DbManager {
     /// and reconnect-loop tasks so all sides observe/refresh the SAME
     /// current handle (see module docs, Pitfall 2).
     db: Arc<RwLock<Surreal<Client>>>,
-    /// CQ-B48: a handle cloned ONCE at startup — the same auth-snapshot
-    /// generation the request-serving repositories receive from
-    /// `client_cloned()` during composition. The manager's own handle is
-    /// proactively re-signed-in, but those startup repo clones are NOT, so
-    /// after the root-token TTL (~4 weeks) they 401 while the manager handle
-    /// stays valid — an *undetectable* outage if `health_check` probes only the
-    /// manager. `health_check` also probes THIS handle so the readiness gate
-    /// trips exactly when the repositories' tokens expire (it shares their
-    /// lifetime); recovery still requires a restart, which is the honest signal
-    /// until the repo handles are made renewable.
-    health_probe: Surreal<Client>,
     /// Handle to the background proactive re-signin task (D-03/D-04),
     /// owned so it is explicitly droppable/abortable rather than a
     /// fire-and-forget detached task.
@@ -248,6 +270,41 @@ impl DbManager {
         // ever actually reaching this extended TTL.
         Self::extend_root_token_duration(config, ttl).await;
 
+        let (db, refresh_handle, reconnect_handle) = Self::connect_handle(config, ttl).await?;
+
+        info!("Successfully connected to SurrealDB");
+
+        Ok(Self {
+            db,
+            refresh_handle,
+            reconnect_handle,
+        })
+    }
+
+    /// Build ONE fully-independent, authenticated HTTP handle and spawn its
+    /// per-handle proactive re-signin ([`spawn_proactive_resignin`]) and
+    /// reconnect ([`spawn_reconnect_loop`]) tasks. This is the single shared
+    /// "one live handle + its own D-04/PERF-04 lifecycle" path that both
+    /// [`connect_with_ttl`](Self::connect_with_ttl) (the single-handle manager)
+    /// and [`crate::DbPool`] (N handles) construct through — so a pooled handle
+    /// is genuinely an independent connection with its own router task,
+    /// `reqwest` client and renewable session, never a `.clone()` that shares
+    /// one `Arc<inner>`.
+    ///
+    /// `pub(crate)` because the pool lives in a sibling module; the caller is
+    /// responsible for running [`extend_root_token_duration`](Self::extend_root_token_duration)
+    /// beforehand (idempotent, so once per process is enough even for N handles).
+    pub(crate) async fn connect_handle(
+        config: &DbConfig,
+        ttl: Duration,
+    ) -> Result<
+        (
+            Arc<RwLock<Surreal<Client>>>,
+            JoinHandle<()>,
+            JoinHandle<()>,
+        ),
+        surrealdb::Error,
+    > {
         let db = Surreal::new::<Http>(&config.url).await?;
         db.signin(Root {
             username: config.username.clone(),
@@ -258,28 +315,19 @@ impl DbManager {
             .use_db(&config.database)
             .await?;
 
-        info!("Successfully connected to SurrealDB");
-
         let db = Arc::new(RwLock::new(db));
-        // CQ-B48: capture a startup-generation clone (same lineage as the repo
-        // clones built during composition) for expiry-detecting health checks.
-        let health_probe = db.read().await.clone();
         let refresh_handle = Self::spawn_proactive_resignin(Arc::clone(&db), config, ttl);
         let reconnect_handle = Self::spawn_reconnect_loop(Arc::clone(&db), config.clone());
-
-        Ok(Self {
-            db,
-            health_probe,
-            refresh_handle,
-            reconnect_handle,
-        })
+        Ok((db, refresh_handle, reconnect_handle))
     }
 
     /// Best-effort: redefine the root user with a long token duration so the
     /// connection's cached JWT does not expire mid-process. Failures are logged
     /// and ignored (the server still starts; it just reverts to the ~1h window).
-    /// Idempotent — safe to run on every startup.
-    async fn extend_root_token_duration(config: &DbConfig, ttl: Duration) {
+    /// Idempotent — safe to run on every startup (and once per process is
+    /// enough even when [`crate::DbPool`] builds N handles). `pub(crate)` so the
+    /// pool module can run it once before constructing its handles.
+    pub(crate) async fn extend_root_token_duration(config: &DbConfig, ttl: Duration) {
         let setup = match Surreal::new::<Http>(&config.url).await {
             Ok(s) => s,
             Err(e) => {
@@ -497,11 +545,12 @@ impl DbManager {
     /// successful reconnect-loop swap is observed by the very next call.
     ///
     /// Callers may further `.clone()` the returned value to obtain an
-    /// additional handle. With the HTTP engine clones share the stored
-    /// namespace/database selection, but NOT future re-signin/reconnect
-    /// traffic on the manager's own handle — see module docs' "Known
-    /// residual gap"; repositories keep their own independent snapshot
-    /// exactly as before this migration (RESEARCH Pitfall 2 — out of scope).
+    /// additional handle sharing this handle's `Arc<inner>` (same router +
+    /// `reqwest` client). Production composition no longer uses this to fan out
+    /// repositories — that path is now [`crate::DbPool::handle_for_repo`], which
+    /// hands out INDEPENDENT, renewable pooled handles (see the module-doc
+    /// "Session lifecycle" section). This accessor is retained for the
+    /// single-handle [`DbManager`] and its resilience tests.
     pub async fn client_cloned(&self) -> Surreal<Client> {
         // F1 instrumentation (zero behavior change): count how many handles are
         // handed out. Under the current single-router architecture every clone
@@ -537,17 +586,6 @@ impl DbManager {
             .map_err(Self::classify_query_error)?;
         // Surface any statement-level error (HTTP returns 200 even on SQL error).
         result.check().map_err(Self::classify_query_error)?;
-        drop(guard);
-
-        // CQ-B48: also exercise the startup-generation handle so the readiness
-        // probe alarms when the request-serving repositories' tokens expire —
-        // the manager handle above is proactively re-signed-in and would report
-        // healthy even while every repo DB request 401s.
-        let probe =
-            metrics::instrument_query("health_check.probe", self.health_probe.query("RETURN 1"))
-                .await
-                .map_err(Self::classify_query_error)?;
-        probe.check().map_err(Self::classify_query_error)?;
         Ok(())
     }
 

--- a/crates/axiam-db/src/connection.rs
+++ b/crates/axiam-db/src/connection.rs
@@ -297,14 +297,8 @@ impl DbManager {
     pub(crate) async fn connect_handle(
         config: &DbConfig,
         ttl: Duration,
-    ) -> Result<
-        (
-            Arc<RwLock<Surreal<Client>>>,
-            JoinHandle<()>,
-            JoinHandle<()>,
-        ),
-        surrealdb::Error,
-    > {
+    ) -> Result<(Arc<RwLock<Surreal<Client>>>, JoinHandle<()>, JoinHandle<()>), surrealdb::Error>
+    {
         let db = Surreal::new::<Http>(&config.url).await?;
         db.signin(Root {
             username: config.username.clone(),

--- a/crates/axiam-db/src/lib.rs
+++ b/crates/axiam-db/src/lib.rs
@@ -10,6 +10,7 @@
 mod connection;
 mod error;
 pub mod helpers;
+pub mod metrics;
 pub mod repository;
 mod schema;
 pub mod seeder;

--- a/crates/axiam-db/src/lib.rs
+++ b/crates/axiam-db/src/lib.rs
@@ -17,9 +17,9 @@ mod schema;
 pub mod seeder;
 
 pub use connection::{DbConfig, DbManager};
-pub use pool::{DbCheckout, DbPool};
 pub use error::DbError;
 pub use helpers::{CountRow, parse_uuid, take_first_or_not_found};
+pub use pool::{DbCheckout, DbPool};
 pub use repository::{
     SurrealAccountDeletionRepository, SurrealAmqpNonceRepository, SurrealAssertionReplayRepository,
     SurrealAuditLogRepository, SurrealAuthorizationCodeRepository, SurrealCaCertificateRepository,

--- a/crates/axiam-db/src/lib.rs
+++ b/crates/axiam-db/src/lib.rs
@@ -11,11 +11,13 @@ mod connection;
 mod error;
 pub mod helpers;
 pub mod metrics;
+mod pool;
 pub mod repository;
 mod schema;
 pub mod seeder;
 
 pub use connection::{DbConfig, DbManager};
+pub use pool::{DbCheckout, DbPool};
 pub use error::DbError;
 pub use helpers::{CountRow, parse_uuid, take_first_or_not_found};
 pub use repository::{

--- a/crates/axiam-db/src/metrics.rs
+++ b/crates/axiam-db/src/metrics.rs
@@ -1,0 +1,191 @@
+//! Zero-behavior-change instrumentation for the `axiam-db` boundary (F1).
+//!
+//! ## Why instrument here and not inside `surrealdb`
+//!
+//! The pinned `surrealdb` 3.2.1 HTTP engine spawns a tokio task **per request**
+//! over one shared `reqwest::Client`, and every `Surreal::clone()` shares the
+//! same `Arc<inner>` — so the whole process funnels DB traffic through a single
+//! router dispatch task with **no upper bound** on concurrency (see
+//! `connection.rs` module docs and `claude_dev/db-pool-design.md`). The crate
+//! exposes no hook into that router channel, so we cannot measure its internal
+//! queue depth directly. Instead we instrument **our own** call path — the point
+//! at which `axiam-db` hands a query to the SurrealDB client — which is the
+//! boundary a `DbPool` (F2) will own.
+//!
+//! ## What this module provides
+//!
+//! * [`db_in_flight`] — a process-wide gauge of DB requests currently awaiting a
+//!   response through the `axiam-db` boundary. Under the current single-funnel
+//!   architecture this is the count of requests contending for the one shared
+//!   dispatcher; after F2 it becomes the pool's aggregate in-flight count that
+//!   the `AXIAM__DB__POOL_MAX_IN_FLIGHT` semaphore bounds.
+//! * [`db_handle_checkouts`] — a monotonic counter of how many `Surreal<Client>`
+//!   handles have been handed out via [`DbManager::client_cloned`]. Today every
+//!   one of these is a clone that shares the single router — so this counter
+//!   directly quantifies the "single funnel" fan-in (~30 repositories at
+//!   startup). After F2 the equivalent counter measures per-handle checkouts.
+//! * [`instrument_query`] — a **transparent passthrough** wrapper that measures
+//!   spawn→response latency and maintains the in-flight gauge around a query
+//!   future, emitting a structured `tracing` event on completion.
+//!
+//! ## Zero behavior change (invariant)
+//!
+//! Nothing here introduces a new `.await` that alters ordering or latency
+//! semantics of the wrapped work: [`instrument_query`] awaits exactly the future
+//! it was given and returns its output unchanged; the gauge is a relaxed atomic
+//! inc/dec; the emitted `tracing` event is a no-op when no subscriber is
+//! attached. A gauge/counter read never blocks. F2 will route the repository
+//! query path through [`instrument_query`]; F1 only adds the machinery and wires
+//! the two boundary choke points that already exist today ([`DbManager::client_cloned`]
+//! and [`DbManager::health_check`]).
+
+use std::future::IntoFuture;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::time::Instant;
+
+use tracing::trace;
+
+/// Process-wide count of DB requests currently in flight through the
+/// `axiam-db` boundary (incremented on entry to [`instrument_query`],
+/// decremented when its future resolves — even on error/panic, via the RAII
+/// guard). Relaxed ordering is sufficient: this is an observability gauge, not
+/// a synchronization primitive.
+static DB_IN_FLIGHT: AtomicI64 = AtomicI64::new(0);
+
+/// Monotonic count of `Surreal<Client>` handles handed out by
+/// [`DbManager::client_cloned`]. See module docs — under today's
+/// single-router architecture this measures the single-funnel fan-in.
+static DB_HANDLE_CHECKOUTS: AtomicU64 = AtomicU64::new(0);
+
+/// Current number of DB requests in flight through the `axiam-db` boundary.
+/// Public so tests (and F2's pool) can assert the gauge tracks entry/exit.
+pub fn db_in_flight() -> i64 {
+    DB_IN_FLIGHT.load(Ordering::Relaxed)
+}
+
+/// Total handles checked out via [`DbManager::client_cloned`] since process
+/// start. Public for tests and for a future readiness/metrics endpoint.
+pub fn db_handle_checkouts() -> u64 {
+    DB_HANDLE_CHECKOUTS.load(Ordering::Relaxed)
+}
+
+/// Record that a client handle was checked out (called from
+/// [`DbManager::client_cloned`]). Zero behavior change — a single relaxed
+/// atomic increment plus a `trace` event.
+pub(crate) fn record_handle_checkout() {
+    let n = DB_HANDLE_CHECKOUTS.fetch_add(1, Ordering::Relaxed) + 1;
+    trace!(
+        target: "axiam_db::metrics",
+        handle_checkouts_total = n,
+        "axiam-db client handle checked out (single-router funnel until F2 pool lands)"
+    );
+}
+
+/// RAII gauge guard: increments [`DB_IN_FLIGHT`] on construction and
+/// decrements it on drop, so the gauge is correct even if the guarded future
+/// is cancelled or panics. Not exported directly — callers use
+/// [`instrument_query`], but F2 may reuse this pattern for the pool's own
+/// checkout guard.
+struct InFlightGuard {
+    op: &'static str,
+    started: Instant,
+    peak: i64,
+}
+
+impl InFlightGuard {
+    fn enter(op: &'static str) -> Self {
+        let peak = DB_IN_FLIGHT.fetch_add(1, Ordering::Relaxed) + 1;
+        Self {
+            op,
+            started: Instant::now(),
+            peak,
+        }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        DB_IN_FLIGHT.fetch_sub(1, Ordering::Relaxed);
+        // Emit spawn→response latency at TRACE so it is free when no subscriber
+        // is attached and opt-in when the operator wants DB-boundary timing.
+        trace!(
+            target: "axiam_db::metrics",
+            op = self.op,
+            latency_us = self.started.elapsed().as_micros() as u64,
+            in_flight_at_entry = self.peak,
+            "axiam-db query completed"
+        );
+    }
+}
+
+/// Wrap a DB query future so the in-flight gauge and spawn→response latency are
+/// observed at the `axiam-db` boundary.
+///
+/// **Transparent passthrough:** awaits exactly `fut` and returns its output
+/// unchanged — no added await points, no reordering, no altered error
+/// semantics. Safe to drop onto the hot path (F2 routes the repository query
+/// path through here); F1 wires only the choke points that exist today.
+pub async fn instrument_query<F, T>(op: &'static str, fut: F) -> T
+where
+    // `IntoFuture` (not `Future`) so this accepts SurrealDB's `Query`/`Select`/…
+    // request builders directly — they implement `IntoFuture`, not `Future`, and
+    // `.await` drives them through it. Plain futures also satisfy this bound.
+    F: IntoFuture<Output = T>,
+{
+    let _guard = InFlightGuard::enter(op);
+    fut.await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_checkout_counter_increments_monotonically() {
+        let before = db_handle_checkouts();
+        record_handle_checkout();
+        record_handle_checkout();
+        assert_eq!(
+            db_handle_checkouts(),
+            before + 2,
+            "checkout counter must increment by exactly the number of checkouts"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_flight_gauge_is_incremented_during_and_restored_after() {
+        let baseline = db_in_flight();
+        // The gauge must read baseline+1 *inside* the instrumented future and
+        // return to baseline once it resolves.
+        let observed_inside = instrument_query("test.op", async { db_in_flight() }).await;
+        assert_eq!(
+            observed_inside,
+            baseline + 1,
+            "gauge must reflect the in-flight request while the future runs"
+        );
+        assert_eq!(
+            db_in_flight(),
+            baseline,
+            "gauge must return to baseline after the future resolves"
+        );
+    }
+
+    #[tokio::test]
+    async fn instrument_query_returns_inner_output_unchanged() {
+        // Passthrough invariant: the wrapper must yield exactly the inner value.
+        let out = instrument_query("test.passthrough", async { 40 + 2 }).await;
+        assert_eq!(out, 42);
+    }
+
+    #[tokio::test]
+    async fn gauge_restored_even_when_future_errors() {
+        let baseline = db_in_flight();
+        let r: Result<(), &str> = instrument_query("test.err", async { Err("boom") }).await;
+        assert!(r.is_err());
+        assert_eq!(
+            db_in_flight(),
+            baseline,
+            "gauge must be decremented on the error path too (RAII drop)"
+        );
+    }
+}

--- a/crates/axiam-db/src/pool.rs
+++ b/crates/axiam-db/src/pool.rs
@@ -378,7 +378,10 @@ mod tests {
         // times out — the acquire-timeout path cannot fire under the default.
         let a = pool.checkout().await.expect("checkout 1");
         let b = pool.checkout().await.expect("checkout 2");
-        let c = pool.checkout().await.expect("checkout 3 (never caps when disabled)");
+        let c = pool
+            .checkout()
+            .await
+            .expect("checkout 3 (never caps when disabled)");
         assert_eq!(
             pool.handles[0].in_flight.load(Ordering::Relaxed),
             3,
@@ -415,7 +418,11 @@ mod tests {
             .iter()
             .map(|h| h.in_flight.load(Ordering::Relaxed))
             .collect();
-        assert_eq!(counts, vec![3, 3, 3], "least-in-flight must spread load evenly");
+        assert_eq!(
+            counts,
+            vec![3, 3, 3],
+            "least-in-flight must spread load evenly"
+        );
         assert!(counts.iter().all(|c| *c > 0), "no handle may be starved");
 
         drop(held);
@@ -429,7 +436,10 @@ mod tests {
     #[tokio::test]
     async fn saturated_pool_times_out_to_service_unavailable() {
         let pool = DbPool::from_handles(vec![new_mem().await], 2, Duration::from_millis(20));
-        assert!(pool.semaphore.is_some(), "a positive cap must build a semaphore");
+        assert!(
+            pool.semaphore.is_some(),
+            "a positive cap must build a semaphore"
+        );
 
         // Saturate the 2 permits.
         let _a = pool.checkout().await.expect("1st permit");

--- a/crates/axiam-db/src/pool.rs
+++ b/crates/axiam-db/src/pool.rs
@@ -1,0 +1,522 @@
+//! Database connection pool (F2) — N independent `Surreal<Client>` handles.
+//!
+//! See `claude_dev/db-pool-design.md` for the full design rationale. In short:
+//!
+//! * The pinned `surrealdb` 3.2.1 HTTP engine offers **no** native connection
+//!   pool, and every `Surreal::clone()` shares one `Arc<inner>` (one router
+//!   task + one `reqwest` client). So the only way to get genuine dispatch
+//!   parallelism, N independent TCP pools, and independently-renewable sessions
+//!   is N separate `Surreal::new::<Http>(..) + signin` connections — exactly
+//!   what [`DbManager::connect_handle`] builds. [`DbPool`] holds N of them.
+//! * Each pooled handle carries its OWN proactive re-signin + reconnect loop
+//!   (the D-04/PERF-04 machinery previously applied only to the manager's
+//!   handle), so **CQ-B48 is closed**: no request can reach an un-renewed
+//!   snapshot session, and the former restart-only ~4-week token outage is gone.
+//! * A process-wide `tokio::sync::Semaphore` optionally bounds total concurrent
+//!   in-flight DB ops (the stampede fix, analogous to B1's Argon2id gate). On
+//!   acquire-timeout the checkout returns the **existing** overload error,
+//!   [`AxiamError::ServiceUnavailable`] → HTTP 503 — reusing B1's taxonomy
+//!   exactly (see [`acquire_db_permit`]).
+//!
+//! ## Safe-rollout invariant (`pool_size = 1`, cap disabled — the default)
+//!
+//! With the default [`DbConfig`] (`pool_size = 1`, `pool_max_in_flight = 0`)
+//! the pool is observably identical to today: exactly one handle (so
+//! least-in-flight selection and round-robin are no-ops), and **no** semaphore
+//! is built — [`DbPool::checkout`] never acquires a permit and the
+//! acquire-timeout path can never fire, preserving today's unbounded DB
+//! concurrency byte-for-byte. `pool_size > 1` / a positive cap is opt-in.
+
+use std::ops::Deref;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use axiam_core::error::AxiamError;
+use surrealdb::engine::remote::http::Client;
+use surrealdb::{Connection, Surreal};
+use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::task::JoinHandle;
+
+use crate::connection::{DbConfig, DbManager, ROOT_TOKEN_DURATION};
+use crate::error::DbError;
+use crate::metrics;
+
+/// One pooled handle: an independent `Surreal<C>` connection behind the same
+/// swappable `Arc<RwLock<..>>` [`DbManager`] uses (D-12, so its own reconnect
+/// loop can evict a poisoned handle), plus this handle's in-flight count
+/// (least-in-flight checkout input) and its two owned background tasks.
+struct PooledHandle<C: Connection> {
+    /// Swappable so the per-handle reconnect loop can atomically evict a
+    /// poisoned handle (D-12) — identical to `DbManager::db`.
+    db: Arc<RwLock<Surreal<C>>>,
+    /// In-flight count for THIS handle — the least-in-flight selection input.
+    /// Incremented by [`DbPool::checkout`], decremented when the returned
+    /// [`DbCheckout`] guard drops.
+    in_flight: Arc<AtomicUsize>,
+    /// Proactive re-signin task (D-04) for this handle. `None` for test-only
+    /// pools built over the embedded `kv-mem` engine, whose tokens never expire.
+    refresh_handle: Option<JoinHandle<()>>,
+    /// Reconnect loop (PERF-04) for this handle. `None` for `kv-mem` test pools.
+    reconnect_handle: Option<JoinHandle<()>>,
+}
+
+/// A pool of N independent, individually-renewable SurrealDB handles.
+///
+/// Generic over the connection type so the checkout/selection logic can be
+/// unit-tested against the embedded `kv-mem` engine (`DbPool<Db>`) where a live
+/// server would otherwise be required; production always uses the default
+/// `DbPool<Client>` (the HTTP engine) built via [`DbPool::connect`].
+pub struct DbPool<C: Connection = Client> {
+    handles: Vec<PooledHandle<C>>,
+    /// `None` when the in-flight cap is disabled (`pool_max_in_flight == 0`,
+    /// the default) — checkout then never acquires a permit, so today's
+    /// unbounded concurrency is preserved exactly.
+    semaphore: Option<Arc<Semaphore>>,
+    /// How long [`DbPool::checkout`] waits for a permit before returning the
+    /// overload error. Only consulted when `semaphore` is `Some`.
+    acquire_timeout: Duration,
+    /// Round-robin cursor for [`DbPool::handle_for_repo`] construction-time
+    /// binding (spreads repositories evenly across handles at startup).
+    rr: AtomicUsize,
+}
+
+impl DbPool<Client> {
+    /// Connect and build the pool using the fixed production
+    /// [`ROOT_TOKEN_DURATION`]. Mirrors [`DbManager::connect`].
+    pub async fn connect(config: &DbConfig) -> Result<Self, surrealdb::Error> {
+        Self::connect_with_ttl(config, ROOT_TOKEN_DURATION).await
+    }
+
+    /// Build a pool of `config.pool_size` INDEPENDENT handles (each via the
+    /// shared [`DbManager::connect_handle`] path — its own router task, its own
+    /// `reqwest` client, its own proactive re-signin + reconnect loop). The
+    /// root-token duration is extended once up-front (the DEFINE USER is
+    /// idempotent), then each handle signs in fresh and minting its own
+    /// long-lived token.
+    ///
+    /// `ttl` is a test hook (short TTLs prove per-handle session renewal without
+    /// waiting four weeks); production passes [`ROOT_TOKEN_DURATION`] via
+    /// [`connect`](Self::connect).
+    pub async fn connect_with_ttl(
+        config: &DbConfig,
+        ttl: Duration,
+    ) -> Result<Self, surrealdb::Error> {
+        // Guard against a misconfigured `pool_size = 0`: at least one handle.
+        let size = config.pool_size.max(1);
+        tracing::info!(
+            pool_size = size,
+            pool_max_in_flight = config.pool_max_in_flight,
+            "Building SurrealDB connection pool"
+        );
+
+        // Idempotent, once per process even for N handles (D-04/CORR-02).
+        DbManager::extend_root_token_duration(config, ttl).await;
+
+        let mut handles = Vec::with_capacity(size);
+        for _ in 0..size {
+            let (db, refresh, reconnect) = DbManager::connect_handle(config, ttl).await?;
+            handles.push(PooledHandle {
+                db,
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                refresh_handle: Some(refresh),
+                reconnect_handle: Some(reconnect),
+            });
+        }
+
+        tracing::info!(pool_size = size, "SurrealDB connection pool ready");
+        Ok(Self::assemble(
+            handles,
+            config.pool_max_in_flight,
+            Duration::from_secs(config.pool_acquire_timeout_secs),
+        ))
+    }
+
+    /// Assemble the pool struct from already-built handles. The semaphore is
+    /// built ONLY when `max_in_flight > 0` — a `0` (default) cap means no
+    /// semaphore at all, so the acquire path is entirely bypassed.
+    fn assemble(
+        handles: Vec<PooledHandle<Client>>,
+        max_in_flight: usize,
+        acquire_timeout: Duration,
+    ) -> Self {
+        Self {
+            handles,
+            semaphore: (max_in_flight > 0).then(|| Arc::new(Semaphore::new(max_in_flight))),
+            acquire_timeout,
+            rr: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl<C: Connection> DbPool<C> {
+    /// Number of pooled handles.
+    pub fn size(&self) -> usize {
+        self.handles.len()
+    }
+
+    /// Bind a handle to a repository at CONSTRUCTION time — the minimal-churn
+    /// repo seam (design §6, Option B). Returns an owned `Surreal<C>` bound to
+    /// one pooled handle, chosen round-robin so repositories spread evenly
+    /// across handles at startup. The repository then calls `self.db.query(..)`
+    /// exactly as before — repo bodies are untouched.
+    ///
+    /// This replaces the ~48 `db.client_cloned().await` composition sites. At
+    /// `pool_size = 1` it hands out clones of the single pooled handle exactly
+    /// as `DbManager::client_cloned()` did — byte-for-byte identical routing —
+    /// the only difference being that the handle is now proactively re-signed-in
+    /// (a strict improvement over the frozen snapshot it replaces).
+    pub async fn handle_for_repo(&self) -> Surreal<C> {
+        // Preserve the F1 checkout counter semantics (handles handed to repos).
+        metrics::record_handle_checkout();
+        let idx = self.rr.fetch_add(1, Ordering::Relaxed) % self.handles.len();
+        self.handles[idx].db.read().await.clone()
+    }
+
+    /// Per-operation checkout with least-in-flight handle selection and, when
+    /// the cap is enabled, a process-wide concurrency bound.
+    ///
+    /// 1. If the in-flight cap is enabled, acquire a semaphore permit within
+    ///    `acquire_timeout`; on timeout return [`AxiamError::ServiceUnavailable`]
+    ///    (HTTP 503, B1's overload taxonomy — see [`acquire_db_permit`]). When
+    ///    the cap is disabled (default) this step is skipped entirely.
+    /// 2. Pick the handle with the smallest current in-flight count (ties → the
+    ///    lowest index); this is load-aware and steers work away from a
+    ///    momentarily-congested handle. It is a no-op at `pool_size = 1`.
+    /// 3. Increment that handle's in-flight count and return a [`DbCheckout`]
+    ///    RAII guard that holds the permit and decrements the count on drop.
+    pub async fn checkout(&self) -> Result<DbCheckout<C>, AxiamError> {
+        let permit = match &self.semaphore {
+            Some(sem) => Some(acquire_db_permit(sem, self.acquire_timeout).await?),
+            None => None,
+        };
+
+        let idx = self.select_least_in_flight();
+        let slot = &self.handles[idx];
+        slot.in_flight.fetch_add(1, Ordering::Relaxed);
+        let handle = slot.db.read().await.clone();
+
+        Ok(DbCheckout {
+            handle,
+            in_flight: Arc::clone(&slot.in_flight),
+            _permit: permit,
+        })
+    }
+
+    /// Index of the least-in-flight handle (ties broken by lowest index).
+    /// Reads each count `Relaxed` — an approximate hint is fine, so no lock is
+    /// taken on the hot path (design §3.1).
+    fn select_least_in_flight(&self) -> usize {
+        let mut best = 0usize;
+        let mut best_load = usize::MAX;
+        for (i, h) in self.handles.iter().enumerate() {
+            let load = h.in_flight.load(Ordering::Relaxed);
+            if load < best_load {
+                best_load = load;
+                best = i;
+            }
+        }
+        best
+    }
+
+    /// Readiness probe: query EVERY pooled handle so readiness reflects the
+    /// whole pool (an auth-expired or poisoned handle anywhere trips the gate).
+    /// Each probe is routed through the F1 [`metrics::instrument_query`] gauge.
+    /// An auth failure classifies as [`DbError::Unhealthy`] (D-05) so `/ready`
+    /// alarms rather than treating it as a transient query error.
+    pub async fn health_check(&self) -> Result<(), DbError> {
+        for slot in &self.handles {
+            let guard = slot.db.read().await;
+            let result = metrics::instrument_query("health_check.pool", guard.query("RETURN 1"))
+                .await
+                .map_err(DbManager::classify_query_error)?;
+            result.check().map_err(DbManager::classify_query_error)?;
+        }
+        Ok(())
+    }
+
+    /// Test-only constructor: build a pool directly over already-open handles
+    /// (e.g. embedded `kv-mem` instances) with no background renewal tasks, so
+    /// the checkout/selection/cap logic can be exercised without a live server.
+    #[cfg(test)]
+    fn from_handles(raw: Vec<Surreal<C>>, max_in_flight: usize, acquire_timeout: Duration) -> Self {
+        let handles = raw
+            .into_iter()
+            .map(|db| PooledHandle {
+                db: Arc::new(RwLock::new(db)),
+                in_flight: Arc::new(AtomicUsize::new(0)),
+                refresh_handle: None,
+                reconnect_handle: None,
+            })
+            .collect();
+        Self {
+            handles,
+            semaphore: (max_in_flight > 0).then(|| Arc::new(Semaphore::new(max_in_flight))),
+            acquire_timeout,
+            rr: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl<C: Connection> Drop for DbPool<C> {
+    fn drop(&mut self) {
+        // Explicitly stop each handle's background tasks (mirrors
+        // `DbManager::drop`) so a dropped pool never leaks detached tasks.
+        for slot in &self.handles {
+            if let Some(t) = &slot.refresh_handle {
+                t.abort();
+            }
+            if let Some(t) = &slot.reconnect_handle {
+                t.abort();
+            }
+        }
+    }
+}
+
+/// RAII checkout guard. `Deref`s to the chosen `Surreal<C>` so callers use it
+/// exactly like the owned handle they hold today (`checkout().query(..)`).
+/// Holds the semaphore permit (released on drop) and decrements the chosen
+/// handle's in-flight count on drop.
+pub struct DbCheckout<C: Connection = Client> {
+    /// Owned clone of the chosen pooled handle, read once out of its `RwLock`
+    /// at checkout time (a later reconnect-loop swap is observed by the NEXT
+    /// checkout, not this in-flight one).
+    handle: Surreal<C>,
+    in_flight: Arc<AtomicUsize>,
+    /// `None` when the cap is disabled; `Some` holds a permit released on drop.
+    _permit: Option<OwnedSemaphorePermit>,
+}
+
+impl<C: Connection> Deref for DbCheckout<C> {
+    type Target = Surreal<C>;
+    fn deref(&self) -> &Self::Target {
+        &self.handle
+    }
+}
+
+impl<C: Connection> Drop for DbCheckout<C> {
+    fn drop(&mut self) {
+        self.in_flight.fetch_sub(1, Ordering::Relaxed);
+        // `_permit` (if any) is released as the field drops.
+    }
+}
+
+/// Acquire a permit from the pool's in-flight semaphore, bounded by `timeout`.
+///
+/// Mirrors `axiam_auth::crypto_gate::acquire_hash_permit` EXACTLY so the DB
+/// pool and the Argon2id gate (B1) share ONE overload taxonomy:
+///
+/// * success → the held [`OwnedSemaphorePermit`] (drop to release),
+/// * acquire-timeout → [`AxiamError::ServiceUnavailable`] (the REST layer maps
+///   this to **HTTP 503** — a transient server-capacity condition, not a
+///   per-client rate-limit),
+/// * a closed semaphore (never happens — the pool never closes it) →
+///   [`AxiamError::Internal`].
+///
+/// `DbError` intentionally grows NO `ServiceUnavailable` variant — surfacing the
+/// existing `AxiamError` here keeps a single overload shape across B1 and F2
+/// (design §3.2).
+async fn acquire_db_permit(
+    sem: &Arc<Semaphore>,
+    timeout: Duration,
+) -> Result<OwnedSemaphorePermit, AxiamError> {
+    match tokio::time::timeout(timeout, Arc::clone(sem).acquire_owned()).await {
+        Ok(Ok(permit)) => Ok(permit),
+        Ok(Err(_closed)) => Err(AxiamError::Internal("db pool semaphore closed".into())),
+        Err(_elapsed) => Err(AxiamError::ServiceUnavailable(
+            "database is at capacity; please retry shortly".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surrealdb::engine::local::{Db, Mem};
+
+    /// A fresh embedded `kv-mem` handle with ns/db selected.
+    async fn new_mem() -> Surreal<Db> {
+        let db = Surreal::new::<Mem>(()).await.expect("in-memory connect");
+        db.use_ns("test").use_db("test").await.expect("use ns/db");
+        db
+    }
+
+    /// A `kv-mem` handle carrying a distinguishing marker row, so a handle swap
+    /// (D-12) is observable across handles.
+    async fn new_marked(marker: &str) -> Surreal<Db> {
+        let db = new_mem().await;
+        db.query(format!("CREATE marker SET value = '{marker}'"))
+            .await
+            .and_then(|r| r.check())
+            .expect("seed marker row");
+        db
+    }
+
+    async fn read_marker(db: &Surreal<Db>) -> Vec<String> {
+        let mut result = db
+            .query("SELECT VALUE value FROM marker")
+            .await
+            .and_then(|r| r.check())
+            .expect("read marker rows");
+        result.take(0).expect("deserialize marker values")
+    }
+
+    /// Safe-rollout invariant: `pool_size = 1` with the DISABLED cap (the
+    /// default) builds no semaphore, routes every checkout/handle to the single
+    /// handle, and NEVER trips the acquire-timeout path no matter how many
+    /// checkouts are held concurrently.
+    #[tokio::test]
+    async fn pool_size_one_default_is_a_single_uncapped_handle() {
+        let pool = DbPool::from_handles(vec![new_mem().await], 0, Duration::from_millis(20));
+        assert_eq!(pool.size(), 1);
+        assert!(
+            pool.semaphore.is_none(),
+            "disabled cap (0) must build NO semaphore — today's unbounded behavior"
+        );
+
+        // Hold several checkouts at once; with the cap disabled none blocks or
+        // times out — the acquire-timeout path cannot fire under the default.
+        let a = pool.checkout().await.expect("checkout 1");
+        let b = pool.checkout().await.expect("checkout 2");
+        let c = pool.checkout().await.expect("checkout 3 (never caps when disabled)");
+        assert_eq!(
+            pool.handles[0].in_flight.load(Ordering::Relaxed),
+            3,
+            "all checkouts map to the one handle"
+        );
+        drop((a, b, c));
+        assert_eq!(
+            pool.handles[0].in_flight.load(Ordering::Relaxed),
+            0,
+            "in-flight returns to zero once guards drop"
+        );
+
+        // handle_for_repo always hands out the single handle.
+        let _h = pool.handle_for_repo().await;
+    }
+
+    /// Least-in-flight spreads concurrent load evenly across handles and starves
+    /// none; releasing the guards returns every handle to zero in-flight.
+    #[tokio::test]
+    async fn checkout_spreads_load_least_in_flight_across_handles() {
+        let pool = DbPool::from_handles(
+            vec![new_mem().await, new_mem().await, new_mem().await],
+            0,
+            Duration::from_millis(20),
+        );
+
+        // 9 simultaneously-held checkouts over 3 handles → 3 each (least-in-flight).
+        let mut held = Vec::new();
+        for _ in 0..9 {
+            held.push(pool.checkout().await.expect("checkout"));
+        }
+        let counts: Vec<usize> = pool
+            .handles
+            .iter()
+            .map(|h| h.in_flight.load(Ordering::Relaxed))
+            .collect();
+        assert_eq!(counts, vec![3, 3, 3], "least-in-flight must spread load evenly");
+        assert!(counts.iter().all(|c| *c > 0), "no handle may be starved");
+
+        drop(held);
+        for h in &pool.handles {
+            assert_eq!(h.in_flight.load(Ordering::Relaxed), 0, "all released");
+        }
+    }
+
+    /// Bounded concurrency + acquire-timeout → the reused overload error.
+    /// Mirrors `crypto_gate::times_out_to_service_unavailable_when_saturated`.
+    #[tokio::test]
+    async fn saturated_pool_times_out_to_service_unavailable() {
+        let pool = DbPool::from_handles(vec![new_mem().await], 2, Duration::from_millis(20));
+        assert!(pool.semaphore.is_some(), "a positive cap must build a semaphore");
+
+        // Saturate the 2 permits.
+        let _a = pool.checkout().await.expect("1st permit");
+        let _b = pool.checkout().await.expect("2nd permit");
+
+        // A 3rd checkout with a tiny timeout must return the 503 overload error.
+        match pool.checkout().await {
+            Err(AxiamError::ServiceUnavailable(_)) => {}
+            Err(other) => panic!("expected ServiceUnavailable backpressure error, got {other:?}"),
+            Ok(_) => panic!("expected ServiceUnavailable backpressure error, got a checkout"),
+        }
+    }
+
+    /// Peak concurrency never exceeds the permit count (memory/stampede bound).
+    /// Mirrors `crypto_gate::concurrency_is_bounded_to_permit_count`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrency_is_bounded_to_permit_count() {
+        const PERMITS: usize = 2;
+        const TASKS: usize = 8;
+        let pool = Arc::new(DbPool::from_handles(
+            vec![new_mem().await],
+            PERMITS,
+            Duration::from_secs(5),
+        ));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_observed = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::new();
+        for _ in 0..TASKS {
+            let pool = Arc::clone(&pool);
+            let in_flight = Arc::clone(&in_flight);
+            let max_observed = Arc::clone(&max_observed);
+            tasks.push(tokio::spawn(async move {
+                let _guard = pool.checkout().await.expect("checkout within timeout");
+                let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                max_observed.fetch_max(now, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        assert!(
+            max_observed.load(Ordering::SeqCst) <= PERMITS,
+            "observed concurrency {} exceeded permit bound {PERMITS}",
+            max_observed.load(Ordering::SeqCst)
+        );
+    }
+
+    /// Per-handle poisoned-handle eviction (D-12) — mirrors
+    /// `connection.rs::poisoned_handle_is_evicted_and_never_returned_after_swap`
+    /// but proves the swap is isolated to ONE pooled handle: swapping handle 0's
+    /// `Arc<RwLock<Surreal<C>>>` under the write guard leaves the OTHER pooled
+    /// handles untouched.
+    #[tokio::test]
+    async fn poisoned_handle_evicted_per_handle_others_unaffected() {
+        let pool = DbPool::from_handles(
+            vec![new_marked("old-0").await, new_marked("keep-1").await],
+            0,
+            Duration::from_millis(20),
+        );
+
+        // Pre-swap: handle 0 is the "old" (poisoned) one.
+        {
+            let pre = pool.handles[0].db.read().await.clone();
+            assert_eq!(read_marker(&pre).await, vec!["old-0".to_string()]);
+        }
+
+        // Evict handle 0 by swapping a fresh handle in under the write guard,
+        // exactly as spawn_reconnect_loop does (`*db.write().await = fresh`).
+        let fresh = new_marked("new-0").await;
+        *pool.handles[0].db.write().await = fresh;
+
+        // Handle 0 now observes ONLY the new handle...
+        let post0 = pool.handles[0].db.read().await.clone();
+        assert_eq!(
+            read_marker(&post0).await,
+            vec!["new-0".to_string()],
+            "the poisoned handle must never be observed after the swap (D-12)"
+        );
+        // ...and the sibling handle is entirely unaffected by that swap.
+        let post1 = pool.handles[1].db.read().await.clone();
+        assert_eq!(
+            read_marker(&post1).await,
+            vec!["keep-1".to_string()],
+            "swapping one pooled handle must not disturb the others"
+        );
+    }
+}

--- a/crates/axiam-db/tests/connection_resilience_test.rs
+++ b/crates/axiam-db/tests/connection_resilience_test.rs
@@ -12,7 +12,7 @@
 
 use std::time::Duration;
 
-use axiam_db::{DbConfig, DbError, DbManager};
+use axiam_db::{DbConfig, DbError, DbManager, DbPool};
 use surrealdb::types::AuthError;
 
 /// Four weeks in seconds, mirroring `connection.rs`'s private
@@ -117,6 +117,9 @@ async fn recovers_from_token_expiry_without_restart() {
         reconnect_base_ms: 250,
         reconnect_ceiling_ms: 30_000,
         reconnect_max_retries: 10,
+        pool_size: 1,
+        pool_max_in_flight: 0,
+        pool_acquire_timeout_secs: 5,
     };
 
     // Short TTL: a 4s token, proactive re-signin at 0.5 * 4s = 2s — well
@@ -174,6 +177,9 @@ async fn reconnect_exhaustion_stays_unhealthy_and_keeps_probing_forever() {
         reconnect_base_ms: 50,
         reconnect_ceiling_ms: 200,
         reconnect_max_retries: 3,
+        pool_size: 1,
+        pool_max_in_flight: 0,
+        pool_acquire_timeout_secs: 5,
     };
 
     // Connect against the live server first (proves the manager itself is
@@ -227,6 +233,9 @@ async fn successful_reconnect_flips_health_back_to_ok_without_restart() {
         reconnect_base_ms: 50,
         reconnect_ceiling_ms: 200,
         reconnect_max_retries: 3,
+        pool_size: 1,
+        pool_max_in_flight: 0,
+        pool_acquire_timeout_secs: 5,
     };
 
     let short_ttl = Duration::from_secs(4);
@@ -240,4 +249,60 @@ async fn successful_reconnect_flips_health_back_to_ok_without_restart() {
     db.health_check()
         .await
         .expect("health_check should still be healthy without a process restart");
+}
+
+/// CQ-B48 closure proof (F2): a multi-handle [`DbPool`] built with a short,
+/// test-only root-token TTL keeps EVERY pooled handle authenticated past the
+/// raw TTL via each handle's own proactive re-signin task — so the repositories
+/// that bind those handles never hit the former restart-only ~4-week 401
+/// outage. Before F2, the ~30 `client_cloned()` repo snapshots were NOT renewed
+/// and would 401 once their token expired; here we drive queries through the
+/// pooled handles well past the TTL and assert no auth outage.
+///
+/// Requires a running SurrealDB (`just dev-up`). Run explicitly:
+/// `cargo test -p axiam-db --test connection_resilience_test -- --ignored`
+#[tokio::test]
+#[ignore = "requires a live SurrealDB instance (just dev-up)"]
+async fn pooled_handles_survive_token_expiry_without_restart() {
+    let config = DbConfig {
+        url: std::env::var("AXIAM_TEST_DB_URL").unwrap_or_else(|_| "127.0.0.1:8000".into()),
+        namespace: "axiam_test_cqb48".into(),
+        database: "pool_renewal".into(),
+        username: "root".into(),
+        password: "root".into(),
+        token_refresh_fraction: 0.5,
+        reconnect_base_ms: 250,
+        reconnect_ceiling_ms: 30_000,
+        reconnect_max_retries: 10,
+        // Three independent handles, each with its OWN renewal lifecycle.
+        pool_size: 3,
+        pool_max_in_flight: 0,
+        pool_acquire_timeout_secs: 5,
+    };
+
+    // 4s token, proactive re-signin at 0.5 * 4s = 2s per handle.
+    let short_ttl = Duration::from_secs(4);
+    let pool = DbPool::connect_with_ttl(&config, short_ttl)
+        .await
+        .expect("pool connect_with_ttl should succeed against a live SurrealDB");
+    assert_eq!(pool.size(), 3, "pool should have built three handles");
+
+    // Wait well past several proactive-refresh cycles and past the raw TTL.
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    // health_check probes ALL pooled handles — every one must still authenticate
+    // (the per-handle re-signin kept it inside the TTL; no 401 outage).
+    pool.health_check().await.expect(
+        "every pooled handle should still be healthy — per-handle re-signin \
+         kept each session alive without a process restart (CQ-B48 closed)",
+    );
+
+    // Drive a repo-style bound handle past the TTL too: a handle checked out for
+    // a repository must run a query cleanly, proving the snapshot-401 is gone.
+    let bound = pool.handle_for_repo().await;
+    bound
+        .query("RETURN 1")
+        .await
+        .and_then(|r| r.check())
+        .expect("a query on a pooled repo-bound handle should succeed post-TTL");
 }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -295,7 +295,8 @@ async fn main() -> std::io::Result<()> {
     {
         let boot_fed_repo =
             axiam_db::SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
-        let boot_audit_repo = axiam_db::SurrealAuditLogRepository::new(pool.handle_for_repo().await);
+        let boot_audit_repo =
+            axiam_db::SurrealAuditLogRepository::new(pool.handle_for_repo().await);
         if let Some(fed_key) = config.auth.federation_encryption_key {
             match axiam_federation::secrets::migrate_plaintext_federation_secrets(
                 &boot_fed_repo,
@@ -369,10 +370,12 @@ async fn main() -> std::io::Result<()> {
                 // Back-fill default-role grants for any permissions added to the
                 // registry since this tenant was bootstrapped (bootstrap, which
                 // grants permissions to roles, self-disables after first admin).
-                let backfilled =
-                    axiam_db::reconcile_default_role_grants(&pool.handle_for_repo().await, tenant.id)
-                        .await
-                        .expect("Failed to reconcile default role grants for tenant");
+                let backfilled = axiam_db::reconcile_default_role_grants(
+                    &pool.handle_for_repo().await,
+                    tenant.id,
+                )
+                .await
+                .expect("Failed to reconcile default role grants for tenant");
                 if backfilled > 0 {
                     tracing::info!(
                         tenant = %tenant.id,
@@ -515,7 +518,8 @@ async fn main() -> std::io::Result<()> {
     // `web::Data<SurrealNotificationRuleRepository>` extractor. Without this
     // registration every /api/v1/notification-rules request 500s with
     // "App data is not configured".
-    let notification_rule_repo = SurrealNotificationRuleRepository::new(pool.handle_for_repo().await);
+    let notification_rule_repo =
+        SurrealNotificationRuleRepository::new(pool.handle_for_repo().await);
     // Email-config repository (28-04, FUNC-03) — required by the
     // `handlers::email_config::*` handlers' `web::Data<SurrealEmailConfigRepository<C>>`
     // extractor. Only constructed when AXIAM__EMAIL_ENCRYPTION_KEY is present (same
@@ -537,7 +541,8 @@ async fn main() -> std::io::Result<()> {
                 None
             }
         };
-    let federation_config_repo = SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
+    let federation_config_repo =
+        SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
     let federation_link_repo = SurrealFederationLinkRepository::new(pool.handle_for_repo().await);
     let assertion_replay_repo = SurrealAssertionReplayRepository::new(pool.handle_for_repo().await);
     // NEW-4: durable AMQP nonce store for replay protection, shared by the
@@ -564,7 +569,8 @@ async fn main() -> std::io::Result<()> {
     let refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
     // Separate instance for password-reset/change handlers that need direct
     // RefreshTokenRepository access via web::Data (TokenService owns the main one).
-    let handler_refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
+    let handler_refresh_token_repo =
+        SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
 
     // OAuth2 authorization code grant services.
     let authorize_service = AuthorizeService::new(

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -48,7 +48,7 @@ use axiam_auth::{
 };
 use axiam_core::repository::{OrganizationRepository, Pagination, TenantRepository};
 use axiam_db::{
-    DbConfig, DbManager, SurrealAccountDeletionRepository, SurrealAmqpNonceRepository,
+    DbConfig, SurrealAccountDeletionRepository, SurrealAmqpNonceRepository,
     SurrealAssertionReplayRepository, SurrealAuditLogRepository,
     SurrealAuthorizationCodeRepository, SurrealCaCertificateRepository,
     SurrealCertificateRepository, SurrealEmailConfigRepository, SurrealEmailTemplateRepository,
@@ -247,13 +247,18 @@ async fn main() -> std::io::Result<()> {
         }
     }
 
-    // Connect to SurrealDB
-    let db = DbManager::connect(&config.db)
-        .await
-        .expect("Failed to connect to SurrealDB");
+    // Connect to SurrealDB. `DbPool` holds N independent, individually-renewable
+    // handles (default `pool_size = 1` ⇒ byte-for-byte today's single handle).
+    // Held as `Arc` because it is both the source of every repository's bound
+    // handle (`handle_for_repo`) and the process health checker.
+    let pool = Arc::new(
+        axiam_db::DbPool::connect(&config.db)
+            .await
+            .expect("Failed to connect to SurrealDB"),
+    );
 
     // Run schema migrations
-    axiam_db::run_migrations(&db.client_cloned().await)
+    axiam_db::run_migrations(&pool.handle_for_repo().await)
         .await
         .expect("Failed to run database migrations");
 
@@ -264,7 +269,7 @@ async fn main() -> std::io::Result<()> {
     // Errors are logged, never fatal — an unminted token just means the
     // env-var gate (AXIAM_BOOTSTRAP_ADMIN_EMAIL) remains the only way in,
     // which is a safe (fail-closed) degraded state, not a startup blocker.
-    match axiam_db::mint_bootstrap_setup_token_if_needed(&db.client_cloned().await).await {
+    match axiam_db::mint_bootstrap_setup_token_if_needed(&pool.handle_for_repo().await).await {
         Ok(Some(token)) => {
             // D-03b: the ONE deliberate secret-log exception — logged exactly
             // once, at first boot only. Only the sha256 hash is ever
@@ -289,8 +294,8 @@ async fn main() -> std::io::Result<()> {
     // to avoid serving plaintext-secret rows after this deploy.
     {
         let boot_fed_repo =
-            axiam_db::SurrealFederationConfigRepository::new(db.client_cloned().await);
-        let boot_audit_repo = axiam_db::SurrealAuditLogRepository::new(db.client_cloned().await);
+            axiam_db::SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
+        let boot_audit_repo = axiam_db::SurrealAuditLogRepository::new(pool.handle_for_repo().await);
         if let Some(fed_key) = config.auth.federation_encryption_key {
             match axiam_federation::secrets::migrate_plaintext_federation_secrets(
                 &boot_fed_repo,
@@ -316,7 +321,7 @@ async fn main() -> std::io::Result<()> {
     {
         if let Some(email_key) = config.email_encryption_key {
             let boot_email_repo =
-                SurrealEmailConfigRepository::new(db.client_cloned().await, email_key);
+                SurrealEmailConfigRepository::new(pool.handle_for_repo().await, email_key);
             match boot_email_repo.backfill_plaintext_secrets().await {
                 Ok(n) => tracing::info!(migrated = n, "email config secrets backfill complete"),
                 Err(e) => tracing::warn!(error = %e, "email config secrets backfill failed"),
@@ -332,8 +337,8 @@ async fn main() -> std::io::Result<()> {
     // Seed permissions for all existing tenants (D-07).
     // Uses UPSERT — safe to run on every startup.
     {
-        let seed_org_repo = SurrealOrganizationRepository::new(db.client_cloned().await);
-        let seed_tenant_repo = SurrealTenantRepository::new(db.client_cloned().await);
+        let seed_org_repo = SurrealOrganizationRepository::new(pool.handle_for_repo().await);
+        let seed_tenant_repo = SurrealTenantRepository::new(pool.handle_for_repo().await);
         let all_orgs = seed_org_repo
             .list(Pagination {
                 offset: 0,
@@ -355,7 +360,7 @@ async fn main() -> std::io::Result<()> {
                 .expect("Failed to list tenants for permission seeding");
             for tenant in tenants.items {
                 axiam_db::seed_permissions(
-                    &db.client_cloned().await,
+                    &pool.handle_for_repo().await,
                     tenant.id,
                     axiam_api_rest::permissions::PERMISSION_REGISTRY,
                 )
@@ -365,7 +370,7 @@ async fn main() -> std::io::Result<()> {
                 // registry since this tenant was bootstrapped (bootstrap, which
                 // grants permissions to roles, self-disables after first admin).
                 let backfilled =
-                    axiam_db::reconcile_default_role_grants(&db.client_cloned().await, tenant.id)
+                    axiam_db::reconcile_default_role_grants(&pool.handle_for_repo().await, tenant.id)
                         .await
                         .expect("Failed to reconcile default role grants for tenant");
                 if backfilled > 0 {
@@ -405,11 +410,11 @@ async fn main() -> std::io::Result<()> {
 
     // Raw SurrealDB handle — registered as app_data so handlers that need direct
     // access (e.g. /api/v1/admin/bootstrap) can request `web::Data<Surreal<C>>`.
-    let db_handle = db.client_cloned().await;
-    let org_repo = SurrealOrganizationRepository::new(db.client_cloned().await);
-    let tenant_repo = SurrealTenantRepository::new(db.client_cloned().await);
+    let db_handle = pool.handle_for_repo().await;
+    let org_repo = SurrealOrganizationRepository::new(pool.handle_for_repo().await);
+    let tenant_repo = SurrealTenantRepository::new(pool.handle_for_repo().await);
     let user_repo = SurrealUserRepository::with_pepper(
-        db.client_cloned().await,
+        pool.handle_for_repo().await,
         config
             .auth
             .pepper
@@ -417,25 +422,25 @@ async fn main() -> std::io::Result<()> {
             .map(|p| p.expose_secret().to_string())
             .unwrap_or_default(),
     );
-    let group_repo = SurrealGroupRepository::new(db.client_cloned().await);
-    let role_repo = SurrealRoleRepository::new(db.client_cloned().await);
-    let permission_repo = SurrealPermissionRepository::new(db.client_cloned().await);
-    let resource_repo = SurrealResourceRepository::new(db.client_cloned().await);
-    let scope_repo = SurrealScopeRepository::new(db.client_cloned().await);
-    let service_account_repo = SurrealServiceAccountRepository::new(db.client_cloned().await);
-    let session_repo = SurrealSessionRepository::new(db.client_cloned().await);
+    let group_repo = SurrealGroupRepository::new(pool.handle_for_repo().await);
+    let role_repo = SurrealRoleRepository::new(pool.handle_for_repo().await);
+    let permission_repo = SurrealPermissionRepository::new(pool.handle_for_repo().await);
+    let resource_repo = SurrealResourceRepository::new(pool.handle_for_repo().await);
+    let scope_repo = SurrealScopeRepository::new(pool.handle_for_repo().await);
+    let service_account_repo = SurrealServiceAccountRepository::new(pool.handle_for_repo().await);
+    let session_repo = SurrealSessionRepository::new(pool.handle_for_repo().await);
     // REQ-7 / D-15: per-request session-validity check so revoked sessions'
     // access tokens are rejected immediately (the AuthenticatedUser extractor
     // consults this on every authenticated request).
     let session_validator: std::sync::Arc<dyn axiam_api_rest::SessionValidator> =
         std::sync::Arc::new(session_repo.clone());
-    let audit_repo = SurrealAuditLogRepository::new(db.client_cloned().await);
-    let ca_cert_repo = SurrealCaCertificateRepository::new(db.client_cloned().await);
+    let audit_repo = SurrealAuditLogRepository::new(pool.handle_for_repo().await);
+    let ca_cert_repo = SurrealCaCertificateRepository::new(pool.handle_for_repo().await);
     let federation_link_repo_for_auth =
-        SurrealFederationLinkRepository::new(db.client_cloned().await);
+        SurrealFederationLinkRepository::new(pool.handle_for_repo().await);
     // A separate refresh-token repo instance for AuthService (used by
     // revoke_all_sessions / revoke_all_sessions_except on password change and reset).
-    let auth_refresh_token_repo = SurrealRefreshTokenRepository::new(db.client_cloned().await);
+    let auth_refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
     // Single shared bounding semaphore for all CPU-bound crypto operations (CQ-B02 / REQ-14 AC-2).
     // Limits concurrent Argon2 and PKI keygen/sign operations to prevent runtime-thread
     // starvation AND an unauthenticated memory-DoS (each Argon2id arena is ~19 MiB; B1).
@@ -458,13 +463,13 @@ async fn main() -> std::io::Result<()> {
         Arc::clone(&crypto_semaphore),
     );
     // Password history repository — used by the password-change handler.
-    let password_history_repo = SurrealPasswordHistoryRepository::new(db.client_cloned().await);
-    let consent_repo = axiam_db::SurrealConsentRepository::new(db.client_cloned().await);
-    let account_deletion_repo = SurrealAccountDeletionRepository::new(db.client_cloned().await);
-    let export_job_repo = SurrealExportJobRepository::new(db.client_cloned().await);
-    let erasure_proof_repo = SurrealErasureProofRepository::new(db.client_cloned().await);
+    let password_history_repo = SurrealPasswordHistoryRepository::new(pool.handle_for_repo().await);
+    let consent_repo = axiam_db::SurrealConsentRepository::new(pool.handle_for_repo().await);
+    let account_deletion_repo = SurrealAccountDeletionRepository::new(pool.handle_for_repo().await);
+    let export_job_repo = SurrealExportJobRepository::new(pool.handle_for_repo().await);
+    let erasure_proof_repo = SurrealErasureProofRepository::new(pool.handle_for_repo().await);
 
-    let webauthn_cred_repo = SurrealWebauthnCredentialRepository::new(db.client_cloned().await);
+    let webauthn_cred_repo = SurrealWebauthnCredentialRepository::new(pool.handle_for_repo().await);
     let webauthn_service = WebauthnService::new(webauthn_cred_repo.clone(), config.auth.clone())
         .expect("Failed to build WebauthnService");
     let mfa_method_service = MfaMethodService::new(user_repo.clone(), webauthn_cred_repo.clone());
@@ -475,13 +480,13 @@ async fn main() -> std::io::Result<()> {
     let pki_config = PkiConfig {
         encryption_key: load_key_from_env("AXIAM__PKI__ENCRYPTION_KEY"),
     };
-    let cert_repo = SurrealCertificateRepository::new(db.client_cloned().await);
+    let cert_repo = SurrealCertificateRepository::new(pool.handle_for_repo().await);
     let ca_service = CaService::new(
         ca_cert_repo.clone(),
         pki_config.clone(),
         Arc::clone(&crypto_semaphore),
     );
-    let pgp_repo = SurrealPgpKeyRepository::new(db.client_cloned().await);
+    let pgp_repo = SurrealPgpKeyRepository::new(pool.handle_for_repo().await);
     let pgp_service = PgpService::new(pgp_repo, pki_config.clone(), Arc::clone(&crypto_semaphore));
     let cert_service = CertService::new(
         ca_cert_repo,
@@ -493,9 +498,9 @@ async fn main() -> std::io::Result<()> {
     // SurrealCaCertificateRepository is cloned; each clone shares the underlying Surreal<C>.
     let device_auth_service = DeviceAuthService::new(
         cert_repo.clone(),
-        SurrealCaCertificateRepository::new(db.client_cloned().await),
+        SurrealCaCertificateRepository::new(pool.handle_for_repo().await),
     );
-    let webhook_repo = SurrealWebhookRepository::new(db.client_cloned().await);
+    let webhook_repo = SurrealWebhookRepository::new(pool.handle_for_repo().await);
     // SEC-031/SEC-059: Webhook secrets stored AES-256-GCM encrypted using the
     // same PKI encryption key. Absent key -> None (SEC-012 fail-closed
     // pattern, mirrors `pki_config.encryption_key` above): the server still
@@ -505,12 +510,12 @@ async fn main() -> std::io::Result<()> {
     let webhook_enc_key: Option<[u8; 32]> = load_key_from_env("AXIAM__PKI__ENCRYPTION_KEY");
     let webhook_delivery =
         axiam_api_rest::webhook::WebhookDeliveryService::new(webhook_repo.clone(), webhook_enc_key);
-    let settings_repo = SurrealSettingsRepository::new(db.client_cloned().await);
+    let settings_repo = SurrealSettingsRepository::new(pool.handle_for_repo().await);
     // Notification-rule repository — required by the notification_rules handlers'
     // `web::Data<SurrealNotificationRuleRepository>` extractor. Without this
     // registration every /api/v1/notification-rules request 500s with
     // "App data is not configured".
-    let notification_rule_repo = SurrealNotificationRuleRepository::new(db.client_cloned().await);
+    let notification_rule_repo = SurrealNotificationRuleRepository::new(pool.handle_for_repo().await);
     // Email-config repository (28-04, FUNC-03) — required by the
     // `handlers::email_config::*` handlers' `web::Data<SurrealEmailConfigRepository<C>>`
     // extractor. Only constructed when AXIAM__EMAIL_ENCRYPTION_KEY is present (same
@@ -522,7 +527,7 @@ async fn main() -> std::io::Result<()> {
     let email_config_repo: Option<SurrealEmailConfigRepository<axiam_db::DbClient>> =
         match config.email_encryption_key {
             Some(email_key) => Some(SurrealEmailConfigRepository::new(
-                db.client_cloned().await,
+                pool.handle_for_repo().await,
                 email_key,
             )),
             None => {
@@ -532,14 +537,14 @@ async fn main() -> std::io::Result<()> {
                 None
             }
         };
-    let federation_config_repo = SurrealFederationConfigRepository::new(db.client_cloned().await);
-    let federation_link_repo = SurrealFederationLinkRepository::new(db.client_cloned().await);
-    let assertion_replay_repo = SurrealAssertionReplayRepository::new(db.client_cloned().await);
+    let federation_config_repo = SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
+    let federation_link_repo = SurrealFederationLinkRepository::new(pool.handle_for_repo().await);
+    let assertion_replay_repo = SurrealAssertionReplayRepository::new(pool.handle_for_repo().await);
     // NEW-4: durable AMQP nonce store for replay protection, shared by the
     // authz + audit consumers and swept by the periodic cleanup task.
-    let amqp_nonce_repo = SurrealAmqpNonceRepository::new(db.client_cloned().await);
+    let amqp_nonce_repo = SurrealAmqpNonceRepository::new(pool.handle_for_repo().await);
     let federation_login_state_repo =
-        SurrealFederationLoginStateRepository::new(db.client_cloned().await);
+        SurrealFederationLoginStateRepository::new(pool.handle_for_repo().await);
     // Process-wide JWKS cache shared by all OIDC federation handlers (D-01/D-02/D-03).
     let jwks_cache = Arc::new(JwksCache::new());
     // B3: process-wide in-process cache for AXIAM's OWN `GET /oauth2/jwks`
@@ -554,12 +559,12 @@ async fn main() -> std::io::Result<()> {
         .timeout(std::time::Duration::from_secs(10))
         .build()
         .expect("failed to build reqwest client");
-    let oauth2_client_repo = SurrealOAuth2ClientRepository::new(db.client_cloned().await);
-    let auth_code_repo = SurrealAuthorizationCodeRepository::new(db.client_cloned().await);
-    let refresh_token_repo = SurrealRefreshTokenRepository::new(db.client_cloned().await);
+    let oauth2_client_repo = SurrealOAuth2ClientRepository::new(pool.handle_for_repo().await);
+    let auth_code_repo = SurrealAuthorizationCodeRepository::new(pool.handle_for_repo().await);
+    let refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
     // Separate instance for password-reset/change handlers that need direct
     // RefreshTokenRepository access via web::Data (TokenService owns the main one).
-    let handler_refresh_token_repo = SurrealRefreshTokenRepository::new(db.client_cloned().await);
+    let handler_refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
 
     // OAuth2 authorization code grant services.
     let authorize_service = AuthorizeService::new(
@@ -588,9 +593,9 @@ async fn main() -> std::io::Result<()> {
     // purely to build the two hoisted services below; no handler touches
     // them directly, so they are not their own AppState field.
     let password_reset_token_repo =
-        SurrealPasswordResetTokenRepository::new(db.client_cloned().await);
+        SurrealPasswordResetTokenRepository::new(pool.handle_for_repo().await);
     let email_verification_token_repo =
-        SurrealEmailVerificationTokenRepository::new(db.client_cloned().await);
+        SurrealEmailVerificationTokenRepository::new(pool.handle_for_repo().await);
 
     let password_reset_service = PasswordResetService::new(
         user_repo.clone(),
@@ -644,7 +649,7 @@ async fn main() -> std::io::Result<()> {
     let tls_config = config.server.tls.clone();
     let rate_limit_cfg = config.rate_limit.clone();
     let auth_config = config.auth.clone();
-    let health_checker: Arc<dyn HealthChecker> = Arc::new(db);
+    let health_checker: Arc<dyn HealthChecker> = pool;
 
     // PERF-01: initialize the process-wide HIBP circuit breaker from
     // AuthConfig (config-crate wired, not a manual env parse) before the


### PR DESCRIPTION
Follow-up to #206. Now carries the **Phase F implementation** (F1+F2), the laptop re-run runbook, and the D7 compose pass-through.

### Phase F — DB connection management & pooling
Grounded in the vendored `surrealdb` 3.2.1 HTTP-engine source: no native pool/tuning surface; `run_router` spawns a task per request over one shared `reqwest::Client`; every `Surreal::clone()` shares that one router+client (new session id only) → ~30 repos funnel through a single dispatcher, unbounded DB concurrency, and the CQ-B48 session-expiry gap.

- **F1 (Opus)** — `claude_dev/db-pool-design.md` (implementation-ready design) + zero-behavior-change boundary instrumentation in `crates/axiam-db/src/metrics.rs` (in-flight gauge, handle-checkout counter, transparent `instrument_query` latency wrapper).
- **F2 (Opus)** — `crates/axiam-db/src/pool.rs`: `DbPool<C>` of **N genuinely independent** `Surreal<C>` handles (own router task + reqwest client + renewable session each). Round-robin construction seam (`handle_for_repo`) + per-op `DbCheckout` guard (least-in-flight + optional `Semaphore` cap, `Deref` to `Surreal<C>`, `Drop` releases). All **48** `client_cloned().await` sites in `axiam-server/main.rs` rewritten; repository query bodies unchanged.
  - **`pool_size=1` (default) is byte-for-byte today's behavior**: default `POOL_MAX_IN_FLIGHT=0` builds no semaphore (unbounded, as today), one handle makes the checkout policy a no-op — proven by a test.
  - Config: `AXIAM__DB__POOL_SIZE` (1), `AXIAM__DB__POOL_MAX_IN_FLIGHT` (0=disabled), `AXIAM__DB__POOL_ACQUIRE_TIMEOUT_SECS`. Acquire-timeout → `AxiamError::ServiceUnavailable` (503) — the exact variant B1's `crypto_gate` reuses; no new error shape.
  - **CQ-B48 closed**: the pool owns proactive re-signin + reconnect *per handle*; `DbManager::health_probe` removed; `HealthChecker` now impl'd for `DbPool`.
  - Tests (kv-mem): single-handle-no-cap invariant, least-in-flight distribution, acquire-timeout→503, permit-count bound, per-handle poisoned-handle eviction, plus an `#[ignore]` live-server CQ-B48 expiry soak.
- **F3 (Sonnet) — pending the laptop**: pool 1-vs-N bench cells (D7 cache off, per Phase C protocol), the short-TTL expiry soak, and the TCP-socket/in-flight measurements. No live SurrealDB/k6 here.

**Honest framing:** correctness/robustness win first (bounded concurrency, owned session lifecycle, no single funnel); the throughput win is to be *measured* in F3, not presumed — D6 showed the DB CPU cap was the wall on authz cells.

### Verification
`cargo clippy --workspace --all-targets -D warnings` clean; `cargo fmt --check` clean; `cargo test -p axiam-db --lib` 49 pass; `cargo build -p axiam-server` builds.

### Also in this PR
- Laptop re-run runbook appended after the plan's status table (build=1 mandatory, median-of-3, labeled AXIAM-only passes, B2 zero-new-runs check, bench-pack).
- D7 decision-cache env keys wired through the bench compose (default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)