### PR TITLE
feat(bench,authz): run-2 follow-up tasks — A8, A9, D10, D11 + report polish

### DIFF
--- a/benchmarks/PRIVATE_BENCH_ANALYSIS.md
+++ b/benchmarks/PRIVATE_BENCH_ANALYSIS.md
@@ -274,6 +274,26 @@ Next steps (**D10**, supersedes the D1 re-run):
    measured 46), ship that while the query is investigated.
 4. Explain gRPC's exact 2× and eliminate it.
 
+**D10 UPDATE (code landed; measurement pending run 3).** Step 1's grants-query
+hypothesis is **disproven by the source**: the single-check path
+(`AuthorizationEngine::evaluate`, `engine.rs:248`) issues the *same*
+`get_role_permission_grants_for_roles` query and runs at 745/s with the DB
+pegged — so the `meta::id(in)` scan is on the fast path too and is not the batch
+bottleneck. The remaining, evidence-backed cause is the coalesced path's loss of
+query-level parallelism (single checks flood the DB and parallelize to 2 cores;
+the coalesced batch collapses each 5-item request into one serial 3-query chain
+and the DB sits at ~1 core, everything idle, ~1 s p50 — pure waiting).
+Implemented step 3 as the shipped fix: a config-selectable `BatchStrategy`
+(`crates/axiam-authz`), default **`concurrent`** — `check_access_batch` now runs
+each item as an independent cache-aware `check_access`, bounded-concurrently
+(`buffered(batch_max_concurrency)`), byte-identical decisions + order (proven by
+tests). The `coalesced` D1 path is retained behind
+`AXIAM__AUTHZ__BATCH_STRATEGY=coalesced` for the laptop A/B. Full write-up:
+`claude_dev/authz-batch-investigation.md`. gRPC's 2× (step 4) is not a second DB
+query (both handlers route identically through `check_access_batch`; the gRPC
+per-item UUID parse is CPU-trivial) — expected to shrink or vanish once the
+batch parallelizes; confirm on run 3.
+
 ### 4.3 ❌ [HIGH] TLS 1.3 halving persists — resumption hypothesis REFUTED, h2 is the surviving lead
 
 Run 2 p2 vs p0 (capped): CC −49.2%, refresh-fallback −50.2%, introspection

--- a/benchmarks/runner/report.py
+++ b/benchmarks/runner/report.py
@@ -45,6 +45,58 @@ def dash(value, fmt):
     return "—" if value is None else format(value, fmt)
 
 
+def is_full_outage(perf):
+    """True when every iteration failed — throughput/latency then describe the
+    failure path, not the operation being measured, so they get blanked to an
+    em dash (A5.2, generalized here to gRPC — "Report labeling polish").
+
+    Keys off the custom bench_* metrics (bench_error_rate / bench_ok /
+    bench_failed) that every scenario emits uniformly for REST *and* gRPC
+    alike (scenarios/lib/metrics.js) — never an HTTP-specific field like
+    http_req_failed, which doesn't exist at all in a pure-gRPC scenario's k6
+    summary (e.g. zitadel_userinfo_grpc, run 2: ~1725 "req/s" of throughput
+    that was actually 100% non-OK gRPC statuses). The ok_count/failed_count
+    check is a defensive fallback for the edge case where bench_error_rate
+    itself is absent/zero (e.g. a very old summary predating that Rate
+    metric) but the counters still show every iteration failed.
+    """
+    if perf["error_rate"] >= 1.0:
+        return True
+    return perf["failed_count"] > 0 and perf["ok_count"] == 0
+
+
+def classify_fallback(fallback_count, iteration_count):
+    """Distinguish the two situations `bench_fallback` (scenarios/lib/metrics.js)
+    can signal (run-2 analysis, "Report labeling polish" — fold into A5 follow-up):
+
+    - "fallback-op": a PER-ITERATION fallback — the cell measures the WRONG
+      operation on (nearly) every iteration, e.g. token_refresh.js falling
+      back to client_credentials issuance every time. fallback_count is on
+      the order of the iteration count itself (run-2's numbers: AXIAM 145555,
+      Keycloak 32566, Zitadel 34408 — each approx. equal to iterations). This
+      class must stay excluded from head-to-head winner tables — it's a
+      genuinely different (usually cheaper) operation than the label says.
+    - "cc-token-setup": a SETUP-ONLY provenance note — the cell measures the
+      RIGHT operation; only the *token's provenance* is a caveat, e.g.
+      Zitadel's userinfo/userinfo-gRPC setup() minting a client-credentials
+      token exactly once because a real user token wasn't obtainable.
+      fallback_count is a tiny constant (typically 1) no matter how many
+      thousands of iterations ran. This class is kept in comparisons.
+    - "none": bench_fallback never fired for this cell.
+
+    Threshold: fallback_count <= max(2, 1% of iterations) is "clearly a
+    small, bounded, setup-time event" — comfortably above a stray
+    single/double setup-fallback, comfortably below the ~100%-of-iterations
+    rate every per-iteration fallback case observed so far actually has —
+    so it's classified cc-token-setup. Anything above that line recurs on
+    (nearly) every iteration, so it's fallback-op.
+    """
+    if fallback_count <= 0:
+        return "none"
+    threshold = max(2, 0.01 * iteration_count)
+    return "cc-token-setup" if fallback_count <= threshold else "fallback-op"
+
+
 def load_k6_summary(path):
     """Extract throughput, latency percentiles, error rate from a k6 summary."""
     with open(path) as f:
@@ -73,10 +125,20 @@ def load_k6_summary(path):
     # fall back to iteration rate if custom counter absent
     if throughput == 0.0:
         throughput = counter_rate("iterations")
+
+    ok_count = counter_count("bench_ok")
+    failed_count = counter_count("bench_failed")
+    fallback_count = counter_count("bench_fallback")
+    # Iteration-count proxy for classify_fallback()'s heuristic: bench_ok +
+    # bench_failed already accounts for every measured iteration for both
+    # REST and gRPC scenarios alike (scenarios/lib/metrics.js), so reuse them
+    # rather than depending on k6's own built-in "iterations" metric.
+    iteration_count = ok_count + failed_count
+
     return {
         "throughput": throughput,
-        "ok_count": counter_count("bench_ok"),
-        "failed_count": counter_count("bench_failed"),
+        "ok_count": ok_count,
+        "failed_count": failed_count,
         "error_rate": rate_value("bench_error_rate"),
         "p50": trend("bench_op_latency_ms", "med"),
         "p95": trend("bench_op_latency_ms", "p(95)"),
@@ -85,7 +147,18 @@ def load_k6_summary(path):
         # A3: iterations that measured a fallback op (e.g. Zitadel login() ->
         # client_credentials, or a userinfo setup() that fell back) rather than
         # the labelled logical op.
-        "fallback_count": counter_count("bench_fallback"),
+        "fallback_count": fallback_count,
+        # Report labeling polish: which of the two very different situations
+        # above this cell's bench_fallback count represents — see
+        # classify_fallback().
+        "fallback_class": classify_fallback(fallback_count, iteration_count),
+        # D11: gRPC status Trend, present only when the scenario is a gRPC one
+        # (scenarios/lib/metrics.js's bench_grpc_status). Absent entirely for
+        # REST cells and for any results tree predating D11 — tolerated via
+        # has_grpc_status rather than assumed present.
+        "has_grpc_status": "bench_grpc_status" in metrics,
+        "grpc_status_avg": trend("bench_grpc_status", "avg"),
+        "grpc_status_max": trend("bench_grpc_status", "max"),
     }
 
 
@@ -356,7 +429,11 @@ def collect_dir(results_dir, max_error, min_samples):
                     "perf": perf, "res": res, "der": der, "der_server": der_server,
                     "host": host, "host_flags": host_flags(meta, host),
                     "bottleneck": bottleneck(meta, res),
-                    "is_fallback": perf["fallback_count"] > 0,
+                    # Report labeling polish: only "fallback-op" (the cell
+                    # measured the wrong op) is exclusion-worthy; "cc-token-setup"
+                    # (right op, token-provenance caveat) stays comparable — see
+                    # classify_fallback().
+                    "is_fallback": perf["fallback_class"] == "fallback-op",
                     "valid": not reasons, "reasons": reasons,
                 })
     return cells
@@ -379,6 +456,7 @@ RUN_DIR_RE = re.compile(r"run-\d+")
 PERF_MEDIAN_FIELDS = [
     "throughput", "ok_count", "failed_count", "error_rate",
     "p50", "p95", "p99", "avg", "fallback_count",
+    "grpc_status_avg", "grpc_status_max",
 ]
 RES_MEDIAN_FIELDS = ["cpu_cores_avg", "cpu_cores_p95", "mem_mib_avg", "mem_mib_p95", "samples"]
 HOST_MEDIAN_FIELDS = ["mhz_avg", "mhz_min", "mhz_max", "temp_max", "host_cpu_util_avg", "k6_cores_avg", "samples"]
@@ -424,6 +502,21 @@ def aggregate_cell(runs):
     res = _median_res([r["res"] for r in basis])
     host = _median_of([r["host"] for r in basis], HOST_MEDIAN_FIELDS)
 
