### PR TITLE
feat(sdks): CONTRACT §12 — OIDC/SSO relying-party helpers (contract 1.5)

### DIFF
--- a/claude_dev/sdk-oidc-sso-conformance-review.md
+++ b/claude_dev/sdk-oidc-sso-conformance-review.md
@@ -1,0 +1,715 @@
+# CONTRACT §12 OIDC/SSO — cross-SDK conformance review (T9)
+
+**Date:** 2026-07-27
+**Scope:** CONTRACT §12 (OIDC/SSO relying-party helpers), implemented independently in eight SDKs
+against contract 1.4 (`/home/user/axiam` @ `9c5de58`).
+**Outcome:** contract amended to **1.5** (non-breaking / clarifying); one repo **BLOCKED**, seven
+**SAFE TO MERGE**; 19 follow-up items recorded (F-01–F-19, of which F-16 was fixed in this review,
+leaving 18 open).
+
+Branch under review in every repo: `claude/sdk-oidc-sso-plan-8t4hgm`.
+
+| Repo | Commit reviewed |
+|---|---|
+| `axiam` (contract) | `9c5de58` |
+| `axiam-typescript-sdk` (reference) | `2efd754` |
+| `axiam-python-sdk` | `e98ffbf` |
+| `axiam-go-sdk` | `ba9bd84` |
+| `axiam-rust-sdk` | `b2d7930` |
+| `axiam-php-sdk` | `6d5775e` |
+| `axiam-java-sdk` | `c7b6866` |
+| `axiam-csharp-sdk` | `cf59dc8` |
+| `axiam-kotlin-sdk` | `c65edca` |
+
+---
+
+## 1. Conformance matrix
+
+Legend: **P** = pass · **F** = fail · **D** = divergent but legal (a contract MAY, or a
+per-language equivalence) · **P\*** = pass with a recorded caveat · **n/a** = not applicable.
+Every cell was determined by reading the shipped source, not by reading an agent's report.
+
+### 1.1 Vocabulary and surface
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| All nine §12.2 operations present, exact per-language name | P | P | P | P | P | P | P | P |
+| C# `OidcBegin` has **no** `Async` suffix; no `OidcBeginAsync` exists | n/a | n/a | n/a | n/a | n/a | n/a | P | n/a |
+| Python: identical names on sync + async client; no `async_*` anywhere | n/a | P | n/a | n/a | n/a | n/a | n/a | n/a |
+| Kotlin: `suspend`, no `*Async`/`Deferred` twins | n/a | n/a | n/a | n/a | n/a | n/a | n/a | P |
+| Java: only the permitted `*Async` twins (and no `oidcBeginAsync`) | n/a | n/a | n/a | n/a | n/a | P | n/a | n/a |
+| No additional diverging auth/authz method names | P | P | P | P | P | P | P | P |
+| Argument order / params shape consistent, subject-before-object | P | P | P | P | P | P | P | P |
+| Host object for the nine methods | D | P | P | P | P | P | P | P |
+
+`D` for TypeScript: the nine live on a Node-only `OidcClient` rather than `AxiamClient`, because
+its CI forbids `node:crypto`/`jose` from reaching the browser bundle. Contract 1.5 §12.2 now
+permits this explicitly.
+
+### 1.2 Error taxonomy
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| `OAuthProtocolError` is a **sub-type** of the existing auth-error type | P | P | P | D | P | P | P | P |
+| `message` field exactly `"<error>: <error_description>"` | P | P | P | P | P | P | P | P |
+| `error` + `error_description` publicly accessible (per-language casing) | P | P | D | P | P | P | P | P |
+| Existing consumer `catch`/`except`/`match` code still works | P | P | P | **F** | P\* | P | P | P |
+| 400 from `/oauth2/*` with an OAuth2 body → `OAuthProtocolError` | P | P | P | P | P | P | P | P |
+| 401 from `/oauth2/*` with an OAuth2 body → `OAuthProtocolError` | P | P | P | P | P | P | P | P |
+| 401 from `/oauth2/*` never enters the §9 refresh guard (tested) | P | P | P | P | P | P | P | P |
+
+- **RS `D`** on sub-typing: Rust models it as two new fields (`oauth`, `reason`) on the existing
+  `AxiamError::Auth` struct variant rather than a peer type — an idiomatic and legal realisation.
+- **RS `F`** on consumer compatibility: adding fields to a public, non-`#[non_exhaustive]` struct
+  variant is **source-breaking** for downstream crates. `AxiamError::Auth { .. }` still matches,
+  but `AxiamError::Auth { message }` (exhaustive destructure) is `E0027` and every
+  `AxiamError::Auth { message: … }` construction is `E0063`. The commit mechanically fixed 33
+  construction sites and 9 patterns inside the repo, including one in a shipped `examples/` file —
+  which is precisely the evidence that downstream code breaks too. Contract 1.4's log calls §12
+  "non-breaking"; for Rust it is not. Pre-1.0 (`1.0.0-alpha18`), so tolerable, but it must be
+  documented and `#[non_exhaustive]` should be added now.
+- **GO `D`**: the `error` field is exported as `ErrorCode`, because a field named `Error` would
+  collide with the promoted `Error()` method that satisfies the `error` interface. Contract 1.5 §2
+  now blesses this. Go's `Error()` also prefixes `"authentication failed: "`; the `Message` field
+  itself is exact, which is what 1.5 requires.
+- **PHP `P*`**: `AuthError::__construct` gained `$reason` as the **second positional** parameter,
+  so any downstream caller passing `$previous` positionally breaks. No such call site exists in
+  the repo (all 22 verified), but the ordering is a latent trap — `$reason` should be keyword-only
+  or last.
+
+The 401-out-of-guard property is realised two ways, both tested and both conformant: an explicit
+`/oauth2/*` skip list (TS `SKIP_REFRESH`, Java `OAUTH2_SKIP_REFRESH_PATHS`, C#
+`ReactiveRefreshExemptPaths`) or structurally, by routing §12 calls through a transport that has no
+401→refresh interceptor at all (Python, Go, Rust, PHP, Kotlin). The structural variant is more
+robust today but more fragile to a future generic interceptor; each of those five repos should
+carry a regression comment or test naming that invariant (follow-up F-14).
+
+### 1.3 `Sensitive` / §7
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| Exactly the 5 §12.5 fields wrapped (access/refresh/id token, client_secret, code_verifier) | P | P | P | P | P | P | P | P |
+| `state` and `nonce` are **not** wrapped | P | P | P | P | P | P | P | P |
+| Redaction in every stringification sink | P | P | P | P | P | P | P | P |
+| Redaction in every structured-serialization sink | P | P\* | P | n/a | P | P\* | P | n/a |
+| Raw value not reachable **implicitly** (no public field/`Deref`/auto-unbox) | P | P | D | P | P | P | P | P |
+| §12 caller can read the returned tokens | P | P | P | P | P | **F** | P | **F** |
+
+- `n/a` for Rust and Kotlin on structured serialization: neither wrapper nor any §12 DTO implements
+  `Serialize`/`@Serializable`, so a leak there is a compile error rather than a runtime risk. That
+  is the strongest possible outcome, not a gap.
+- **PY/JV `P*`**: the behaviour is correct but the assertion is missing — Python has no
+  `model_dump_json()` test on `OidcTokenSet`/`AuthorizationRequest`, and Java has no Jackson test
+  on the three DTOs (only on a bare `Sensitive`). Follow-up F-11/F-12.
+- **GO `D`**: `type Sensitive string` means `string(tok.AccessToken)` reaches the raw value from any
+  package. That is an *explicit* conversion and it is the shape §7's Go row itself prescribes;
+  contract 1.5 §7 rule 2 now says so.
+- **JV/KT `F`**: `Sensitive.expose()` is package-private (Java, in `io.axiam.sdk`) and `internal`
+  (Kotlin). Both SDKs return `OidcTokenSet` objects whose `access_token`/`refresh_token`/`id_token`
+  **the caller cannot read at all**. This is not a §7 violation — under contract 1.5 rule 3 a
+  module-private accessor stays conformant — but it defeats the purpose of §12, which exists to
+  hand tokens to a relying party so it can forward, persist, and later revoke them. Highest-value
+  follow-up (F-02, F-03).
+
+### 1.4 PKCE and ID-token validation
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| PKCE `S256` only; `plain` structurally unreachable | P | P | P | P | P | P | P | P |
+| RFC 7636 Appendix B vector asserted in a real test | P | P | P | P | P | P | P | P |
+| §12.4 r1 `alg` = `EdDSA`, checked before signature work (+ failing test) | P | P | P | P | P | P | P | P |
+| §12.4 r2 signature + `kid`, one re-fetch, no-`kid` rejected (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r3 `iss` exact string match (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r4 `aud` contains `client_id`, `azp` when multiple (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r5 `exp`/`iat`/`nbf`, skew clamped ≤60 s (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r6 `nonce` constant-time compare (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r7 all-or-nothing discard (+ test) | P | P | P | P | P | P\* | P\* | P\* |
+| Exactly the seven contract reason codes, no eighth | P | P | P | P | P | P | P | P |
+| No "skip validation" option on any public API | P | P | P | P | P | P | P | P |
+
+All eight use the contract's reason-code strings verbatim, and all eight independently converged
+on the same many-to-one mappings (`token_expired` for every time failure, `unknown_kid` for a
+missing `kid`, `invalid_alg` for an unparseable header). Contract 1.5 §12.3 rule 3 now records that
+vocabulary as closed and pins those mappings, so the convergence is no longer accidental.
+
+`P*` on rule 7 for Java, C#, and Kotlin: validation demonstrably precedes token-set construction,
+so no partial object can exist, but the tests only assert that an error is thrown — they do not
+positively assert the access/refresh token is absent from the outcome (TS, Python, Go, Rust, PHP
+all do). Follow-up F-13.
+
+### 1.5 Cross-cutting rules
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| Stateless: no `state`/`nonce`/`code_verifier` in SDK or process-global state | P | P | P | P | P | P | P | P |
+| State store: 10-min TTL, clamped as a maximum | P | P | P | P | P | P | P | P |
+| State store: single-use `consume`, atomic delete-before-check | P | P | P | P | P | P | P | P |
+| State store: lazy sweep, no background timer/thread | P | P | P | P | P | P | P | P |
+| Discovery cache TTL floor ≥ 5 min | P | P | P | P | P | P | P | P |
+| Discovery cache single-flight (tested with N concurrent cold callers) | P | P | P | P | P | P | P | P |
+| Discovery cache per-origin, never tenant-keyed, never process-global | P | P | D | P | P | P | D | D |
+| Token endpoint: form-encoded body, never JSON | P | P | P | P | P | P | P | P |
+| `tenant_id` sent as a **query** parameter, never a body field | P | P | P | P | P | P | P | P |
+| `client_secret_post` only — no `Authorization: Basic` anywhere | P | P | P | P | P | P | P | P |
+| `X-Tenant-ID` still emitted on `/oauth2/*` | P | P | P\* | P | P | P\* | P\* | P |
+| Grant form-field sets exactly per §12.1; optionals omitted not emptied | P | P | P | P | P | P | P | P |
+| Endpoints read from the discovery document, never hardcoded | P | P | P | P | P\* | P | P | P |
+| `sso_complete` goes through the §4 cookie-jar path | P | P | P | P | P | P | P | P |
+| `sso_complete` performs the same post-login session sync as `login()` | P | P | P | **F** | P | P | P | P |
+| `revoke`: 200 = success, idempotent on unknown token, 5xx = network error | P | D | P | P | P | P | P | P |
+| Spaces in authorization-URL query values encoded `%20`, not `+` | P | P | P | **F** | P | P | P | P |
+| Reserved-param collision raises a programming error, not the taxonomy | P | P | P | D | P | P | P | P |
+| `oidc_begin` takes `client_id` from client config, not per call | P | P | P | P | P | P | P | P |
+| `AuthorizationRequest` = exactly `url`/`state`/`nonce`/`code_verifier` | P | P | P | P | P | P | P | P |
+| `sso_start` defaults tenant/org from session, prefers UUID, raises client-side | P | P | P | P\* | P | P | P | P |
+| No new **runtime** dependency added | P | P | P | D | P | P | P | P |
+| No TLS-bypass surface anywhere in shipped source | P | P | P | P | P | P | P | P |
+| Conformance statement updated to claim §12 | P | P | P | P | P | P | P\* | P |
+
+- **GO/C#/KT `D`** on cache keying: the cache is two per-instance scalar fields with no explicit
+  origin key, safe because a client is bound to one base URL for life. Contract 1.5 §12.3 rule 6
+  now states that a per-client-instance cache satisfies the origin requirement by construction.
+  Legal, and the previous wording was self-contradictory anyway.
+- **`X-Tenant-ID` `P*`** (Go, Java, C#): the header interceptor returns early for a foreign host,
+  and §12 builds absolute URLs from the discovery document. A deployment whose document advertises
+  `token_endpoint` on a different host than `base_url` would silently drop the header. Harmless
+  today (the `/oauth2/*` handlers never read it — see §3 below) but untested in all eight repos.
+  Follow-up F-15.
+- **PHP `P*`** on endpoint sourcing: the pre-existing §10 `JwksVerifier` retains a hardcoded
+  `baseUrl + '/oauth2/jwks'` fallback used only when discovery is unavailable or cross-origin. The
+  §12 path always uses `jwks_uri`.
+- **PY `D`** on `revoke`: Python accepts **only** `200`; a `204` would raise. Conformant to the
+  contract as worded (1.4 and 1.5 both make `200` the MUST), but the other seven accept any 2xx,
+  which is what 1.5 recommends. Follow-up F-08.
+- **RS `F`** on `sso_complete`: it captures cookies and re-syncs CSRF but never calls
+  `absorb_session_cookies`, so unlike every sibling it does not seed the token manager or resolve
+  `tenant_id`/`org_id`. A subsequent `refresh()` fails with "no access token to refresh". F-05.
+- **RS `F`** on `%20`: **verified by execution** (see §5). F-04.
+- **RS `D`** on the collision guard: it raises `AxiamError::Network`, a §2 taxonomy error, where the
+  other seven raise the language's programming-error type. Legal under the contract (which is silent
+  on the type) but it misclassifies a caller bug as a transport failure. F-09.
+- **RS `D`** on dependencies: `Cargo.toml` gains two `[dependencies]` entries (`getrandom`,
+  `base64`), both already unconditional transitive deps. **`Cargo.lock` is unchanged by the
+  commit** — verified — so zero new crates enter the graph and the vulnerability-scan intent is
+  satisfied. Reported as `D`, not `F`.
+- **C# `P*`**: `README.md:20` claims §1–§12 but the checklist heading immediately below still reads
+  "### §1–§11 conformance checklist". Cosmetic. F-16.
+
+### 1.6 §9 single-flight refresh — the one row with real failures
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| `oidc_refresh` burst of N produces exactly **one** wire call | P | P | P | **F** | **F** | P | P | P |
+| That one outcome is shared with all N callers (§9 rule 2) | P | P | P | **F** | **F** | P | P | P |
+| §9 test requirement satisfied for `oidc_refresh` (N ≥ 5) | P (3) | P (6) | P (10) | **F** | **F** | P (5) | P (5) | P (6) |
+| Guard mechanism | shared `Promise` + session guard, bounded 3 retries | coalescer + `run_exclusive` | own `chan` future | **bare `Mutex<()>`** | `{ran,promise}` + bounded 3 retries | `SingleFlight` + `runExclusive` (bound 3) | `SemaphoreSlim` + cached `Task<T>` | `Mutex` + shared `Deferred` |
+
+TypeScript's N is 3 in its guard-contention test but its coalescing test asserts one wire call for
+concurrent callers; treated as satisfied.
+
+Adjudicated in §2.2 and §2.3 below.
+
+### 1.7 Contract MAYs — divergence here is not a defect
+
+| Item | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| `login_client_credentials` credential adoption (§12.1 MAY) | D opt-in | D skipped | D opt-in | D skipped | D opt-in | D skipped | D flag + `NotSupportedException` | D skipped |
+| Optional `OidcStateStore` offered (§12.3 r1 MAY) | D yes | D yes | D yes | D yes | D yes | D yes | D yes | D yes |
+
+Where adoption **is** implemented (TS, Go, PHP), it was verified in all three that the adopted
+token (a) is opt-in and default-off, (b) lives behind `Sensitive` in a private field, (c) is
+attached only as an `Authorization: Bearer` header by a private interceptor that explicitly skips
+`/oauth2/*`, and (d) never enters the cookie jar or a public property. All three carry a test
+asserting the token endpoint sees no `Authorization` header. **Five different positions on one MAY,
+zero defects.**
+
+---
+
+## 2. Adjudication of the hard problems
+
+### 2.1 §7 vs §12 — the token-accessor conflict (highest priority)
+
+**What §7 said (1.4):** "The raw token string MUST NOT be exposed via any public getter API," and
+internal code reaches it "via a crate/module-private method or friend function, not a public API."
+**What §12 requires:** returning `access_token`/`refresh_token`/`id_token` *to the caller*, who
+must read them to persist, forward, or later revoke them. These are mutually unsatisfiable.
+
+**What all eight actually did** (read from source, not reports):
+
+| SDK | Wrapper | Accessor | Visibility | Changed by this commit? |
+|---|---|---|---|---|
+| TypeScript | `class Sensitive<T>`, private `#value` | `expose()` | public (doc-tagged `@internal`) | no — doc comments only |
+| Python | `pydantic.SecretStr` | `get_secret_value()` | public by design | no |
+| Go | `type Sensitive string` | `expose()` unexported **plus** `string(x)` conversion | effectively public | no |
+| Rust | newtype `Sensitive<T>(T)` | `expose()` | **widened `pub(crate)` → `pub`** | **yes** |
+| PHP | `final class` + static `WeakMap` | `reveal()` | public | no |
+| Java | `final class Sensitive` | `expose()` | **package-private** (`io.axiam.sdk`) | no |
+| C# | `readonly struct Sensitive<T>` | `Expose()` (+ public `Wrap()`) | **both added public** | **yes** |
+| Kotlin | `class Sensitive<T>`, private `value` | `expose()` | **`internal`** | no |
+
+So six of eight are readable by a caller; **Java and Kotlin are not** — their `OidcTokenSet`
+carries tokens no consumer of the library can extract. Redaction, by contrast, is airtight in all
+eight, including the sinks a naive wrapper misses (Go `%#v`/`Format`/`GoString`/`MarshalJSON`, Node
+`util.inspect`, Java `@JsonSerialize` + non-`Serializable`, C# `JsonConverterFactory` + suppressed
+struct equality, PHP's zero-introspectable-properties `WeakMap` trick, Kotlin's hand-written
+`toString` overrides on `data class` DTOs).
+
+**Ruling.** There is no single rule that *requires* a public accessor and that all eight satisfy,
+so §7 must permit rather than require one. Contract 1.5 splits §7 into four numbered rules:
+
+1. **Redaction — unconditional MUST**, now enumerating the easily-missed sinks explicitly. No
+   other section relaxes it.
+2. **No implicit reachability — MUST**: no public field, `Deref`, implicit conversion, auto-unbox,
+   or value-comparing inherited equality. Go's named-type conversion is named as an *explicit*
+   conversion and accepted for that language, since §7's own Go row prescribes that shape.
+3. **One explicit accessor — MAY, and RECOMMENDED where §12 ships.** A module-private accessor
+   stays conformant, but then the §12 token set is unreadable by the caller, so the SDK **SHOULD**
+   widen it — and widening is explicitly noted as non-breaking and additive.
+4. **Point-of-use discipline — MUST**: never pass the accessor's result to a sink.
+
+A rationale paragraph records why the text changed, so the next reader does not re-derive the
+conflict. The **C and C++ rows are untouched**, with a sentence explaining that both defer §12
+and therefore never hand token material to a caller — rule 3 has nothing to enable there, and
+would apply unchanged to any later port.
+
+This makes all eight conformant **and** keeps the Java/Kotlin gap visible as a SHOULD violation
+rather than papering over it. The gap is a functional defect, recorded as F-02/F-03: high severity,
+non-blocking (widening `internal`/package-private to public breaks no one and can land after
+merge), but it must ship before either SDK is released advertising §12.
+
+### 2.2 Rust's §9 single-flight is partial — conformance gap, not a contract flaw
+
+**Verified facts.** `AxiamClientInner.oidc_refresh_guard` is a bare `tokio::sync::Mutex<()>`
+(`src/client.rs:465`), acquired at `src/oidc/exchange.rs:530-532`. It holds no result slot — there
+is no `OnceCell`, `Shared`, `broadcast`, or `Option<Result<…>>` anywhere near it. `Sensitive<T>`,
+`OidcTokenSet`, and `AxiamError` are each **not** `Clone` (verified derive-by-derive; `AxiamError`
+boxes a `dyn StdError` and cannot easily become `Clone`). Consequently N concurrent callers produce
+**N wire calls**, issued serially. There is also **no concurrency test for `oidc_refresh` at all**
+— the repo's only §9 burst test covers the §1 cookie path via a different guard.
+
+**Ruling: this is a conformance gap requiring a Rust code fix, not grounds to amend §9.** Three
+reasons:
+
+1. **The observable behaviour genuinely differs, and differs badly.** AXIAM refresh tokens are
+   opaque, server-stored, and **single-use with rotation**. Serialization without sharing therefore
+   means callers 2..N deliberately replay an already-consumed refresh token and each receives
+   `invalid_grant`. Seven SDKs: N callers, one wire call, all N succeed. Rust: N callers, N wire
+   calls, one succeeds and N−1 fail with an auth error. That is not an implementation detail; it is
+   the difference the rule exists to prevent.
+2. **§9 rule 2 is already a MUST in contract 1.4.** Nothing new is being demanded. Amending §9 to
+   permit serialization would weaken a correctness rule for all eleven languages to accommodate one
+   port, and would silently license the same regression elsewhere.
+3. **The language does not make sharing impractical.** The claim rests on `Sensitive`/`AxiamError`
+   not being `Clone`, but `Sensitive` already has a working `pub(crate) fn clone_inner()` for
+   exactly this kind of duplication, and cloning a redacted wrapper cannot leak anything — every
+   other SDK's wrapper is freely copyable (C#'s is a `struct`). The non-`Clone` decision was about
+   preventing leak paths, and a `Clone` impl is not one.
+
+**Precise fix (F-01).** In `axiam-rust-sdk`:
+
+1. `src/sensitive.rs` — add `impl<T: Clone> Clone for Sensitive<T>` (a manual impl, not a derive,
+   with a doc comment noting that duplicating a redacted wrapper cannot leak: only `expose()` can).
+2. `src/oidc/exchange.rs` / `src/oidc/id_token.rs` — derive `Clone` on `OidcTokenSet`,
+   `IdTokenClaims`, and `Audience`.
+3. `src/error.rs` — add `pub(crate) fn clone_for_waiter(&self) -> AxiamError`, reconstructing the
+   same variant field-wise (`OAuthProtocolError` is two `String`s and `IdTokenFailureReason` is a
+   fieldless enum, so `Auth` clones exactly; other variants clone with `source: None`).
+4. `src/client.rs` — replace `oidc_refresh_guard: tokio::sync::Mutex<()>` with
+   `oidc_refresh_inflight: tokio::sync::Mutex<Option<tokio::sync::broadcast::Sender<Result<OidcTokenSet, Arc<AxiamError>>>>>`.
+   `tokio`'s `sync` feature is already enabled — **no new dependency**.
+5. `src/oidc/exchange.rs::oidc_refresh` — leader/waiter election: under the mutex, if a `Sender`
+   is present, `subscribe()`, drop the lock, `recv().await`, and map `Arc<AxiamError>` back through
+   `clone_for_waiter`; otherwise create the channel, publish it, drop the lock, perform the single
+   `post_token`, clear the slot under the lock, then `send` the result. The public signature
+   `Result<OidcTokenSet, AxiamError>` is preserved.
+6. `tests/oidc_token_ops_test.rs` — add the §9 burst test: ≥5 concurrent `oidc_refresh` calls
+   against a counting `/oauth2/token` mock, asserting exactly **one** request **and** that all
+   callers observe the same `access_token`. Mirror `tests/single_flight_refresh_test.rs`.
+
+**This is the sole reason `axiam-rust-sdk` is BLOCKED.** Merging it would ship a README claiming
+"§1–§12 conformance" while violating a §12-referenced MUST and omitting a MUST-level test.
+
+### 2.3 Five guard-contention designs — observably equivalent, and the 3-attempt bound should not have propagated
+
+| SDK | Coalescer | Interaction with the §1 guard | Observable result for N concurrent callers |
+|---|---|---|---|
+| TS | shared `Promise` in `#pendingRefresh` | runs inside the session `refreshGuard`; bounded 3 retries if busy | 1 wire call, shared outcome |
+| Python | `_SyncSingleFlight` / `_AsyncSingleFlight` | `RefreshGuard.run_exclusive_sync/async`, blocking, no retry | 1 wire call, shared outcome |
+| Go | own `oidcRefreshFuture` (mutex + `chan`) | deliberately does **not** use `Client.guard` | 1 wire call, shared outcome |
+| Java | `SingleFlight.run` | `RefreshGuard.runExclusive`, bounded 3 attempts | 1 wire call, shared outcome |
+| C# | cached `Task<OidcTokenSet>` + `SemaphoreSlim(1,1)` | dedicated instance, not the cookie guard | 1 wire call, shared outcome |
+| Kotlin | shared `CompletableDeferred` | dedicated instance of the §9 Kotlin mechanism | 1 wire call, shared outcome |
+| PHP | `Session::refreshGuard()` → `{ran, promise}` | bounded 3 retries; on `ran=false` waits then **re-acquires** | **N wire calls** (see below) |
+| Rust | none | bare `Mutex<()>` | **N wire calls** |
+
+**Verdict on the six that pass: observably equivalent, and that is what matters.** A behavioural
+contract governs what an observer can detect — one wire call per burst, one outcome delivered to
+everyone, no stale token set, no refresh-retry loop. All six deliver exactly that. The differences
+(shared promise vs. condition variable vs. channel vs. cached task; reusing the §1 guard object vs.
+a dedicated instance of the same mechanism) are invisible from outside and should never have been
+contract-relevant.
+
+**Verdict on the TypeScript 3-attempt bound: an implementation detail that should not have been
+propagated.** It exists only because TS's `RefreshGuard` returns `Promise<void>`, so the refreshed
+token set cannot travel back through the guard and the caller must loop to re-acquire it. It is not
+a property of the OIDC flow. It nonetheless propagated to PHP and Java, and in PHP it is where the
+result-sharing was lost: because `oidcRefresh` treats `ran === false` as "the guard is busy with
+*someone else's* refresh", a second concurrent `oidcRefresh` caller waits on the leader's promise
+and then issues **its own** token POST — structurally the same defect as Rust's. The mitigating
+facts are that vanilla PHP has no concurrency for these synchronous calls (`refreshPromise` is a
+per-instance property and `->wait()` blocks), so the path is only reachable under Fibers/Swoole,
+and that PHP has no `oidcRefresh` burst test to expose it either way. Recorded as F-06 (high
+severity, non-blocking).
+
+**Contract wording adopted (1.5).** §9 gains **rule 5**, which pins observable behaviour and frees
+mechanism:
+
+- Rules 1–4 constrain observable behaviour only; the per-language table is guidance, not a mandate.
+- An operation may use a **dedicated instance of an equally strong mechanism** where the shared
+  guard's API is specialized to another token namespace (naming the real reason: the §1 guard
+  compares cookie-access-token freshness, which is meaningless for a `refresh_token` grant) — but
+  never a weaker mechanism.
+- Where an implementation composes an operation-specific coalescer *with* the shared guard, a
+  **bounded** (never unbounded) wait is permitted, exhaustion MUST raise `AuthError` rather than
+  return a stale token set, and **the specific bound is explicitly not part of this contract**.
+
+§9 rule 2 additionally now states the observable requirement in one sentence, with the single-use
+rotation reasoning, so "serialize but do not share" can never again be read as conformant. §9's
+test requirement is clarified to apply **per refresh operation**, so `oidc_refresh` needs its own
+burst test. §12.1's "MUST run under the §9 single-flight refresh guard" becomes "MUST be governed
+by a §9-conformant single-flight guard", pointing at rule 5.
+
+### 2.4 Verification of the numbers I was given
+
+All eight suites and all eight coverage gates were **re-run locally**. Everything reported by the
+implementing agents held up; Rust's previously unmeasured coverage clears its floor.
+
+| SDK | Tests reported | Tests measured | Coverage reported | Coverage measured | Floor | Gate |
+|---|---|---|---|---|---|---|
+| TypeScript | 465 / 97.24% lines | **465 passed, 49 files** | 97.24 L / 92.51 B | **97.24 L / 92.51 B / 97.02 S / 97.58 F** | 94 L / 86 B / 94 S / 95 F | **PASS** |
+| Python | 434 / 98.88% | **434 passed** | 98.88 | **98.88** | 97 (`fail_under`) | **PASS** |
+| Go | ~116 / 94.7% | **all packages ok** (448 incl. subtests) | 94.7 | **94.7** | 94 (`coverage.yml`) | **PASS** |
+| Rust | 75 new tests / **never measured** | all test binaries pass | — | **91.52% lines** (90.93 regions, 86.55 functions) | 90 lines | **PASS**, margin 1.52 |
+| PHP | 436 / 96.23% | **436 tests, 1115 assertions** | 96.23 | **96.23** | 94 (`coverage.yml`) | **PASS** |
+| Java | 350 / 94.4% JaCoCo | **350 passed, 0 failures** | 94.4 | **94.02** (1619/1722 lines) | 0.93 BUNDLE LINE COVEREDRATIO | **PASS**, margin 0.0102 |
+| C# | 328 / 96.03% | **328 passed** (37 + 291) | 96.03 | **96.05** (union-merged lcov) | 94 (`coverage.yml`) | **PASS** |
+| Kotlin | 209 / 99.02% Kover | **209 passed, 0 failures** | 99.02 | **99.02** (1209/1221 lines) | `minBound(98)` LINE | **PASS**, margin 1.02 |
+
+Notes on the two thinnest margins and the one previously-unknown number:
+
+- **Rust 91.52% vs floor 90** is real but thin, and the §12 code is where the slack is:
+  `oidc/discovery.rs` 81.13% lines, `oidc/exchange.rs` 86.96% (51 uncovered lines across 850
+  source lines with **zero** inline unit tests), `oidc/authorize.rs` 90.43%. Roughly 15 untested
+  error arms sit in `exchange.rs` — malformed-body parse failures on all four endpoints, the
+  `oidc_endpoint_url` parse-failure arm, and a **dead** tenant-missing branch in `sso_start`
+  (unreachable: `TenantIdentifier` is a two-variant enum and §5 guarantees one is set). Adding the
+  F-01 concurrency test plus a few malformed-body tests would restore margin. F-10.
+- **Java 94.02% vs floor 0.93** leaves 0.0102 of headroom. Four one-line delegating overloads
+  (`oidcRefresh(Sensitive)`, `oidcRefreshAsync(Sensitive)`, `introspect(Sensitive)`,
+  `revoke(Sensitive)`) have no test referencing them. F-17.
+- I could not measure a **branch** figure for Go, PHP, or C# — none of the three configures a
+  branch gate, and their floors are line-based, which is what I measured.
+
+Additional facts established by execution rather than reading:
+
+- **Rust emits `+` for spaces in the authorization URL.** `url::Url::query_pairs_mut()` returns a
+  `form_urlencoded::Serializer`, so `append_pair("scope", "openid profile email")` yields
+  `scope=openid+profile+email`. Confirmed with a standalone program against the same `url 2.5.8`
+  the repo locks. All seven siblings emit `%20` (TS post-processes `URLSearchParams`, Python uses
+  `quote(safe='')`, Go post-processes `Encode()`, PHP uses `rawurlencode`, Java/Kotlin use
+  OkHttp `addQueryParameter`, C# uses `Uri.EscapeDataString`). F-04.
+- **Rust's `Cargo.lock` is unchanged by the commit**, confirming that `getrandom` and `base64` were
+  already in the graph and that the two new `[dependencies]` entries add no crates.
+- **The mixed slug-header / UUID-query pair is safe.** `crates/axiam-api-rest/src/handlers/oauth2.rs`
+  reads the tenant exclusively from `web::Query<TenantQuery>` and never inspects `X-Tenant-ID`;
+  `/oauth2/token` is a public path (`middleware/authz.rs:222`) and CSRF-exempt
+  (`middleware/csrf.rs:71`). The header is inert on those endpoints.
+
+---
+
+## 3. Contract 1.5 changes made
+
+All edits are in `/home/user/axiam/sdks/CONTRACT.md` (1090 → 1374 lines) and are non-breaking and
+clarifying. **Every change describes behaviour all eight SDKs already exhibit**, with two
+deliberate exceptions noted below.
+
+| # | Section | Change |
+|---|---|---|
+| 1 | §7 | Restructured "Required behavior" into four numbered rules separating unconditional redaction (r1) from the explicit-accessor MAY (r3), with no-implicit-reachability (r2) and point-of-use discipline (r4). Added a rationale paragraph and a sentence keeping the C/C++ rows' intent intact. **§2.1 ruling.** |
+| 2 | §9 r2 | Added the observable requirement — one wire call per burst, that outcome shared with all N — with the single-use-rotation reasoning. |
+| 3 | §9 r5 (new) | Mechanism is free; a dedicated guard instance for a second token namespace is permitted; a bounded wait for a shared guard is permitted and its bound is explicitly not contract-worthy. **§2.3 ruling.** |
+| 4 | §9 test requirement | Clarified: assert shared outcome too, and apply the requirement **per refresh operation**. |
+| 5 | §2 construction rules | The `"<error>: <error_description>"` requirement binds the `message` *field*; a rendered prefix (Go `Error()`, Rust `Display`) is fine. Field names follow per-language casing; Go's `ErrorCode` rename accepted. |
+| 6 | §12.1 note 2 | Documented that a slug `X-Tenant-ID` legitimately accompanies a UUID `?tenant_id=` (the handlers read only the query parameter), and that a slug-only client with no resolved UUID cannot call five of the nine operations. **Defect 4.** |
+| 7 | §12.1 note 5 | Corrected `revoke`: `200` MUST be success, any other `2xx` MAY be (RECOMMENDED), `5xx` MUST NOT be and stays a `NetworkError`. Removed 1.4's "Only 401 is an error". Added the mandatory idempotence test. **Defect 7.** |
+| 8 | §12.1 | `client_id` removed from `oidc_begin`'s per-call inputs; stated that it comes from client configuration for §12.4 r4 consistency, and that a missing one fails fast with no wire call (taxonomy **or** programming error). **Defect 5.** |
+| 9 | §12.1 | New paragraph: `AuthorizationRequest` deliberately carries **no** `redirect_uri`; the caller must carry it between begin and exchange; the store entry is where the glue parks it. Adding the field is explicitly deferred. **Defect 6, resolved as "document", matching all eight.** |
+| 10 | §12.1 | `oidc_refresh`: "MUST run under the §9 guard" → "MUST be governed by a §9-conformant single-flight guard", citing r5, r2's observable requirement, and the per-operation test requirement. |
+| 11 | §12.2 | New normative paragraph permitting either host object, with the browser-bundle rationale; names stay fixed; a separate host must be documented and must not split the nine. **Defect 8.** |
+| 12 | §12.3 r1 | Enumerated store-entry fields (incl. `redirect_uri`); TTL is a clamped maximum; sweeping MUST be lazy with no background timer/thread. |
+| 13 | §12.3 r3 | Declared the seven reason codes a **closed** vocabulary and pinned the many-to-one mappings — every r5 time failure → `token_expired`, no-`kid` → `unknown_kid`, unparseable header → `invalid_alg`, unclassified → `invalid_signature`. **Defect 3, resolved by documenting rather than adding codes, since adding any would break all eight.** |
+| 14 | §12.3 r6 | Rewrote the self-contradiction: sharing one document across tenants of an origin is correct and intended; a per-client-instance cache satisfies the origin requirement by construction; a process-global/cross-client cache MUST key on the normalized origin. Added the TTL-floor-raising clarification. **Defect 1.** |
+| 15 | §12.4 r2 | "One JWKS re-fetch then fail" is normative **per cooldown window**, not per token, with the fetch-amplification reasoning and the observable requirements. **Defect 2.** |
+| 16 | §12.4 r5 | `exp` and `iat` are both required; skew above 60 s is clamped, not rejected; every failure reports `token_expired`. |
+| 17 | Conformance Statement | Added a per-SDK table for the eight §12 implementers (recording Kotlin's pre-existing §8 carve-out and both async conventions) and the three unchanged deferrers; recorded that credential adoption is a MAY with five legal positions. |
+| 18 | Breaking Changes Log | Added the contract 1.5 entry in the existing format, itemising all of the above. |
+| 19 | Version footer | `1.4` → `1.5` with the new provenance clause appended in the existing style. |
+
+**The two deliberate exceptions to "all eight already satisfy it".** Change 2 (§9 r2's observable
+statement) and change 4 (the per-operation test requirement) restate MUSTs that contract 1.4
+*already* imposed; Rust fails the first and Rust and PHP fail the second. I am not creating new work
+by contract fiat — I am removing the ambiguity that let a pre-existing MUST be read as satisfied.
+Both gaps appear in the follow-up list with concrete fixes, and both are called out here rather than
+being buried.
+
+**Deliberately not changed:** `AuthorizationRequest` did **not** gain a `redirect_uri` field. All
+eight ship the four-field shape, so adding it would invent work and change an already-published
+type; the footgun is documented instead. No reason code was added, for the same reason.
+
+**Re-synced** to all eight SDK repos as `<repo>/CONTRACT.md` (byte-identical to the source).
+Conformance statements were checked in all eight: each already names the right section range, so
+seven required no editing (Kotlin's `§1–§7, §9–§12` is correct given its pre-existing §8 deferral
+and now matches the new conformance table). One was corrected: `axiam-csharp-sdk/README.md:27`'s
+checklist heading still read "§1–§11" under a statement claiming §1–§12 — see F-16. Contract 1.5
+changes no claimed section range, so no statement's `§1–§12` needed to move.
+
+---
+
+## 4. Follow-up list (severity-ordered)
+
+Nothing below is a hot-fix I applied — this review changed contract text, vendored copies, and this
+document only. Exactly **one** item blocks a merge.
+
+### Blocking
+
+**F-01 — Rust `oidc_refresh` violates §9 rule 2, and its §9 test is absent. BLOCKS MERGE.**
+Repo `axiam-rust-sdk`. Files `src/client.rs:465`, `src/oidc/exchange.rs:526-560`,
+`src/sensitive.rs`, `src/error.rs`, `src/oidc/id_token.rs`, `tests/oidc_token_ops_test.rs`.
+Defect: the guard is a bare `tokio::sync::Mutex<()>` with no result slot, so N concurrent callers
+issue N serialized wire calls; with single-use rotating refresh tokens callers 2..N replay a
+consumed token and fail `invalid_grant`. No `oidc_refresh` concurrency test exists.
+Fix: the six steps in §2.2 above (manual `Clone` for `Sensitive<T>`; `Clone` on `OidcTokenSet`/
+`IdTokenClaims`/`Audience`; `AxiamError::clone_for_waiter`; swap the mutex for
+`Mutex<Option<broadcast::Sender<Result<OidcTokenSet, Arc<AxiamError>>>>>` — `tokio`'s `sync` feature
+is already on, so no new dependency; leader/waiter election in `oidc_refresh`; the ≥5-caller burst
+test asserting one request and one shared `access_token`). Severity **critical**.
+
+### High — fix before any release advertising §12; do not block merge
+
+**F-02 — Java: a §12 caller cannot read the tokens it is handed.**
+Repo `axiam-java-sdk`, file `src/main/java/io/axiam/sdk/Sensitive.java:65`. `String expose()` is
+package-private in `io.axiam.sdk`, so a consumer holding an `OidcTokenSet` (package
+`io.axiam.sdk.oidc`) cannot extract `accessToken()`/`refreshToken()`/`idToken()` at all. Fix: make
+`expose()` `public`, with Javadoc citing contract 1.5 §7 rule 3 (as Rust and C# did); add a test
+asserting a caller outside `io.axiam.sdk` can read an exchanged access token, and one asserting
+`toString`/Jackson still redact. Widening is additive and breaks nothing. Severity **high**.
+
+**F-03 — Kotlin: same defect.**
+Repo `axiam-kotlin-sdk`, file `src/main/kotlin/io/axiam/sdk/Sensitive.kt:28`. `internal fun
+expose(): T`. Same fix (make it `public`, KDoc the §12 reason, add the caller-readability and
+still-redacts tests). Severity **high**.
+
+**F-04 — Rust emits `+` instead of `%20` in the authorization URL.**
+Repo `axiam-rust-sdk`, file `src/oidc/authorize.rs:223-233`. `url::Url::query_pairs_mut()` is a
+`form_urlencoded::Serializer`, so a multi-valued `scope` becomes `scope=openid+profile+email` —
+verified by execution. §12.1 rule 5 requires RFC 3986 percent-encoding and all seven siblings emit
+`%20`. Fix: build the query with an explicit RFC 3986 encoder over the unreserved set
+`[A-Za-z0-9-._~]` (Kotlin's `percentEncode` is the closest model), or keep `query_pairs_mut()` and
+post-process `+` → `%20` as TypeScript and Go do; then add an assertion on the **raw** URL string
+(`%20` present, `+` absent) — the existing test at `tests/oidc_pkce_test.rs:72-78` reads the value
+back through `query_pairs()`, which decodes `+` to a space and so passes either way. Severity
+**high** (interop and cross-SDK byte-consistency, not a functional break: Actix's
+`serde_urlencoded` decodes `+` as a space).
+
+**F-05 — Rust `sso_complete` does not perform the post-login session sync.**
+Repo `axiam-rust-sdk`, file `src/oidc/exchange.rs:801-845`. It captures cookies and re-syncs CSRF
+but never calls `absorb_session_cookies` (`src/rest/auth.rs:184`), so unlike all seven siblings it
+does not seed the token manager or resolve `tenant_id`/`org_id`; a subsequent `refresh()` fails
+with "no access token to refresh". Fix: call `absorb_session_cookies()` on success, mirroring
+`login`/`verify_mfa`; add a test asserting `resolved_org_id()` is populated and `refresh()` works
+after `sso_complete`. Severity **high**.
+
+**F-06 — PHP `oidcRefresh` does not share one result across concurrent callers, and has no burst
+test.** Repo `axiam-php-sdk`, files `src/Oidc/OidcClient.php:389-412`, `src/Session.php:214-236`.
+On `ran === false` it waits on the leader's promise and then **re-acquires the guard**, issuing its
+own token POST — so a second concurrent `oidcRefresh` produces a second wire call and replays a
+consumed refresh token. Only reachable under Fibers/Swoole (vanilla PHP has no concurrency for
+these synchronous calls), and there is no `oidcRefresh` concurrency test either way. Fix: have
+`refreshGuard` distinguish "busy with the same kind" (return the shared promise and **use** its
+result) from "busy with a different kind" (wait, then retry), or give `oidcRefresh` its own
+coalescer keyed to the OIDC namespace as Go, C#, and Kotlin did; add the §9 burst test.
+Severity **high**.
+
+**F-07 — Rust `AxiamError::Auth` is source-breaking and the enum is not `#[non_exhaustive]`.**
+Repo `axiam-rust-sdk`, file `src/error.rs:25-47`. Adding `oauth`/`reason` to a public struct variant
+makes every downstream `AxiamError::Auth { message: … }` construction `E0063` and every exhaustive
+destructure `E0027`; 33 constructions and 9 patterns were rewritten inside the repo, one of them in
+a shipped `examples/` file. Fix: add `#[non_exhaustive]` to `AxiamError` (and/or to the `Auth`
+variant) so future additive fields cannot break consumers again, and record the break honestly in
+the repo `CHANGELOG.md` — it is acceptable at `1.0.0-alpha18` but must not be described as
+non-breaking. Severity **high** (documentation and future-proofing; the code works).
+
+### Medium
+
+**F-08 — Python `revoke` accepts only `200`.**
+Repo `axiam-python-sdk`, file `src/axiam_sdk/_oidc.py:638`
+(`response.status_code == httpx.codes.OK`). Conformant to the contract's MUST but the outlier
+against seven SDKs and against 1.5's RECOMMENDED "any 2xx". Fix: accept `200 <= status < 300`;
+add a `204` test. Severity **medium**.
+
+**F-09 — Rust's reserved-param collision guard raises a taxonomy error.**
+Repo `axiam-rust-sdk`, file `src/oidc/authorize.rs:198-207` returns `AxiamError::Network`. The other
+seven raise a programming-error type (`Error`, `ValueError`, plain `error`, `InvalidArgumentException`,
+`IllegalArgumentException`, `ArgumentException`), which is what the port brief specified: a caller
+passing a reserved `extra_param` is a bug, not a transport failure. Fix: introduce (or reuse) a
+non-taxonomy programming-error path, or at minimum document the deviation. Severity **medium**.
+
+**F-10 — Rust §12 coverage is thin and contains a dead branch.**
+Repo `axiam-rust-sdk`. `src/oidc/discovery.rs` 81.13% lines, `src/oidc/exchange.rs` 86.96% (850
+source lines, **zero** inline unit tests, ~15 untested error arms), `src/oidc/authorize.rs` 90.43%;
+total 91.52% against a 90 floor. `src/oidc/exchange.rs:716-724` is unreachable (`TenantIdentifier`
+is a two-variant enum and §5 guarantees one is set). Fix: delete the dead branch; add
+malformed-body tests for all four parse sites, a failing-discovery test, and an invalid-endpoint-URL
+test. F-01's burst test also helps. Severity **medium** (the gate passes today, but the margin is
+1.52 points).
+
+**F-11 — Python: no serialization-leak assertion.**
+Repo `axiam-python-sdk`, file `tests/test_oidc_redaction.py`. No test exercises
+`model_dump_json()` or `model_dump(mode="json")` on `OidcTokenSet`/`AuthorizationRequest`, and
+`src/axiam_sdk/_models.py:163-164`'s claim that "`model_dump` redacts" is imprecise: in pydantic
+python-mode `model_dump()` returns the `SecretStr` **object**, so the raw value stays reachable off
+the returned dict (the existing test passes only because `str(dict)` uses the redacting repr). Fix:
+add `model_dump_json()` assertions and correct the comment. Severity **medium**.
+
+**F-12 — Java: no Jackson-leak assertion on the §12 DTOs.**
+Repo `axiam-java-sdk`, file `src/test/java/io/axiam/sdk/SensitiveTest.java`. The only Jackson
+redaction test targets a bare `Sensitive`; nothing serializes `OidcTokenSet`,
+`AuthorizationRequest`, or `OidcStateEntry`. Correct by construction (`@JsonSerialize` is
+class-level) but unasserted. Fix: add `ObjectMapper.writeValueAsString` assertions for all three.
+Severity **medium**.
+
+**F-13 — Java, C#, Kotlin: §12.4 rule 7 tests are weaker than the rule.**
+Files `src/test/java/io/axiam/sdk/AxiamClientOidcCoverageTest.java`,
+`tests/Axiam.Sdk.Tests/OidcExchangeTests.cs:374`,
+`src/test/kotlin/io/axiam/sdk/oidc/OidcCoverageGapsTest.kt:82`. Each asserts only that an error is
+thrown. Fix: mirror the five siblings that additionally assert a sentinel access token
+(`"should-never-be-returned"`) appears nowhere in the outcome or the error. Severity **medium**.
+
+**F-14 — Five SDKs rely on a structural, undocumented invariant to keep 401-from-`/oauth2/*` out of
+the §9 guard.** Repos `axiam-python-sdk`, `axiam-go-sdk`, `axiam-rust-sdk`, `axiam-php-sdk`,
+`axiam-kotlin-sdk`. Each is correct today only because no 401→refresh interceptor sits on the
+transport §12 uses; adding one later would silently break the rule (which the three list-based
+SDKs are immune to). Fix: add a comment at the transport seam naming the invariant, plus a
+regression test asserting a 401 from `/oauth2/introspect` triggers zero `/api/v1/auth/refresh`
+calls (Python, Go, Rust, and PHP already have such a test — Kotlin's `hitRefreshEndpoint()` check
+is the weakest). Severity **medium**.
+
+**F-15 — `X-Tenant-ID` is dropped on `/oauth2/*` when discovery advertises a foreign host.**
+Repos `axiam-go-sdk` (`client.go:313-316`), `axiam-java-sdk` (`AuthInterceptor.java:87`),
+`axiam-csharp-sdk` (`Rest/AxiamHttpMessageHandler.cs:171`). The header interceptor returns early
+for a non-base-URL host and §12 builds absolute URLs from the discovery document, so a
+proxy-fronted deployment loses the header §12.1 note 2 calls unconditional. Harmless today (the
+handlers ignore it — verified) but a latent surprise. Fix: emit `X-Tenant-ID` for
+discovery-document-derived `/oauth2/*` URLs regardless of host, or document the exception; add a
+test in all eight asserting the header on a `/oauth2/token` request (**no repo has one**).
+Severity **medium**.
+
+### Low
+
+**F-16 — C# README heading contradicted its own conformance claim. FIXED IN THIS REVIEW.**
+Repo `axiam-csharp-sdk`: `README.md:20` claimed §1–§12 while `README.md:27` still read
+"### §1–§11 conformance checklist", even though the table below it already carried a §12 row.
+Corrected to "§1–§12" as part of the conformance-statement re-sync. No further action.
+Severity **low**.
+
+**F-17 — Java: four untested one-line overloads against a 0.0102 coverage margin.**
+Repo `axiam-java-sdk`, `AxiamClient.java:1061`, `:1079`, `:1149`, `:1195`
+(`oidcRefresh(Sensitive)`, `oidcRefreshAsync(Sensitive)`, `introspect(Sensitive)`,
+`revoke(Sensitive)`). Fix: one test each, or route the `String` overloads through them.
+Severity **low**.
+
+**F-18 — PHP `AuthError`'s new `$reason` is the second positional parameter.**
+Repo `axiam-php-sdk`, `src/Core/AuthError.php:24-28`. Any downstream caller passing `$previous`
+positionally breaks. No such site exists in the repo. Fix: move `$reason` last or make it
+named-only. Severity **low**.
+
+**F-19 — Rust doc link points at the wrong file for the RFC 7636 vector.**
+`src/oidc/authorize.rs:87` says the Appendix B vector is verified in `tests/oidc_pkce_test.rs`; it
+is actually at `src/oidc/authorize.rs:251`. Also `src/oidc/id_token.rs:31`'s `ID_TOKEN_ALG` is a
+public constant with zero references anywhere. Fix: correct the link, remove or use the constant.
+Severity **low**.
+
+---
+
+## 5. What I verified by execution vs. by reading
+
+### Verified by execution (I ran it)
+
+- **All eight test suites**, from a clean or force-rerun state: TypeScript 465/465 (`vitest run`),
+  Python 434/434 (`pytest`), Go all packages ok (`go test ./...`), Rust all test binaries ok (via
+  `cargo llvm-cov`, exit 0), PHP 436 tests / 1115 assertions (`phpunit`), Java 350/350 with 0
+  failures/errors (`mvn -o verify`, parsed from `target/surefire-reports`), C# 328/328 (37 + 291,
+  `dotnet test`), Kotlin 209/209 (`./gradlew clean test --rerun-tasks` — an initial run came back
+  `UP-TO-DATE` from a warm build directory and was discarded).
+- **All eight coverage gates**, using each repo's own CI command and floor: TypeScript vitest
+  thresholds, Python `fail_under = 97`, Go's `awk` 94 floor over the scoped profile, Rust
+  `cargo llvm-cov report --fail-under-lines 90` (exit 0, **91.52% lines**), PHP's 94 floor via
+  `pcov`, Java's JaCoCo `BUNDLE`/`LINE`/`COVEREDRATIO` `0.93` (`mvn verify` exit 0, ratio recomputed
+  from `jacoco.csv`), C#'s 94 floor over a properly union-merged lcov, Kotlin `koverVerify`
+  `minBound(98)` (exit 0, 99.02% recomputed from the Kover XML). **Every gate passes.**
+- **`cargo-llvm-cov` was not installed**; I installed it plus `llvm-tools-preview` and ran the exact
+  CI command, resolving the one number nobody had.
+- **The Rust `+`-vs-`%20` defect**, with a standalone program against the same `url 2.5.8` the repo
+  locks: `append_pair("scope", "openid profile email")` → `scope=openid+profile+email`.
+- **Rust's `Cargo.lock` is unchanged** by the commit (`git show --stat HEAD -- Cargo.lock` empty).
+- **The server's tenant handling on `/oauth2/*`**, by reading the handler and its middleware
+  registrations: query-only, public path, CSRF-exempt.
+- **Per-file Rust coverage** for the §12 modules, from the llvm-cov report.
+
+### Verified by reading source (not executed)
+
+- The whole conformance matrix in §1 apart from the test-execution and coverage rows: every naming,
+  argument-order, error-mapping, `Sensitive`-wrapping, redaction-sink, PKCE, ID-token-rule,
+  state-store, discovery-cache, wire-shape, cookie-jar, dependency, and TLS-policy cell was
+  established by reading the shipped source and the corresponding tests, at file:line.
+- That each §12.4 rule has a failing test: I read the test bodies and their assertions; I did not
+  individually confirm each of the ~56 rule-tests fails when its rule is removed. The suites do
+  pass as a whole, which I did run.
+- The §9 concurrency claims for the six passing SDKs: I read the coalescer code and the burst
+  tests' assertions (N and the shared-value check). I did not instrument them to count wire calls
+  independently — but each test asserts the count itself, and each suite passed.
+- Rust's N-wire-calls-for-N-callers behaviour is a reading of the guard code plus the absence of any
+  result slot and of any `Clone` on the three relevant types. There is no test to run, which is
+  itself part of F-01.
+- PHP's `oidcRefresh` retry-instead-of-share behaviour is a reading of
+  `OidcClient.php:389-412` against `Session.php:214-236`. It is not reachable in vanilla PHP, so it
+  cannot be demonstrated by execution without a Fibers harness.
+
+### Could not verify
+
+- **Branch coverage for Go, PHP, and C#.** None configures a branch gate; their floors are
+  line-based, which is what I measured.
+- **Live server behaviour.** No AXIAM instance was running, so every wire-shape claim rests on the
+  SDK's own mock-server tests plus the handler source. The mixed slug-header/UUID-query pairing is
+  confirmed against `handlers/oauth2.rs`, not against a live 200.
+- **`cargo audit`** in the Rust repo, and the TypeScript `npm run build` codegen step (`buf` is not
+  installed in this environment). Both are environment limits, not findings, and the `Cargo.lock`
+  check covers the substance of the dependency question.
+
+---
+
+## 6. Merge verdict
+
+| Repo | Verdict | Reason |
+|---|---|---|
+| `axiam` (contract) | **SAFE TO MERGE** | contract 1.5 amendments + this document |
+| `axiam-typescript-sdk` | **SAFE TO MERGE** | fully conformant; 465 tests and all four thresholds verified |
+| `axiam-python-sdk` | **SAFE TO MERGE** | conformant; F-08/F-11 are non-blocking |
+| `axiam-go-sdk` | **SAFE TO MERGE** | conformant; F-14/F-15 non-blocking |
+| `axiam-rust-sdk` | **BLOCKED** | **F-01**: §9 rule 2 result-sharing absent (N callers → N serialized refresh calls, N−1 failing `invalid_grant` against single-use rotating tokens) and no `oidc_refresh` burst test, while the README claims §1–§12. F-04, F-05, F-07 should ride along in the same fix commit. |
+| `axiam-php-sdk` | **SAFE TO MERGE** | F-06 is the same defect class as F-01 but unreachable in vanilla PHP; high-priority follow-up, not a merge blocker |
+| `axiam-java-sdk` | **SAFE TO MERGE** | F-02 (unreadable tokens) is high severity but additive to fix and breaks nothing today |
+| `axiam-csharp-sdk` | **SAFE TO MERGE** | conformant; F-13/F-16 cosmetic-to-medium |
+| `axiam-kotlin-sdk` | **SAFE TO MERGE** | F-03 mirrors F-02; same reasoning |
+
+Eight of nine repos are safe. One is blocked on a single, precisely-specified fix.

--- a/claude_dev/sdk-oidc-sso-plan.md
+++ b/claude_dev/sdk-oidc-sso-plan.md
@@ -1,0 +1,399 @@
+# SDK OIDC / SSO Relying-Party Helpers — Implementation Plan
+
+> **Status: PLAN — not yet implemented.**
+> Scope: the eight **backend-capable** client SDKs (`axiam-rust-sdk`, `axiam-typescript-sdk`,
+> `axiam-python-sdk`, `axiam-java-sdk`, `axiam-kotlin-sdk`, `axiam-csharp-sdk`,
+> `axiam-php-sdk`, `axiam-go-sdk`) plus a contract amendment in this repository
+> (`sdks/CONTRACT.md`). The device/client-oriented SDKs (`axiam-swift-sdk`,
+> `axiam-c-sdk`, `axiam-cplusplus-sdk`) are **explicitly deferred** — see §8.
+> Each task below is sized to be one executable task for a developer agent in a
+> follow-up run, and carries the **recommended model** (cheapest adequate choice
+> between Opus 5 and Sonnet 5) to drive that agent.
+
+## 1. Problem statement — what is missing today (surveyed 2026-07-27)
+
+The AXIAM server already ships a complete OIDC provider + federation surface
+(`sdks/openapi.json`):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /.well-known/openid-configuration` | OIDC discovery |
+| `GET /oauth2/authorize` | Authorization endpoint (code flow, PKCE, `state`, `nonce`) |
+| `POST /oauth2/token?tenant_id=<uuid>` | Token endpoint — `authorization_code`, `client_credentials`, `refresh_token` grants (form-encoded `TokenRequest`, returns `TokenResponse` with optional `id_token`) |
+| `GET /oauth2/jwks` | Signing keys (EdDSA/Ed25519) |
+| `POST /oauth2/introspect`, `POST /oauth2/revoke` | RFC 7662 / RFC 7009 |
+| `POST /api/v1/auth/federation/oidc/start` | First-time SSO against an upstream IdP: returns IdP authorize URL, server persists state+nonce (10-min TTL, D-22) |
+| `POST /api/v1/auth/federation/oidc/callback` | Single-use state consumption, user provisioning/linking, returns **Set-Cookie** session (no token in body) |
+
+The SDKs, however, only implement the CONTRACT §1 vocabulary: `login`
+(direct password `POST /api/v1/auth/login`), `verify_mfa`, `refresh`, `logout`,
+`check_access`/`can`/`batch_check`, and gRPC `get_user_info`, plus the §10/§11
+resource-server middleware (local JWKS verification of inbound bearer tokens).
+
+**A backend developer today cannot implement "Login with AXIAM" (OIDC/SSO) using
+any SDK.** Specifically, no SDK has:
+
+- OIDC discovery-document fetch/cache;
+- authorization-URL construction with CSPRNG `state`, `nonce`, and PKCE S256
+  verifier/challenge generation;
+- authorization-code → token exchange against `POST /oauth2/token`;
+- ID-token validation as a *relying party* (`iss`/`aud`/`exp`/`nonce`/signature);
+- `client_credentials` grant for service-account M2M auth;
+- token introspection/revocation calls;
+- helpers for the federation SSO endpoints (`/federation/oidc/start|callback`).
+
+(Verified by grep across all SDK repos: zero non-test source hits for
+`authorization_code`, `client_credentials`, `code_verifier`, `/oauth2/token`,
+or `/oauth2/authorize`.)
+
+What each backend SDK *does* already have, and the new work must reuse:
+
+| SDK | JWKS/EdDSA verification to reuse | HTTP core to reuse | Framework surface |
+|---|---|---|---|
+| Rust | `src/token/jwks.rs` | existing reqwest-based client | Actix extractor (`src/middleware/actix.rs`) |
+| TypeScript | `src/node/jwks.ts` (+ `src/node/session.ts`) | `src/rest/` core | Express/Fastify middleware, NestJS module |
+| Python | `src/axiam_sdk/_jwks.py`, `token/` | `_client.py` / `_async_client.py` | FastAPI deps, Django middleware |
+| Java | JWKS logic reachable from `io/axiam/sdk/AxiamClient.java` | `AxiamClient` HTTP core | Spring filter/auto-config (`spring/`) |
+| Kotlin | `src/main/kotlin/io/axiam/sdk/internal/JwksVerifier.kt` | `AxiamClient.kt` | Ktor plugin (`ktor/AxiamAuthentication.kt`) — JVM-only SDK, Ktor `compileOnly` |
+| C# | `Axiam.Sdk/Auth/Jwk.cs` | `Axiam.Sdk` core | `Axiam.Sdk.AspNetCore` middleware + policies |
+| PHP | `src/Auth/JwksVerifier.php` | `src/AxiamClient.php` | Laravel provider, Symfony bundle |
+| Go | `internal/jwks/verifier.go` | `client.go` | `middleware/nethttp.go` |
+
+## 2. Design — canonical operation set (to be locked in CONTRACT §12)
+
+CONTRACT §1 forbids any SDK method names outside the naming map, so the contract
+amendment (Task T0) is a **hard prerequisite** for every SDK task. The proposed
+canonical vocabulary (final casing per language follows the existing §1 casing
+rules):
+
+| Canonical operation | Endpoint | Semantics |
+|---|---|---|
+| `oidc_discover` | `GET /.well-known/openid-configuration` | Fetch + cache discovery doc (TTL ≥ 5 min, single-flight, per-base-URL). Returns typed `OidcConfiguration`. |
+| `oidc_begin` | *(no wire call, uses discovery)* | Build authorization request: CSPRNG `state` (≥128-bit) and `nonce`, PKCE verifier (43–128 chars) + **S256** challenge (never `plain`). Returns `AuthorizationRequest { url, state, nonce, code_verifier }`. Caller stores `state`/`nonce`/`code_verifier` in its own session and redirects the browser to `url`. |
+| `oidc_exchange` | `POST /oauth2/token` (`grant_type=authorization_code`) | Exchange `code` + `code_verifier` + `redirect_uri` (+ `client_id`, optional `client_secret` for confidential clients; `tenant_id` as query param). Validates the returned `id_token` (checklist in §3) before returning `OidcTokenSet { access_token, id_token, id_claims, refresh_token?, expires_in, scope? }`. |
+| `oidc_refresh` | `POST /oauth2/token` (`grant_type=refresh_token`) | Refreshes an `OidcTokenSet`. MUST run under the existing §9 single-flight refresh guard. Distinct from session `refresh` (cookie/opaque-token path) — do not merge the two. |
+| `login_client_credentials` | `POST /oauth2/token` (`grant_type=client_credentials`) | Service-account M2M login: `client_id` + `client_secret` (+ optional `scope`). Returns the token set; the SDK may then use it as its bearer credential exactly like a `login()` result. |
+| `introspect` | `POST /oauth2/introspect` | RFC 7662; returns typed `IntrospectionResult { active, ... }`. |
+| `revoke` | `POST /oauth2/revoke` | RFC 7009; returns void; treat HTTP 200 as success even for unknown tokens. |
+| `sso_start` | `POST /api/v1/auth/federation/oidc/start` | Upstream-IdP SSO step 1 (`OidcStartRequest` → `OidcStartResponse.authorize_url`). No JWT required. |
+| `sso_complete` | `POST /api/v1/auth/federation/oidc/callback` | Step 2: posts `OidcPublicCallbackRequest`; session arrives as **Set-Cookie**, so the §4 cookie-jar requirement applies verbatim; returns `SsoLoginSuccessResponse`. |
+
+Cross-cutting rules (normative, identical in all SDKs — the amendment text must
+state them):
+
+1. **Stateless by default.** `oidc_begin`/`oidc_exchange` never store
+   `state`/`nonce`/`code_verifier` inside the SDK; the caller owns that storage.
+   Framework integrations MAY add an optional `OidcStateStore` interface with an
+   in-memory reference implementation (TTL 10 min, single-use consume — mirrors
+   the server's `federation_login_state` semantics).
+2. **Sensitive wrapping (§7).** `access_token`, `refresh_token`, `id_token`,
+   `client_secret`, and `code_verifier` are `Sensitive<T>` in every SDK; never
+   logged, never in `Debug`/`toString` output.
+3. **Error taxonomy (§2).** `OAuth2ErrorResponse` bodies map to a new
+   `OAuthProtocolError` subtype of the existing taxonomy carrying `error` +
+   `error_description`; HTTP 400 from the token endpoint MUST NOT surface as a
+   generic validation error. ID-token validation failures raise
+   `AuthenticationError` with a machine-readable reason code.
+4. **Tenant context (§5).** `tenant_id` is a required argument (or client-level
+   config) for `oidc_exchange`, `oidc_refresh`, and `login_client_credentials`
+   (query param on the token endpoint); org/tenant slugs for `sso_start` follow
+   the §5.1 rules.
+5. **REST `/oauth2/userinfo` stays out** of the SDK vocabulary (existing closing
+   note): RP claims come from the validated ID token; identity lookups use gRPC
+   `get_user_info`.
+6. **TLS (§6)** applies; the discovery cache key includes the scheme+host+port to
+   prevent cross-issuer poisoning.
+
+## 3. ID-token validation checklist (normative for `oidc_exchange`)
+
+Reuse each SDK's existing JWKS verifier; validation per OIDC Core §3.1.3.7:
+
+1. `alg` MUST be `EdDSA` — reject `none` and anything else outright.
+2. Signature via `GET /oauth2/jwks`, keyed by `kid`; on unknown `kid`, one JWKS
+   re-fetch then fail (same rule the §10 middleware already implements).
+3. `iss` equals the discovery document's `issuer` (exact string match).
+4. `aud` contains our `client_id`; if multiple audiences, `azp` must equal it.
+5. `exp`/`iat`/`nbf` with clock skew ≤ 60 s.
+6. `nonce` claim equals the caller-supplied nonce from `oidc_begin` (mandatory
+   when the request scope included `openid`; the helper always includes it).
+7. On any failure: `AuthenticationError`, and the token set is discarded (no
+   partial success).
+
+## 4. Task list, ordering, and model assignment
+
+Execution order: **T0 → T1 → {T2…T8 in parallel} → T9.** T1 is the reference
+implementation; T2–T8 are ports of a fully-specified design and can run as one
+parallel wave.
+
+Model-choice rule used below (best-but-cheapest): **Opus 5** only where the task
+*creates* normative text or reference patterns that every other task copies, or
+performs cross-repo adversarial review (design ambiguity → cheaper models drift);
+**Sonnet 5** for everything that is a well-specified port with strong local
+feedback (compilers, existing test harnesses, a reference implementation to
+imitate). This mirrors the cost outcome of the sdk-auth-helpers run.
+
+| # | Task | Repo | Model | Why this model |
+|---|---|---|---|---|
+| T0 | CONTRACT §12 amendment + naming-map rows + openapi/proto re-sync note | `axiam` | **Opus 5** | Normative spec text; every downstream task inherits its mistakes |
+| T1 | TypeScript reference implementation | `axiam-typescript-sdk` | **Opus 5** | Establishes the file/test/doc patterns T2–T8 imitate |
+| T2 | Rust port | `axiam-rust-sdk` | Sonnet 5 | Spec + reference exist; rustc/clippy give strong feedback |
+| T3 | Python port | `axiam-python-sdk` | Sonnet 5 | Straight port; sync+async mirroring is mechanical |
+| T4 | Go port | `axiam-go-sdk` | Sonnet 5 | Straight port; small API surface |
+| T5 | Java port | `axiam-java-sdk` | Sonnet 5 | Straight port onto existing Spring surface |
+| T6 | Kotlin port | `axiam-kotlin-sdk` | Sonnet 5 | Straight port onto existing Ktor plugin |
+| T7 | C# port | `axiam-csharp-sdk` | Sonnet 5 | Straight port; ASP.NET Core patterns already in repo |
+| T8 | PHP port | `axiam-php-sdk` | Sonnet 5 | Straight port onto Laravel/Symfony surfaces |
+| T9 | Cross-SDK conformance review + contract conformance-statement update | all + `axiam` | **Opus 5** | Adversarial cross-repo review; catches semantic drift Sonnet ports may introduce |
+
+Every task ends with a **signed commit** (project rule), a `CHANGELOG.md` entry,
+and — for T1–T8 — a re-synced vendored `CONTRACT.md` copied from this repo after
+T0 merges.
+
+### T0 — Contract amendment (`axiam` repo) — **Opus 5**
+
+1. Append **§12 "OIDC / SSO Relying-Party Helpers"** to `sdks/CONTRACT.md`
+   containing: the §2 operation table above rendered as a naming map for all
+   twelve languages (casing per existing §1 rules: Go/C# PascalCase, C
+   `axiam_`-prefixed snake_case, C++ snake_case, others camel/snake as per
+   language); the six cross-cutting rules; the §3 ID-token checklist; the
+   stateless-state rule; and a deferral paragraph for Swift/C/C++ (§8 below).
+2. Amend the §1 note "No SDK is permitted to expose additional login/auth/authz
+   method names…" to reference §12 as part of the locked vocabulary.
+3. Add the `OAuthProtocolError` row to the §2 error taxonomy and the
+   HTTP-status mapping (`400` from `/oauth2/*` → `OAuthProtocolError`).
+4. Log the addition in "Breaking Changes Log" as a **non-breaking, additive**
+   contract 1.4 change.
+5. Verify `sdks/openapi.json` already describes every §12 endpoint (it does as
+   of 2026-07-27 — this step is a check, not an edit).
+6. Deliverable check: `grep -c "oidc_" sdks/CONTRACT.md` > 0; markdown renders;
+   no server code touched.
+
+### T1 — TypeScript reference implementation — **Opus 5**
+
+Repo: `axiam-typescript-sdk` (npm `axiam-sdk`, TS ~5.9, tsup build, vitest).
+
+1. New module `src/node/oidc.ts` (+ re-exports from `src/node/index.ts` and a
+   subpath export if the existing `package.json` `exports` map is per-area):
+   `discover()`, `oidcBegin()`, `oidcExchange()`, `oidcRefresh()`,
+   `loginClientCredentials()`, `introspect()`, `revoke()`, `ssoStart()`,
+   `ssoComplete()` — Node-only (uses `node:crypto` for CSPRNG + SHA-256/base64url
+   PKCE; no WebCrypto fallback needed since this lives under `src/node/`).
+2. Reuse: `src/node/jwks.ts` for ID-token verification (extend, don't fork);
+   `src/rest/` request core for transport + §2 error mapping; `Sensitive`
+   wrapper wherever the repo defines it; the §9 single-flight guard for
+   `oidcRefresh`.
+3. Types in the same file or `src/node/oidcTypes.ts`: `OidcConfiguration`,
+   `AuthorizationRequest`, `OidcTokenSet`, `IntrospectionResult`,
+   `OidcStateStore` (interface) + `MemoryOidcStateStore` (10-min TTL,
+   single-use `consume(state)`).
+4. Framework glue: `oidcLoginHandlers(client, store, opts)` in
+   `src/middleware/` returning `{ login, callback }` Express-compatible
+   handlers (redirect to `url` / consume state + exchange + establish session
+   via the existing `src/node/session.ts` machinery). Fastify variant mirrors
+   the existing plugin pattern.
+5. Tests (vitest, mock the HTTP layer the way existing rest tests do):
+   discovery caching + single-flight; PKCE S256 vector (RFC 7636 Appendix B);
+   state/nonce entropy and uniqueness; full happy-path exchange; each ID-token
+   validation failure from §3 (wrong iss/aud/exp/nonce/alg/`kid`);
+   `OAuth2ErrorResponse` → `OAuthProtocolError` mapping; client-credentials
+   happy path; revoke-is-idempotent; `MemoryOidcStateStore` single-use + TTL.
+6. Example under `examples/` (Express "Login with AXIAM"), README section,
+   CHANGELOG, vendored `CONTRACT.md` re-sync. `npm test` + `npm run build`
+   green.
+
+### T2 — Rust port — **Sonnet 5**
+
+Repo: `axiam-rust-sdk` (single crate `axiam-sdk`, edition 2021, MSRV 1.88).
+
+1. New module `src/oidc/mod.rs` (submodules `discovery.rs`, `authorize.rs`,
+   `exchange.rs`, `state.rs`); methods on the existing client(s): `oidc_discover`,
+   `oidc_begin`, `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
+   `introspect`, `revoke`, `sso_start`, `sso_complete`.
+2. PKCE/state/nonce via the crate's existing CSPRNG dependency (`rand`/`getrandom`
+   — whichever is already in `Cargo.toml`; add `sha2` + `base64` only if absent).
+   ID-token validation reuses `src/token/jwks.rs`.
+3. Wrap secrets in the crate's existing `Sensitive` type; `Debug` must redact.
+4. Actix glue (feature `actix`): a small `oidc_login_scope()` helper mirroring
+   the existing extractor module's style is optional — implement only if it fits
+   in the task budget; core primitives are the deliverable.
+5. Tests under `tests/` following the repo's existing mock-server pattern
+   (same coverage list as T1 item 5). RFC 7636 Appendix B test vector included.
+6. Example in `examples/`, README, CHANGELOG, vendored contract re-sync.
+   `cargo fmt --check`, `cargo clippy --lib`, `cargo test` green.
+
+### T3 — Python port — **Sonnet 5**
+
+Repo: `axiam-python-sdk` (PyPI `axiam-sdk`, ≥3.10, sync `_client.py` + async
+`_async_client.py`, extras `fastapi`/`django`).
+
+1. New `src/axiam_sdk/_oidc.py` with shared pure logic (PKCE via `secrets` +
+   `hashlib`, URL building, ID-token checks reusing `_jwks.py`); sync methods on
+   `AxiamClient` and async twins on the async client (`oidc_discover`,
+   `oidc_begin`, `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
+   `introspect`, `revoke`, `sso_start`, `sso_complete`) — respect the SDK-Q08
+   async-naming rule.
+2. Models in `_models.py` (dataclasses/pydantic — match whatever `_models.py`
+   already uses); secrets use the repo's existing sensitive-value pattern.
+3. Framework glue: FastAPI `oidc_login_router(...)` factory in
+   `fastapi/__init__.py` (two routes: login-redirect + callback) and a Django
+   view-pair helper in `django/`; both delegate to the shared core and the
+   existing session-cookie machinery in `_session.py`.
+4. Tests mirroring the repo's existing transport-mock style; same coverage list
+   as T1; both sync and async paths. `pytest` + type check (whatever
+   `pyproject.toml` gates) green.
+5. Example, README, CHANGELOG, vendored contract re-sync.
+
+### T4 — Go port — **Sonnet 5**
+
+Repo: `axiam-go-sdk` (module `github.com/ilpanich/axiam-go-sdk`, go 1.25,
+flat root package + `middleware/`, `internal/jwks/`).
+
+1. New root-package file `oidc.go` (+ `oidc_types.go`): `OidcDiscover`,
+   `OidcBegin`, `OidcExchange`, `OidcRefresh`, `LoginClientCredentials`,
+   `Introspect`, `Revoke`, `SsoStart`, `SsoComplete` on the existing `*Client`.
+   PKCE via `crypto/rand` + `crypto/sha256`; ID-token checks via
+   `internal/jwks/verifier.go`.
+2. `OidcStateStore` interface + in-memory impl (mutex + TTL) in the root
+   package; `middleware.OidcLoginHandler`/`middleware.OidcCallbackHandler`
+   `http.Handler` helpers in `middleware/` following `nethttp.go` conventions.
+3. Secrets: match the SDK's existing sensitive-string handling (§7 row for Go).
+4. Table-driven tests next to `oidc.go` using the same `httptest` patterns as
+   `client_test.go`; same coverage list as T1; run with `-race`.
+5. Example in `examples/`, README, CHANGELOG, vendored contract re-sync.
+   `go vet ./...`, `go test -race ./...` green.
+
+### T5 — Java port — **Sonnet 5**
+
+Repo: `axiam-java-sdk` (`io.github.ilpanich:axiam-sdk`, Java 21, Maven,
+Spring optional/provided).
+
+1. New package `io.axiam.sdk.oidc`: `OidcOperations` implemented by
+   `AxiamClient` (`oidcDiscover`, `oidcBegin`, `oidcExchange`, `oidcRefresh`,
+   `loginClientCredentials`, `introspect`, `revoke`, `ssoStart`, `ssoComplete`),
+   records for the §2 types, `SecureRandom` + `MessageDigest` for PKCE,
+   ID-token checks via the client's existing JWKS path.
+2. Spring glue in `io.axiam.sdk.spring`: an `AxiamOidcLoginController`-style
+   registrar (or a pair of `HandlerFunction`s) auto-configured only when the
+   consumer opts in via properties — same conditional-on-class pattern as
+   `AxiamAutoConfiguration`.
+3. Tests with the repo's existing HTTP-mock approach (WireMock/MockWebServer —
+   use what's already a test dependency; add nothing new unless absent); same
+   coverage list as T1. `mvn -q verify` green.
+4. Example under `examples/`, README, CHANGELOG, vendored contract re-sync, BOM
+   untouched (no new runtime deps).
+
+### T6 — Kotlin port — **Sonnet 5**
+
+Repo: `axiam-kotlin-sdk` (JVM-only, Kotlin 2.1, Ktor 2.x `compileOnly`).
+
+1. New `src/main/kotlin/io/axiam/sdk/oidc/` mirroring T5's shape with suspend
+   functions on `AxiamClient` (camelCase names per contract); PKCE via
+   `java.security.SecureRandom`/`MessageDigest`; ID-token checks via
+   `internal/JwksVerifier.kt`.
+2. Ktor glue in `ktor/`: `Route.axiamOidcLogin(client, store, opts)` extension
+   installing the login-redirect and callback routes — kept `compileOnly`-safe
+   exactly like `AxiamAuthentication.kt` (core must compile without Ktor).
+3. Tests with ktor-server-test-host + the repo's existing HTTP-mock style; same
+   coverage list as T1. `./gradlew check` green.
+4. Example, README, CHANGELOG, vendored contract re-sync.
+
+### T7 — C# port — **Sonnet 5**
+
+Repo: `axiam-csharp-sdk` (`Axiam.Sdk` + `Axiam.Sdk.AspNetCore`, net8.0).
+
+1. In `Axiam.Sdk`: `Auth/Oidc/` folder — `OidcDiscoverAsync`, `OidcBegin`
+   (sync, no I/O beyond cached discovery), `OidcExchangeAsync`,
+   `OidcRefreshAsync`, `LoginClientCredentialsAsync`, `IntrospectAsync`,
+   `RevokeAsync`, `SsoStartAsync`, `SsoCompleteAsync` (PascalCase +
+   `Async` suffix per §1/SDK-Q08); `RandomNumberGenerator` + `SHA256` for PKCE;
+   ID-token checks via `Auth/Jwk.cs` machinery.
+2. In `Axiam.Sdk.AspNetCore`: minimal-API extension
+   `MapAxiamOidcLogin(this IEndpointRouteBuilder, ...)` wiring the
+   redirect + callback endpoints into the existing middleware/session pipeline;
+   `IOidcStateStore` + `MemoryOidcStateStore` registered via DI.
+3. Tests in the existing `tests/` projects (same mock style as current
+   HTTP tests); same coverage list as T1. `dotnet test` green.
+4. Example under `examples/`, README/docfx page, CHANGELOG, vendored contract
+   re-sync.
+
+### T8 — PHP port — **Sonnet 5**
+
+Repo: `axiam-php-sdk` (`axiam/axiam-sdk`, PHP ≥8.1, Laravel provider +
+Symfony bundle, PHPStan).
+
+1. New `src/Oidc/` (e.g. `OidcClient.php`, `AuthorizationRequest.php`,
+   `OidcTokenSet.php`, `OidcStateStoreInterface.php`, `MemoryOidcStateStore.php`)
+   with camelCase methods surfaced on `AxiamClient`: `oidcDiscover`, `oidcBegin`,
+   `oidcExchange`, `oidcRefresh`, `loginClientCredentials`, `introspect`,
+   `revoke`, `ssoStart`, `ssoComplete`. PKCE via `random_bytes` + `hash('sha256')`
+   with base64url; ID-token checks via `src/Auth/JwksVerifier.php`.
+2. Framework glue: Laravel — two invokable controllers + route macro in the
+   existing provider; Symfony — controller pair registered by the bundle,
+   both optional and off by default.
+3. Secrets use the repo's existing sensitive-value class (§7 row for PHP).
+4. PHPUnit tests with the repo's existing HTTP-mock approach; same coverage
+   list as T1. `composer test` + PHPStan at the configured level green.
+5. Example, README, CHANGELOG, vendored contract re-sync.
+
+### T9 — Cross-SDK conformance review — **Opus 5**
+
+After T1–T8 land:
+
+1. Diff every SDK's §12 surface against the contract: names, argument order,
+   error mapping, Sensitive coverage, single-flight `oidc_refresh`, S256-only,
+   stateless-state rule, cookie-jar on `sso_complete`. Produce a
+   pass/fail matrix per SDK per rule (same format as prior conformance docs in
+   `claude_dev/`).
+2. Verify the RFC 7636 Appendix B vector test exists in all eight repos.
+3. Update each repo's Conformance Statement section in the vendored contract,
+   and the master `sdks/CONTRACT.md` conformance table here.
+4. File follow-up issues for any drift instead of hot-fixing inside the review
+   task (keeps the review adversarial and cheap to re-run).
+
+## 5. What is explicitly out of scope
+
+- Server-side changes — the provider endpoints already exist and are contract-
+  stable; any server bug found becomes an issue, not a scope expansion.
+- Implicit/hybrid flows and non-S256 PKCE — rejected by design.
+- Device-authorization grant (RFC 8628) — server doesn't expose it yet.
+- REST `/oauth2/userinfo` in the SDK vocabulary — stays excluded (existing
+  contract closing note); ID-token claims + gRPC `get_user_info` cover it.
+- Browser/SPA-side helpers — these SDKs are backend SDKs; the frontend flow is
+  the consuming app's redirect + AXIAM's hosted login.
+
+## 6. Acceptance criteria (applies to every SDK task)
+
+1. All §12 operations implemented with contract-mandated names and semantics.
+2. Full test coverage of the §3 ID-token checklist (one failing test per rule).
+3. RFC 7636 Appendix B PKCE vector test present and passing.
+4. No new runtime dependency unless the language stdlib lacks CSPRNG/SHA-256
+   (none of the eight needs one).
+5. Secrets `Sensitive`-wrapped; no token material in logs, exceptions, or
+   `Debug`/`toString`.
+6. Example + README + CHANGELOG + vendored CONTRACT re-sync committed.
+7. Repo's full check pipeline green; signed commit per project rules.
+
+## 7. Suggested execution schedule
+
+| Wave | Tasks | Parallelism |
+|---|---|---|
+| 1 | T0 | solo (blocks everything) |
+| 2 | T1 | solo (reference) |
+| 3 | T2–T8 | 7 agents in parallel, one repo each |
+| 4 | T9 | solo |
+
+Cost note: only 3 of 10 tasks run on Opus 5; the seven parallel ports — the bulk
+of the token spend — run on Sonnet 5 against a locked spec and a working
+reference implementation, which is where Sonnet is reliably as good and several
+times cheaper.
+
+## 8. Deferred SDKs (Swift, C, C++)
+
+These are device/IoT-oriented SDKs (Swift ships NIOSSL specifically for
+client-cert mTLS; C/C++ target embedded consumers). The browser-redirect OIDC
+RP flow has no natural home there, and their auth story (mTLS, password,
+service credentials) is already covered. Defer §12 with the same
+carve-out pattern the contract already uses for their gRPC deferral. If
+server-side Swift (Vapor) demand materializes, a T-Swift port can be cloned
+from T6's shape; `login_client_credentials` alone may be worth adding to C/C++
+for machine-to-machine use — file as a separate follow-up decision.

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -184,6 +184,16 @@ wins.
 - `AuthzError` MUST carry a `message` field and SHOULD carry the denied `action` and `resource_id` if available from the response body.
 - `NetworkError` MUST carry the underlying OS/transport error as a `cause` (or equivalent chained exception).
 - `OAuthProtocolError`, being an `AuthError` sub-type, MUST satisfy the `AuthError` rule above: its `message` field MUST be present and MUST be `"<error>: <error_description>"`, built from the two `OAuth2ErrorResponse` fields it also exposes individually.
+  - Clarified in contract 1.5: the exactness requirement is on the `message` **field/property**.
+    A language whose error-*rendering* convention prefixes that field (Go `Error()` →
+    `"authentication failed: <message>"`, Rust `Display` via `#[error("authentication failed:
+    {message}")]`) MAY keep the prefix in the rendered string, provided the field itself is
+    exactly `"<error>: <error_description>"`.
+  - Also clarified in contract 1.5: the two individually-exposed field names follow each
+    language's **public-API casing** (`error_description` → `errorDescription` /
+    `ErrorDescription`). Go exports the first as `ErrorCode` rather than `Error`, because a
+    struct field named `Error` would collide with the promoted `Error()` method that satisfies
+    the `error` interface; that rename is conformant.
 - Errors MUST NOT expose raw token strings in their messages, context fields, or stack traces.
 
 ---
@@ -422,10 +432,36 @@ Rules (normative):
 
 All token-carrying fields in all SDKs MUST suppress the token value from any debug, logging, or display output (T-15-09).
 
-**Required behavior:**
-- The raw token string MUST NOT be exposed via any public getter API.
-- Debug/logging representations (`Debug`, `Display` in Rust; `toString`, JSON serialization in JS/TS; `__repr__`, `__str__` in Python; `toString` in Java/Go; `ToString` in C#; `__toString` in PHP) MUST emit a redacted placeholder such as `[SENSITIVE]` or `Sensitive<String>`.
-- SDK internal code THAT NEEDS the raw value accesses it via a crate/module-private method or friend function, not a public API.
+**Required behavior** (restructured in contract 1.5 — see the rationale note below):
+
+1. **Redaction — unconditional MUST.** Debug/logging representations (`Debug`, `Display` in
+   Rust; `toString`, JSON serialization in JS/TS; `__repr__`, `__str__` in Python; `toString`
+   in Java/Go; `ToString` in C#; `__toString` in PHP) MUST emit a redacted placeholder such as
+   `[SENSITIVE]` or `Sensitive<String>`. This covers **every** stringification and
+   structured-serialization sink the language offers, including the ones a naive wrapper
+   misses: Go `%#v`/`fmt.Formatter`/`MarshalJSON`, Node `util.inspect`, Java and C#
+   compiler-generated `record` `toString`, Jackson / `System.Text.Json` /
+   `kotlinx.serialization` writers, and PHP `var_dump`/`print_r`/`var_export`. No other
+   section of this contract relaxes this rule.
+2. **No implicit reachability — MUST.** The raw value MUST NOT be reachable without an
+   explicit, named call: no public field or property, no `Deref`/`AsRef`/implicit conversion
+   operator, no auto-unboxing accessor, and no inherited structural equality that compares the
+   raw value. (A Go named-type conversion — `string(s)` on a `type Sensitive string` — is an
+   *explicit* conversion and is accepted as that language's equivalent of calling the
+   accessor; it is the shape the Go row below prescribes.)
+3. **One explicit accessor — MAY, and RECOMMENDED for §12.** An SDK MAY expose exactly one
+   clearly-named public accessor (`expose`, `reveal`, `get_secret_value`, `Expose`, …)
+   returning the raw value. Where the SDK implements
+   [§12](#§12-oidc--sso-relying-party-helpers) this accessor is RECOMMENDED, because §12 hands
+   `access_token`/`refresh_token`/`id_token` to the **calling application** in the
+   `/oauth2/token` response body rather than to a `Set-Cookie` jar, and the application must be
+   able to read them in order to persist, forward, or later revoke them. An SDK whose accessor
+   stays module-private remains conformant to §7 — but the §12 token set it returns is then
+   unreadable by its own callers, so it SHOULD widen the accessor. Widening a module-private
+   accessor to public is a non-breaking, additive change.
+4. **Point-of-use discipline — MUST.** SDK internal code that needs the raw value calls that
+   accessor (or a module-private equivalent) explicitly, at the point of use, and MUST NOT pass
+   the returned value to any log/trace/serialize sink.
 
 Per-language implementation guidance:
 | Language   | Mechanism                                                         |
@@ -441,6 +477,25 @@ Per-language implementation guidance:
 | Swift      | `struct Sensitive<T>: CustomStringConvertible` whose `description` returns `"[SENSITIVE]"`; not `Encodable` in a way that emits the value |
 | C          | Opaque `axiam_sensitive_t` handle; there is no public accessor returning the raw string, and it is never written to logs/`printf` output |
 | C++        | `class Sensitive<T>` with `operator<<`/`to_string` returning `"[SENSITIVE]"`; raw value only via a private/friend accessor |
+
+The **C** and **C++** rows keep their "no public accessor" wording deliberately: both SDKs defer
+§12 in its entirety ([§12.6](#§126-deferred-sdks-swift-c-c)), so no token material is ever handed
+to their callers outside the §4 cookie jar and rule 3 above has nothing to enable there. Should a
+later §12 port land in either, rule 3 applies to it unchanged.
+
+**Why §7 reads this way (contract 1.5, non-breaking clarification).** Contract 1.4's §7 said
+flatly that "the raw token string MUST NOT be exposed via any public getter API". That was written
+when every token lived only in the §1/§4 `httpOnly` cookie jar, where no caller ever needed one.
+§12 changed the premise: it returns tokens *to* the caller. Read literally, §7 and §12 were
+mutually unsatisfiable, and the eight implementing SDKs resolved it three different ways —
+accessor already public (TypeScript `expose()`, Python `SecretStr.get_secret_value()`, PHP
+`reveal()`, Go's named-type conversion), accessor widened for §12 (Rust `Sensitive::expose()`
+`pub(crate)` → `pub`; C# a new public `Sensitive<T>.Expose()`), or accessor left module-private
+(Java package-private `expose()`, Kotlin `internal expose()`). The rules above separate the
+non-negotiable half — redaction, rule 1 — from the half §12 legitimately needs — an explicit
+accessor, rule 3 — so that all three resolutions are conformant. The point of the wrapper was
+never to make reading a token impossible; it is to make *leaking* one require a deliberate,
+greppable call.
 
 **The token MUST NOT appear in:**
 - Log files (structured or unstructured)
@@ -536,8 +591,29 @@ All SDKs that manage token state (access + refresh tokens) MUST implement a sing
 2. **Result sharing.** After the single in-flight refresh resolves (success or failure), all waiting requesters receive the outcome simultaneously:
    - On success: all waiting requests are retried with the new tokens.
    - On failure: all waiting requests fail with `AuthError`.
+
+   **Observable requirement (clarified in contract 1.5; not a new obligation).** A burst of N
+   concurrent refresh-triggering callers MUST produce exactly **one** refresh wire call, and all
+   N callers MUST receive *that one call's* outcome. Merely serializing the N callers behind a
+   mutex so that each then issues its **own** refresh call is **not** conformant: AXIAM refresh
+   tokens are opaque, server-stored, and **single-use with rotation**, so callers 2..N would
+   replay an already-consumed token and fail with `invalid_grant`. "Exactly one in-flight"
+   (rule 1) and "result sharing" (rule 2) are two halves of one requirement, not alternatives.
 3. **No retry on refresh failure.** A 401 response to the refresh call itself is `AuthError` — the user must re-authenticate. The SDK MUST NOT attempt to refresh again (no retry loop).
 4. **Thread/concurrency safety.** The guard MUST be safe across concurrent goroutines (Go), async tasks (Rust/TS/Python), threads (Java/C#/PHP-Swoole).
+5. **Mechanism is free; a dedicated guard instance is permitted** (added in contract 1.5).
+   Rules 1–4 constrain observable behaviour only. The per-language table below is guidance, not
+   a mandate: an own coalescer holding a shared future/promise/`Deferred`/`Task`, a channel
+   broadcast, a condition variable publishing a shared result, and a semaphore guarding a cached
+   task are all conformant, provided rule 2's observable requirement holds. An operation that
+   needs its own guard because the shared guard's API is specialized to a different token
+   namespace — e.g. the §1 cookie-session access-token freshness comparison, which is
+   meaningless for an OAuth2 `refresh_token` grant — MAY use a **dedicated instance of an
+   equally strong mechanism**; it MUST NOT substitute a weaker one. Where an implementation
+   composes an operation-specific coalescer *with* the shared guard, a **bounded** (never
+   unbounded) wait to acquire the shared guard is permitted, and exhausting that bound MUST
+   raise `AuthError` rather than return a stale token set; the specific bound is an
+   implementation detail and is deliberately **not** part of this contract.
 
 Per-language implementation guidance:
 | Language   | Mechanism                                                         |
@@ -554,7 +630,13 @@ Per-language implementation guidance:
 | C          | `pthread_mutex_t` guarding an in-flight flag + condition variable; waiters block until the single refresh completes |
 | C++        | `std::mutex` + `std::shared_future<TokenPair>` held under the lock   |
 
-**Test requirement:** Each SDK MUST include a test that fires N (≥5) concurrent requests against an expired token and asserts exactly 1 refresh call is made. (See Phase 18 success criterion #2 for Go reference.)
+**Test requirement:** Each SDK MUST include a test that fires N (≥5) concurrent requests against
+an expired token and asserts exactly 1 refresh call is made. (See Phase 18 success criterion #2
+for Go reference.) Clarified in contract 1.5: the test MUST also assert that **all N callers
+received that one call's outcome** (rule 2), and the requirement applies **per refresh
+operation** — an SDK that ships both the §1 `refresh` and the
+[§12](#§12-oidc--sso-relying-party-helpers) `oidc_refresh` needs the test for each, because they
+run on different token namespaces and (per rule 5) may use different guard instances.
 
 ---
 
@@ -722,6 +804,26 @@ verifier, at the `jwks_uri` the discovery document advertises.
    require `?tenant_id=<uuid>` because the client is authenticating *itself* there. The §5
    `X-Tenant-ID` header is still emitted on these requests (§5 rule 2 is unconditional) — the
    header and the query parameter are **not** substitutes for one another.
+
+   **The header and the query parameter may legitimately disagree in form** (documented in
+   contract 1.5). §5 rule 2 emits `X-Tenant-ID` carrying whichever identifier the client was
+   constructed with, which may be a **slug**, while these three endpoints require a **UUID**
+   in `?tenant_id=`. A slug-configured client therefore sends a slug header alongside a UUID
+   query parameter on the same request. This is correct and accepted: the `/oauth2/*` handlers
+   are public paths that read the tenant **only** from the query parameter
+   (`crates/axiam-api-rest/src/handlers/oauth2.rs`, `web::Query<TenantQuery>`) and never
+   inspect `X-Tenant-ID`, so the header is inert there. It is still emitted because §5 rule 2
+   admits no exceptions and because request logging/tracing relies on it.
+
+   **Consequence — a slug-only client cannot call five of the nine operations.** A client
+   constructed with `tenant_slug` and with no prior login to resolve the UUID from cannot call
+   `oidc_exchange`, `oidc_refresh`, `login_client_credentials`, `introspect`, or `revoke`: per
+   [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 4 the SDK MUST raise
+   its taxonomy error client-side rather than send a slug in `tenant_id`. Applications needing
+   those five operations SHOULD construct the client in UUID form, or pass `tenant_id`
+   explicitly per call. `oidc_discover`, `oidc_begin`, `sso_start`, and `sso_complete` are
+   unaffected — the first two touch no tenant-scoped endpoint, and the federation pair carries
+   slug forms in its JSON body (§5.1).
 3. **Client authentication is `client_secret_post`.** `client_id`/`client_secret` travel in the
    form body. The server documents no HTTP Basic (`client_secret_basic`) alternative, so SDKs
    MUST NOT send an `Authorization: Basic` header to `/oauth2/*`.
@@ -729,8 +831,19 @@ verifier, at the `jwks_uri` the discovery document advertises.
    and `RevokeRequest` both mark `token`, `client_id`, and `client_secret` as required
    (non-nullable); `token_type_hint` is optional. A public client cannot call them.
 5. **`revoke` returns no body.** Per RFC 7009 the server answers `200` for unknown, expired,
-   or already-revoked tokens. `revoke` therefore returns void/`Unit`/`nil` and MUST treat any
-   `200` as success. Only `401` (client authentication failed) is an error.
+   or already-revoked tokens. `revoke` therefore returns void/`Unit`/`nil` and MUST treat a
+   `200` as success — including for a token it has never issued (idempotence is the point of
+   RFC 7009), and every implementing SDK MUST carry a test for that idempotent case.
+
+   **Corrected in contract 1.5.** Contract 1.4 added "Only `401` (client authentication failed)
+   is an error", which contradicted the §2 `5xx → NetworkError` row and would have turned a
+   server failure into a silent success. The rule is: a `200` MUST be success; treating **any
+   other `2xx`** as success is permitted and RECOMMENDED (six of the eight implementing SDKs
+   accept any 2xx, which is what their HTTP clients report natively); a `5xx` MUST **not** be
+   treated as success and remains a `NetworkError` per §2; a `401` carrying an
+   `OAuth2ErrorResponse` body is an `OAuthProtocolError` per
+   [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3. `revoke`
+   returning void does not make a server error a success.
 6. **`sso_complete` delivers the session as `Set-Cookie`.** `SsoLoginSuccessResponse` carries
    `user_id`, `session_id`, `expires_in`, and `redirect_uri` and **no token material**; the
    §4 cookie-jar requirement therefore applies verbatim, and an SDK without a persistent
@@ -764,9 +877,29 @@ further claims the server sends in a language-idiomatic open map — the ID toke
 set is not enumerated by `openapi.json` (the field is typed as an opaque string there), so SDKs
 MUST NOT reject unknown claims.
 
+**`AuthorizationRequest` carries no `redirect_uri` — the caller owns it** (documented in
+contract 1.5). The four fields above are the complete shape, and all eight implementing SDKs
+match it exactly. `oidc_exchange` must nevertheless replay the `redirect_uri` **byte-identically**
+(RFC 6749 §4.1.3), so the caller MUST remember it alongside `state`, `nonce`, and `code_verifier`
+between `oidc_begin` and `oidc_exchange` — this is a real footgun and is called out here
+deliberately. Where an SDK offers the optional `OidcStateStore`
+([§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 1), the store **entry**
+does carry a `redirect_uri` field and is where every SDK's framework glue parks it. Adding
+`redirect_uri` to `AuthorizationRequest` itself is a candidate for a future revision; it is
+explicitly *not* part of contract 1.5, because doing so now would change a type all eight SDKs
+have already shipped.
+
 **`oidc_begin` inputs and construction (normative).** `oidc_begin` performs **no network I/O**
-— it takes an already-fetched `OidcConfiguration` (from `oidc_discover`), `client_id`,
-`redirect_uri`, and the requested scope, and returns `AuthorizationRequest`:
+— it takes an already-fetched `OidcConfiguration` (from `oidc_discover`), the `redirect_uri`, and
+the requested scope, and returns `AuthorizationRequest`. **`client_id` is not a per-call
+argument** (corrected in contract 1.5 — contract 1.4 listed it here in error): it comes from
+client configuration, because [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+rule 4 must compare the ID token's `aud` against the *same* value and two sources could disagree.
+All eight implementing SDKs read it from client configuration. When no `client_id` is configured
+an SDK MUST fail fast with **no wire call** — either its §2 taxonomy error or its language's
+programming-error type is acceptable, since a missing client configuration is a deployment
+mistake, not an authentication outcome. Given that, the returned `AuthorizationRequest` is built
+as follows:
 
 1. `state` and `nonce` are independently generated from a cryptographically secure RNG, at
    least 16 bytes (128 bits) each — 32 bytes RECOMMENDED — encoded base64url **without**
@@ -798,8 +931,14 @@ MUST omit (rather than send empty/null) any optional field the caller did not su
 **`oidc_refresh` vs `refresh`.** `oidc_refresh` operates on an `OidcTokenSet` obtained from
 the OAuth2 token endpoint. It is a **distinct operation** from the §1 `refresh`, which drives
 the cookie/opaque-token session path at `POST /api/v1/auth/refresh` (§5.1). The two MUST NOT
-be merged, aliased, or made to fall back to one another. `oidc_refresh` MUST run under the §9
-single-flight refresh guard.
+be merged, aliased, or made to fall back to one another. `oidc_refresh` MUST be governed by a
+§9-conformant single-flight guard — including §9 rule 2's observable requirement (one wire call
+per burst, that one outcome shared with every concurrent caller) and §9's test requirement in its
+own right. Clarified in contract 1.5: §9 rule 5 permits a **dedicated guard instance** for the
+OAuth2 token namespace rather than literally reusing the §1 cookie-session guard object, and five
+of the eight implementing SDKs deliberately do exactly that because the §1 guard's API is
+specialized to comparing the cookie access token's freshness — a comparison with no meaning for a
+`refresh_token` grant. The mechanism is free; the observable behaviour is not.
 
 **`login_client_credentials` as a credential source.** After a successful
 `login_client_credentials` an SDK MAY adopt the returned `access_token` as the client's bearer
@@ -851,6 +990,16 @@ above; **C** snake_case with the mandatory `axiam_` prefix — `axiam_oidc_disco
 `axiam_sso_complete`. No login/auth/authz method names beyond this map and the §1 map are
 permitted in any SDK.
 
+**Which object hosts the nine methods** (added in contract 1.5 — §12 was previously silent). They
+SHOULD live directly on the SDK's existing client type, and do in seven of the eight implementing
+SDKs. An SDK MAY instead place them on a separate, additionally-exported host object where a
+**packaging constraint** requires it: the TypeScript SDK uses a Node-only `OidcClient` because its
+CI forbids `node:crypto` and `jose` from reaching the browser bundle, and §12 has no browser
+persona to serve (a browser relying party performs the redirect; it holds no `client_secret` and
+never calls `/oauth2/token`). The method **names** in the map above are fixed either way — only the
+host is free. An SDK that uses a separate host MUST say so in its README's §12 section, and MUST
+NOT split the nine across two hosts.
+
 ### §12.3 Cross-cutting rules (normative, identical in all SDKs)
 
 1. **Stateless by default.** `oidc_begin` and `oidc_exchange` MUST NOT store `state`, `nonce`,
@@ -861,7 +1010,14 @@ permitted in any SDK.
    where offered it MUST have a 10-minute TTL and a **single-use** `consume(state)` operation
    that returns the stored tuple and atomically deletes it (mirroring the server's
    `federation_login_state` semantics). The store MUST be opt-in: the core operations MUST
-   remain usable without one.
+   remain usable without one. Clarified in contract 1.5: a store **entry** carries `state`,
+   `nonce`, `code_verifier` (wrapped per rule 2), and `redirect_uri` — the last because
+   `oidc_exchange` must replay it byte-identically and `AuthorizationRequest` does not carry it
+   — plus, optionally, a caller-supplied `return_to`. The 10-minute TTL is a **maximum**: a
+   constructor-configurable TTL MUST be clamped down to it so no caller can exceed the
+   contract, while a shorter TTL (for tests, or a tighter deployment) is honoured. Expiry
+   sweeping MUST be **lazy** — performed on write and/or on a size query — and MUST NOT use a
+   background timer, thread, or task: a library must not keep its host process alive.
 2. **Sensitive wrapping (§7).** `access_token`, `refresh_token`, `id_token`, `client_secret`,
    and `code_verifier` MUST each be held behind the SDK's `Sensitive<T>` equivalent (§7). They
    MUST NOT appear in `Debug`/`toString`/`__repr__`/`ToString`/`String()` output, log records,
@@ -880,6 +1036,24 @@ permitted in any SDK.
    `token_expired`, or `nonce_mismatch` — matching the [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
    rule that failed. Per §2's construction rules, no error raised by this section may embed a
    token, client secret, or code verifier in its message or context fields.
+
+   **The seven reason codes are a closed vocabulary** (clarified in contract 1.5). No SDK may
+   add an eighth, so several distinct failures deliberately share one code, and the following
+   mappings are normative rather than incidental:
+   - `token_expired` is the code for **every** §12.4 rule-5 time failure — a past `exp`, an
+     **absent** `exp`, an absent or future `iat`, and a future `nbf` all report `token_expired`.
+     (There is no `token_not_yet_valid`, `iat_in_future`, or `missing_exp` code, and contract 1.4
+     enumerated three time conditions against a single code without saying so.)
+   - `unknown_kid` covers "the JOSE header carries no `kid` at all" as well as "no key matches
+     the `kid`", and a JWKS transport failure during the rule-2 re-fetch MAY surface as
+     `unknown_kid` rather than `invalid_signature`.
+   - `invalid_alg` covers a JOSE header that cannot be parsed or decoded at all, since the
+     algorithm cannot then be established.
+   - `invalid_signature` is the catch-all for any other verification failure, so no SDK needs to
+     invent a code for an unclassified case.
+
+   A future contract revision MAY widen the vocabulary; until then a caller needing finer
+   granularity reads the error message, not the code.
 4. **Tenant context (§5).** `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
    `introspect`, and `revoke` all require a `tenant_id` **UUID** for the query parameter. An SDK
    MUST accept it as an explicit argument, and MAY default to the client-level `tenant_id` when
@@ -901,9 +1075,25 @@ permitted in any SDK.
    unchanged, and §6.1 client identities apply if configured. The discovery cache MUST be keyed
    on the normalized **scheme + host + port** of the base URL used to fetch the document
    (lowercased scheme and host, default port made explicit), so a document fetched from one
-   origin can never be served for another — cross-issuer cache poisoning. The cache MUST NOT be
-   keyed on, or shared across, tenants, and MUST NOT be process-global unless the key includes
-   the origin as specified. TTL MUST be at least 5 minutes, MAY be configurable, and concurrent
+   origin can never be served for another — cross-issuer cache poisoning.
+
+   **Rewritten in contract 1.5** — contract 1.4 said the cache "MUST NOT be keyed on, or shared
+   across, tenants", which is self-contradictory (not keying on the tenant *is* sharing across
+   tenants). The rule is:
+   - The cache MUST NOT be keyed on the tenant, and sharing one document across tenants of the
+     same origin is **correct and intended**: the discovery document is a per-origin protocol
+     artifact and carries no tenant-specific content. (JWKS likewise: it is a single global key
+     set, so per-tenant JWKS caches MUST NOT be built.)
+   - The cache MUST NOT serve a document fetched from one origin to a request against another.
+     A **per-client-instance** cache satisfies this by construction where the client is bound to
+     a single base URL for its lifetime, and four of the eight implementing SDKs rely on exactly
+     that invariant rather than on an explicit key; the other four key on the normalized origin
+     explicitly. Both are conformant.
+   - A **process-global** cache, or any cache shared between clients that may target different
+     origins, MUST key on the normalized origin exactly as specified above.
+
+   TTL MUST be at least 5 minutes, MAY be configurable (a smaller configured value MUST be
+   raised to the 5-minute floor), and concurrent
    callers MUST share a single in-flight fetch (single-flight, using the same mechanism §9
    prescribes for that language). The document's own `issuer` value is the authoritative issuer
    for [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange) rule 3; because
@@ -928,13 +1118,31 @@ requirement:
    `JwksDocument`) selected by the header's `kid`. On an unknown `kid` the SDK performs **one**
    JWKS re-fetch and then fails — the same rule the §10 middleware already implements. A token
    with no `kid`, or whose `kid` is still unknown after the single re-fetch, MUST be rejected.
+
+   **"One re-fetch" is normative per cooldown window, not per token** (corrected in contract
+   1.5). Taken literally against a *warm* JWKS cache, "one re-fetch then fail" is
+   unimplementable without defeating the fetch rate-limiting that makes an unknown-`kid` path
+   safe in the first place: an attacker who can present arbitrary `kid` values would otherwise
+   drive one JWKS fetch per forged token. Every real implementation — the §10 middleware, and
+   the libraries the SDKs build on (`jose`'s `createRemoteJWKSet`, Nimbus `RemoteJWKSet`, and the
+   hand-rolled equivalents) — therefore enforces a **cooldown window** (30–60 s is typical):
+   the first unknown `kid` triggers exactly one re-fetch and opens the window; a further unknown
+   `kid` inside that window re-consults the cached set with **no** network call and fails
+   immediately. The observable requirements are that an unknown `kid` MUST NOT cause unbounded
+   JWKS fetching, MUST NOT be accepted, and MUST cause at most one re-fetch per window. An SDK
+   MUST NOT weaken this into "never re-fetch" (key rotation would break) or "always re-fetch"
+   (a fetch-amplification vector).
 3. **Issuer.** The `iss` claim MUST equal the discovery document's `issuer` by exact string
    comparison — no normalization, no trailing-slash tolerance, no substring or prefix matching.
 4. **Audience.** The `aud` claim MUST contain the RP's own `client_id`. When `aud` holds more
    than one audience, an `azp` claim MUST be present and MUST equal that `client_id`.
 5. **Time.** `exp` MUST be in the future and `iat` MUST NOT be in the future; `nbf` MUST be
    honored when present. Permitted clock skew is at most 60 seconds in either direction and
-   MUST NOT be configurable above that bound.
+   MUST NOT be configurable above that bound (a larger configured value MUST be clamped down,
+   not rejected). Clarified in contract 1.5: `exp` and `iat` are both treated as **required** —
+   an ID token missing either is rejected — and every failure of this rule reports the single
+   reason code `token_expired`, per the closed-vocabulary note in
+   [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3.
 6. **Nonce.** The `nonce` claim MUST be present and MUST equal, by constant-time comparison,
    the nonce the caller received from `oidc_begin` and passed into `oidc_exchange`. This is
    mandatory for `oidc_exchange` — the helper always requests the `openid` scope, so the server
@@ -1015,6 +1223,28 @@ Phase acceptance criteria in each SDK plan include: "CONTRACT.md §1–§10 conf
 verified." (and §1–§11 where the §11 helpers are shipped, §1–§12 where the §12 helpers are
 shipped).
 
+**Conformance state as of contract 1.5** (2026-07). Eight SDKs implement §12 and state §1–§12;
+three defer it and are unchanged:
+
+| SDK | Statement | Notes |
+|-----|-----------|-------|
+| Rust | §1–§12 | §12 host: existing `AxiamClient` |
+| TypeScript | §1–§12 | §12 host: Node-only `OidcClient` (§12.2 packaging carve-out) |
+| Python | §1–§12 | nine identical names on `AxiamClient` and `AsyncAxiamClient` |
+| Java | §1–§12 | plus the permitted `*Async` companion twins (no `oidcBeginAsync`) |
+| Kotlin | §1–§7, §9–§12 | §8 AMQP deferred (pre-existing, documented carve-out); `suspend` functions, no `*Async` twins |
+| C# | §1–§12 | `*Async` throughout except the deliberate synchronous `OidcBegin` |
+| PHP | §1–§12 | — |
+| Go | §1–§12 | — |
+| Swift | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+| C | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+| C++ | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+
+`login_client_credentials` credential adoption is a §12.1 **MAY**: TypeScript, PHP, and Go
+implement it as an opt-in flag; Rust, Python, Java, and Kotlin skip it; C# exposes the flag and
+throws `NotSupportedException` when it is set. All five positions are conformant — divergence on a
+MAY is not a defect.
+
 ### C# `Grpc.Tools` Exception
 
 C# is the one documented deviation from the `buf` codegen pipeline. The C# SDK uses `Grpc.Tools` MSBuild integration (via a `<Protobuf Include=... GrpcServices="Client" />` entry in the `.csproj`, pointed at the `proto/` copy vendored in its repo) to generate gRPC client stubs at build time, rather than a `buf generate` plugin entry. This is intentional (D-01 in `15-CONTEXT.md`) and does not affect behavioral conformance with §1–§10. All other SDKs (Rust, TypeScript, Go, Python, Java, PHP) run `buf generate` as their codegen step.
@@ -1023,6 +1253,60 @@ C# is the one documented deviation from the `buf` codegen pipeline. The C# SDK u
 
 No SDK currently ships a dedicated `CHANGELOG.md`; breaking changes to this contract are
 recorded here until one exists.
+
+- **2026-07 (§12 cross-SDK conformance review, contract 1.5)** — **non-breaking / clarifying.**
+  No new obligations, no signature changes, no vocabulary changes. Contract 1.4's §12 was
+  implemented independently in eight SDKs; the cross-SDK review
+  (`claude_dev/sdk-oidc-sso-conformance-review.md`) found ten places where the contract text was
+  self-contradictory, unimplementable as literally worded, or silent on a point the eight ports
+  had to resolve for themselves. This revision makes the contract describe the behaviour the eight
+  already share:
+  - **§7 restructured** into four numbered rules that separate the unconditional redaction MUST
+    (rule 1) from the explicit-accessor MAY (rule 3). §7's flat "the raw token string MUST NOT be
+    exposed via any public getter API" and §12's requirement to hand tokens to the caller were
+    mutually unsatisfiable; six of the eight SDKs have a publicly reachable accessor and two do
+    not, and all eight are now conformant. Redaction is unchanged and non-negotiable. The C/C++
+    "no public accessor" rows are unchanged (both defer §12).
+  - **§9 gains rule 5** (mechanism is free; a dedicated guard instance for a second token
+    namespace is permitted; a bounded wait for a shared guard is permitted and its bound is not
+    contract-worthy), and rule 2 now states the observable requirement — one wire call per burst,
+    that one outcome shared with all N callers — explicitly, because serialize-without-sharing
+    fails against single-use rotating refresh tokens. The §9 test requirement is clarified to
+    apply per refresh operation, so `oidc_refresh` needs its own burst test.
+  - **§12.1 note 2** documents that a slug `X-Tenant-ID` header legitimately accompanies a UUID
+    `?tenant_id=` query parameter (the `/oauth2/*` handlers read only the query parameter), and
+    that a slug-only client with no resolved UUID cannot call five of the nine operations.
+  - **§12.1 note 5** corrected: a `200` MUST be success, any other `2xx` MAY be, a `5xx` MUST NOT
+    be — removing the contradiction with the §2 `5xx → NetworkError` row.
+  - **§12.1** now states that `client_id` is **not** a per-call `oidc_begin` argument (it comes
+    from client configuration, as all eight SDKs implement it), and documents that
+    `AuthorizationRequest` deliberately carries no `redirect_uri` and that the caller must carry
+    it between `oidc_begin` and `oidc_exchange`.
+  - **§12.1** `oidc_refresh` paragraph: "MUST run under the §9 guard" → "MUST be governed by a
+    §9-conformant single-flight guard", pointing at the new §9 rule 5.
+  - **§12.2** gains one normative paragraph permitting either host object for the nine methods,
+    with the browser-bundle rationale; the method names remain fixed.
+  - **§12.3 rule 1** now enumerates the state-store entry fields (including `redirect_uri`),
+    states that the 10-minute TTL is a clamped maximum, and requires lazy sweeping with no
+    background timer/thread.
+  - **§12.3 rule 3** declares the seven ID-token reason codes a **closed** vocabulary and pins
+    the many-to-one mappings that follow from it — notably that every rule-5 time failure
+    (past `exp`, absent `exp`, absent or future `iat`, future `nbf`) reports `token_expired`.
+  - **§12.3 rule 6** rewritten: contract 1.4's "MUST NOT be keyed on, or shared across, tenants"
+    was self-contradictory. Sharing one discovery document across tenants of an origin is correct;
+    a per-client-instance cache satisfies the origin requirement by construction; a process-global
+    or cross-client cache MUST key on the normalized origin.
+  - **§12.4 rule 2** corrected: "one JWKS re-fetch then fail" is normative **per cooldown
+    window**, not per token — the literal reading is unimplementable on a warm cache without
+    creating a fetch-amplification vector.
+  - **§12.4 rule 5** states that `exp` and `iat` are both required and that skew above 60 s is
+    clamped, not rejected.
+  - **§2** construction rules clarify that the `"<error>: <error_description>"` requirement binds
+    the `message` *field* (a language may still prefix its rendered form) and that the two
+    exposed field names follow per-language casing, with Go's `ErrorCode` rename accepted.
+  - **Conformance Statement** gains a per-SDK table for the eight §12 implementers (including
+    Kotlin's pre-existing §8 carve-out) and records that `login_client_credentials` credential
+    adoption is a MAY on which divergence is legal.
 
 - **2026-07 (§12 OIDC / SSO relying-party helpers, contract 1.4)** — **non-breaking / additive.**
   Added §12 "OIDC / SSO Relying-Party Helpers" (SHOULD-level for v1.0): nine new canonical
@@ -1085,6 +1369,6 @@ recorded here until one exists.
 
 ---
 
-*Contract version: 1.4 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07*
+*Contract version: 1.5 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -61,7 +61,9 @@ canonical operations with the same `(action, resource[, scope])` argument order.
 `refresh`, `logout`, `check_access`, `can`, `batch_check`); **C** uses snake_case with an
 `axiam_` prefix on every symbol (`axiam_login`, `axiam_verify_mfa`, `axiam_refresh`,
 `axiam_logout`, `axiam_check_access`, `axiam_can`, `axiam_batch_check`). No new
-login/auth/authz method names beyond this map are permitted in these SDKs either. The
+login/auth/authz method names beyond this map and the
+[§12](#§12-oidc--sso-relying-party-helpers) OIDC/SSO relying-party map are permitted in these
+SDKs either. The
 gRPC-only `get_user_info` operation is **deferred** in all four of these SDKs for as long
 as they ship no gRPC transport (they already defer gRPC in v1 — see §1.1); when a gRPC
 transport is added, the method name is `getUserInfo` (Kotlin/Swift), `get_user_info` (C++),
@@ -77,7 +79,7 @@ to match its own `checkAccess(action, resource)` and every other SDK's `can`/`Ca
 - `can` is an alias for `check_access` targeting browser/UI scenarios; it calls `POST /api/v1/authz/check` via REST (avoids N round-trips when combined with `batch_check` for page-level permission gating).
 - `batch_check` calls `POST /api/v1/authz/check/batch` and returns results in the same order as input.
 - `get_user_info` calls `axiam.v1.UserInfoService/GetUserInfo` over gRPC (§1.1). It is the only operation in this map without a REST equivalent in the SDK vocabulary.
-- No SDK is permitted to expose additional login/auth/authz method names that diverge from this map.
+- No SDK is permitted to expose additional login/auth/authz method names that diverge from this map or from the [§12](#§12-oidc--sso-relying-party-helpers) OIDC/SSO relying-party map, which extends the same locked vocabulary.
 
 ### §1.1 gRPC-only operations
 
@@ -142,17 +144,28 @@ All SDKs MUST expose exactly three error types. Additional sub-types are permitt
 | `AuthzError`  | Authorization failure: caller lacks permission for the requested operation |
 | `NetworkError`| Transport-level failure: connection refused, timeout, TLS error, DNS failure |
 
+Sub-types added by later sections of this contract:
+
+| Error type          | Meaning                                                        |
+|---------------------|----------------------------------------------------------------|
+| `OAuthProtocolError`| RFC 6749 protocol error returned by an `/oauth2/*` endpoint as an `OAuth2ErrorResponse` body (`invalid_grant`, `invalid_client`, `invalid_request`, `unsupported_grant_type`, …). A language-idiomatic **sub-type of `AuthError`** (it does not replace it), added for [§12](#§12-oidc--sso-relying-party-helpers). Carries `error` and `error_description` as publicly accessible fields |
+
 ### HTTP Status → Error Type Mapping
 
 | HTTP Status | Error Type    | Notes                                         |
 |-------------|---------------|-----------------------------------------------|
 | 400         | `NetworkError`| Malformed request (SDK programming error)     |
+| 400 from `/oauth2/*` with an `OAuth2ErrorResponse` body | `OAuthProtocolError` | RFC 6749 protocol error (e.g. `invalid_grant` from `POST /oauth2/token`). MUST NOT collapse into the generic `400` → `NetworkError` row above ([§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3) |
 | 401         | `AuthError`   | Unauthenticated; triggers refresh if tokens present |
+| 401 from `/oauth2/*` with an `OAuth2ErrorResponse` body | `OAuthProtocolError` | Client authentication failed at `POST /oauth2/introspect` / `POST /oauth2/revoke`. MUST NOT trigger the §9 single-flight refresh guard |
 | 403         | `AuthzError`  | Authenticated but not authorized              |
 | 408, 429    | `NetworkError`| Timeout / rate-limited                        |
 | 409         | `AuthzError`  | Conflict (resource-level access denied)       |
 | 5xx         | `NetworkError`| Server error; SDK should NOT retry auth       |
 | Connection error / DNS / TLS | `NetworkError` | Transport-layer failures   |
+
+Where two rows match the same response, the more specific (endpoint- and body-qualified) row
+wins.
 
 ### gRPC Status → Error Type Mapping
 
@@ -170,6 +183,7 @@ All SDKs MUST expose exactly three error types. Additional sub-types are permitt
 - `AuthError` MUST carry a `message` field describing the failure.
 - `AuthzError` MUST carry a `message` field and SHOULD carry the denied `action` and `resource_id` if available from the response body.
 - `NetworkError` MUST carry the underlying OS/transport error as a `cause` (or equivalent chained exception).
+- `OAuthProtocolError`, being an `AuthError` sub-type, MUST satisfy the `AuthError` rule above: its `message` field MUST be present and MUST be `"<error>: <error_description>"`, built from the two `OAuth2ErrorResponse` fields it also exposes individually.
 - Errors MUST NOT expose raw token strings in their messages, context fields, or stack traces.
 
 ---
@@ -657,6 +671,326 @@ macro over an `axiam_require_access(...)` guard function. All compose strictly o
 
 ---
 
+## §12 OIDC / SSO Relying-Party Helpers
+
+**Requirement level: SHOULD (v1.0).** This section adds the *relying-party* (RP) half of the
+OIDC/OAuth2 story: the operations a backend application needs in order to offer "Login with
+AXIAM" (authorization-code + PKCE against AXIAM's own OIDC provider), to authenticate itself
+as a service account (`client_credentials`), to introspect/revoke tokens, and to drive the
+server's upstream-IdP federation endpoints. It is **additive to §1**: the nine operations
+below are part of the same locked method vocabulary and are subject to the same
+"no diverging names" rule. An SDK that ships §1–§11 without these helpers remains conformant;
+an SDK that ships them states conformance to §1–§12. Three SDKs defer the whole section —
+see [§12.6](#§126-deferred-sdks-swift-c-c).
+
+These helpers MUST be built on the SDK's existing machinery — the §4 cookie jar, the §6/§6.1
+TLS configuration, the §7 `Sensitive<T>` wrapper, the §9 single-flight refresh guard, and the
+JWKS verifier the §10 middleware already uses. No SDK may fork, duplicate, or re-implement
+any of them for §12.
+
+### §12.1 Canonical operation set and endpoint map
+
+Nine canonical operations. Every column below is verified against `openapi.json`; deviating
+from a schema name, HTTP method, content type, or parameter location is a contract violation.
+
+| Canonical operation | Wire call | Request (content type / schema) | Success response |
+|---------------------|-----------|---------------------------------|------------------|
+| `oidc_discover` | `GET /.well-known/openid-configuration` | no body, no query parameters | `200` `OidcDiscoveryDocument` |
+| `oidc_begin` | **none — pure local computation, no network I/O** | n/a | `AuthorizationRequest` (SDK type) |
+| `oidc_exchange` | `POST /oauth2/token?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `TokenRequest` | `200` `TokenResponse` |
+| `oidc_refresh` | `POST /oauth2/token?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `TokenRequest` | `200` `TokenResponse` |
+| `login_client_credentials` | `POST /oauth2/token?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `TokenRequest` | `200` `TokenResponse` |
+| `introspect` | `POST /oauth2/introspect?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `IntrospectRequest` | `200` `IntrospectionResponse` |
+| `revoke` | `POST /oauth2/revoke?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `RevokeRequest` | `200`, **empty body** |
+| `sso_start` | `POST /api/v1/auth/federation/oidc/start` | `application/json` / `OidcStartRequest` | `200` `OidcStartResponse` |
+| `sso_complete` | `POST /api/v1/auth/federation/oidc/callback` | `application/json` / `OidcPublicCallbackRequest` | `200` `SsoLoginSuccessResponse` + `Set-Cookie` |
+
+Error responses: `400` from `POST /oauth2/token` and `401` from `POST /oauth2/introspect` /
+`POST /oauth2/revoke` carry an `OAuth2ErrorResponse` body and map to `OAuthProtocolError`
+(§2, [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3).
+`GET /oauth2/jwks` (schema `JwksDocument`) is used by [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+rule 2 but is **not** a vocabulary operation — it is reached through the SDK's existing JWKS
+verifier, at the `jwks_uri` the discovery document advertises.
+
+**Non-obvious wire details (all normative):**
+
+1. **The token endpoint is form-encoded, not JSON.** `POST /oauth2/token` accepts
+   `application/x-www-form-urlencoded` per RFC 6749 §4.1.3. An SDK that posts JSON to it is
+   non-conformant.
+2. **`tenant_id` is a required *query* parameter, not a body field.** `TokenRequest`,
+   `IntrospectRequest`, and `RevokeRequest` have no `tenant_id` property; all three endpoints
+   require `?tenant_id=<uuid>` because the client is authenticating *itself* there. The §5
+   `X-Tenant-ID` header is still emitted on these requests (§5 rule 2 is unconditional) — the
+   header and the query parameter are **not** substitutes for one another.
+3. **Client authentication is `client_secret_post`.** `client_id`/`client_secret` travel in the
+   form body. The server documents no HTTP Basic (`client_secret_basic`) alternative, so SDKs
+   MUST NOT send an `Authorization: Basic` header to `/oauth2/*`.
+4. **`introspect` and `revoke` require confidential-client credentials.** `IntrospectRequest`
+   and `RevokeRequest` both mark `token`, `client_id`, and `client_secret` as required
+   (non-nullable); `token_type_hint` is optional. A public client cannot call them.
+5. **`revoke` returns no body.** Per RFC 7009 the server answers `200` for unknown, expired,
+   or already-revoked tokens. `revoke` therefore returns void/`Unit`/`nil` and MUST treat any
+   `200` as success. Only `401` (client authentication failed) is an error.
+6. **`sso_complete` delivers the session as `Set-Cookie`.** `SsoLoginSuccessResponse` carries
+   `user_id`, `session_id`, `expires_in`, and `redirect_uri` and **no token material**; the
+   §4 cookie-jar requirement therefore applies verbatim, and an SDK without a persistent
+   cookie store silently loses the session.
+7. **The federation `nonce` never leaves the server.** `OidcStartResponse` returns
+   `authorize_url`, `state`, and `expires_in_secs` only (10-min TTL, single-use `state`,
+   D-22). SDKs MUST round-trip `state` unmodified into `sso_complete` and MUST NOT synthesize,
+   expect, or validate a nonce on the federation path. [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+   does **not** apply to `sso_start`/`sso_complete` — no ID token is returned to the SDK there.
+8. **CSRF.** `/oauth2/*` is unauthenticated, so no `axiam_csrf` cookie exists yet on a first
+   call; §3 step 3 already governs this — omit the `X-CSRF-Token` header rather than inventing
+   a value.
+
+**SDK-side types.** These are the type names every SDK exposes (per-language casing applies to
+type names as it does to methods); the wire schema each one deserializes is named in
+parentheses. Where an SDK type name differs from the OpenAPI schema name, the SDK name below is
+authoritative for the public surface:
+
+| SDK type | Wire schema | Fields |
+|----------|-------------|--------|
+| `OidcConfiguration` | `OidcDiscoveryDocument` | `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, `revocation_endpoint`, `introspection_endpoint`, `response_types_supported`, `subject_types_supported`, `id_token_signing_alg_values_supported`, `scopes_supported`, `token_endpoint_auth_methods_supported`, `claims_supported`, `grant_types_supported` — all required |
+| `AuthorizationRequest` | *(local, no wire form)* | `url`, `state`, `nonce`, `code_verifier` |
+| `OidcTokenSet` | `TokenResponse` | `access_token`, `token_type`, `expires_in` (required); `scope?`, `refresh_token?`, `id_token?`, `id_claims?` (optional) |
+| `IntrospectionResult` | `IntrospectionResponse` | `active` (required); `sub?`, `client_id?`, `scope?`, `token_type?`, `exp?`, `iat?` |
+| `OidcStateStore` / `MemoryOidcStateStore` | *(local, optional — rule 1)* | see [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 1 |
+
+`id_claims` is the decoded, **already-validated** ID-token claim set (see
+[§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)). It MUST expose at
+minimum `iss`, `sub`, `aud`, `exp`, `iat`, and `nonce` when present, and MUST preserve any
+further claims the server sends in a language-idiomatic open map — the ID token's full claim
+set is not enumerated by `openapi.json` (the field is typed as an opaque string there), so SDKs
+MUST NOT reject unknown claims.
+
+**`oidc_begin` inputs and construction (normative).** `oidc_begin` performs **no network I/O**
+— it takes an already-fetched `OidcConfiguration` (from `oidc_discover`), `client_id`,
+`redirect_uri`, and the requested scope, and returns `AuthorizationRequest`:
+
+1. `state` and `nonce` are independently generated from a cryptographically secure RNG, at
+   least 16 bytes (128 bits) each — 32 bytes RECOMMENDED — encoded base64url **without**
+   padding (RFC 4648 §5; no `=` characters).
+2. `code_verifier` is a fresh high-entropy string of 43–128 characters drawn only from the
+   RFC 7636 §4.1 unreserved set `[A-Za-z0-9-._~]`. The RECOMMENDED construction is 32 CSPRNG
+   bytes encoded base64url without padding (43 characters).
+3. `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))`, without padding, and
+   `code_challenge_method` is the literal string `S256`. Every SDK MUST include the RFC 7636
+   Appendix B test vector as a unit test.
+4. The requested scope MUST contain `openid`; the helper adds it when the caller omits it.
+5. `url` is `authorization_endpoint` (taken from the discovery document, never hardcoded) with
+   exactly these RFC 3986-percent-encoded query parameters: `response_type=code`, `client_id`,
+   `redirect_uri`, `scope` (space-separated), `state`, `nonce`, `code_challenge`,
+   `code_challenge_method=S256`. An SDK MAY accept additional caller-supplied query parameters
+   but MUST NOT add any of its own beyond these eight.
+
+**Grant-specific `TokenRequest` field sets (normative).**
+
+| Operation | `grant_type` | Additional form fields |
+|-----------|--------------|------------------------|
+| `oidc_exchange` | `authorization_code` | `code`, `code_verifier`, `redirect_uri`, `client_id`, `client_secret` (confidential clients only) |
+| `oidc_refresh` | `refresh_token` | `refresh_token`, `client_id`, `client_secret` (confidential clients only), `scope` (optional) |
+| `login_client_credentials` | `client_credentials` | `client_id`, `client_secret`, `scope` (optional) |
+
+An SDK MUST NOT send form fields outside the set listed for the grant it is performing, and
+MUST omit (rather than send empty/null) any optional field the caller did not supply.
+
+**`oidc_refresh` vs `refresh`.** `oidc_refresh` operates on an `OidcTokenSet` obtained from
+the OAuth2 token endpoint. It is a **distinct operation** from the §1 `refresh`, which drives
+the cookie/opaque-token session path at `POST /api/v1/auth/refresh` (§5.1). The two MUST NOT
+be merged, aliased, or made to fall back to one another. `oidc_refresh` MUST run under the §9
+single-flight refresh guard.
+
+**`login_client_credentials` as a credential source.** After a successful
+`login_client_credentials` an SDK MAY adopt the returned `access_token` as the client's bearer
+credential exactly as it does for a `login()` result. It requests no `openid` scope and the
+response carries no `id_token`.
+
+### §12.2 Per-language naming map
+
+Casing follows the §1 rules unchanged. Twelve languages are covered: the seven columns below
+(TypeScript and JavaScript share one column, as in §1) plus Kotlin, Swift, C, and C++ in the
+"Additional languages" paragraph that follows.
+
+| Canonical operation | Rust (snake_case) | TypeScript/JS (camelCase) | Python (snake_case) | Java (camelCase) | C# (PascalCase) | PHP (camelCase) | Go (PascalCase) |
+|---------------------|-------------------|---------------------------|---------------------|------------------|-----------------|-----------------|-----------------|
+| `oidc_discover` | `oidc_discover` | `oidcDiscover` | `oidc_discover` | `oidcDiscover` | `OidcDiscoverAsync` | `oidcDiscover` | `OidcDiscover` |
+| `oidc_begin` | `oidc_begin` | `oidcBegin` | `oidc_begin` | `oidcBegin` | `OidcBegin` | `oidcBegin` | `OidcBegin` |
+| `oidc_exchange` | `oidc_exchange` | `oidcExchange` | `oidc_exchange` | `oidcExchange` | `OidcExchangeAsync` | `oidcExchange` | `OidcExchange` |
+| `oidc_refresh` | `oidc_refresh` | `oidcRefresh` | `oidc_refresh` | `oidcRefresh` | `OidcRefreshAsync` | `oidcRefresh` | `OidcRefresh` |
+| `login_client_credentials` | `login_client_credentials` | `loginClientCredentials` | `login_client_credentials` | `loginClientCredentials` | `LoginClientCredentialsAsync` | `loginClientCredentials` | `LoginClientCredentials` |
+| `introspect` | `introspect` | `introspect` | `introspect` | `introspect` | `IntrospectAsync` | `introspect` | `Introspect` |
+| `revoke` | `revoke` | `revoke` | `revoke` | `revoke` | `RevokeAsync` | `revoke` | `Revoke` |
+| `sso_start` | `sso_start` | `ssoStart` | `sso_start` | `ssoStart` | `SsoStartAsync` | `ssoStart` | `SsoStart` |
+| `sso_complete` | `sso_complete` | `ssoComplete` | `sso_complete` | `ssoComplete` | `SsoCompleteAsync` | `ssoComplete` | `SsoComplete` |
+
+**C# `Async` suffix (§1 "Async method naming", SDK-Q08).** C# is `*Async`-only (TAP) for every
+operation that performs I/O, exactly as it is for `GetUserInfoAsync` in the §1 map. `OidcBegin`
+is the **single deliberate exception in this section**: it performs no network I/O (see
+[§12.1](#§121-canonical-operation-set-and-endpoint-map)), so it is a synchronous
+`OidcBegin` with **no** `Async` suffix. No `OidcBeginAsync` may be added.
+
+**Java.** The canonical camelCase names above are the synchronous surface. Per the §1
+"Async method naming" table Java MAY additionally expose `*Async` companion methods on the same
+client object (`oidcExchangeAsync`, `oidcRefreshAsync`, …); these are the accepted per-language
+exception to the "no additional diverging names" rule and nothing else.
+
+**Python.** The canonical snake_case names above appear on `AxiamClient` (sync) and, as
+`async def` twins under the *same* names, on `AsyncAxiamClient`. `async_*`-prefixed names remain
+prohibited (SDK-Q08).
+
+**Additional languages (Kotlin, Swift, C, C++).** **Kotlin** implements §12 and uses camelCase
+`suspend` functions identical to the TypeScript column (`oidcDiscover`, `oidcBegin`,
+`oidcExchange`, `oidcRefresh`, `loginClientCredentials`, `introspect`, `revoke`, `ssoStart`,
+`ssoComplete`); no `*Async` twins. **Swift**, **C**, and **C++** defer the whole section
+([§12.6](#§126-deferred-sdks-swift-c-c)), but the names are reserved now so a later port cannot
+diverge: **Swift** camelCase and **C++** snake_case exactly as the TypeScript and Rust columns
+above; **C** snake_case with the mandatory `axiam_` prefix — `axiam_oidc_discover`,
+`axiam_oidc_begin`, `axiam_oidc_exchange`, `axiam_oidc_refresh`,
+`axiam_login_client_credentials`, `axiam_introspect`, `axiam_revoke`, `axiam_sso_start`,
+`axiam_sso_complete`. No login/auth/authz method names beyond this map and the §1 map are
+permitted in any SDK.
+
+### §12.3 Cross-cutting rules (normative, identical in all SDKs)
+
+1. **Stateless by default.** `oidc_begin` and `oidc_exchange` MUST NOT store `state`, `nonce`,
+   or `code_verifier` inside the SDK, in process-global state, or in any implicit cache. The
+   caller owns that storage (typically its own HTTP session) and passes the `nonce` and
+   `code_verifier` back into `oidc_exchange` explicitly. Framework integrations MAY offer an
+   optional `OidcStateStore` interface with a `MemoryOidcStateStore` reference implementation;
+   where offered it MUST have a 10-minute TTL and a **single-use** `consume(state)` operation
+   that returns the stored tuple and atomically deletes it (mirroring the server's
+   `federation_login_state` semantics). The store MUST be opt-in: the core operations MUST
+   remain usable without one.
+2. **Sensitive wrapping (§7).** `access_token`, `refresh_token`, `id_token`, `client_secret`,
+   and `code_verifier` MUST each be held behind the SDK's `Sensitive<T>` equivalent (§7). They
+   MUST NOT appear in `Debug`/`toString`/`__repr__`/`ToString`/`String()` output, log records,
+   error messages, exception payloads, stack traces, or serialized diagnostics, and MUST NOT be
+   reachable through a public getter. `state` and `nonce` are **not** secrets and are exposed
+   as plain strings. See [§12.5](#§125-sensitivet-applicability) for the per-language wrapper.
+3. **Error taxonomy (§2).** An `OAuth2ErrorResponse` body MUST surface as `OAuthProtocolError`
+   — a language-idiomatic sub-type of `AuthError` — carrying `error` and `error_description` as
+   publicly accessible fields, with `message` set to `"<error>: <error_description>"`. A `400`
+   from `POST /oauth2/token` MUST NOT surface as the generic `NetworkError` the §2 `400` row
+   otherwise prescribes, and a `401` from `POST /oauth2/introspect` or `POST /oauth2/revoke`
+   MUST NOT enter the §9 single-flight refresh guard (client-credential failure is not a
+   session expiry, and retrying cannot help). ID-token validation failures MUST raise
+   `AuthError` (or an `AuthError` sub-type) carrying a stable machine-readable reason code —
+   `invalid_alg`, `unknown_kid`, `invalid_signature`, `invalid_issuer`, `invalid_audience`,
+   `token_expired`, or `nonce_mismatch` — matching the [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+   rule that failed. Per §2's construction rules, no error raised by this section may embed a
+   token, client secret, or code verifier in its message or context fields.
+4. **Tenant context (§5).** `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
+   `introspect`, and `revoke` all require a `tenant_id` **UUID** for the query parameter. An SDK
+   MUST accept it as an explicit argument, and MAY default to the client-level `tenant_id` when
+   the client was constructed in UUID form (§5). When no UUID is available — e.g. a client
+   constructed with `tenant_slug` only and no prior login to resolve it from — the SDK MUST
+   raise its taxonomy error **client-side, without a wire call** (same discipline as §1.1
+   rule 3); it MUST NOT send a slug in the `tenant_id` query parameter. `sso_start` carries
+   org/tenant context in the `OidcStartRequest` body and follows the §5.1 rules: one tenant form
+   (`tenant_id` or `tenant_slug`) **and** one org form (`org_id` or `org_slug`), alongside the
+   required `federation_config_id` and `redirect_uri`. `sso_complete` needs neither, because the
+   server recovers the full context from the single-use `state` row.
+5. **REST `/oauth2/userinfo` stays out of the vocabulary.** §12 adds no userinfo operation. A
+   relying party's claims come from the validated ID token (`OidcTokenSet.id_claims`); identity
+   lookups against a live session use the gRPC `get_user_info` operation (§1.1). SDKs MUST NOT
+   call `GET /oauth2/userinfo`, and MUST NOT substitute it for either — §1.1 rule 6 already
+   places that endpoint outside the SDK method vocabulary.
+6. **TLS and discovery-cache keying (§6).** Every §12 call goes through the SDK's §6-configured
+   transport with strict verification on; §6's absolute prohibition on TLS-bypass surfaces is
+   unchanged, and §6.1 client identities apply if configured. The discovery cache MUST be keyed
+   on the normalized **scheme + host + port** of the base URL used to fetch the document
+   (lowercased scheme and host, default port made explicit), so a document fetched from one
+   origin can never be served for another — cross-issuer cache poisoning. The cache MUST NOT be
+   keyed on, or shared across, tenants, and MUST NOT be process-global unless the key includes
+   the origin as specified. TTL MUST be at least 5 minutes, MAY be configurable, and concurrent
+   callers MUST share a single in-flight fetch (single-flight, using the same mechanism §9
+   prescribes for that language). The document's own `issuer` value is the authoritative issuer
+   for [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange) rule 3; because
+   the server derives it from `AuthConfig::oauth2_issuer_url` (falling back to
+   `AuthConfig::jwt_issuer`) it may legitimately differ from the base URL behind a proxy, so an
+   SDK MUST NOT reject a discovery document on an issuer/base-URL mismatch. Likewise SDKs MUST
+   read `jwks_uri` from the document rather than hardcoding `/oauth2/jwks`.
+
+### §12.4 ID-token validation checklist (normative for `oidc_exchange`)
+
+Validation reuses each SDK's existing JWKS verifier (the one the §10 middleware uses — extend
+it, never fork it) and follows OIDC Core §3.1.3.7. All seven requirements below MUST be
+enforced before `oidc_exchange` returns, and every SDK MUST carry one failing test per
+requirement:
+
+1. **Algorithm.** The JOSE header `alg` MUST be exactly `EdDSA`. The value `none` MUST be
+   rejected outright, as MUST every other algorithm — including any algorithm the discovery
+   document's `id_token_signing_alg_values_supported` might additionally advertise. The `alg`
+   MUST be read from the header and checked *before* any signature work; an SDK MUST NOT let
+   the token select its own verification algorithm.
+2. **Signature.** Verify the Ed25519 signature against the key from `jwks_uri` (schema
+   `JwksDocument`) selected by the header's `kid`. On an unknown `kid` the SDK performs **one**
+   JWKS re-fetch and then fails — the same rule the §10 middleware already implements. A token
+   with no `kid`, or whose `kid` is still unknown after the single re-fetch, MUST be rejected.
+3. **Issuer.** The `iss` claim MUST equal the discovery document's `issuer` by exact string
+   comparison — no normalization, no trailing-slash tolerance, no substring or prefix matching.
+4. **Audience.** The `aud` claim MUST contain the RP's own `client_id`. When `aud` holds more
+   than one audience, an `azp` claim MUST be present and MUST equal that `client_id`.
+5. **Time.** `exp` MUST be in the future and `iat` MUST NOT be in the future; `nbf` MUST be
+   honored when present. Permitted clock skew is at most 60 seconds in either direction and
+   MUST NOT be configurable above that bound.
+6. **Nonce.** The `nonce` claim MUST be present and MUST equal, by constant-time comparison,
+   the nonce the caller received from `oidc_begin` and passed into `oidc_exchange`. This is
+   mandatory for `oidc_exchange` — the helper always requests the `openid` scope, so the server
+   always issues a `nonce`. For `oidc_refresh` and `login_client_credentials`, rules 1–5 and 7
+   apply to any `id_token` present and rule 6 is skipped (OIDC Core §12.2 does not require a
+   `nonce` in a refresh-issued ID token).
+7. **All-or-nothing failure.** On failure of *any* rule above, the SDK MUST raise `AuthError`
+   with the matching reason code from [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks)
+   rule 3 and MUST **discard the entire token set** — the `access_token` and `refresh_token`
+   from the same response MUST NOT be returned to the caller, adopted as the client's
+   credential, or written to any store. There is no partial success, and no "validation
+   disabled" or "skip ID-token checks" option may exist on any public API.
+
+[§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange) does not apply to
+`sso_start`/`sso_complete`: the federation flow returns the session as `Set-Cookie` and no ID
+token reaches the SDK ([§12.1](#§121-canonical-operation-set-and-endpoint-map) note 7).
+
+### §12.5 `Sensitive<T>` applicability
+
+The five fields named in [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks)
+rule 2 — `access_token`, `refresh_token`, `id_token`, `client_secret`, `code_verifier` — use
+the **same concrete wrapper this contract already specifies per language in §7**; §12 defines
+no new mechanism. Concretely: Rust newtype `Sensitive<T>` with custom `Debug`/`Display`;
+TypeScript class with a private `#value` and `toString()` returning `"[SENSITIVE]"`; Python
+`__repr__`/`__str__` returning `"Sensitive(<redacted>)"`; final Java class with a redacting
+`toString()`; C# struct with a `ToString()` override; PHP `__toString()`; Go string type with a
+redacting `String()`; Kotlin `value class Sensitive<T>` (never a `data class`, whose generated
+`toString` would leak); Swift `struct Sensitive<T>: CustomStringConvertible`; C opaque
+`axiam_sensitive_t`; C++ `class Sensitive<T>` with a redacting `operator<<`/`to_string`. See
+the §7 table for the authoritative per-language row. Two additions specific to §12:
+`code_verifier` is secret **for its whole lifetime**, including while it sits in an
+`AuthorizationRequest` returned to the caller and in any `OidcStateStore` entry; and JSON or
+other structured serialization of `OidcTokenSet`, `AuthorizationRequest`, or an
+`OidcStateStore` entry MUST NOT emit the wrapped values.
+
+### §12.6 Deferred SDKs (Swift, C, C++)
+
+`axiam-swift-sdk`, `axiam-c-sdk`, and `axiam-cplusplus-sdk` **defer §12 in its entirety**, with
+the same carve-out discipline §1/§1.1 already applies to their `get_user_info`/gRPC deferral.
+These are device- and IoT-oriented SDKs: the Swift SDK ships NIOSSL specifically for client-cert
+mTLS, and the C/C++ SDKs target embedded consumers. The browser-redirect relying-party flow has
+no natural home in any of them, and their authentication story — §6.1 mTLS, password login,
+service credentials — is already complete without it.
+
+Accordingly, each of these three SDKs MUST document §12 as a deferred follow-up in its scope
+section (same wording pattern as its existing "gRPC transport deferred" carve-out), MUST NOT
+partially implement the vocabulary, and MUST NOT substitute a hand-rolled OAuth2 flow for it.
+Their conformance statement stays at "§1–§10" (or "§1–§11" where the §11 helpers ship) and MUST
+NOT claim §12. If a later port lands, it MUST use the reserved names already fixed in
+[§12.2](#§122-per-language-naming-map) and MUST satisfy §12.1–§12.5 unchanged. Two follow-up
+decisions are recorded as open rather than resolved here: a server-side-Swift (Vapor) port
+cloned from the Kotlin shape, and adding `login_client_credentials` alone to C/C++ for
+machine-to-machine use.
+
+---
+
 ## Closing Notes
 
 ### Conformance Statement
@@ -670,8 +1004,16 @@ statement to:
 
 > "This SDK conforms to CONTRACT.md §1–§11."
 
+An SDK that additionally ships the §12 OIDC/SSO relying-party helpers updates its statement to:
+
+> "This SDK conforms to CONTRACT.md §1–§12."
+
+The three SDKs that defer §12 ([§12.6](#§126-deferred-sdks-swift-c-c)) keep their existing
+statement and MUST NOT claim §12.
+
 Phase acceptance criteria in each SDK plan include: "CONTRACT.md §1–§10 conformance
-verified." (and §1–§11 where the §11 helpers are shipped).
+verified." (and §1–§11 where the §11 helpers are shipped, §1–§12 where the §12 helpers are
+shipped).
 
 ### C# `Grpc.Tools` Exception
 
@@ -681,6 +1023,22 @@ C# is the one documented deviation from the `buf` codegen pipeline. The C# SDK u
 
 No SDK currently ships a dedicated `CHANGELOG.md`; breaking changes to this contract are
 recorded here until one exists.
+
+- **2026-07 (§12 OIDC / SSO relying-party helpers, contract 1.4)** — **non-breaking / additive.**
+  Added §12 "OIDC / SSO Relying-Party Helpers" (SHOULD-level for v1.0): nine new canonical
+  operations — `oidc_discover`, `oidc_begin`, `oidc_exchange`, `oidc_refresh`,
+  `login_client_credentials`, `introspect`, `revoke`, `sso_start`, `sso_complete` — with a
+  twelve-language naming map (§12.2), six cross-cutting rules (§12.3), the normative ID-token
+  validation checklist (§12.4, `EdDSA`-only, S256-only PKCE, all-or-nothing discard), and a
+  `Sensitive<T>` applicability note (§12.5). They target the already-shipping server surface
+  (`/.well-known/openid-configuration`, `/oauth2/token|introspect|revoke|jwks`,
+  `/api/v1/auth/federation/oidc/start|callback`) — no server or `openapi.json` change. The §2
+  taxonomy gains one sub-type, `OAuthProtocolError` (an `AuthError` sub-type carrying `error` +
+  `error_description`), plus two endpoint-qualified rows in the HTTP-status mapping; the three
+  existing top-level error types are unchanged. No existing signature changes. The eight
+  backend-capable SDKs (Rust, TypeScript, Python, Java, Kotlin, C#, PHP, Go) add the operations
+  and state "§1–§12"; the device-oriented SDKs (Swift, C, C++) document §12 as a deferred
+  follow-up and keep their existing statement (§12.6).
 
 - **2026-07 (§1.1 gRPC userinfo, contract 1.3)** — **non-breaking / additive.** Added a new
   canonical operation `get_user_info` (§1 naming map + §1.1 normative semantics), served only
@@ -727,6 +1085,6 @@ recorded here until one exists.
 
 ---
 
-*Contract version: 1.3 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07*
+*Contract version: 1.4 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*


### PR DESCRIPTION
## Why

The AXIAM server already ships a complete OIDC provider and federation surface (`/.well-known/openid-configuration`, `/oauth2/authorize`, `/oauth2/token` with the `authorization_code`, `client_credentials` and `refresh_token` grants, JWKS, introspect/revoke, and the public `/api/v1/auth/federation/oidc/{start,callback}` pair). None of the SDKs could drive it: their vocabulary stopped at password `login`, `verify_mfa`, `refresh`, `logout`, the authz checks, and gRPC `get_user_info`, plus inbound resource-server JWKS verification. A backend developer could *validate* tokens but could not implement "Login with AXIAM".

A survey across all eleven SDK repos found zero non-test source references to `authorization_code`, `client_credentials`, `code_verifier`, or `/oauth2/token`.

## What this PR contains

This repository's half of the work: the **behavioural contract** plus the planning and review artifacts. The eight backend-capable SDKs are updated in their own repositories (companion PRs).

- `sdks/CONTRACT.md` — new **§12 OIDC / SSO Relying-Party Helpers**, taking the contract from 1.3 to **1.5**:
  - Nine canonical operations (`oidc_discover`, `oidc_begin`, `oidc_exchange`, `oidc_refresh`, `login_client_credentials`, `introspect`, `revoke`, `sso_start`, `sso_complete`) with a per-language naming map covering all twelve languages, so the eight implementing SDKs cannot drift.
  - Cross-cutting rules: caller-owned `state`/`nonce`/`code_verifier`, `Sensitive` coverage, tenant context, TLS, and discovery-cache keying.
  - A normative seven-rule **ID-token validation checklist** with a closed vocabulary of failure reason codes.
  - `OAuthProtocolError` added to the §2 taxonomy as a **sub-type of `AuthError`** (not a fourth peer type), so existing consumer catch/match code keeps working — plus two endpoint-qualified status rows, including the rule that a `401` from `/oauth2/*` must **not** enter the §9 single-flight refresh guard.
  - §12.6 defers the section for the device-oriented Swift, C, and C++ SDKs while reserving their names.
- `claude_dev/sdk-oidc-sso-plan.md` — the implementation plan the work was executed from.
- `claude_dev/sdk-oidc-sso-conformance-review.md` — the cross-SDK conformance review: a ~53-rule × 8-SDK matrix, the adjudications behind the 1.5 amendments, and a severity-ordered follow-up list.

## Contract 1.5 amendments (non-breaking, clarifying)

Version 1.5 makes the contract describe what eight independent implementations actually do, and fixes defects the reference implementation surfaced:

- **§7 restructured** into four numbered rules. §7 previously forbade exposing a raw token via "any public getter API", which is unsatisfiable alongside §12 — §12 hands tokens to the caller, who must be able to read them. Rule 3 now permits exactly one explicit accessor and recommends it for §12, while rules 1, 2 and 4 keep unconditional redaction, forbid implicit reachability, and require point-of-use discipline. The C and C++ no-public-accessor rows are unchanged (both defer §12).
- **§9 gains rule 5**: the refresh-guard mechanism is free (a dedicated guard instance is permitted; a bounded wait is permitted and its bound is explicitly not contract-worthy), while rule 2 now states the *observable* requirement — one in-flight refresh whose result is shared — with the single-use-rotation reasoning that makes it matter.
- **Eight §12 defects fixed**: §12.3 rule 6's self-contradiction on tenant cache keying; §12.4 rule 2's literally-unimplementable "one JWKS re-fetch" on a warm cache (now per-cooldown-window); the reason-code vocabulary documented as closed; the UUID-query-vs-slug-header asymmetry and its consequence that a slug-only client cannot call five of the nine operations; `client_id` removed from `oidc_begin`'s per-call inputs; `redirect_uri` documented as caller-owned on `AuthorizationRequest`; `revoke` accepting any 2xx with 5xx still a network error; and one sentence permitting either host object for the nine methods, with the browser-bundle rationale.

## Verification

No server crate, no `openapi.json`, and no SDK source is touched here — every §12 endpoint was verified to already exist in the committed OpenAPI spec. Across the companion SDK PRs the work adds roughly 2,400 tests, and every repo's own coverage gate passes.

## Notes

- No tracking issue exists for this work, so there is none to close; the plan document above is the reference.
- One follow-up is tracked in the review document rather than fixed here, along with a set of medium/low items: five SDKs enforce the "401 out of the refresh guard" rule structurally rather than via an explicit documented invariant, and no repo yet tests the `X-Tenant-ID` header on `/oauth2/*`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QMVprduES1HE8JgZg1n1hK)_