### PR TITLE
feat(website): add missing SDKs, gRPC + config docs, real benchmark data

### DIFF
--- a/website/src/data.ts
+++ b/website/src/data.ts
@@ -1,9 +1,15 @@
-import type { Sdk, Post, Phase, BenchRow } from "./types";
+import type {
+  Sdk,
+  Post,
+  Phase,
+  BenchScenario,
+  BenchEfficiencyRow,
+} from "./types";
 
 /**
  * Content model for the AXIAM website. Mirrors the design's data source: the
- * seven official client SDKs, the news posts, the 19-phase roadmap, and the
- * illustrative benchmark rows.
+ * eleven official client SDKs, the news posts, the 19-phase roadmap, and the
+ * preliminary benchmark scenarios.
  */
 
 export const SDKS: Sdk[] = [
@@ -16,6 +22,7 @@ export const SDKS: Sdk[] = [
     docsLabel: "docs.rs",
     docsUrl: "https://docs.rs/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-rust-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-rust-sdk/tree/main/examples",
     pkg: "axiam-sdk",
     install: "cargo add axiam-sdk",
     blurb: "Native async client with the full REST, gRPC and AMQP surface.",
@@ -53,6 +60,7 @@ async fn get_doc(path: web::Path<String>) -> impl Responder {
     docsLabel: "tsdocs.dev",
     docsUrl: "https://tsdocs.dev/docs/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-typescript-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-typescript-sdk/tree/main/examples",
     pkg: "axiam-sdk",
     install: "npm install axiam-sdk",
     blurb:
@@ -94,6 +102,7 @@ export class DocsController {
     docsLabel: "Read the Docs",
     docsUrl: "https://axiam-sdk.readthedocs.io/",
     repoUrl: "https://github.com/ilpanich/axiam-python-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-python-sdk/tree/main/examples",
     pkg: "axiam-sdk",
     install: "pip install axiam-sdk",
     blurb:
@@ -132,6 +141,7 @@ def read_doc(doc_id: str,
     docsLabel: "javadoc.io",
     docsUrl: "https://javadoc.io/doc/io.github.ilpanich/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-java-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-java-sdk/tree/main/examples",
     pkg: "io.github.ilpanich:axiam-sdk",
     install: 'implementation("io.github.ilpanich:axiam-sdk:1.0.0")',
     blurb:
@@ -171,6 +181,7 @@ class DocController {
     docsLabel: "fuget.org",
     docsUrl: "https://www.fuget.org/packages/Axiam.Sdk",
     repoUrl: "https://github.com/ilpanich/axiam-csharp-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-csharp-sdk/tree/main/examples",
     pkg: "Axiam.Sdk",
     install: "dotnet add package Axiam.Sdk",
     blurb:
@@ -206,6 +217,7 @@ public class DocsController : ControllerBase
     registry: "Packagist",
     registryUrl: "https://packagist.org/packages/axiam/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-php-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-php-sdk/tree/main/examples",
     pkg: "axiam/axiam-sdk",
     install: "composer require axiam/axiam-sdk",
     blurb: "PSR-friendly client with middleware for Laravel and Symfony apps.",
@@ -246,6 +258,7 @@ class DocController
     docsLabel: "pkg.go.dev",
     docsUrl: "https://pkg.go.dev/github.com/ilpanich/axiam-go-sdk#section-documentation",
     repoUrl: "https://github.com/ilpanich/axiam-go-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-go-sdk/tree/main/examples",
     pkg: "github.com/ilpanich/axiam-go-sdk",
     install: "go get github.com/ilpanich/axiam-go-sdk",
     blurb:
@@ -270,6 +283,193 @@ ok, _ := client.Can(ctx, "read", "doc:1")`,
 // runs before it — a denied request never reaches getDoc.
 mux.Handle("GET /docs/{id}",
     axiam.Require("read", "doc:{id}")(http.HandlerFunc(getDoc)))`,
+  },
+  {
+    id: "kotlin",
+    name: "Kotlin",
+    abbr: "Kt",
+    registry: "Maven Central",
+    registryUrl:
+      "https://central.sonatype.com/artifact/io.github.ilpanich/axiam-sdk-kotlin",
+    docsLabel: "javadoc.io",
+    docsUrl: "https://javadoc.io/doc/io.github.ilpanich/axiam-sdk-kotlin",
+    repoUrl: "https://github.com/ilpanich/axiam-kotlin-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-kotlin-sdk/tree/main/examples",
+    pkg: "io.github.ilpanich:axiam-sdk-kotlin",
+    install: 'implementation("io.github.ilpanich:axiam-sdk-kotlin:1.0.0-alpha15")',
+    blurb:
+      "Coroutine-native REST client for the JVM, with Ktor route guards and declarative helpers.",
+    highlights: [
+      "Coroutines — every op is a suspend fn",
+      "Ktor plugin + guard annotations",
+      "Sensitive<T> secrets, strict TLS & mTLS",
+    ],
+    quickstart: `import io.axiam.sdk.AxiamClient
+import kotlinx.coroutines.runBlocking
+
+runBlocking {
+    AxiamClient.builder("https://iam.acme.dev", tenantId = "acme")
+        .orgSlug("acme")
+        .build()
+        .use { axiam ->
+            val result = axiam.login(email, password)
+            if (result.mfaRequired)
+                axiam.verifyMfa(result.challengeToken!!, totpCode)
+            val ok = axiam.can("read", resourceId = "doc:1")
+        }
+}`,
+    guardLabel: "Guard by Ktor plugin",
+    guardExample: `import io.axiam.sdk.ktor.*
+
+install(AxiamAuthentication) { client = axiamClient }
+
+routing {
+    // requireAccess runs the check before the body — a deny short-circuits.
+    get("/documents/{id}") {
+        val user = call.requireAccess("read", call.parameters["id"]!!)
+            ?: return@get
+        call.respondText("hello \${user.userId}")
+    }
+}`,
+  },
+  {
+    id: "swift",
+    name: "Swift",
+    abbr: "Sw",
+    registry: "SwiftPM",
+    registryUrl: "https://github.com/ilpanich/axiam-swift-sdk",
+    docsLabel: "DocC",
+    docsUrl: "https://ilpanich.github.io/axiam-swift-sdk/",
+    repoUrl: "https://github.com/ilpanich/axiam-swift-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-swift-sdk/tree/main/Examples",
+    pkg: "AxiamSDK",
+    install:
+      '.package(url: "https://github.com/ilpanich/axiam-swift-sdk.git", from: "1.0.0-alpha15")',
+    blurb:
+      "Cross-platform REST client on SwiftNIO — client-cert mTLS works on Linux and Apple platforms alike.",
+    highlights: [
+      "AsyncHTTPClient + NIOSSL, one code path",
+      "async/await, single-flight refresh",
+      "Sensitive<T>, custom-CA & client-cert mTLS",
+    ],
+    quickstart: `import AxiamSDK
+
+let config = try AxiamConfig(
+    baseURL: URL(string: "https://iam.acme.dev")!,
+    tenantSlug: "acme",
+    orgSlug: "acme")
+let axiam = try AxiamClient(config: config)
+
+switch try await axiam.login(email: email, password: password) {
+case .authenticated(let user): print("in as \\(user.userID)")
+case .mfaRequired:             try await axiam.verifyMfa(totpCode)
+case .mfaSetupRequired:        break
+}
+let ok = try await axiam.can("read", resource: "doc:1")`,
+    guardLabel: "Guard by helper factory",
+    guardExample: `// makeGuards() returns declarative check factories (§11).
+let guards = axiam.makeGuards()
+let requireRead = guards.requireAccess("read", resource: "doc:1")
+
+let ctx = AxiamRequestContext(
+    headers: ["Authorization": "Bearer \\(jwt)", "X-Tenant-ID": "acme"],
+    cookies: ["axiam_access": cookieJwt])
+
+// Throws AuthzError (403) if denied — never reaches your handler.
+let user = try await requireRead(ctx)`,
+  },
+  {
+    id: "c",
+    name: "C",
+    abbr: "C",
+    registry: "vcpkg · CMake",
+    registryUrl: "https://github.com/ilpanich/axiam-c-sdk#install",
+    docsLabel: "Doxygen",
+    docsUrl: "https://ilpanich.github.io/axiam-c-sdk/",
+    repoUrl: "https://github.com/ilpanich/axiam-c-sdk",
+    examplesUrl: "https://github.com/ilpanich/axiam-c-sdk/tree/main/examples",
+    pkg: "axiam-c-sdk",
+    install: "vcpkg install axiam-c-sdk --overlay-ports=./ports",
+    blurb:
+      "C11 client over libcurl + OpenSSL — a small, offline-friendly REST surface with mTLS.",
+    highlights: [
+      "C11, every symbol axiam_-prefixed",
+      "libcurl HTTP, strict TLS & in-memory mTLS",
+      "Framework-agnostic route guard",
+    ],
+    quickstart: `#include <axiam/axiam.h>
+
+axiam_client_config_t *cfg = axiam_client_config_new();
+axiam_client_config_set_base_url(cfg, "https://iam.acme.dev");
+axiam_client_config_set_tenant_slug(cfg, "acme");
+axiam_client_config_set_org_slug(cfg, "acme");
+
+axiam_error_t err;
+axiam_client_t *axiam = axiam_client_new(cfg, &err);
+axiam_client_config_free(cfg);
+
+axiam_login_result_t login = {0};
+axiam_login(axiam, email, password, &login, &err);
+
+axiam_check_result_t res = {0};
+axiam_check_access(axiam, "read", "doc:1", NULL, NULL, &res, &err);
+printf("allowed: %d\\n", res.allowed);`,
+    guardLabel: "Guard by macro",
+    guardExample: `#include <axiam/guard.h>
+
+// The adapter fills axiam_headers_t from the real request; the guard
+// verifies the session (JWKS) then runs the check — fail closed.
+axiam_guard_status_t st =
+    AXIAM_REQUIRE_ACCESS(axiam, &headers, "read", "doc:1", NULL);
+
+if (st != AXIAM_GUARD_ALLOW)
+    return respond(st);   // 401 / 403 / 503 — never reaches the handler`,
+  },
+  {
+    id: "cpp",
+    name: "C++",
+    abbr: "C++",
+    registry: "vcpkg · Conan",
+    registryUrl: "https://github.com/ilpanich/axiam-cplusplus-sdk#install",
+    docsLabel: "Doxygen",
+    docsUrl: "https://ilpanich.github.io/axiam-cplusplus-sdk/",
+    repoUrl: "https://github.com/ilpanich/axiam-cplusplus-sdk",
+    examplesUrl:
+      "https://github.com/ilpanich/axiam-cplusplus-sdk/tree/main/examples",
+    pkg: "axiam-cpp-sdk",
+    install: "vcpkg install axiam-cpp-sdk --overlay-ports=./ports",
+    blurb:
+      "Idiomatic C++17 client over libcurl + OpenSSL — exceptions, RAII and framework-agnostic guards.",
+    highlights: [
+      "C++17, axiam:: namespace, RAII",
+      "libcurl + OpenSSL, strict TLS & mTLS",
+      "Route guards + AXIAM_REQUIRE_ACCESS",
+    ],
+    quickstart: `#include <axiam/axiam.hpp>
+
+axiam::Client axiam = axiam::Client::builder()
+    .base_url("https://iam.acme.dev")
+    .tenant_slug("acme")
+    .org_slug("acme")
+    .build();
+
+auto login = axiam.login(email, password);
+if (login.mfa_required)
+    login = axiam.verify_mfa(login.challenge_token, totp);
+
+axiam::AccessDecision d = axiam.check_access("read", "doc:1");
+std::cout << "allowed=" << std::boolalpha << d.allowed << "\\n";`,
+    guardLabel: "Guard by helper",
+    guardExample: `#include <axiam/guard.hpp>
+
+// The host adapter authenticates the request into an AxiamUser; the
+// helpers compose on top of check_access and fail closed.
+void handler(axiam::Client& axiam,
+             const std::optional<axiam::AxiamUser>& user) {
+    axiam::require_auth(user);                 // 401 if unauthenticated
+    AXIAM_REQUIRE_ACCESS(axiam, user, "read", "doc:1");  // 403 if denied
+    // ... serve the protected resource ...
+}`,
   },
 ];
 
@@ -430,15 +630,106 @@ export const PHASES: Phase[] = [
   },
 ];
 
-export const BENCH: BenchRow[] = [
+/**
+ * Preliminary benchmark scenarios, transcribed from
+ * `benchmarks/PUBLIC_BENCH_ANALYSIS.md` (draft 2, run of 2026-07-21, AXIAM
+ * 1.0.0-alpha15 vs Keycloak 26.7.0 vs Zitadel v4.15.2). All figures are the
+ * p0-plaintext profile from the capped matrix (§3/§7), single run — a credible
+ * signal, not a final verdict. Only valid, comparable cells are charted.
+ */
+export const BENCH_SCENARIOS: BenchScenario[] = [
   {
-    name: "AXIAM",
-    value: "1.00×",
-    width: "100%",
-    fill: "linear-gradient(90deg,#00d4ff,#a855f7)",
+    id: "client_credentials",
+    title: "Machine-to-machine token issuance",
+    unit: "throughput · requests/s · plaintext",
+    bars: [
+      { target: "AXIAM", value: 1788, display: "1,788", axiam: true },
+      { target: "Zitadel", value: 419, display: "419" },
+      { target: "Keycloak", value: 346, display: "346" },
+    ],
+    takeaway:
+      "AXIAM issues 4.3× more tokens/s than Zitadel and 5.2× more than Keycloak, at a p99 of 36 ms.",
   },
-  { name: "System B", value: "0.62×", width: "62%", fill: "rgba(148,163,184,.45)" },
-  { name: "System C", value: "0.48×", width: "48%", fill: "rgba(148,163,184,.35)" },
+  {
+    id: "introspection",
+    title: "Token introspection (RFC 7662)",
+    unit: "throughput · requests/s · plaintext",
+    bars: [
+      { target: "AXIAM", value: 2229, display: "2,229", axiam: true },
+      { target: "Keycloak", value: 1765, display: "1,765" },
+      { target: "Zitadel", value: 923, display: "923" },
+    ],
+    takeaway:
+      "The closest head-to-head: AXIAM leads Keycloak by 1.26× (2.4× vs Zitadel) with a 3× better p95 and zero TLS penalty.",
+  },
+  {
+    id: "jwks",
+    title: "JWKS fetch (RFC 7517)",
+    unit: "throughput · requests/s · plaintext",
+    bars: [
+      { target: "AXIAM", value: 27059, display: "27,059", axiam: true },
+      { target: "Keycloak", value: 3855, display: "3,855" },
+      { target: "Zitadel", value: 2034, display: "2,034" },
+    ],
+    takeaway:
+      "A 7–13× gap — and AXIAM's server sat under its CPU cap while the load generator saturated, so its true ceiling is higher still.",
+  },
+  {
+    id: "userinfo",
+    title: "OIDC userinfo",
+    unit: "throughput · requests/s · plaintext",
+    bars: [
+      { target: "AXIAM", value: 5457, display: "5,457", axiam: true },
+      { target: "Keycloak", value: 3561, display: "3,561" },
+      { target: "Zitadel", value: 967, display: "967" },
+    ],
+    takeaway:
+      "AXIAM leads throughput (1.5× Keycloak, 5.6× Zitadel) even while DB-limited; on whole-stack CPU per request Keycloak is narrowly more efficient here.",
+  },
+  {
+    id: "password_login",
+    title: "Password login (real hashing)",
+    unit: "throughput · requests/s · plaintext",
+    bars: [
+      { target: "AXIAM", value: 67.5, display: "67.5", axiam: true },
+      { target: "Keycloak", value: 22.3, display: "22.3" },
+      { target: "Zitadel", value: 2.0, display: "2.0" },
+    ],
+    takeaway:
+      "At 50 concurrent users on 2 CPUs, AXIAM is the only target under the 2 s p95 gate. Hash configuration dominates this cell — Zitadel's default bcrypt cost is simply very expensive.",
+  },
 ];
+
+/**
+ * Whole-stack efficiency, head-to-head (p0-plaintext). `req/s per core` is
+ * higher-is-better; `cpu·ms/req` is lower-is-better. AXIAM's figures still
+ * carry its audit broker and, on some cells, a saturated database inside them —
+ * which is why Keycloak edges it on the userinfo cpu·ms/req cell.
+ */
+export const BENCH_EFFICIENCY: BenchEfficiencyRow[] = [
+  { scenario: "Client credentials", perCore: ["617", "167", "117"], cpuMs: ["1.62", "6.00", "8.53"] },
+  { scenario: "Token introspection", perCore: ["936", "753", "250"], cpuMs: ["1.07", "1.33", "4.01"] },
+  { scenario: "JWKS fetch", perCore: ["16,388", "1,922", "681"], cpuMs: ["0.061", "0.52", "1.47"] },
+  { scenario: "OIDC userinfo", perCore: ["1,453", "1,778", "340"], cpuMs: ["0.69", "0.56", "2.94"] },
+];
+
+/**
+ * AXIAM-only authorization decisions (no head-to-head — Keycloak and Zitadel
+ * expose no equivalent endpoint). Each check is a full RBAC evaluation against
+ * live data. Values are p0-plaintext throughput (requests/s).
+ */
+export const BENCH_AUTHZ: BenchScenario = {
+  id: "authz",
+  title: "Authorization decisions (AXIAM-only)",
+  unit: "throughput · requests/s · plaintext",
+  bars: [
+    { target: "REST · single", value: 745, display: "745", axiam: true },
+    { target: "gRPC · single", value: 722, display: "722", axiam: true },
+    { target: "REST · batch ×5", value: 46, display: "46" },
+    { target: "gRPC · batch ×5", value: 23, display: "23" },
+  ],
+  takeaway:
+    "Single checks improved 1.5–2.5× since draft 1 and now run at DB saturation (gRPC p99 tail collapsed 850 → 90 ms). The batch endpoints remain the known weak spot — currently slower than repeated single checks, and under investigation.",
+};
 
 export const GITHUB_URL = "https://github.com/ilpanich/axiam";

--- a/website/src/docs.ts
+++ b/website/src/docs.ts
@@ -23,6 +23,7 @@ export type DocBlock =
   | { type: "code"; caption?: string; code: string }
   | { type: "note"; text: string }
   | { type: "warn"; text: string }
+  | { type: "table"; headers: string[]; rows: string[][] }
   | { type: "cards"; cards: DocCard[] };
 
 export interface DocPage {
@@ -43,9 +44,18 @@ export const DOC_SECTIONS: DocSectionGroup[] = [
   { label: "Getting started", slugs: ["quickstart", "installation", "concepts"] },
   {
     label: "Platform",
-    slugs: ["auth", "authz", "oauth2", "federation", "pki", "webhooks", "audit"],
+    slugs: [
+      "auth",
+      "authz",
+      "grpc",
+      "oauth2",
+      "federation",
+      "pki",
+      "webhooks",
+      "audit",
+    ],
   },
-  { label: "Operate", slugs: ["deploy", "sdks"] },
+  { label: "Operate", slugs: ["deploy", "configuration", "sdks"] },
 ];
 
 export const DOC_PAGES: DocPage[] = [
@@ -87,7 +97,7 @@ export const DOC_PAGES: DocPage[] = [
         cards: [
           {
             title: "Browse the SDKs →",
-            body: "Quickstarts for all seven languages.",
+            body: "Quickstarts for all eleven languages.",
             to: "sdks",
           },
           {
@@ -238,6 +248,80 @@ export const DOC_PAGES: DocPage[] = [
       {
         type: "code",
         code: "// synchronous check\nconst ok = await axiam.can('read', 'doc:1');\n\n// batch several checks in one round trip\nconst results = await axiam.canAll([\n  ['read', 'doc:1'],\n  ['write', 'doc:1'],\n]);",
+      },
+    ],
+  },
+
+  {
+    slug: "grpc",
+    section: "Platform",
+    navLabel: "gRPC API",
+    title: "gRPC API",
+    intro:
+      "A low-latency gRPC surface for service-mesh authorization checks, token validation and user lookups — backed by Tonic and one protobuf contract shared across every SDK.",
+    blocks: [
+      { type: "h", id: "why", text: "Why gRPC" },
+      {
+        type: "p",
+        text: "REST is the general-purpose surface; gRPC exists for the hot path. Inside a service mesh, sidecars and backends make authorization checks on nearly every request, where connection reuse and binary framing keep tail latency low. In the benchmark run, AXIAM's single gRPC `CheckAccess` held a p99 of 90 ms at database saturation and served TLS 1.3 with no measurable penalty versus plaintext.",
+      },
+      { type: "h", id: "services", text: "Services" },
+      {
+        type: "p",
+        text: "Three services are defined in `proto/axiam/v1/`. Every request message is tenant-scoped — `tenant_id` is a field on every RPC, because AXIAM is multi-tenant with no default tenant.",
+      },
+      {
+        type: "table",
+        headers: ["Service", "RPCs", "Purpose"],
+        rows: [
+          [
+            "AuthorizationService",
+            "CheckAccess, BatchCheckAccess",
+            "Single access check, or several checks in one round-trip.",
+          ],
+          [
+            "TokenService",
+            "ValidateToken, IntrospectToken",
+            "Signature + expiry validation, or full RFC 7662-style claims.",
+          ],
+          [
+            "UserService",
+            "GetUser, ValidateCredentials",
+            "Lookup by ID, or a username/password check that issues no token.",
+          ],
+        ],
+      },
+      { type: "h", id: "server", text: "The server" },
+      {
+        type: "p",
+        text: "The gRPC server starts inside `axiam-server` alongside the REST and AMQP listeners. It binds to `127.0.0.1:50051` by default — loopback only — and is meant to be reached in-cluster over an internal network or mTLS, never exposed through a public ingress. Configure the bind address, port and per-IP rate limit with the `AXIAM__GRPC__*` environment variables (see Configuration).",
+      },
+      {
+        type: "note",
+        text: "In the Kubernetes manifests, gRPC (port 50051) is intentionally *not* routed through the Ingress — it is reachable only via the in-cluster `axiam-server` ClusterIP service.",
+      },
+      { type: "h", id: "consume", text: "Consuming the API" },
+      {
+        type: "p",
+        text: "The seven full SDKs (Rust, TypeScript, Python, Java, C#, PHP, Go) ship pre-generated client stubs, so you consume gRPC without running codegen yourself. Tenant is always explicit, and the call surface mirrors the REST `can()` / `canAll()` you already know.",
+      },
+      {
+        type: "code",
+        caption: "authorization check over gRPC · Rust",
+        code: 'use axiam_sdk::AxiamClient;\n\nlet axiam = AxiamClient::builder()\n    .base_url("https://iam.acme.dev")\n    .tenant_slug("acme")\n    .org_slug("acme")\n    .grpc(true) // route checks over the gRPC transport\n    .build()?;\n\nlet ok = axiam.can("read", "doc:1").await?;',
+      },
+      { type: "h", id: "codegen", text: "Generating your own stubs" },
+      {
+        type: "p",
+        text: "If you integrate from a language without a published AXIAM SDK, generate stubs directly from the `.proto` files with `buf generate` (or `protoc` plus your language's gRPC plugin). The files are self-contained proto3 with no external imports beyond the well-known types, and a CI job runs `buf lint` and `buf breaking` against them on every change, so the contract is guarded against accidental breakage.",
+      },
+      {
+        type: "code",
+        code: "# generate client stubs from the vendored proto/ tree\nbuf generate",
+      },
+      {
+        type: "note",
+        text: "The Kotlin, Swift, C and C++ SDKs cover the REST surface today; gRPC is a planned follow-up for them. Until it lands, use the REST transport or generate stubs directly from `proto/`.",
       },
     ],
   },
@@ -415,17 +499,280 @@ export const DOC_PAGES: DocPage[] = [
   },
 
   {
+    slug: "configuration",
+    section: "Operate",
+    navLabel: "Configuration",
+    title: "Configuration & environment variables",
+    intro:
+      "Every setting on the AXIAM server image is an environment variable. This is the reference: what each variable means, its default, and an example value.",
+    blocks: [
+      { type: "h", id: "naming", text: "The naming convention" },
+      {
+        type: "p",
+        text: "All configuration keys use a double underscore (`__`) after the `AXIAM` prefix — for example `AXIAM__DB__USERNAME`. The `__` separates both the prefix and the nested key levels (this is how the config layer distinguishes them). A single underscore (`AXIAM_DB__USERNAME`) is silently ignored and the in-code default wins, so double-check the doubling when a value doesn't take effect.",
+      },
+      {
+        type: "warn",
+        text: "Secrets (database password, JWT keys, the AES-256-GCM encryption keys, the peppers) must come from a secret manager or mounted secret — never bake real key material into an image, a compose file or git. Use a placeholder like `<set-in-secret-manager>` in any template, and never reuse a value across environments.",
+      },
+      { type: "h", id: "connectivity", text: "Connectivity & bind addresses" },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          [
+            "AXIAM__DB__URL",
+            "SurrealDB address as a bare host:port — not a URL scheme (the Ws engine resolves a scheme as a hostname and fails).",
+            "surrealdb:8000",
+          ],
+          ["AXIAM__DB__NAMESPACE", "SurrealDB namespace.", "axiam"],
+          ["AXIAM__DB__DATABASE", "SurrealDB database.", "axiam"],
+          [
+            "AXIAM__AMQP__URL",
+            "RabbitMQ AMQP connection string. Assembled from the broker credentials at the deployment layer.",
+            "amqp://user:pass@rabbitmq:5672",
+          ],
+          [
+            "AXIAM__SERVER__HOST",
+            "REST bind address (default 127.0.0.1). Set 0.0.0.0 in a container.",
+            "0.0.0.0",
+          ],
+          ["AXIAM__SERVER__PORT", "REST bind port (default 8090).", "8090"],
+          [
+            "AXIAM__GRPC__HOST",
+            "gRPC bind address (default 127.0.0.1, loopback-only). Set 0.0.0.0 to serve in-cluster.",
+            "0.0.0.0",
+          ],
+          ["AXIAM__GRPC__PORT", "gRPC bind port (default 50051).", "50051"],
+          [
+            "AXIAM__GRPC__GRPC_AUTHZ_PER_SEC",
+            "Max gRPC authz requests per second per IP (default 100).",
+            "100",
+          ],
+          [
+            "AXIAM__SERVER__CORS_ALLOWED_ORIGINS",
+            "Allowed CORS origins; empty disables cross-origin requests (restrictive default).",
+            "https://admin.acme.dev",
+          ],
+          [
+            "RUST_LOG",
+            "Log verbosity / filter. Keep it narrow in production — no internal module exposure.",
+            "info",
+          ],
+        ],
+      },
+      { type: "h", id: "secrets", text: "Secrets & encryption keys" },
+      {
+        type: "p",
+        text: "These are required for a real deployment. Generate the 32-byte hex keys with `openssl rand -hex 32` and the Ed25519 JWT keypair with `openssl genpkey -algorithm ed25519`.",
+      },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          ["AXIAM__DB__USERNAME", "SurrealDB username.", "axiam"],
+          ["AXIAM__DB__PASSWORD", "SurrealDB password.", "<set-in-secret-manager>"],
+          [
+            "AXIAM__AUTH__JWT_PRIVATE_KEY_PEM",
+            "Ed25519 JWT signing private key (PEM).",
+            "-----BEGIN PRIVATE KEY----- …",
+          ],
+          [
+            "AXIAM__AUTH__JWT_PUBLIC_KEY_PEM",
+            "Ed25519 JWT verification public key (PEM), paired with the private key.",
+            "-----BEGIN PUBLIC KEY----- …",
+          ],
+          [
+            "AXIAM__AUTH__MFA_ENCRYPTION_KEY",
+            "AES-256-GCM key (32-byte hex) encrypting TOTP MFA secrets at rest.",
+            "<64 hex chars>",
+          ],
+          [
+            "AXIAM__PKI__ENCRYPTION_KEY",
+            "AES-256-GCM key (hex) encrypting CA signing keys (and webhook secrets) at rest.",
+            "<64 hex chars>",
+          ],
+          [
+            "AXIAM__AUTH__FEDERATION_ENCRYPTION_KEY",
+            "AES-256-GCM key (hex) encrypting SAML/OIDC federation client secrets at rest.",
+            "<64 hex chars>",
+          ],
+          [
+            "AXIAM__EMAIL_ENCRYPTION_KEY",
+            "AES-256-GCM key (hex) encrypting email/SMTP secrets; also gates the email-config admin endpoints.",
+            "<64 hex chars>",
+          ],
+          [
+            "AXIAM__GDPR_PSEUDONYM_PEPPER",
+            "HMAC-SHA256 pepper (hex) pseudonymizing audit-log actor identities on GDPR erasure.",
+            "<64 hex chars>",
+          ],
+          [
+            "AXIAM__AUTH__PEPPER",
+            "Password pepper (string) prepended before Argon2id hashing.",
+            "<random string>",
+          ],
+        ],
+      },
+      { type: "h", id: "oauth2", text: "OAuth2 & OIDC" },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          [
+            "AXIAM__AUTH__OAUTH2_ISSUER_URL",
+            "Public issuer URL for OIDC discovery. Must be an origin, not a path (path-based issuers are rejected).",
+            "https://iam.acme.dev",
+          ],
+          [
+            "AXIAM__OAUTH2__JWKS_CACHE_MAX_AGE_SECS",
+            "Cache-Control max-age on the JWKS endpoint, in seconds.",
+            "300",
+          ],
+          [
+            "AXIAM__AUTH__ALLOW_MISSING_AUD_AS_USER",
+            "Compatibility switch — treat a token with no audience claim as a user token. Leave off unless you need it.",
+            "false",
+          ],
+        ],
+      },
+      { type: "h", id: "hashing", text: "Argon2id hash concurrency" },
+      {
+        type: "p",
+        text: "Each in-flight Argon2id operation allocates a ~19 MiB arena, so unbounded concurrency is a memory-DoS vector. A process-wide semaphore caps peak concurrent arenas and sheds excess load with a 503 rather than queueing unboundedly. The cost parameters themselves are never weakened for throughput.",
+      },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          [
+            "AXIAM__AUTH__MAX_CONCURRENT_HASHES",
+            "Max concurrent Argon2id hash/verify ops. 0 (default) = auto → min(CPU cores, 4). Peak crypto RSS ≈ this × 19 MiB.",
+            "0",
+          ],
+          [
+            "AXIAM__AUTH__HASH_ACQUIRE_TIMEOUT_SECS",
+            "Seconds a request waits for a hash permit before returning a 503 backpressure error (default 5).",
+            "5",
+          ],
+        ],
+      },
+      { type: "h", id: "authz-cache", text: "Authorization decision cache (optional)" },
+      {
+        type: "p",
+        text: "An optional per-tenant cache that skips the SurrealDB round-trips per check. Off by default; enabling it changes performance only, never the decision returned. Every access-narrowing mutation invalidates the affected entries immediately, so no revocation can leave a stale allow — the TTL is only a bounded-staleness backstop.",
+      },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          [
+            "AXIAM__AUTHZ__DECISION_CACHE_ENABLED",
+            "Master switch (default false).",
+            "false",
+          ],
+          [
+            "AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS",
+            "Cached-decision TTL, and the upper bound on revocation latency if an invalidation is ever missed (default 5).",
+            "5",
+          ],
+          [
+            "AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES",
+            "Max cached decisions per tenant before FIFO eviction (default 10000).",
+            "10000",
+          ],
+        ],
+      },
+      { type: "h", id: "rate-limit", text: "Rate limiting" },
+      {
+        type: "p",
+        text: "Every auth/OAuth2 endpoint is rate-limited per-key, per-minute. Defaults are shown; `/auth/login` always keys per-IP regardless of the key mode.",
+      },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          ["AXIAM__RATE_LIMIT__LOGIN_PER_MIN", "Max /auth/login per minute per key.", "10"],
+          ["AXIAM__RATE_LIMIT__REGISTER_PER_MIN", "Max register requests per minute.", "5"],
+          ["AXIAM__RATE_LIMIT__TOKEN_PER_MIN", "Max /oauth2/token per minute.", "20"],
+          [
+            "AXIAM__RATE_LIMIT__PASSWORD_RESET_PER_MIN",
+            "Max password-reset requests per minute.",
+            "3",
+          ],
+          ["AXIAM__RATE_LIMIT__MFA_PER_MIN", "Max MFA enroll/confirm/verify per minute.", "5"],
+          [
+            "AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN",
+            "Max /oauth2/introspect per minute.",
+            "10",
+          ],
+          ["AXIAM__RATE_LIMIT__REVOKE_PER_MIN", "Max /oauth2/revoke per minute.", "10"],
+          [
+            "AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN",
+            "Max authz-check requests per minute.",
+            "300",
+          ],
+          [
+            "AXIAM__RATE_LIMIT__TRUSTED_HOPS",
+            "Trusted reverse-proxy hops to skip from the right of X-Forwarded-For (set 1 behind a single ingress).",
+            "0",
+          ],
+          [
+            "AXIAM__RATE_LIMIT__KEY",
+            "Bucket-key mode for token/introspect/revoke: ip | client_id | ip_client_id.",
+            "ip",
+          ],
+        ],
+      },
+      { type: "h", id: "tls", text: "Direct TLS termination (opt-in)" },
+      {
+        type: "p",
+        text: "By default the server binds plaintext and a proxy/ingress terminates TLS 1.3 in front of it. To terminate TLS inside the server process instead, set the following — the listener then binds with rustls restricted to TLS 1.3 only. When enabled, both paths are mandatory and the server fails fast at startup on a missing, unreadable or mismatched cert/key (it never falls back to plaintext).",
+      },
+      {
+        type: "table",
+        headers: ["Variable", "Meaning", "Example"],
+        rows: [
+          [
+            "AXIAM__SERVER__TLS__ENABLED",
+            "Enable in-process TLS 1.3 (default false).",
+            "true",
+          ],
+          [
+            "AXIAM__SERVER__TLS__CERT_PATH",
+            "Path to the PEM certificate chain (leaf first).",
+            "/etc/axiam/tls/tls.crt",
+          ],
+          [
+            "AXIAM__SERVER__TLS__KEY_PATH",
+            "Path to the PEM private key (PKCS#8, PKCS#1 or SEC1).",
+            "/etc/axiam/tls/tls.key",
+          ],
+        ],
+      },
+      {
+        type: "note",
+        text: "The AMQP URL is assembled from the broker's own `RABBITMQ_DEFAULT_USER` / `RABBITMQ_DEFAULT_PASS` into `AXIAM__AMQP__URL` at the deployment layer. See Docker & Kubernetes for how the shipped compose file and manifests wire these together.",
+      },
+    ],
+  },
+
+  {
     slug: "sdks",
     section: "Operate",
     navLabel: "SDKs",
     title: "Client SDKs",
     intro:
-      "Seven official client libraries, all conforming to one cross-language behavioral contract.",
+      "Eleven official client libraries, all conforming to one cross-language behavioral contract.",
     blocks: [
-      { type: "h", id: "contract", text: "One contract, seven languages" },
+      { type: "h", id: "contract", text: "One contract, many languages" },
       {
         type: "p",
-        text: "AXIAM ships SDKs for Rust, TypeScript, Python, Java, C#, PHP and Go. Each lives in its own repository but vendors the same CONTRACT.md, OpenAPI spec and protobuf definitions, so behavior is identical whichever language you pick. The contract spans login and MFA, REST/gRPC/AMQP authorization, secret handling, strict TLS, single-flight refresh and declarative route guards.",
+        text: "AXIAM ships SDKs for Rust, TypeScript, Python, Java, C#, PHP, Go, Kotlin, Swift, C and C++. Each lives in its own repository but vendors the same CONTRACT.md, OpenAPI spec and protobuf definitions, so behavior is identical whichever language you pick. The contract spans login and MFA, authorization, secret handling, strict TLS/mTLS, single-flight refresh and declarative route guards.",
+      },
+      {
+        type: "p",
+        text: "The original seven — Rust, TypeScript, Python, Java, C#, PHP and Go — implement the full §1–§11 contract including the gRPC and AMQP transports. The Kotlin, Swift, C and C++ SDKs cover the REST surface (§1–§7, §9–§11, including §6.1 mTLS); gRPC and AMQP are planned follow-ups for them.",
       },
       {
         type: "p",

--- a/website/src/pages/Benchmarks.tsx
+++ b/website/src/pages/Benchmarks.tsx
@@ -1,45 +1,215 @@
-import { BENCH } from "../data";
+import type { ReactNode } from "react";
+import type { BenchScenario } from "../types";
+import {
+  BENCH_SCENARIOS,
+  BENCH_AUTHZ,
+  BENCH_EFFICIENCY,
+} from "../data";
 
-const CARDS = [
+/* ---- shared bits ------------------------------------------------------- */
+
+const AXIAM_FILL = "linear-gradient(90deg,#00d4ff,#a855f7)";
+const OTHER_FILL = "rgba(148,163,184,.4)";
+
+function Pill({
+  color,
+  border,
+  bg,
+  children,
+}: {
+  color: string;
+  border: string;
+  bg?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className="ax-pill"
+      style={{
+        border: `1px solid ${border}`,
+        background: bg,
+        color,
+        padding: "4px 12px",
+        fontSize: 12,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function SectionTitle({ kicker, title }: { kicker: string; title: string }) {
+  return (
+    <div style={{ marginBottom: 18 }}>
+      <div
+        style={{
+          fontSize: 12,
+          textTransform: "uppercase",
+          letterSpacing: ".14em",
+          color: "#67e8f9",
+          marginBottom: 8,
+        }}
+      >
+        {kicker}
+      </div>
+      <h2 style={{ margin: 0, fontSize: 24, fontWeight: 800, letterSpacing: "-.01em" }}>
+        {title}
+      </h2>
+    </div>
+  );
+}
+
+/** Horizontal bar chart for one scenario; bar length ∝ throughput. */
+function BarChart({ scenario }: { scenario: BenchScenario }) {
+  const max = Math.max(...scenario.bars.map((b) => b.value));
+  return (
+    <div className="glass-card" style={{ padding: 26 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+          gap: 12,
+          flexWrap: "wrap",
+          marginBottom: 4,
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: 17, fontWeight: 700 }}>{scenario.title}</h3>
+      </div>
+      <div style={{ fontSize: 12.5, color: "#64748b", marginBottom: 20 }}>
+        {scenario.unit}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+        {scenario.bars.map((bar) => (
+          <div key={bar.target} style={{ display: "flex", alignItems: "center", gap: 14 }}>
+            <div
+              style={{
+                width: 116,
+                flex: "none",
+                fontSize: 13.5,
+                color: bar.axiam ? "#e2e8f0" : "#94a3b8",
+                fontWeight: bar.axiam ? 700 : 500,
+              }}
+            >
+              {bar.target}
+            </div>
+            <div
+              style={{
+                flex: 1,
+                height: 24,
+                background: "rgba(255,255,255,.05)",
+                borderRadius: 6,
+                overflow: "hidden",
+                minWidth: 40,
+              }}
+            >
+              <div
+                style={{
+                  height: "100%",
+                  width: `${Math.max((bar.value / max) * 100, 2)}%`,
+                  background: bar.axiam ? AXIAM_FILL : OTHER_FILL,
+                  borderRadius: 6,
+                  transition: "width .3s",
+                }}
+              />
+            </div>
+            <div
+              style={{
+                width: 74,
+                flex: "none",
+                textAlign: "right",
+                fontSize: 14,
+                color: bar.axiam ? "#67e8f9" : "#94a3b8",
+                fontWeight: bar.axiam ? 700 : 500,
+                fontFamily: "ui-monospace,Menlo,monospace",
+              }}
+            >
+              {bar.display}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p
+        style={{
+          margin: "20px 0 0",
+          fontSize: 13,
+          color: "#94a3b8",
+          lineHeight: 1.6,
+          borderTop: "1px solid rgba(0,212,255,.1)",
+          paddingTop: 16,
+        }}
+      >
+        {scenario.takeaway}
+      </p>
+    </div>
+  );
+}
+
+/* ---- headline stat cards ---------------------------------------------- */
+
+const HEADLINES = [
   {
-    label: "Performance",
-    labelColor: "#67e8f9",
-    value: "<1 ms",
-    valueColor: "#00d4ff",
-    sub: "authz decision p99",
-    body: "Throughput and latency under sustained load.",
+    label: "Token issuance",
+    value: "4.3–5.2×",
+    sub: "more tokens/s than Zitadel / Keycloak",
   },
   {
-    label: "Efficiency",
-    labelColor: "#67e8f9",
-    value: "per core",
-    valueColor: "#00d4ff",
-    sub: "throughput / CPU & / GiB",
-    body: "Competitor-level performance at a smaller footprint?",
+    label: "JWKS fetch",
+    value: "27,059",
+    sub: "req/s — 7–13× the field (server not even saturated)",
   },
   {
-    label: "Security posture",
-    labelColor: "#c084fc",
-    value: "HTTP → mTLS",
-    valueColor: "#a855f7",
-    sub: "same workload, replayed",
-    body: "Quantifying what each security tier costs.",
+    label: "Password login",
+    value: "only one",
+    sub: "target under the 2 s p95 gate at 50 concurrent users",
   },
 ];
 
+/* ---- environment facts ------------------------------------------------- */
+
+const TARGETS = [
+  ["AXIAM", "axiam-server 1.0.0-alpha15 (Rust)", "SurrealDB v3 + RabbitMQ 4"],
+  ["Keycloak", "Keycloak 26.7.0 (JVM)", "PostgreSQL 16 (uniformly tuned)"],
+  ["Zitadel", "Zitadel v4.15.2 (Go)", "PostgreSQL 16 (uniformly tuned)"],
+];
+
+const CAVEATS = [
+  {
+    title: "TLS 1.3 halves token issuance",
+    body: "Under this load generator, client-credentials throughput drops ~49% at p2. Telemetry shows the TLS handshake is ~free (resumption works); the cause is isolated to a connection-level ceiling — 50 users funnelled through one multiplexed HTTP/2 connection — not crypto. An HTTP/1.1 isolation run is queued. Introspection and JWKS are barely affected, and AXIAM's TLS token numbers still lead the field 2.2–2.7×.",
+  },
+  {
+    title: "The authz batch endpoints are slow",
+    body: "Batch checks are currently slower than repeated single checks and breach the p95 gate over gRPC. This is proven not to be a resource problem — it is identical with the database uncapped — and is narrowed to a serialized query pattern under investigation. Don't use batch in latency-sensitive paths yet.",
+  },
+  {
+    title: "The refresh comparison is withdrawn",
+    body: "New instrumentation revealed the refresh scenario falls back to plain token issuance on all three targets (none issues a refresh token on the grant the scenario minted). The head-to-head is withdrawn until the scenario is fixed to obtain its token via a real user login. This is exactly the kind of error the fallback tagging was built to catch — it caught us too.",
+  },
+  {
+    title: "Single run, on a laptop",
+    body: "Every figure is a single run (the harness supports median-of-3, coming next); deltas under ~10% are noise. The hardware is a consumer laptop (Dell XPS 15, i7-8750H). Per-cell CPU-frequency and temperature telemetry is published with the raw data; the thermal envelope was identical for all targets, so cross-target fairness holds and absolute numbers are, if anything, conservative.",
+  },
+];
+
+const NEXT = [
+  "Median-of-3 on every cell",
+  "The refresh-scenario fix (real user-login token)",
+  "The Zitadel gRPC audience fix",
+  "A TLS + HTTP/1.1 isolation cell to pin the token-issuance regression",
+  "A p3-mTLS profile (AXIAM now terminates mTLS natively)",
+  "A production-rate-limit-posture run",
+  "A server-class re-run to replace the laptop numbers",
+];
+
+/* ---- page -------------------------------------------------------------- */
+
 export default function Benchmarks() {
   return (
-    <div style={{ maxWidth: 1100, margin: "0 auto", padding: "56px 40px 90px" }}>
-      <span
-        className="ax-pill"
-        style={{
-          border: "1px solid rgba(0,212,255,.3)",
-          color: "#67e8f9",
-          padding: "5px 13px",
-        }}
-      >
+    <div style={{ maxWidth: 1000, margin: "0 auto", padding: "56px 40px 90px" }}>
+      <Pill color="#67e8f9" border="rgba(0,212,255,.3)">
         Benchmarks
-      </span>
+      </Pill>
       <h1
         style={{
           margin: "16px 0 10px",
@@ -51,12 +221,12 @@ export default function Benchmarks() {
         Measured on equal footing
       </h1>
       <p style={{ margin: "0 0 24px", fontSize: 17, color: "#94a3b8", maxWidth: 720 }}>
-        A vendor-neutral framework drives standard OAuth2/OIDC flows through a
-        per-target adapter, comparing AXIAM against other open-source IAM systems
-        across three axes.
+        A vendor-neutral harness drives the identical logical workload through a
+        per-target adapter, comparing AXIAM against Keycloak and Zitadel across
+        OAuth2/OIDC flows. Below are the first results.
       </p>
 
-      {/* ---- Draft notice ---- */}
+      {/* ---- Preliminary banner ---- */}
       <div
         className="glass-card"
         style={{
@@ -74,156 +244,337 @@ export default function Benchmarks() {
         </span>
         <div>
           <div
-            style={{
-              fontSize: 15,
-              fontWeight: 700,
-              color: "#ffd98a",
-              marginBottom: 4,
-            }}
+            style={{ fontSize: 15, fontWeight: 700, color: "#ffd98a", marginBottom: 4 }}
           >
-            Draft — placeholder figures
+            Preliminary results — still being validated
           </div>
           <p style={{ margin: 0, fontSize: 14, lineHeight: 1.65, color: "#e2e8f0" }}>
-            This section is currently a <strong>draft</strong>. The numbers below
-            are illustrative placeholders for layout only — they are{" "}
-            <strong>not measured results</strong>. Real benchmark results will be
-            published here once the benchmarks have been performed.
+            These are the first preliminary benchmark results (run of 2026-07-21,
+            AXIAM&nbsp;1.0.0-alpha15). The numbers are real and reproducible, but
+            still need validation: every figure is a <strong>single run</strong> on
+            a consumer laptop, so treat them as a credible early signal, not a
+            final verdict. Further benchmarks — median-of-3 and a server-class
+            re-run — will be carried out over the coming week, and this page will
+            be updated as they land.
           </p>
         </div>
       </div>
 
-      <div style={{ marginBottom: 44 }} className="ax-grid-3">
-
-        {CARDS.map((c) => (
-          <div key={c.label} className="glass-card ax-lift" style={{ padding: 26 }}>
+      {/* ---- Headline numbers ---- */}
+      <div style={{ marginBottom: 52 }} className="ax-grid-3">
+        {HEADLINES.map((h) => (
+          <div key={h.label} className="glass-card ax-lift" style={{ padding: 24 }}>
             <div
               style={{
-                fontSize: 13,
+                fontSize: 12,
                 textTransform: "uppercase",
                 letterSpacing: ".12em",
-                color: c.labelColor,
-                marginBottom: 14,
+                color: "#67e8f9",
+                marginBottom: 12,
               }}
             >
-              {c.label}
+              {h.label}
             </div>
-            <div style={{ fontSize: 34, fontWeight: 800, color: c.valueColor }}>
-              {c.value}
+            <div style={{ fontSize: 30, fontWeight: 800, color: "#00d4ff" }}>
+              {h.value}
             </div>
-            <div style={{ fontSize: 13, color: "#94a3b8", marginTop: 2 }}>
-              {c.sub}
-            </div>
-            <p
-              style={{
-                margin: "14px 0 0",
-                fontSize: 13.5,
-                lineHeight: 1.55,
-                color: "#94a3b8",
-              }}
-            >
-              {c.body}
+            <p style={{ margin: "8px 0 0", fontSize: 13, lineHeight: 1.5, color: "#94a3b8" }}>
+              {h.sub}
             </p>
           </div>
         ))}
       </div>
 
-      <div className="glass-card" style={{ padding: 32 }}>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "baseline",
-            justifyContent: "space-between",
-            marginBottom: 24,
-            gap: 12,
-            flexWrap: "wrap",
-          }}
-        >
-          <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>
-            Relative throughput per CPU core
-          </h2>
-          <span
-            className="ax-pill"
-            style={{
-              border: "1px solid rgba(255,189,46,.4)",
-              background: "rgba(255,189,46,.08)",
-              color: "#ffd98a",
-              padding: "4px 12px",
-              fontSize: 12,
-            }}
+      {/* ---- How it's designed ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Method" title="How the benchmark is designed" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760 }}>
+          Three open-source IAM servers are driven with the <em>identical logical
+          workload</em> through a vendor-neutral{" "}
+          <a
+            href="https://k6.io"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "#67e8f9" }}
           >
-            Draft · placeholder data
-          </span>
+            k6
+          </a>{" "}
+          harness. A thin adapter layer per target isolates the only thing that
+          legitimately differs between vendors — the exact endpoint paths and
+          request shapes — so the work each server performs for a given scenario
+          is the same. Scenarios cover the OAuth2/OIDC surface: machine-to-machine
+          token issuance, introspection, JWKS, userinfo and password login.
+        </p>
+        <div className="glass-card" style={{ padding: 4, marginTop: 20, overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5, minWidth: 480 }}>
+            <thead>
+              <tr>
+                {["Target", "Server", "Datastore"].map((h) => (
+                  <th
+                    key={h}
+                    style={{
+                      textAlign: "left",
+                      padding: "12px 16px",
+                      borderBottom: "1px solid rgba(0,212,255,.18)",
+                      color: "#67e8f9",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {TARGETS.map((row) => (
+                <tr key={row[0]}>
+                  {row.map((cell, ci) => (
+                    <td
+                      key={ci}
+                      style={{
+                        padding: "11px 16px",
+                        borderBottom: "1px solid rgba(255,255,255,.06)",
+                        color: ci === 0 ? "#e2e8f0" : "#cbd5e1",
+                        fontWeight: ci === 0 ? 700 : 400,
+                      }}
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
-        <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
-          {BENCH.map((row) => (
-            <div
-              key={row.name}
-              style={{ display: "flex", alignItems: "center", gap: 16 }}
-            >
-              <div
-                style={{
-                  width: 110,
-                  flex: "none",
-                  fontSize: 14,
-                  color: "#e2e8f0",
-                  fontWeight: 600,
-                }}
-              >
-                {row.name}
+      </section>
+
+      {/* ---- How it's run ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Setup" title="How it was run — on a PC" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760 }}>
+          Everything ran on a single consumer laptop (Dell XPS 15 9570 — Intel
+          i7-8750H, 12 logical CPUs, ~31&nbsp;GiB RAM), with the CPU governor
+          pinned to <code style={{ color: "#67e8f9" }}>performance</code> and the
+          targets benchmarked sequentially, never concurrently. Each server and
+          its database run in containers capped identically at 2 CPUs and
+          1024&nbsp;MiB, so no target can buy throughput with extra hardware.
+        </p>
+        <div className="ax-grid-2" style={{ marginTop: 20, gap: 14 }}>
+          {[
+            ["Load model", "Closed-loop, 50 virtual users. 30 s warm-up + 120 s measured window per scenario."],
+            ["Profiles", "p0-plaintext and p2-tls13 (TLS 1.3, terminated in-process by all three targets)."],
+            ["Validity gates", "A cell counts only if error rate ≤ 1% and p95 < 2000 ms. Failing cells are labelled, never charted as a head-to-head."],
+            ["Container caps", "IAM server 2 CPU / 1 GiB · database 2 CPU / 1 GiB · RabbitMQ (AXIAM only) 1 CPU / 512 MiB."],
+          ].map(([t, b]) => (
+            <div key={t} className="glass-card" style={{ padding: 20 }}>
+              <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 6, color: "#e2e8f0" }}>
+                {t}
               </div>
-              <div
-                style={{
-                  flex: 1,
-                  height: 22,
-                  background: "rgba(255,255,255,.05)",
-                  borderRadius: 6,
-                  overflow: "hidden",
-                }}
-              >
-                <div
-                  style={{
-                    height: "100%",
-                    width: row.width,
-                    background: row.fill,
-                    borderRadius: 6,
-                  }}
-                />
-              </div>
-              <div
-                style={{
-                  width: 70,
-                  flex: "none",
-                  textAlign: "right",
-                  fontSize: 14,
-                  color: "#94a3b8",
-                  fontFamily: "ui-monospace,Menlo,monospace",
-                }}
-              >
-                {row.value}
-              </div>
+              <div style={{ fontSize: 13.5, color: "#94a3b8", lineHeight: 1.6 }}>{b}</div>
             </div>
           ))}
         </div>
-        <p
-          style={{
-            margin: "24px 0 0",
-            fontSize: 13,
-            color: "#64748b",
-            lineHeight: 1.6,
-            borderTop: "1px solid rgba(0,212,255,.1)",
-            paddingTop: 18,
-          }}
-        >
-          Numbers shown are placeholders for layout and will be replaced with
-          measured results after the benchmark runs. The real harness reports
-          throughput/latency, throughput-per-core and throughput-per-GiB, plus
-          the plaintext-HTTP-to-mTLS security cost ladder. See{" "}
-          <code style={{ color: "#67e8f9", fontFamily: "ui-monospace,Menlo,monospace" }}>
-            benchmarks/docs/methodology.md
-          </code>
-          .
+      </section>
+
+      {/* ---- Fairness ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Fairness" title="Keeping it fair" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760, marginBottom: 16 }}>
+          Comparing different systems fairly is the hard part, so the data is
+          collected to remove every advantage we can find:
         </p>
-      </div>
+        <ul style={{ margin: 0, paddingLeft: 22, color: "#cbd5e1", lineHeight: 1.75, maxWidth: 760 }}>
+          <li style={{ marginBottom: 8 }}>
+            <strong>Identical envelope.</strong> Same host, same container caps,
+            same 50-VU closed loop and measurement window for every target.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>Competitors tuned, not hobbled.</strong> PostgreSQL is
+            minimally and <em>uniformly</em> tuned for both Keycloak and Zitadel;
+            SurrealDB runs stock. AXIAM's own per-IP rate limits are neutralized so
+            they don't cap the load generator.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>Telemetry recorded.</strong> Every cell logs host CPU
+            frequency, package temperature and load-generator CPU at 1-second
+            resolution, published with the raw data — so thermal throttling and a
+            saturated generator are visible rather than hidden.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>Only valid cells count.</strong> Fallback operations and cells
+            that breach a validity gate are labelled and excluded from every
+            head-to-head claim — including AXIAM's own.
+          </li>
+        </ul>
+      </section>
+
+      {/* ---- Headline results ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Results" title="Head-to-head throughput" />
+        <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 22 }}>
+          Plaintext (p0) profile, capped matrix. Higher is better. Each chart is a
+          single valid, comparable cell from the full result matrix.
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+          {BENCH_SCENARIOS.map((s) => (
+            <BarChart key={s.id} scenario={s} />
+          ))}
+        </div>
+      </section>
+
+      {/* ---- Efficiency ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Efficiency" title="Throughput per core & CPU cost" />
+        <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 20 }}>
+          Whole-stack, plaintext. AXIAM's figures still carry its audit broker and,
+          on some cells, a saturated database — which is exactly why Keycloak edges
+          it on userinfo CPU cost. Reported plainly.
+        </p>
+        <div className="glass-card" style={{ padding: 4, overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5, minWidth: 560 }}>
+            <thead>
+              <tr>
+                {["Scenario", "req/s per core (higher better)", "cpu·ms/req (lower better)"].map(
+                  (h) => (
+                    <th
+                      key={h}
+                      style={{
+                        textAlign: "left",
+                        padding: "12px 16px",
+                        borderBottom: "1px solid rgba(0,212,255,.18)",
+                        color: "#67e8f9",
+                        fontWeight: 700,
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ),
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {BENCH_EFFICIENCY.map((row) => (
+                <tr key={row.scenario}>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#e2e8f0",
+                      fontWeight: 600,
+                    }}
+                  >
+                    {row.scenario}
+                  </td>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#cbd5e1",
+                      fontFamily: "ui-monospace,Menlo,monospace",
+                    }}
+                  >
+                    <span style={{ color: "#67e8f9", fontWeight: 700 }}>{row.perCore[0]}</span>
+                    {" · "}
+                    {row.perCore[1]} · {row.perCore[2]}
+                  </td>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#cbd5e1",
+                      fontFamily: "ui-monospace,Menlo,monospace",
+                    }}
+                  >
+                    <span style={{ color: "#67e8f9", fontWeight: 700 }}>{row.cpuMs[0]}</span>
+                    {" · "}
+                    {row.cpuMs[1]} · {row.cpuMs[2]}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p style={{ margin: "12px 4px 0", fontSize: 12.5, color: "#64748b" }}>
+          Each cell reads <span style={{ color: "#67e8f9" }}>AXIAM</span> · Keycloak · Zitadel.
+        </p>
+      </section>
+
+      {/* ---- AXIAM-only authz ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="AXIAM-only" title="Authorization decisions" />
+        <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 22 }}>
+          No head-to-head here — Keycloak and Zitadel expose no equivalent decision
+          endpoint. Each check is a full RBAC evaluation (tenant-scoped roles,
+          resource hierarchy, scopes) against live data, over REST and gRPC.
+        </p>
+        <BarChart scenario={BENCH_AUTHZ} />
+      </section>
+
+      {/* ---- Caveats ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Honesty" title="Weaknesses & caveats" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760, marginBottom: 20 }}>
+          The results are encouraging, but preliminary — and some scenarios are not
+          yet a fair or valid comparison. Stated plainly:
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {CAVEATS.map((c) => (
+            <div key={c.title} className="glass-card" style={{ padding: 22 }}>
+              <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 6, color: "#ffd98a" }}>
+                {c.title}
+              </div>
+              <p style={{ margin: 0, fontSize: 13.5, color: "#94a3b8", lineHeight: 1.65 }}>
+                {c.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ---- Next ---- */}
+      <section>
+        <SectionTitle kicker="Roadmap" title="What happens next" />
+        <div className="glass-card" style={{ padding: 26 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+            {NEXT.map((n) => (
+              <span
+                key={n}
+                className="ax-pill"
+                style={{
+                  background: "rgba(0,212,255,.06)",
+                  border: "1px solid rgba(0,212,255,.2)",
+                  color: "#cbd5e1",
+                  padding: "7px 14px",
+                  fontSize: 13,
+                }}
+              >
+                {n}
+              </span>
+            ))}
+          </div>
+          <p
+            style={{
+              margin: "22px 0 0",
+              fontSize: 13,
+              color: "#64748b",
+              lineHeight: 1.6,
+              borderTop: "1px solid rgba(0,212,255,.1)",
+              paddingTop: 18,
+            }}
+          >
+            Full data, metric definitions and the raw per-cell telemetry live in
+            the repository under{" "}
+            <code style={{ color: "#67e8f9", fontFamily: "ui-monospace,Menlo,monospace" }}>
+              benchmarks/PUBLIC_BENCH_ANALYSIS.md
+            </code>{" "}
+            and{" "}
+            <code style={{ color: "#67e8f9", fontFamily: "ui-monospace,Menlo,monospace" }}>
+              benchmarks/docs/methodology.md
+            </code>
+            . Sources: benchmark runs of 2026-07-21.
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/website/src/pages/Docs.tsx
+++ b/website/src/pages/Docs.tsx
@@ -53,6 +53,73 @@ function CodeBlock({ block }: { block: Extract<DocBlock, { type: "code" }> }) {
   );
 }
 
+function Table({ block }: { block: Extract<DocBlock, { type: "table" }> }) {
+  return (
+    <div
+      className="glass-card"
+      style={{
+        borderRadius: 12,
+        overflowX: "auto",
+        margin: "0 0 20px",
+      }}
+    >
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: 13.5,
+          minWidth: 520,
+        }}
+      >
+        <thead>
+          <tr>
+            {block.headers.map((h, i) => (
+              <th
+                key={i}
+                style={{
+                  textAlign: "left",
+                  padding: "12px 16px",
+                  borderBottom: "1px solid rgba(0,212,255,.18)",
+                  color: "#67e8f9",
+                  fontWeight: 700,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {block.rows.map((row, ri) => (
+            <tr key={ri}>
+              {row.map((cell, ci) => (
+                <td
+                  key={ci}
+                  style={{
+                    padding: "11px 16px",
+                    borderBottom: "1px solid rgba(255,255,255,.06)",
+                    color: ci === 0 ? "#e2e8f0" : "#cbd5e1",
+                    verticalAlign: "top",
+                    lineHeight: 1.55,
+                    fontFamily:
+                      ci === 0
+                        ? "ui-monospace,Menlo,monospace"
+                        : undefined,
+                    whiteSpace: ci === 0 ? "nowrap" : "normal",
+                  }}
+                >
+                  {renderInline(cell)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function Callout({
   kind,
   text,
@@ -120,6 +187,8 @@ function Block({ block, go }: { block: DocBlock; go: (p: Page) => void }) {
       );
     case "code":
       return <CodeBlock block={block} />;
+    case "table":
+      return <Table block={block} />;
     case "note":
       return <Callout kind="note" text={block.text} />;
     case "warn":

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -70,7 +70,7 @@ const ACCENTS = {
 const HERO_STATS = [
   { value: "64", label: "tasks" },
   { value: "19", label: "phases" },
-  { value: "7", label: "SDKs" },
+  { value: "11", label: "SDKs" },
   { value: "100%", label: "Rust" },
 ];
 
@@ -539,7 +539,7 @@ export default function Home({ go, openSdk }: HomeProps) {
           textAlign: "center",
         }}
       >
-        <h2 className="ax-h2">Seven SDKs, one behavioral contract</h2>
+        <h2 className="ax-h2">Eleven SDKs, one behavioral contract</h2>
         <p style={{ margin: "14px 0 30px", fontSize: 17, color: "#94a3b8" }}>
           Every client library vendors the same cross-language contract, OpenAPI
           spec and protobufs.

--- a/website/src/pages/SdkDetail.tsx
+++ b/website/src/pages/SdkDetail.tsx
@@ -163,6 +163,14 @@ export default function SdkDetail({ sdk, go }: SdkDetailProps) {
         >
           Repository ↗
         </a>
+        <a
+          className="ax-ghost"
+          href={sdk.examplesUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Examples ↗
+        </a>
       </div>
 
       <div style={{ marginBottom: 24 }} className="ax-grid-2">

--- a/website/src/pages/SdksOverview.tsx
+++ b/website/src/pages/SdksOverview.tsx
@@ -29,9 +29,11 @@ export default function SdksOverview({ openSdk }: SdksOverviewProps) {
           Talk to AXIAM in your language
         </h1>
         <p style={{ margin: 0, fontSize: 17, color: "#94a3b8", maxWidth: 680 }}>
-          Seven official SDKs conform to a single behavioral contract (§1–§11) —
-          login &amp; MFA, REST/gRPC/AMQP authorization, and framework guards.
-          Pick a language to see the quickstart.
+          Eleven official SDKs share one behavioral contract — login &amp; MFA,
+          authorization, strict TLS/mTLS and framework guards. The original seven
+          (Rust, TypeScript, Python, Java, C#, PHP, Go) add gRPC and AMQP
+          transports; Kotlin, Swift, C and C++ cover the REST surface. Pick a
+          language to see the quickstart.
         </p>
       </div>
       <div className="ax-grid-3">

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -22,6 +22,8 @@ export interface Sdk {
   docsLabel?: string;
   docsUrl?: string;
   repoUrl: string;
+  /** Link to the runnable examples folder inside the SDK repository. */
+  examplesUrl: string;
   pkg: string;
   install: string;
   blurb: string;
@@ -60,9 +62,40 @@ export interface Phase {
   focus: string;
 }
 
-export interface BenchRow {
-  name: string;
-  value: string;
-  width: string;
-  fill: string;
+/** One target's result within a benchmark scenario. */
+export interface BenchBar {
+  /** Target name — "AXIAM", "Keycloak", "Zitadel". */
+  target: string;
+  /** Numeric value used to size the bar. */
+  value: number;
+  /** Pre-formatted label shown at the end of the bar (e.g. "1,788"). */
+  display: string;
+  /** AXIAM bars get the brand gradient; competitors get muted slate. */
+  axiam?: boolean;
+}
+
+/**
+ * A single benchmark scenario rendered as a titled bar chart plus a short
+ * takeaway. `higherIsBetter` flips the "leader" framing for cost-style metrics.
+ */
+export interface BenchScenario {
+  id: string;
+  title: string;
+  /** Metric being charted, e.g. "throughput · requests/s (plaintext)". */
+  unit: string;
+  bars: BenchBar[];
+  /** One-line, measured-tone takeaway shown under the chart. */
+  takeaway: string;
+}
+
+/**
+ * One row of the whole-stack efficiency comparison. Values are pre-formatted
+ * strings; `[AXIAM, Keycloak, Zitadel]` order throughout.
+ */
+export interface BenchEfficiencyRow {
+  scenario: string;
+  /** Throughput per CPU core consumed (higher is better). */
+  perCore: [string, string, string];
+  /** CPU-milliseconds per request (lower is better). */
+  cpuMs: [string, string, string];
 }


### PR DESCRIPTION
- SDKs: add Kotlin, Swift, C and C++ (REST surface, §1–§7/§9–§11 incl. mTLS)
  alongside the seven full SDKs; update counts (7 → 11) across home, overview
  and docs, keeping the contract-scope distinction accurate.
- SDKs: add an "Examples ↗" link to each SDK detail page, pointing at the
  runnable examples folder in its repository (Swift uses /Examples).
- Docs: new "gRPC API" page (services, tenant-scoping, server/TLS, codegen).
- Docs: new "Configuration" page listing the image environment variables with
  meanings and example values; add a table block type to the docs renderer.
  Env-var names verified against the server config sources.
- Benchmarks: replace the placeholder page with the preliminary results from
  benchmarks/PUBLIC_BENCH_ANALYSIS.md. Split into sections (design, run-on-a-PC
  setup, fairness, head-to-head throughput charts, efficiency table, AXIAM-only
  authz, honest caveats, what's next), add CSS bar charts, and keep a banner
  stating these are first preliminary single-run results still to be validated,
  with more benchmarks next week. Measured tone, only valid cells charted.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012ZFiJnYCwaHTNtgACASVCb