+    # Report labeling polish: fallback_class/has_grpc_status aren't numeric,
+    # so _median_of (PERF_MEDIAN_FIELDS) can't aggregate them — combine
+    # across ALL raw runs (not just `basis`) the same way `is_fallback` used
+    # to, below. fallback-op wins over cc-token-setup if the runs disagree
+    # (shouldn't happen for a stable scenario, but fallback-op is the more
+    # conservative/exclusion-worthy label).
+    fb_classes = {r["perf"].get("fallback_class", "none") for r in runs}
+    if "fallback-op" in fb_classes:
+        perf["fallback_class"] = "fallback-op"
+    elif "cc-token-setup" in fb_classes:
+        perf["fallback_class"] = "cc-token-setup"
+    else:
+        perf["fallback_class"] = "none"
+    perf["has_grpc_status"] = any(r["perf"].get("has_grpc_status") for r in basis)
+
     thr_vals = [r["perf"]["throughput"] for r in basis]
     thr_median = perf["throughput"]
     thr_spread_pct = (((max(thr_vals) - min(thr_vals)) / 2.0) / thr_median * 100.0
@@ -443,7 +536,7 @@ def aggregate_cell(runs):
         "perf": perf, "res": res, "der": der, "der_server": der_server,
         "host": host, "host_flags": host_flags(meta, host),
         "bottleneck": bottleneck(meta, res),
-        "is_fallback": any(r["is_fallback"] for r in runs),
+        "is_fallback": perf["fallback_class"] == "fallback-op",
         "valid": n_valid >= 2 and not reasons,
         "reasons": reasons,
         "n_valid_runs": n_valid, "n_runs": n_total, "thr_spread_pct": thr_spread_pct,
@@ -523,20 +616,30 @@ def build_report(cells, multi_run=False):
         "**cpu_ms_per_request** answer *can AXIAM match competitors at lower cost?* "
         "Compare across targets at equal profile + latency.",
         "",
-        "> `fallback` = the cell measured a fallback operation instead of the "
-        "labelled logical op (e.g. Zitadel's login() falling back to "
-        "client_credentials — see docs/methodology.md). Fallback cells are "
-        "excluded from head-to-head winner tables but kept here for the full "
-        "picture.",
+        "> `fallback` = `fallback-op` when the cell measured a fallback "
+        "operation instead of the labelled logical op (e.g. Zitadel's "
+        "login() falling back to client_credentials — see "
+        "docs/methodology.md). fallback-op cells are excluded from "
+        "head-to-head winner tables but kept here for the full picture. "
+        "`cc-token-setup` means only the *token's provenance* is a caveat — "
+        "a client-credentials token was minted once in setup() (e.g. "
+        "Zitadel's userinfo/userinfo-gRPC scenarios, when a real user token "
+        "wasn't obtainable) but the measured operation is still the "
+        "labelled one, so these cells stay in head-to-head comparisons "
+        "(Report labeling polish).",
         "",
         "> `bottleneck` names the stack container(s) whose average CPU reached "
         "≥ 95% of their configured cap during the measure window — `none` "
         "means nothing in the stack saturated (the client, network, or an "
         "un-pegged serialization point is the limiter instead).",
         "",
-        "> Cells with `err`=100% have their throughput/latency columns blanked "
-        "(`—`) — those numbers would describe the failure path, not the "
-        "operation being measured.",
+        "> Cells with 100% error have their throughput/latency columns "
+        "blanked (`—`) — those numbers would describe the failure path, not "
+        "the operation being measured. This applies to gRPC cells too "
+        "(keyed off `bench_error_rate`/`bench_ok`/`bench_failed`, not an "
+        "HTTP-specific field, since a pure-gRPC scenario's k6 summary has no "
+        "http_req_* metrics at all); see the gRPC status appendix below for "
+        "which status code dominated a failing gRPC cell.",
         "",
     ]
     if multi_run:
@@ -559,7 +662,7 @@ def build_report(cells, multi_run=False):
     rows = []
     for c in sorted(cells, key=lambda c: (c["scenario"], c["profile"], c["target"])):
         p, r, d, h = c["perf"], c["res"], c["der"], c["host"]
-        full_outage = p["error_rate"] >= 1.0
+        full_outage = is_full_outage(p)
         thr = None if full_outage else p["throughput"]
         p50 = None if full_outage else p["p50"]
         p95 = None if full_outage else p["p95"]
@@ -567,8 +670,9 @@ def build_report(cells, multi_run=False):
         thr_core = None if full_outage else d["throughput_per_core"]
         cpu_ms = None if full_outage else d["cpu_ms_per_request"]
         mhz_ratio = (h["mhz_min"] / h["mhz_max"]) if h["mhz_max"] > 0 else 0.0
+        fb_class = p.get("fallback_class", "none")
         flags = list(c["host_flags"])
-        if c["is_fallback"]:
+        if fb_class == "fallback-op":
             flags.append("fallback-op")
         row = [
             c["scenario"], c["profile"], c["target"], c["rate_limits"],
@@ -577,7 +681,7 @@ def build_report(cells, multi_run=False):
             f"{r['cpu_cores_avg']:.2f}", f"{r['mem_mib_avg']:.0f}",
             dash(thr_core, ".0f"), dash(cpu_ms, ".3f"),
             c["bottleneck"],
-            "yes" if c["is_fallback"] else "no",
+            fb_class if fb_class != "none" else "no",
             f"{h['mhz_avg']:.0f}", f"{mhz_ratio:.2f}", f"{h['temp_max']:.0f}",
             f"{h['k6_cores_avg']:.2f}",
             ";".join(flags) or "-",
@@ -622,7 +726,7 @@ def build_report(cells, multi_run=False):
         rows = []
         for c in sorted(prod_cells, key=lambda c: (c["scenario"], c["profile"])):
             p = c["perf"]
-            full_outage = p["error_rate"] >= 1.0
+            full_outage = is_full_outage(p)
             rows.append([
                 c["scenario"], c["profile"],
                 dash(None if full_outage else p["throughput"], ".0f"),
@@ -656,12 +760,26 @@ def build_report(cells, multi_run=False):
                 continue
             fallback_cells = [c for c in group_all if c["is_fallback"]]
             group = [c for c in group_all if not c["is_fallback"]]
+            # Report labeling polish: cc-token-setup cells (right op, only the
+            # token's provenance is a caveat) are NOT excluded — `group`
+            # already includes them since is_fallback is fallback-op-only —
+            # just called out with a lighter footnote below.
+            cc_cells = [c for c in group if c["perf"].get("fallback_class") == "cc-token-setup"]
             lines += [f"### {sc} @ {pr}", ""]
             if fallback_cells:
                 lines += [
                     "> ⚠️ fallback-op cell(s) excluded from this head-to-head: "
                     + ", ".join(sorted(f"{c['target']}" for c in fallback_cells))
                     + " (see the full matrix above; comparability: fallback-op).", "",
+                ]
+            if cc_cells:
+                lines += [
+                    "> ℹ️ cc-token-setup provenance note (kept in this "
+                    "head-to-head): "
+                    + ", ".join(sorted(f"{c['target']}" for c in cc_cells))
+                    + " — the measured operation is the labelled one; only the "
+                    "token used to reach it was minted via client_credentials "
+                    "once in setup() (comparability: cc-token-setup).", "",
                 ]
             if len(group) < 2:
                 lines += ["_Fewer than 2 non-fallback targets — nothing to compare._", ""]
@@ -688,7 +806,8 @@ def build_report(cells, multi_run=False):
             for c in sorted(group, key=lambda c: -c["der"]["throughput_per_core"]):
                 d, ds, p = c["der"], c["der_server"], c["perf"]
                 marker = " 🏆" if c is best else ""
-                rows.append([c["target"] + marker, f"{p['throughput']:.0f}",
+                note = " (cc-token-setup)" if p.get("fallback_class") == "cc-token-setup" else ""
+                rows.append([c["target"] + marker + note, f"{p['throughput']:.0f}",
                              f"{p['p50']:.1f}", f"{p['p95']:.1f}",
                              f"{d['throughput_per_core']:.0f}", f"{d['throughput_per_gib']:.0f}",
                              f"{d['cpu_ms_per_request']:.3f}",
@@ -719,6 +838,11 @@ def build_report(cells, multi_run=False):
                                if c["target"] == tg and c["scenario"] == grpc_sc and c["profile"] == pr), None)
                 if not rest_c or not grpc_c:
                     continue
+                # Report labeling polish: only fallback-op (wrong op measured)
+                # skips the pair. cc-token-setup cells (e.g. Zitadel's
+                # userinfo/userinfo-gRPC, whose setup() mints a
+                # client-credentials token once) still measure the labelled
+                # op and are kept, with a footnote on the affected row(s).
                 if rest_c["is_fallback"] or grpc_c["is_fallback"]:
                     continue  # A3: a fallback-op cell measures a different operation — skip the pair.
                 any_pair_rendered = True
@@ -728,11 +852,13 @@ def build_report(cells, multi_run=False):
                 d_thr = ((gp["throughput"] - rp["throughput"]) / rp["throughput"] * 100.0
                          if rp["throughput"] else 0.0)
                 d_cpu_ms = gd["cpu_ms_per_request"] - rd["cpu_ms_per_request"]
+                rest_note = " (cc-token-setup)" if rp.get("fallback_class") == "cc-token-setup" else ""
+                grpc_note = " (cc-token-setup)" if gp.get("fallback_class") == "cc-token-setup" else ""
                 rows = [
-                    ["REST (" + rest_sc + ")", f"{rp['throughput']:.0f}", f"{rp['p50']:.1f}",
+                    ["REST (" + rest_sc + ")" + rest_note, f"{rp['throughput']:.0f}", f"{rp['p50']:.1f}",
                      f"{rp['p95']:.1f}", f"{rd['throughput_per_core']:.0f}",
                      f"{rd['cpu_ms_per_request']:.3f}", "baseline"],
-                    ["gRPC (" + grpc_sc + ")", f"{gp['throughput']:.0f}", f"{gp['p50']:.1f}",
+                    ["gRPC (" + grpc_sc + ")" + grpc_note, f"{gp['throughput']:.0f}", f"{gp['p50']:.1f}",
                      f"{gp['p95']:.1f}", f"{gd['throughput_per_core']:.0f}",
                      f"{gd['cpu_ms_per_request']:.3f}", f"{d_thr:+.1f}% thr, {d_cpu_ms:+.3f} cpu_ms/req"],
                 ]
@@ -808,6 +934,37 @@ def build_report(cells, multi_run=False):
             rows), ""]
     else:
         lines += ["_No per-container samples available (no res.csv rows)._", ""]
+
+    # 4b. Appendix: gRPC status codes (D11 + Report labeling polish). Only
+    # rendered for cells whose k6 summary actually carried the
+    # bench_grpc_status Trend (gRPC scenarios only — absent for REST cells
+    # and for any results tree predating D11, tolerated via has_grpc_status
+    # rather than assumed present). Lets a 100%-error gRPC cell (throughput/
+    # latency blanked above) be diagnosed straight from the report: which
+    # status code dominated.
+    grpc_cells = [c for c in cells if c["perf"].get("has_grpc_status")]
+    if grpc_cells:
+        lines += [
+            "## Appendix: gRPC status codes", "",
+            "`status_avg`/`status_max` are the average/maximum raw gRPC "
+            "status code seen during the measure window (e.g. 0=OK, "
+            "7=PermissionDenied, 16=Unauthenticated) — only present for gRPC "
+            "scenarios (scenarios/lib/metrics.js's `bench_grpc_status` "
+            "Trend). Useful for diagnosing a 100%-error gRPC cell where the "
+            "throughput/latency columns in \"All results\" are blanked "
+            "(`—`).", "",
+        ]
+        rows = []
+        for c in sorted(grpc_cells, key=lambda c: (c["scenario"], c["profile"], c["target"])):
+            p = c["perf"]
+            rows.append([
+                c["scenario"], c["profile"], c["target"],
+                f"{p['error_rate'] * 100:.2f}%",
+                f"{p['grpc_status_avg']:.1f}", f"{p['grpc_status_max']:.0f}",
+            ])
+        lines += [md_table(
+            ["scenario", "profile", "target", "err", "status_avg", "status_max"],
+            rows), ""]
 
     # 5. Excluded
     if invalid:

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -156,6 +156,16 @@ RL_POSTURE="$(detect_rl_posture)"
 echo "[run] rate-limit posture: $RL_POSTURE"
 
 # --- Reproducibility metadata (methodology.md §7 / A4) ----------------------
+# A9: git commit of the working tree this run executed from. Recorded
+# unconditionally (harmless when the AXIAM image was pulled prebuilt) but
+# especially meaningful when the target was launched with `just build=1 …`
+# (or BENCH_BUILD=1 / a `--build` compose invocation): a locally-built image
+# has no useful RepoDigests/tag provenance of its own (see image_id fallback
+# in containers_json below), so build_ref is what actually pins the source
+# for that binary. $BENCH is this repo's benchmarks/ dir, so its parent is
+# the repo root.
+BUILD_REF="$(git -C "$BENCH/.." rev-parse HEAD 2>/dev/null || echo unknown)"
+
 # Host facts that don't change across scenarios in this run — gathered once.
 HOST_KERNEL="$(uname -r 2>/dev/null || echo unknown)"
 DOCKER_VERSION="$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
@@ -244,18 +254,34 @@ role_default_mem_mib() {
 
 # Emits the JSON array for meta.json's "containers" field: one entry per
 # running container in this target's stack, with image, image_digest (from
-# `docker inspect`), role, and its CPU + mem cap. Both caps are read straight
-# off the running container (`HostConfig.NanoCpus`/`HostConfig.Memory`, what
-# `--cpus`/`--memory` (compose `cpus:`/`mem_limit:`) actually set) rather than
-# trusted from this shell's env — BENCH_DB_CPUS/BENCH_DB_MEM/BENCH_MQ_CPUS/
+# `docker inspect`), image_id, role, and its CPU + mem cap. Both caps are read
+# straight off the running container (`HostConfig.NanoCpus`/`HostConfig.Memory`,
+# what `--cpus`/`--memory` (compose `cpus:`/`mem_limit:`) actually set) rather
+# than trusted from this shell's env — BENCH_DB_CPUS/BENCH_DB_MEM/BENCH_MQ_CPUS/
 # BENCH_EDGE_CPUS are only exported inside `just bench-up`'s own subshell, so
 # a separate `bench-run` invocation would otherwise silently miss a
 # non-default cap the operator set at bench-up time (this is how a C2
 # `dbcaps=uncapped` run ends up correctly recorded even though `bench-run` is
 # a separate process from `bench-up`). Falls back to the compose-file default
 # only if the inspected value is unset (no `--cpus`/`--memory` was applied).
+#
+# A9: `image` is `.Config.Image` — what the container was actually launched
+# as (e.g. reflects BENCH_AXIAM_IMAGE at `bench-up` time, so it tracks the
+# real tag rather than a value hardcoded here). `image_digest` is the
+# RepoDigests[0] entry when one exists (pulled-by-digest or a registry image
+# docker has resolved); for a LOCALLY-BUILT image (`just build=1 …` /
+# `--build`) RepoDigests is empty (no registry involved), which is exactly
+# the "unknown" gap this fixes: we now fall back to the image ID — first the
+# container's own `.Image` field (the sha256 the container was created
+# against), then `docker image inspect` on the image ref itself — so
+# image_digest is only ever the literal "unknown" when docker can give us
+# neither. `image_id` is always populated (when obtainable) as a sibling
+# field so a digest-vs-id distinction is never lost even when image_digest
+# did find a real RepoDigest. Together with build_ref (git commit, above)
+# this makes every binary in the stack identifiable even when the tag string
+# is stale or generic (e.g. ":latest").
 containers_json() {
-  local first=1 line cname role img dig cap nanocpus mem_bytes mem_mib
+  local first=1 line cname role img dig id cap nanocpus mem_bytes mem_mib
   echo -n "["
   while read -r line; do
     [ -z "$line" ] && continue
@@ -263,7 +289,21 @@ containers_json() {
     docker inspect "$cname" >/dev/null 2>&1 || continue
     img="$(docker inspect --format '{{.Config.Image}}' "$cname" 2>/dev/null || echo unknown)"
     dig="$(docker inspect --format '{{index .RepoDigests 0}}' "$cname" 2>/dev/null || echo '')"
-    [ -z "$dig" ] && dig="unknown"
+    # RepoDigests is empty (or the literal Go zero-value "<no value>" if the
+    # index itself is out of range) for locally-built images — fall back to
+    # the container's own image ID, then to `docker image inspect` on the
+    # image ref, before giving up and recording "unknown".
+    [ "$dig" = "<no value>" ] && dig=""
+    id="$(docker inspect --format '{{.Image}}' "$cname" 2>/dev/null || echo '')"
+    [ "$id" = "<no value>" ] && id=""
+    if [ -z "$id" ]; then
+      id="$(docker image inspect --format '{{.Id}}' "$img" 2>/dev/null || echo '')"
+      [ "$id" = "<no value>" ] && id=""
+    fi
+    if [ -z "$dig" ]; then
+      if [ -n "$id" ]; then dig="$id"; else dig="unknown"; fi
+    fi
+    [ -n "$id" ] || id="unknown"
     nanocpus="$(docker inspect --format '{{.HostConfig.NanoCpus}}' "$cname" 2>/dev/null || echo 0)"
     if [ -n "$nanocpus" ] && [ "$nanocpus" != "0" ]; then
       cap="$(awk -v n="$nanocpus" 'BEGIN{printf "%.3f", n/1000000000}')"
@@ -278,8 +318,8 @@ containers_json() {
     fi
     [ "$first" -eq 1 ] || echo -n ","
     first=0
-    printf '{"name":"%s","role":"%s","image":"%s","image_digest":"%s","cpu_cap":%s,"mem_cap_mib":%s}' \
-      "$(json_escape "$cname")" "$role" "$(json_escape "$img")" "$(json_escape "$dig")" "$cap" "$mem_mib"
+    printf '{"name":"%s","role":"%s","image":"%s","image_digest":"%s","image_id":"%s","cpu_cap":%s,"mem_cap_mib":%s}' \
+      "$(json_escape "$cname")" "$role" "$(json_escape "$img")" "$(json_escape "$dig")" "$(json_escape "$id")" "$cap" "$mem_mib"
   done < <(container_specs_for_target)
   echo -n "]"
 }
@@ -352,6 +392,7 @@ run_one() {
   "docker_version": "$(json_escape "$DOCKER_VERSION")",
   "cpu_model": "$(json_escape "$CPU_MODEL")",
   "cpu_governor": "$(json_escape "$CPU_GOVERNOR")",
+  "build_ref": "$(json_escape "$BUILD_REF")",
   "k6_cpu_cores_avg": $k6_cpu_cores_avg,
   "containers": $(containers_json)
 }

--- a/benchmarks/scenarios/authz_batch_grpc.js
+++ b/benchmarks/scenarios/authz_batch_grpc.js
@@ -75,6 +75,9 @@ export default function (data) {
     'results length matches batch size': (r) =>
       r && r.message && Array.isArray(r.message.results) && r.message.results.length === BATCH_SIZE,
   });
+  // D11: record the raw gRPC status code so the summary alone can show which
+  // code dominates on a failing run (mirrors zitadel_userinfo_grpc.js).
+  m.grpcStatus.add(res && res.status != null ? res.status : -1);
   m.latency.add(Date.now() - start);
   m.errorRate.add(!ok);
   if (ok) m.ok.add(1); else m.failed.add(1);

--- a/benchmarks/scenarios/authz_check_grpc.js
+++ b/benchmarks/scenarios/authz_check_grpc.js
@@ -63,6 +63,9 @@ export default function (data) {
     { metadata: { authorization: `Bearer ${data.access_token}` } },
   );
   const ok = check(res, { 'grpc status OK': (r) => r && r.status === grpc.StatusOK });
+  // D11: record the raw gRPC status code so the summary alone can show which
+  // code dominates on a failing run (mirrors zitadel_userinfo_grpc.js).
+  m.grpcStatus.add(res && res.status != null ? res.status : -1);
   m.latency.add(Date.now() - start);
   m.errorRate.add(!ok);
   if (ok) m.ok.add(1); else m.failed.add(1);

--- a/benchmarks/scenarios/lib/metrics.js
+++ b/benchmarks/scenarios/lib/metrics.js
@@ -15,6 +15,12 @@ export const m = {
   // token). report.py annotates any cell with bench_fallback > 0 as
   // comparability: fallback-op and excludes it from head-to-head tables.
   fallback: new Counter('bench_fallback'),
+  // D11: gRPC status code of each invoke(), so a 100%-non-OK scenario is
+  // diagnosable from the summary alone (e.g. 7=PermissionDenied,
+  // 16=Unauthenticated) instead of just showing up as failed checks with no
+  // hint why. A Trend (not a Counter) so the summary's percentile/avg stats
+  // surface which code dominates. Recorded by the gRPC scenarios only.
+  grpcStatus: new Trend('bench_grpc_status'),
 };
 
 // Execute one built request (from targets.js) and record uniform metrics.

--- a/benchmarks/scenarios/lib/targets.js
+++ b/benchmarks/scenarios/lib/targets.js
@@ -243,11 +243,21 @@ const zitadel = {
   clientCredentials() {
     // Add the bench project's reserved audience scope so the issued token is
     // introspectable by the resource server: Zitadel only marks a token `active`
-    // to an API app whose project is in the token's aud. Falls back to plain
-    // openid when no project was seeded (e.g. manual/jwks-only setups).
+    // to an API app whose project is in the token's aud.
+    //
+    // D11: ALWAYS also request Zitadel's own reserved `zitadel` project
+    // audience (`urn:zitadel:iam:org:project:id:zitadel:aud`), in addition to
+    // the bench-project audience above. Zitadel's Auth API (zitadel.auth.v1,
+    // e.g. AuthService/GetMyUser used by zitadel_userinfo_grpc.js) rejects any
+    // token whose aud doesn't include that reserved project id — REST
+    // `/oidc/v1/userinfo` doesn't care, which is why REST userinfo worked
+    // while the gRPC AuthService call returned 100% non-OK. Adding the extra
+    // audience is harmless for introspection/userinfo (extra audiences are
+    // fine), so it's simplest to always include it here rather than plumb a
+    // separate "reserved audience" request path through to the gRPC scenario.
     const scope = cfg.projectId
-      ? `openid urn:zitadel:iam:org:project:id:${cfg.projectId}:aud`
-      : 'openid';
+      ? `openid urn:zitadel:iam:org:project:id:zitadel:aud urn:zitadel:iam:org:project:id:${cfg.projectId}:aud`
+      : 'openid urn:zitadel:iam:org:project:id:zitadel:aud';
     return {
       method: 'POST',
       url: `${baseUrl()}/oauth/v2/token`,

--- a/benchmarks/scenarios/token_refresh.js
+++ b/benchmarks/scenarios/token_refresh.js
@@ -5,7 +5,7 @@ import { sleep } from 'k6';
 import { loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
 import { adapter } from './lib/targets.js';
 import { doOp, m } from './lib/metrics.js';
-import { mintToken } from './lib/auth.js';
+import { mintUserToken } from './lib/auth.js';
 
 export const options = Object.assign(
   {
@@ -30,12 +30,19 @@ export default function () {
   if (!vuRefresh) {
     let tok;
     try {
-      tok = mintToken();
+      // A8: mint via a real user login (mintUserToken), not client_credentials
+      // (mintToken). No target issues a refresh token on the CC grant, so
+      // minting CC-first meant every VU permanently took the fallback branch
+      // below — the cell measured CC issuance, not refresh, on ALL targets.
+      // mintUserToken() logs in as the seeded user first (AXIAM: axiam_refresh
+      // cookie; Keycloak: ROPC JSON body), so a genuine refresh_token is
+      // issued and actually exercised here.
+      tok = mintUserToken();
     } catch (_e) {
       // Could not obtain a token to refresh — typically the token endpoint is
       // throttling this VU (prod rate-limit posture), or seeding/OAuth2 is
       // misconfigured. Record it as a failed logical op and back off: otherwise
-      // mintToken's throw aborts the iteration WITHOUT touching bench_ok/
+      // mintUserToken's throw aborts the iteration WITHOUT touching bench_ok/
       // bench_failed, so the scenario silently under-reports its true error rate
       // (the p0-plaintext incident: 10k iterations, 26 recorded ops).
       m.failed.add(1);
@@ -45,9 +52,15 @@ export default function () {
     }
     vuRefresh = tok.refresh_token;
     if (!vuRefresh) {
-      // Target issued no refresh token (e.g. pure client_credentials) — nothing to
-      // measure; mint again as the closest comparable token-issuance op. This is
-      // not a refresh, so tag + count it as a fallback (comparability: fallback-op).
+      // Target issued no refresh token off a user login either (e.g. Zitadel:
+      // mintUserToken() falls back to client_credentials because its login()
+      // returns a session-API `sessionToken`, not an OIDC token — a real
+      // refresh token would require driving a full OIDC auth-code flow with
+      // `offline_access`, which this harness cannot easily do). Nothing to
+      // measure; mint again as the closest comparable token-issuance op. This
+      // is not a refresh, so tag + count it as a fallback
+      // (comparability: fallback-op). For AXIAM/Keycloak this branch should
+      // no longer be reached.
       m.fallback.add(1);
       doOp(a.clientCredentials());
       return;

--- a/benchmarks/scenarios/zitadel_userinfo_grpc.js
+++ b/benchmarks/scenarios/zitadel_userinfo_grpc.js
@@ -87,6 +87,10 @@ export default function (data) {
     { metadata: { authorization: `Bearer ${data.access_token}` } },
   );
   const ok = check(res, { 'grpc status OK': (r) => r && r.status === grpc.StatusOK });
+  // D11: record the raw gRPC status code (e.g. 7=PermissionDenied,
+  // 16=Unauthenticated) so a 100%-non-OK run is diagnosable from the summary
+  // alone, not just a failed-checks count with no hint why.
+  m.grpcStatus.add(res && res.status != null ? res.status : -1);
   m.latency.add(Date.now() - start);
   m.errorRate.add(!ok);
   if (ok) m.ok.add(1); else m.failed.add(1);

--- a/benchmarks/targets/axiam/docker-compose.yml
+++ b/benchmarks/targets/axiam/docker-compose.yml
@@ -145,7 +145,19 @@ services:
     restart: "no"
 
   surrealdb:
-    image: surrealdb/surrealdb:v3
+    # A9: surrealdb/surrealdb:v3 is a floating tag — it can point at a different
+    # build over time, which breaks provenance ("what exactly did this run
+    # measure against?"). No network/registry access is available where this
+    # override was authored, so a real digest can't be resolved and pinned
+    # here without risking a fabricated (unpullable) sha256. Instead, pin it
+    # at run time: pull once, resolve the digest, then export
+    # BENCH_SURREALDB_IMAGE to override this default, e.g.:
+    #   docker pull surrealdb/surrealdb:v3
+    #   export BENCH_SURREALDB_IMAGE="surrealdb/surrealdb@$(docker inspect --format '{{index .RepoDigests 0}}' surrealdb/surrealdb:v3 | cut -d@ -f2)"
+    # (run-benchmark.sh's meta.json also now records image_id/build_ref as a
+    # fallback identifier for whatever tag actually ran — see A9 in
+    # claude_dev/benchmark-improvement-plan.md.)
+    image: ${BENCH_SURREALDB_IMAGE:-surrealdb/surrealdb:v3}
     container_name: bench-axiam-surrealdb
     cpus: ${BENCH_DB_CPUS:-2}
     mem_limit: ${BENCH_DB_MEM:-1024m}

--- a/benchmarks/targets/keycloak/docker-compose.yml
+++ b/benchmarks/targets/keycloak/docker-compose.yml
@@ -87,7 +87,13 @@ services:
     networks: [bench]
 
   postgres:
-    image: postgres:16-alpine
+    # A9: postgres:16-alpine is a floating tag (breaks provenance — see the
+    # matching note on surrealdb in targets/axiam/docker-compose.yml). No
+    # registry access here to resolve+pin a real digest, so pin it at run
+    # time instead by exporting BENCH_PG_IMAGE, e.g.:
+    #   docker pull postgres:16-alpine
+    #   export BENCH_PG_IMAGE="postgres@$(docker inspect --format '{{index .RepoDigests 0}}' postgres:16-alpine | cut -d@ -f2)"
+    image: ${BENCH_PG_IMAGE:-postgres:16-alpine}
     container_name: bench-keycloak-postgres
     cpus: ${BENCH_DB_CPUS:-2}
     mem_limit: ${BENCH_DB_MEM:-1024m}

--- a/benchmarks/targets/zitadel/docker-compose.yml
+++ b/benchmarks/targets/zitadel/docker-compose.yml
@@ -85,7 +85,14 @@ services:
     networks: [bench]
 
   postgres:
-    image: postgres:16-alpine
+    # A9: postgres:16-alpine is a floating tag (breaks provenance — see the
+    # matching note on surrealdb in targets/axiam/docker-compose.yml, and on
+    # keycloak's own postgres in targets/keycloak/docker-compose.yml). No
+    # registry access here to resolve+pin a real digest, so pin it at run
+    # time instead by exporting BENCH_PG_IMAGE, e.g.:
+    #   docker pull postgres:16-alpine
+    #   export BENCH_PG_IMAGE="postgres@$(docker inspect --format '{{index .RepoDigests 0}}' postgres:16-alpine | cut -d@ -f2)"
+    image: ${BENCH_PG_IMAGE:-postgres:16-alpine}
     container_name: bench-zitadel-postgres
     cpus: ${BENCH_DB_CPUS:-2}
     mem_limit: ${BENCH_DB_MEM:-1024m}

--- a/claude_dev/authz-batch-investigation.md
+++ b/claude_dev/authz-batch-investigation.md
@@ -1,0 +1,125 @@
+# D10 — Authz batch serialization investigation
+
+**Status:** root-cause narrowed by static analysis + run-2 evidence; fix
+implemented as a config-selectable batch strategy (default flipped to
+`concurrent`). Final wall-clock confirmation is a **laptop step** (this sandbox
+has no k6 / live stack). Companion to `benchmarks/PRIVATE_BENCH_ANALYSIS.md` §4.2.
+
+## The symptom (run-2, capped p0, unchanged under caps/TLS)
+
+| cell | thr | p50 | server CPU | DB CPU |
+|---|---|---|---|---|
+| authz_check_rest (single) | 745/s | 67 ms | 0.66 | **2.01 (pegged)** |
+| authz_batch_rest (5/req) | 46/s | 1060 ms | 0.06 | 1.09 |
+| authz_batch_grpc (5/req) | 23/s | 2153 ms | 0.03 | 1.03 |
+
+The batch cell leaves **everything idle** (server 0.06, DB ~1 core) yet each
+request takes ~1 s. With 50 closed-loop VUs, `50 / 46 ≈ 1.09 s` — i.e. the
+throughput is *fixed by the per-request latency*, and that latency is spent
+waiting, not computing. DB pinned at ~1 core **in every configuration,
+including the DB-uncapped pass (4 cores available)** → the batch's DB work is
+**serialized**, not resource-starved.
+
+## What was DISPROVEN
+
+The prior hypothesis (`PRIVATE` draft, D10 task text) was that the batched
+grants query `get_role_permission_grants_for_roles` — which filters
+`WHERE meta::id(in) IN $role_ids` (a per-row function call that cannot use the
+`grants` edge's record-link index, forcing a table scan) — was the serialized
+cost.
+
+**This is disproven by the code:** the *single*-check path
+(`AuthorizationEngine::evaluate`, `engine.rs:248`) calls the **exact same**
+`get_role_permission_grants_for_roles`. The single-check cell runs at 745 req/s
+with the DB pegged at 2 cores. So that query shape is on the hot path of the
+*fast* cell too — it is not what makes the batch slow. (The `meta::id(in)`
+scan is still a latent inefficiency worth fixing on its own once the grants
+table is large; it is simply not this bottleneck. Tracked as a follow-up
+below.)
+
+## What the evidence points to
+
+Both handlers (`crates/axiam-api-rest/src/handlers/authz_check.rs:263` and
+`crates/axiam-api-grpc/.../authorization.rs:177`) route the whole batch through
+`AuthorizationEngine::check_access_batch`, which (pre-D10) ran the **coalesced**
+path: gather every item's shared lookups, then issue one role-assignment, one
+ancestor, and one grants query for the *entire* batch (3 round-trips for the
+bench's 5-item same-subject shape). That is strictly fewer round-trips than 5
+single checks (≈15), so on paper it should be faster.
+
+But the whole coalesced batch resolves on **one task, issuing its 3 queries
+sequentially**. A single `check_access` also issues 3 sequential queries — the
+difference is *how many run concurrently across the stack*:
+
+- **Single-check cell:** 50 VUs → ~745 req/s → hundreds of small queries in
+  flight at once → SurrealDB parallelizes them across both its cores.
+- **Batch cell:** 50 VUs, but each request is one coalesced task doing 3
+  sequential queries and little else. The observed behaviour (DB stuck at ~1
+  core, ~1 s latency, nothing saturated) is the signature of the batch tasks
+  **not** achieving the same query-level concurrency the single-check flood
+  does — the coalescing collapsed 5 items into a single serial dependency
+  chain, removing the parallelism that let single checks saturate the DB.
+
+The precise internal reason the coalesced chain caps DB utilisation at ~1 core
+(single shared SurrealDB dispatch task? per-request connection affinity in the
+F2 pool? a lock around the coalesce maps?) is **not determinable from static
+reading** and needs a server-side trace under load — the per-item / per-query
+`tracing` spans added in D1 are already in place (`engine.rs` `evaluate_batch`)
+to capture it on the laptop. What *is* determinable: single checks parallelize
+to the DB cap, and the coalesced batch does not.
+
+## The fix (implemented)
+
+Rather than keep optimizing a path whose serialization we cannot fully explain
+from source, D10 makes the batch reuse the mechanism that is *proven* to
+parallelize — the single check — for every item, concurrently:
+
+- New `BatchStrategy` config enum (`crates/axiam-authz/src/config.rs`):
+  - `Concurrent` **(new default)** — `check_access_batch` evaluates each item
+    as an independent, cache-aware `check_access`, run with
+    `futures::stream::…buffered(batch_max_concurrency)`; **input order and every
+    decision/deny-reason are byte-identical** to a standalone `check_access`
+    (the cache is consulted per item exactly as before).
+  - `Coalesced` — the original D1 path, retained and selectable via
+    `AXIAM__AUTHZ__BATCH_STRATEGY=coalesced` for an apples-to-apples laptop A/B.
+- Bounded by the existing `AXIAM__AUTHZ__BATCH_MAX_CONCURRENCY` (default 16) so
+  a large batch cannot self-DoS the DB pool (D-07); the bound now lives on the
+  engine (`with_batch_config`) and is applied at all three server construction
+  sites (REST, gRPC, AMQP).
+
+### Why default to `concurrent`
+
+- **Zero authorization risk:** the concurrent path *is* per-item
+  `check_access`. The existing correctness tests already compare the batch to
+  the sequential per-item baseline; the gRPC service test and the new
+  `concurrent_strategy_is_per_item_and_matches_sequential` unit test assert
+  byte-identical decisions and order.
+- **Evidence-backed:** single checks demonstrably reach the DB cap under 50-VU
+  concurrency; a batch of concurrent items is the same access pattern.
+- **Reversible:** one env var restores the coalesced path; the maintainer
+  picks the final default from the laptop A/B (same pattern as F3's
+  pool-size decision).
+
+### Expected laptop result (to confirm, not claimed)
+
+A 5-item batch as 5 concurrent single-checks does ~15 round-trips but at the
+single-check DB rate (~2235 q/s pegged) ⇒ order-of-magnitude ~150 batch/s,
+p50 ≈ 50 VUs / 150 ≈ 0.33 s — comfortably inside the 2 s gate and **above**
+the single-check-equivalent (745/5 ≈ 149 checks-worth/s). Acceptance
+(`batch checks/s > single checks/s`; `authz_batch_grpc` passes the 2 s p95
+gate) is verified on the run-3 laptop matrix.
+
+## Follow-ups (not required for D10 acceptance)
+
+1. **Index the `grants` edge lookup regardless.** Rewrite
+   `get_role_permission_grants_for_roles` to match `in` against role
+   record-links (`WHERE in IN [role:\`…\`, …]`, mirroring the single-role
+   `get_role_permission_grants`) instead of `meta::id(in) IN $role_ids`, so it
+   never table-scans when the grants table grows. Independent of the batch
+   strategy (the single-check path uses it too). Low risk, but wants the same
+   embedded-engine test coverage; deferred to keep the D10 diff focused on the
+   serialization fix.
+2. **Trace the coalesced serialization on the laptop** to positively identify
+   the ~1-core ceiling (pool dispatch vs lock vs connection affinity). If it
+   turns out cheap to remove, a *coalesced-and-parallel* path could beat both;
+   until measured, `concurrent` is the safe, evidence-backed default.

--- a/claude_dev/benchmark-improvement-plan.md
+++ b/claude_dev/benchmark-improvement-plan.md
@@ -936,3 +936,24 @@ errors).
    sensitivity set), D9 jemalloc A/B.
 5. E4 public-doc refresh from run-3 medians (run-2 second draft is already
    published as preliminary).
+
+### Run-2 follow-up tasks — implementation status (2026-07-21)
+
+Implemented on branch `claude/benchmark-analysis-docs-wm7wyq`, **each with the
+model the task specifies** (A8/A9/D11/labeling via Sonnet agents; D10 via Opus).
+Same sandbox caveat as before: no `k6`/live stack here, so measured-number
+acceptance (batch throughput, gRPC cell validity, `bench_fallback==0`) is
+confirmed on the run-3 laptop matrix. All logic changes are unit/behaviour-tested
+here.
+
+| Task | Model | Status | Notes |
+|------|-------|--------|-------|
+| A8 token_refresh user-token | Sonnet | ✅ / ⏳ | `token_refresh.js` → `mintUserToken()` (login-first); AXIAM `axiam_refresh` cookie + KC ROPC `refresh_token` now feed real rotation; Zitadel keeps the tagged fallback (needs offline_access flow). `bench_fallback==0` for AXIAM/KC ⏳ run-3 |
+| A9 provenance | Sonnet | ✅ | `image_id` fallback when RepoDigests empty, `build_ref`=`git rev-parse HEAD` in meta, `${BENCH_SURREALDB_IMAGE}`/`${BENCH_PG_IMAGE}` digest-pin overrides in composes; `bash -n` + `compose config` clean |
+| D11 Zitadel gRPC audience | Sonnet | ✅ / ⏳ | reserved `urn:zitadel:iam:org:project:id:zitadel:aud` added to Zitadel CC scope; `bench_grpc_status` Trend records gRPC status in all 3 gRPC scenarios. Valid 0%-error cell ⏳ run-3 |
+| Report labeling polish | Sonnet | ✅ | `report.py`: `fallback-op` vs `cc-token-setup` split (keeps Zitadel userinfo comparable), gRPC 100%-error blanking keyed off `bench_*`, gRPC-status appendix; `py_compile` + synthetic-tree validation |
+| D10 batch serialization | Opus | ✅ / ⏳ | grants-query hypothesis **disproven** (single-check uses the same query); shipped config-selectable `BatchStrategy` (default `concurrent` = per-item parallel, byte-identical decisions; `coalesced` retained). `claude_dev/authz-batch-investigation.md`. Batch>single throughput ⏳ run-3 |
+
+The run-3 checklist above is unchanged; A8/A9/D11/labeling land the "small harness
+diffs" of step 1, and D10 lands the batch fix ahead of step 3's laptop A/B (run
+both `AXIAM__AUTHZ__BATCH_STRATEGY` modes to confirm the default).

--- a/crates/axiam-api-grpc/src/services/authorization.rs
+++ b/crates/axiam-api-grpc/src/services/authorization.rs
@@ -23,11 +23,11 @@ where
     G: GroupRepository,
 {
     engine: AuthorizationEngine<R, P, Res, S, G>,
-    /// Retained from the pre-D1 concurrent-fan-out design and still accepted by
-    /// [`Self::new`] for call-site/config compatibility (`AuthzConfig::
-    /// batch_max_concurrency`, default 16). The D1 coalesced batch path issues
-    /// a small fixed number of DB round-trips per batch rather than one
-    /// per-item future, so the concurrency bound is no longer applied here.
+    /// Retained for call-site/config compatibility (`AuthzConfig::
+    /// batch_max_concurrency`, default 16). As of D10 the concurrency bound is
+    /// owned by the `AuthorizationEngine` itself (applied via
+    /// `with_batch_config` at construction and enforced by
+    /// [`BatchStrategy::Concurrent`]), so this copy is no longer consulted here.
     #[allow(dead_code)]
     batch_max_concurrency: usize,
 }

--- a/crates/axiam-authz/Cargo.toml
+++ b/crates/axiam-authz/Cargo.toml
@@ -17,6 +17,9 @@ tracing = { workspace = true }
 # thiserror: used for AuthzError derive; verified by cargo check
 thiserror = { workspace = true }
 uuid = { workspace = true }
+# futures: bounded-concurrency (buffered) per-item batch evaluation in engine.rs
+# (D10 concurrent BatchStrategy); verified by cargo check.
+futures = "0.3"
 
 [dev-dependencies]
 axiam-db = { path = "../axiam-db" }

--- a/crates/axiam-authz/src/config.rs
+++ b/crates/axiam-authz/src/config.rs
@@ -7,6 +7,32 @@ use serde::Deserialize;
 
 use crate::decision_cache::{DecisionCache, DecisionCacheConfig};
 
+/// Strategy for evaluating a `BatchCheckAccess` call (REST + gRPC).
+///
+/// Both strategies produce **byte-identical decisions in the same order** —
+/// they differ only in how the DB work is scheduled, so switching is a pure
+/// performance choice with no authorization-semantics risk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchStrategy {
+    /// **D1 path.** Coalesce the shared role-assignment, ancestor and grant
+    /// lookups across same-subject/same-resource items into a minimal set of DB
+    /// round-trips (3 for the benchmark's 5-item shape). Minimizes round-trips,
+    /// but the whole batch resolves on a single task: the run-2 benchmark showed
+    /// this serializes on the database (DB pinned at ~1 core while idle, ~1 s
+    /// p50) and did **not** beat repeated single checks.
+    Coalesced,
+    /// **D10 path (default).** Evaluate each item as an independent
+    /// `check_access`, **concurrently**, bounded by `batch_max_concurrency`.
+    /// Issues more DB round-trips (one set per item) but recovers the
+    /// parallelism that lets single checks saturate the DB — the run-2 data
+    /// showed single checks pegging the DB at 745 req/s while the coalesced
+    /// batch left it idle. Decisions and result order are identical to the
+    /// coalesced path (the cache is consulted per item, exactly as for a plain
+    /// `check_access`).
+    Concurrent,
+}
+
 /// Configuration for the authorization engine.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
@@ -14,10 +40,21 @@ pub struct AuthzConfig {
     /// Bound on concurrent `check_access` evaluations within a single
     /// `BatchCheckAccess` call (gRPC and REST). Kept well under the
     /// ~30-connection SurrealDB handle budget so a batch cannot self-DoS
-    /// the connection pool (D-07).
+    /// the connection pool (D-07). Enforced by the `Concurrent`
+    /// [`BatchStrategy`]; ignored by `Coalesced` (which issues a fixed, small
+    /// number of round-trips regardless of batch size).
     ///
     /// Configure via `AXIAM__AUTHZ__BATCH_MAX_CONCURRENCY` env var.
     pub batch_max_concurrency: usize,
+
+    /// How a `BatchCheckAccess` is evaluated (D10). Defaults to
+    /// [`BatchStrategy::Concurrent`] — per-item parallel evaluation, which the
+    /// run-2 benchmark analysis identified as the fix for the coalesced path's
+    /// DB serialization. Set to `coalesced` to restore the D1 round-trip-
+    /// minimizing behavior for an apples-to-apples laptop A/B.
+    ///
+    /// Configure via `AXIAM__AUTHZ__BATCH_STRATEGY` (`concurrent` | `coalesced`).
+    pub batch_strategy: BatchStrategy,
 
     /// Enable the per-tenant authorization **decision cache** (D7). When
     /// `false` (the default) the engine issues its usual DB round-trips on
@@ -53,6 +90,7 @@ impl Default for AuthzConfig {
     fn default() -> Self {
         Self {
             batch_max_concurrency: 16,
+            batch_strategy: BatchStrategy::Concurrent,
             decision_cache_enabled: false,
             decision_cache_ttl_secs: 5,
             decision_cache_max_entries: 10_000,
@@ -103,6 +141,30 @@ mod tests {
         let cfg: AuthzConfig = serde_json::from_str(r#"{"batch_max_concurrency": 4}"#)
             .expect("explicit override must deserialize");
         assert_eq!(cfg.batch_max_concurrency, 4);
+    }
+
+    #[test]
+    fn default_batch_strategy_is_concurrent() {
+        // D10: per-item parallel evaluation is the shipped default (the fix for
+        // the coalesced path's DB serialization); `coalesced` is opt-in.
+        let cfg = AuthzConfig::default();
+        assert_eq!(cfg.batch_strategy, BatchStrategy::Concurrent);
+    }
+
+    #[test]
+    fn deserializes_batch_strategy_override() {
+        let cfg: AuthzConfig = serde_json::from_str(r#"{"batch_strategy": "coalesced"}"#)
+            .expect("batch_strategy override must deserialize");
+        assert_eq!(cfg.batch_strategy, BatchStrategy::Coalesced);
+        let cfg: AuthzConfig = serde_json::from_str(r#"{"batch_strategy": "concurrent"}"#)
+            .expect("batch_strategy override must deserialize");
+        assert_eq!(cfg.batch_strategy, BatchStrategy::Concurrent);
+    }
+
+    #[test]
+    fn empty_object_defaults_batch_strategy_to_concurrent() {
+        let cfg: AuthzConfig = serde_json::from_str("{}").expect("empty object must deserialize");
+        assert_eq!(cfg.batch_strategy, BatchStrategy::Concurrent);
     }
 
     #[test]

--- a/crates/axiam-authz/src/engine.rs
+++ b/crates/axiam-authz/src/engine.rs
@@ -359,7 +359,19 @@ where
     ) -> AxiamResult<Vec<AccessDecision>> {
         use futures::stream::{StreamExt, TryStreamExt};
 
-        futures::stream::iter(requests.iter().map(|req| self.check_access(req)))
+        // Build the per-item futures EAGERLY into a Vec before handing them to
+        // the stream. Mapping `requests.iter()` lazily inside `stream::iter`
+        // would store the `|req| self.check_access(req)` closure in the stream
+        // adapter, and when the whole `check_access_batch` future is erased
+        // behind the `AuthzChecker` trait object (`Pin<Box<dyn Future + Send>>`
+        // in axiam-api-rest / the gRPC async-trait), the borrow checker cannot
+        // prove that closure is `for<'a> FnMut(&'a AccessRequest) -> …`
+        // ("implementation of `FnOnce` is not general enough"). Collecting
+        // first applies the closure in this concrete-lifetime scope, so the
+        // boxed future holds only already-built item futures — no HRTB closure.
+        let item_futures: Vec<_> = requests.iter().map(|req| self.check_access(req)).collect();
+
+        futures::stream::iter(item_futures)
             .buffered(self.batch_max_concurrency.max(1))
             .try_collect()
             .await

--- a/crates/axiam-authz/src/engine.rs
+++ b/crates/axiam-authz/src/engine.rs
@@ -12,6 +12,7 @@ use axiam_core::repository::{
 use tracing::Instrument;
 use uuid::Uuid;
 
+use crate::config::BatchStrategy;
 use crate::decision_cache::DecisionCache;
 use crate::types::{AccessDecision, AccessRequest};
 
@@ -43,6 +44,14 @@ where
     /// When `None`, `check_access` / `check_access_batch` behave exactly as a
     /// build without the cache.
     decision_cache: Option<Arc<DecisionCache>>,
+    /// How `check_access_batch` schedules its work (D10). Defaults to
+    /// [`BatchStrategy::Concurrent`]; `axiam-server` overrides from
+    /// `AXIAM__AUTHZ__BATCH_STRATEGY`. Never affects decisions or their order.
+    batch_strategy: BatchStrategy,
+    /// Bound on in-flight per-item evaluations under
+    /// [`BatchStrategy::Concurrent`] (D-07 pool-safety). Ignored by
+    /// `Coalesced`. Defaults to 16.
+    batch_max_concurrency: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -131,7 +140,24 @@ where
             scope_repo,
             group_repo,
             decision_cache: None,
+            batch_strategy: BatchStrategy::Concurrent,
+            batch_max_concurrency: 16,
         }
+    }
+
+    /// Set the batch-evaluation strategy and its concurrency bound (D10).
+    /// Consumed builder style so existing `new(..)` call sites are unaffected;
+    /// `axiam-server` calls this once per engine from `AuthzConfig`. Neither
+    /// value changes decisions or result order — only DB scheduling.
+    #[must_use]
+    pub fn with_batch_config(
+        mut self,
+        strategy: BatchStrategy,
+        batch_max_concurrency: usize,
+    ) -> Self {
+        self.batch_strategy = strategy;
+        self.batch_max_concurrency = batch_max_concurrency.max(1);
+        self
     }
 
     /// Attach a shared [`DecisionCache`] to this engine (D7). Consumed builder
@@ -288,24 +314,66 @@ where
         }
     }
 
-    /// Evaluate an ordered batch of authorization checks, coalescing the shared
-    /// DB lookups so that items repeating the same subject or resource resolve
-    /// each lookup **once** instead of once per item.
+    /// Evaluate an ordered batch of authorization checks.
     ///
     /// The returned `Vec` has the same length and order as `requests`; result
     /// `i` is the decision for `requests[i]` and is byte-identical to what
-    /// [`Self::check_access`] would return for that request in isolation.
+    /// [`Self::check_access`] would return for that request in isolation — this
+    /// holds for **both** [`BatchStrategy`] variants, which differ only in how
+    /// the DB work is scheduled:
     ///
-    /// Round-trip reduction for the benchmark shape (5 items, one shared subject
-    /// and resource, no scope): **15 round-trips → 3** — one
-    /// `get_user_role_assignments`, one `get_ancestors`, and one batched
-    /// `get_role_permission_grants_for_roles` across every applicable role in
-    /// the batch.
+    /// - [`BatchStrategy::Concurrent`] (default, D10) — each item is an
+    ///   independent cache-aware [`Self::check_access`], run concurrently
+    ///   (bounded by `batch_max_concurrency`). Recovers per-item DB parallelism.
+    /// - [`BatchStrategy::Coalesced`] (D1) — shared role-assignment/ancestor/
+    ///   grant lookups resolved once per (tenant, subject|resource): 15
+    ///   round-trips → 3 for the benchmark's 5-item shape. Fewer round-trips,
+    ///   but serializes on the DB under load (see run-2 analysis).
     pub async fn check_access_batch(
         &self,
         requests: &[AccessRequest],
     ) -> AxiamResult<Vec<AccessDecision>> {
-        // D7: with no cache attached, this is exactly the D1 coalesced path —
+        match self.batch_strategy {
+            BatchStrategy::Concurrent => self.evaluate_concurrent(requests).await,
+            BatchStrategy::Coalesced => self.evaluate_coalesced_cached(requests).await,
+        }
+    }
+
+    /// **D10 default** — evaluate each item as an independent, cache-aware
+    /// [`Self::check_access`], run **concurrently** with a bound of
+    /// `batch_max_concurrency` in-flight, preserving input order.
+    ///
+    /// Why this is the default (run-2 evidence): the coalesced path
+    /// ([`Self::evaluate_batch`]) minimizes round-trips but resolves the whole
+    /// batch on a single task, which serialized on the database (DB pinned at
+    /// ~1 core, ~1 s p50, everything else idle) and did not beat repeated
+    /// single checks. Single `check_access` calls, by contrast, saturated the
+    /// DB (2 cores, 745 req/s) precisely because 50 of them ran concurrently.
+    /// Evaluating a batch's items the same way recovers that parallelism.
+    /// `check_access` is reused verbatim, so every item's decision, deny reason,
+    /// cache lookup and cache insert are identical to a standalone call —
+    /// `buffered` keeps results in request order.
+    async fn evaluate_concurrent(
+        &self,
+        requests: &[AccessRequest],
+    ) -> AxiamResult<Vec<AccessDecision>> {
+        use futures::stream::{StreamExt, TryStreamExt};
+
+        futures::stream::iter(requests.iter().map(|req| self.check_access(req)))
+            .buffered(self.batch_max_concurrency.max(1))
+            .try_collect()
+            .await
+    }
+
+    /// **D1 path** (opt-in via `AXIAM__AUTHZ__BATCH_STRATEGY=coalesced`) —
+    /// coalesced evaluation with the D7 decision cache layered on top: serve
+    /// hits from the cache, evaluate only the misses through the shared-lookup
+    /// batch path, then backfill. Input order is preserved.
+    async fn evaluate_coalesced_cached(
+        &self,
+        requests: &[AccessRequest],
+    ) -> AxiamResult<Vec<AccessDecision>> {
+        // With no cache attached, this is exactly the D1 coalesced path —
         // zero behaviour change.
         let Some(cache) = self.decision_cache.as_ref() else {
             return self.evaluate_batch(requests).await;

--- a/crates/axiam-authz/src/lib.rs
+++ b/crates/axiam-authz/src/lib.rs
@@ -5,7 +5,7 @@ pub mod decision_cache;
 pub mod engine;
 pub mod types;
 
-pub use config::AuthzConfig;
+pub use config::{AuthzConfig, BatchStrategy};
 pub use decision_cache::{DecisionCache, DecisionCacheConfig};
 pub use engine::AuthorizationEngine;
 pub use types::{AccessDecision, AccessRequest};

--- a/crates/axiam-authz/tests/batch_coalescing_test.rs
+++ b/crates/axiam-authz/tests/batch_coalescing_test.rs
@@ -705,3 +705,35 @@ async fn concurrent_strategy_is_per_item_and_matches_sequential() {
     assert_eq!(batched, sequential);
     assert!(batched.iter().all(|d| *d == AccessDecision::Allow));
 }
+
+/// Regression for the HRTB "implementation of `FnOnce` is not general enough"
+/// error: the REST `AuthzChecker` impl and the gRPC async-trait erase
+/// `check_access_batch` into a `Pin<Box<dyn Future + Send + 'a>>`. Reproduce
+/// exactly that coercion here so the engine crate guards the concurrent path's
+/// boxability WITHOUT needing the api-rest/api-grpc build (they require
+/// protoc/libxml2, absent in the dev sandbox — this is where CI first caught it).
+#[tokio::test]
+async fn concurrent_batch_future_is_boxable_as_send_trait_object() {
+    use std::future::Future;
+    use std::pin::Pin;
+
+    let tenant = Uuid::new_v4();
+    let subject = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let (engine, _counters) = build_engine(tenant, subject, resource_id, "read");
+    let engine = engine.with_batch_config(BatchStrategy::Concurrent, 16);
+
+    let requests = vec![AccessRequest {
+        tenant_id: tenant,
+        subject_id: subject,
+        action: "read".into(),
+        resource_id,
+        scope: None,
+    }];
+
+    // Same shape as axiam-api-rest/src/authz.rs check_access_batch.
+    let fut: Pin<Box<dyn Future<Output = AxiamResult<Vec<AccessDecision>>> + Send + '_>> =
+        Box::pin(engine.check_access_batch(&requests));
+    let decisions = fut.await.unwrap();
+    assert_eq!(decisions, vec![AccessDecision::Allow]);
+}

--- a/crates/axiam-authz/tests/batch_coalescing_test.rs
+++ b/crates/axiam-authz/tests/batch_coalescing_test.rs
@@ -26,8 +26,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use axiam_authz::AuthorizationEngine;
 use axiam_authz::types::{AccessDecision, AccessRequest};
+use axiam_authz::{AuthorizationEngine, BatchStrategy};
 use axiam_core::error::AxiamResult;
 use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
 use axiam_core::models::permission::{
@@ -403,6 +403,9 @@ fn build_engine(
         }],
     );
 
+    // These tests assert the COALESCED path's round-trip counts, so pin the
+    // strategy explicitly — the engine default is now `Concurrent` (D10), whose
+    // per-item scheduling deliberately issues one lookup set per item.
     let engine = AuthorizationEngine::new(
         MockRoleRepo {
             counter: counters.role_assignments.clone(),
@@ -421,7 +424,8 @@ fn build_engine(
             by_resource: HashMap::new(),
         },
         MockGroupRepo,
-    );
+    )
+    .with_batch_config(BatchStrategy::Coalesced, 16);
 
     (engine, counters)
 }
@@ -561,7 +565,8 @@ async fn distinct_groups_coalesce_per_group_and_preserve_order() {
             by_resource: HashMap::new(),
         },
         MockGroupRepo,
-    );
+    )
+    .with_batch_config(BatchStrategy::Coalesced, 16);
 
     // Order: A/read/x (allow), A/write/x (deny — no grant), B/write/y (allow),
     // A/read/x (allow again — same group as item 0).
@@ -646,4 +651,57 @@ async fn empty_subject_denies_without_extra_round_trips() {
     assert_eq!(Counters::get(&counters.ancestors), 0);
     assert_eq!(Counters::get(&counters.grants), 0);
     assert_eq!(batched[0], AccessDecision::Deny("no roles assigned".into()));
+}
+
+/// D10: the DEFAULT `Concurrent` strategy evaluates each item independently, so
+/// a same-subject batch of 5 issues one lookup **set per item** (5/5/5) rather
+/// than coalescing to 1/1/1 — the deliberate trade-off that recovers per-item
+/// DB parallelism. Decisions and order must still be byte-identical to the
+/// sequential per-item `check_access` baseline (concurrency introduces no
+/// ordering or decision bug). This is the same-subject counterpart to the
+/// coalescing test above, proving both strategies agree on results while
+/// differing only in scheduling.
+#[tokio::test]
+async fn concurrent_strategy_is_per_item_and_matches_sequential() {
+    let tenant = Uuid::new_v4();
+    let subject = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    // build_engine pins Coalesced; rebuild the SAME topology as Concurrent (the
+    // engine default) to exercise the D10 path explicitly.
+    let (coalesced_engine, counters) = build_engine(tenant, subject, resource_id, "read");
+    // Reconstruct an identical engine in the default (Concurrent) strategy by
+    // toggling the one built above — `with_batch_config` is a pure setter.
+    let engine = coalesced_engine.with_batch_config(BatchStrategy::Concurrent, 16);
+
+    let requests: Vec<AccessRequest> = (0..5)
+        .map(|_| AccessRequest {
+            tenant_id: tenant,
+            subject_id: subject,
+            action: "read".into(),
+            resource_id,
+            scope: None,
+        })
+        .collect();
+
+    // Sequential per-item baseline decisions.
+    counters.reset();
+    let mut sequential = Vec::new();
+    for req in &requests {
+        sequential.push(engine.check_access(req).await.unwrap());
+    }
+
+    // Concurrent batch: per-item round-trips (5 each, NOT coalesced to 1).
+    counters.reset();
+    let batched = engine.check_access_batch(&requests).await.unwrap();
+    assert_eq!(
+        Counters::get(&counters.role_assignments),
+        5,
+        "concurrent strategy issues one role-assignment lookup PER ITEM"
+    );
+    assert_eq!(Counters::get(&counters.ancestors), 5);
+    assert_eq!(Counters::get(&counters.grants), 5);
+
+    // ...yet decisions are byte-identical and in order.
+    assert_eq!(batched, sequential);
+    assert!(batched.iter().all(|d| *d == AccessDecision::Allow));
 }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -711,6 +711,10 @@ async fn main() -> std::io::Result<()> {
             resource_repo.clone(),
             scope_repo.clone(),
             group_repo.clone(),
+        )
+        .with_batch_config(
+            config.authz.batch_strategy,
+            config.authz.batch_max_concurrency,
         );
         Arc::new(match decision_cache.as_ref() {
             Some(cache) => engine.with_decision_cache(cache.clone()),
@@ -731,6 +735,10 @@ async fn main() -> std::io::Result<()> {
             resource_repo.clone(),
             scope_repo.clone(),
             group_repo.clone(),
+        )
+        .with_batch_config(
+            config.authz.batch_strategy,
+            config.authz.batch_max_concurrency,
         );
         match decision_cache.as_ref() {
             Some(cache) => engine.with_decision_cache(cache.clone()),
@@ -893,6 +901,10 @@ async fn main() -> std::io::Result<()> {
             resource_repo.clone(),
             scope_repo.clone(),
             group_repo.clone(),
+        )
+        .with_batch_config(
+            config.authz.batch_strategy,
+            config.authz.batch_max_concurrency,
         );
         match decision_cache.as_ref() {
             Some(cache) => engine.with_decision_cache(cache.clone()),


### PR DESCRIPTION
Implements the new tasks surfaced by the run-2 benchmark analysis (`claude_dev/benchmark-improvement-plan.md`), each with the model the plan assigns it (A8/A9/D11/report-polish → Sonnet; D10 → Opus).

## Harness (benchmark-only)

- **A8 — `token_refresh` mints a user token.** `token_refresh.js` now uses `mintUserToken()` (login-first) so AXIAM (`axiam_refresh` cookie) and Keycloak (ROPC `refresh_token`) exercise **real single-use rotation** instead of the client-credentials fallback that fired on 100% of iterations in run 2. Zitadel keeps the tagged fallback (a real refresh needs an `offline_access` flow the harness doesn't drive).
- **A9 — provenance.** `run-benchmark.sh` records an `image_id` fallback when `RepoDigests` is empty (locally-built images), a `build_ref` (`git rev-parse HEAD`) meta field, and the target composes gain `${BENCH_SURREALDB_IMAGE}` / `${BENCH_PG_IMAGE}` overrides so the floating `v3` / `16-alpine` tags can be digest-pinned at run time.
- **D11 — Zitadel gRPC audience + status visibility.** `clientCredentials()` now also requests the reserved `urn:zitadel:iam:org:project:id:zitadel:aud` audience (Zitadel's Auth API rejects tokens without it — the run-2 gRPC cell was 100% non-OK); a `bench_grpc_status` Trend records the gRPC status code across all three gRPC scenarios.
- **Report labeling polish.** `report.py` distinguishes `fallback-op` (excluded from head-to-head) from `cc-token-setup` (kept, e.g. Zitadel userinfo), blanks throughput/latency for 100%-error **gRPC** cells via the `bench_*` metrics, and adds a gRPC-status appendix.

## Server (`axiam-authz`)

- **D10 — batch-authz serialization.** The prior grants-query hypothesis is **disproven by the source**: the single-check path (`engine.rs`) issues the *same* `get_role_permission_grants_for_roles` query yet runs at 745 req/s with the DB pegged — so the query shape isn't the batch bottleneck. The coalesced batch instead loses the query-level parallelism that lets single checks saturate the DB (DB idle at ~1 core, ~1 s p50). Fix: a config-selectable `BatchStrategy` (`AXIAM__AUTHZ__BATCH_STRATEGY`), default flipped to **`concurrent`** — `check_access_batch` now evaluates each item as an independent, cache-aware `check_access`, bounded-concurrently (`buffered(batch_max_concurrency)`), with **byte-identical decisions and order**. The D1 `coalesced` path is retained for an apples-to-apples laptop A/B. Write-up: `claude_dev/authz-batch-investigation.md`.

## Testing

- `cargo test -p axiam-authz` passes: new config tests, a new `concurrent_strategy_is_per_item_and_matches_sequential` correctness test, the D1 round-trip tests pinned to `BatchStrategy::Coalesced`, and the decision-cache batch test (unchanged, green under the concurrent default). `cargo fmt --check` clean.
- Harness edits validated with `node --check`, `python3 -m py_compile`, `bash -n`.
- `axiam-api-grpc` / `axiam-api-rest` couldn't be built in the dev sandbox (missing `protoc` / `libxml2` system deps) — CI covers the full-workspace build. Their test files are unchanged and assert decisions/order, which the concurrent path preserves byte-for-byte.

Measured acceptance (batch > single throughput, a valid 0%-error Zitadel gRPC cell, `bench_fallback == 0` for AXIAM/Keycloak refresh) is confirmed on the run-3 laptop matrix; all logic/security changes are covered by passing tests here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EURhMmqqMpbogtzU8VCW6

---
_Generated by [Claude Code](https://claude.ai/code/session_018EURhMmqqMpbogtzU8VCW6)_