### PR TITLE
perf(db): use UUIDv7 for persisted record identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ base64 = "0.22"
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 webauthn-rs-proto = "0.5"
 aes-gcm = "0.11"
-uuid = { version = "1", features = ["v4", "v5", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 zeroize = "1"
 secrecy = { version = "0.10", features = ["serde"] }
 

--- a/claude_dev/design-document.md
+++ b/claude_dev/design-document.md
@@ -276,6 +276,7 @@ FROM user:$uid;
 - **MFA**: TOTP (RFC 6238) with encrypted secret storage; extensible for WebAuthn later
 - **Audit logs**: Append-only table, no UPDATE/DELETE allowed (enforced at SurrealDB permission level)
 - **Resource hierarchy**: Computed at query time via graph traversal, not materialized, to keep writes simple and consistent
+- **Record identifiers**: UUIDv7 (`axiam_core::id::new_id`) for every persisted entity id. Record ids are the primary key in SurrealDB's ordered KV engine (`surrealkv:`/`file:`), so v7's leading 48-bit millisecond timestamp keeps time-adjacent inserts physically adjacent instead of scattering them across the keyspace as v4 does. Ids are stored as hyphenated strings, whose lexicographic order matches the byte order, so the locality survives the encoding. **Secrets never use v7**: session/download/reset/cancel tokens and generated passwords stay on a CSPRNG, because v7 spends 48 bits on a timestamp and its per-millisecond monotonic counter leaves same-millisecond ids sharing a long common prefix — ample for uniqueness, useless for secrecy.
 
 ---
 

--- a/crates/axiam-api-rest/src/handlers/bootstrap.rs
+++ b/crates/axiam-api-rest/src/handlers/bootstrap.rs
@@ -26,6 +26,7 @@
 use actix_web::{HttpResponse, web};
 use axiam_auth::password;
 use axiam_core::error::AxiamError;
+use axiam_core::id::new_id;
 use axiam_core::models::organization::CreateOrganization;
 use axiam_core::models::tenant::CreateTenant;
 use axiam_core::repository::{OrganizationRepository, TenantRepository};
@@ -361,11 +362,11 @@ pub async fn bootstrap<C: Connection + Clone>(
     //
     // SurrealDB v3 quirk: BEGIN TRANSACTION occupies result slot 0;
     // the first statement result is at .take(1). (See MEMORY.md)
-    let user_id = Uuid::new_v4();
+    let user_id = new_id();
     let user_id_str = user_id.to_string();
     let role_id_str = seed_result.super_admin_role_id.to_string();
     let tenant_id_str = tenant_id.to_string();
-    let ph_id_str = Uuid::new_v4().to_string();
+    let ph_id_str = new_id().to_string();
 
     // Apply the server-configured password pepper (REQ-14 AC-1) — the same
     // pepper the user repository uses at login-time verification. Previously

--- a/crates/axiam-api-rest/src/webhook.rs
+++ b/crates/axiam-api-rest/src/webhook.rs
@@ -34,6 +34,7 @@
 //! to update for this format change.
 
 use axiam_auth::crypto::{aes256gcm_decrypt, aes256gcm_encrypt};
+use axiam_core::id::new_id;
 use axiam_core::repository::WebhookRepository;
 use axiam_federation::ssrf::{self, SsrfError};
 use chrono::Utc;
@@ -182,7 +183,7 @@ impl<W: WebhookRepository + Clone + 'static> WebhookDeliveryService<W> {
         for webhook in webhooks {
             let msg = axiam_amqp::WebhookMessage {
                 webhook_id: webhook.id,
-                delivery_id: Uuid::new_v4(),
+                delivery_id: new_id(),
                 tenant_id,
                 event_type: event_type.clone(),
                 payload: payload.clone(),

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -165,6 +165,8 @@ pub fn issue_client_credentials_token(
         iss: config.effective_issuer().to_owned(),
         iat: now,
         exp: now + config.access_token_lifetime_secs as i64,
+        // Not `new_id()`: a jti is a uniqueness marker inside an already-signed
+        // JWT, not a record id, so key locality is irrelevant here.
         jti: Uuid::new_v4().to_string(),
         aud: Some(AUD_M2M.to_string()),
         scope,

--- a/crates/axiam-core/src/id.rs
+++ b/crates/axiam-core/src/id.rs
@@ -1,0 +1,150 @@
+//! Identifier generation for persisted entities.
+//!
+//! # Why v7 and not v4
+//!
+//! Every repository in `axiam-db` writes its rows as
+//! `CREATE type::record('<table>', $id)`, where `$id` is the hyphenated string
+//! form of a [`Uuid`]. SurrealDB stores records in an ordered key-value engine
+//! (`surrealkv:` in dev/prod compose, `file:`/RocksDB in the k8s StatefulSet),
+//! so the record id *is* the primary key and its ordering determines physical
+//! layout.
+//!
+//! With v4 the key is uniformly random, so consecutive inserts scatter across
+//! the whole keyspace: every insert dirties a different page, the working set
+//! for a write burst is the entire index rather than its tail, and LSM
+//! compaction rewrites overlapping ranges repeatedly. UUIDv7 (RFC 9562) puts a
+//! 48-bit big-endian Unix-millisecond timestamp in the high bits, so ids
+//! generated close in time sort close together and inserts append to the tail
+//! of the keyspace instead of scattering.
+//!
+//! Two properties this depends on are verified by the tests below rather than
+//! assumed:
+//!
+//! 1. **The string form sorts like the byte form.** We store ids as
+//!    hyphenated strings, so the ordering benefit would be lost if the textual
+//!    encoding permuted it. Lowercase hex is order-preserving here, and the
+//!    hyphens sit at fixed offsets, so it holds — but it is asserted, because
+//!    the whole rationale collapses without it.
+//! 2. **Ids are monotonic within a single millisecond.** `uuid`'s
+//!    [`Uuid::now_v7`] carries a per-millisecond counter (RFC 9562 §6.2
+//!    "monotonic random"), so a burst of inserts inside one millisecond is
+//!    still ordered rather than randomly permuted inside that millisecond's
+//!    bucket.
+//!
+//! # When NOT to use this
+//!
+//! [`new_id`] must not be used for anything whose security depends on being
+//! unguessable — session tokens, download/cancel tokens, reset tokens,
+//! passwords, or any other bearer capability.
+//!
+//! v4 spends 122 bits on randomness. v7 spends 48 on the timestamp and, because
+//! of the monotonic counter, ids minted in the *same* millisecond share a long
+//! common prefix and differ only in the low counter bits. Two adjacent same-ms
+//! ids can therefore share ~90 of their 128 bits, which is ample for collision
+//! resistance but nowhere near enough for secrecy.
+//!
+//! That distinction is the rule this module encodes: **v7 for identifiers, CSPRNG
+//! for secrets.** Identifiers in AXIAM are not capabilities — every repository
+//! read is tenant-scoped and every route is checked by the authz engine, so
+//! knowing another entity's id grants nothing. Secrets are generated separately
+//! (see `generate_cancel_token` in the GDPR handlers, which uses a 256-bit
+//! `rand` draw for exactly this reason).
+//!
+//! # Disclosure trade-off
+//!
+//! A v7 id discloses its own creation time to anyone who can see it. For AXIAM
+//! entities this reveals nothing new: `created_at` is already part of the
+//! public representation of every entity that carries one, and JWTs already
+//! carry `iat` alongside the `jti`/`sub` claims.
+
+use uuid::Uuid;
+
+/// Generate the identifier for a newly created, persisted entity.
+///
+/// Use this for anything that becomes a SurrealDB record id or a foreign key.
+/// See the module docs for why this is v7 and for the cases that must keep
+/// using a CSPRNG instead.
+#[inline]
+#[must_use]
+pub fn new_id() -> Uuid {
+    Uuid::now_v7()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn is_version_7() {
+        let id = new_id();
+        assert_eq!(id.get_version_num(), 7, "new_id must mint UUIDv7");
+        assert_eq!(id.get_variant(), uuid::Variant::RFC4122);
+    }
+
+    /// The ordering guarantee must survive the hyphenated-string encoding,
+    /// because that is the form actually handed to `type::record(...)`.
+    #[test]
+    fn string_form_sorts_in_generation_order() {
+        let ids: Vec<Uuid> = (0..10_000).map(|_| new_id()).collect();
+
+        let generated: Vec<String> = ids.iter().map(Uuid::to_string).collect();
+        let mut sorted = generated.clone();
+        sorted.sort();
+
+        assert_eq!(
+            sorted, generated,
+            "hyphenated string ordering must match generation order, otherwise \
+             storing ids as strings discards the v7 locality benefit"
+        );
+    }
+
+    /// A burst inside one millisecond must stay ordered, not shuffle within
+    /// that millisecond's bucket.
+    #[test]
+    fn monotonic_within_a_single_millisecond() {
+        let ids: Vec<Uuid> = (0..5_000).map(|_| new_id()).collect();
+
+        // Confirm the burst really did share milliseconds, so this test is
+        // exercising the counter rather than trivially passing on distinct
+        // timestamps.
+        let distinct_ms: HashSet<&[u8]> = ids.iter().map(|u| &u.as_bytes()[0..6]).collect();
+        assert!(
+            distinct_ms.len() < ids.len(),
+            "expected several ids per millisecond in a tight burst"
+        );
+
+        for pair in ids.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "v7 ids must increase monotonically: {} !< {}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn ids_are_unique() {
+        let ids: HashSet<Uuid> = (0..50_000).map(|_| new_id()).collect();
+        assert_eq!(ids.len(), 50_000);
+    }
+
+    /// The embedded timestamp must track wall-clock time, since ordering
+    /// across processes and restarts relies on it.
+    #[test]
+    fn embeds_current_unix_millis() {
+        let before = chrono::Utc::now().timestamp_millis();
+        let id = new_id();
+        let after = chrono::Utc::now().timestamp_millis();
+
+        let b = id.as_bytes();
+        let ms = i64::from(u32::from_be_bytes([b[0], b[1], b[2], b[3]])) << 16
+            | i64::from(u16::from_be_bytes([b[4], b[5]]));
+
+        assert!(
+            (before..=after).contains(&ms),
+            "embedded timestamp {ms} outside [{before}, {after}]"
+        );
+    }
+}

--- a/crates/axiam-core/src/lib.rs
+++ b/crates/axiam-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! AXIAM Core — Domain types, repository traits, and error definitions.
 
 pub mod error;
+pub mod id;
 pub mod models;
 pub mod repository;

--- a/crates/axiam-db/src/repository/account_deletion.rs
+++ b/crates/axiam-db/src/repository/account_deletion.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`AccountDeletionRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{AccountDeletion, AccountDeletionStatus, CreateAccountDeletion};
 use axiam_core::repository::AccountDeletionRepository;
 use chrono::{DateTime, Utc};
@@ -178,7 +179,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
         scheduled_purge_at: DateTime<Utc>,
         cancel_token_hash: String,
     ) -> AxiamResult<AccountDeletion> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let created_at = Utc::now();
 
         let query = "BEGIN TRANSACTION; \
@@ -233,7 +234,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
 
 impl<C: Connection> AccountDeletionRepository for SurrealAccountDeletionRepository<C> {
     async fn create(&self, input: CreateAccountDeletion) -> AxiamResult<AccountDeletion> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/amqp_nonce_replay.rs
+++ b/crates/axiam-db/src/repository/amqp_nonce_replay.rs
@@ -6,6 +6,7 @@
 //! reject replayed messages (NEW-4). Mirrors [`super::saml_replay`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::repository::AmqpNonceRepository;
 use chrono::{DateTime, Utc};
 use surrealdb::{Connection, Surreal};
@@ -47,7 +48,7 @@ impl<C: Connection> AmqpNonceRepository for SurrealAmqpNonceRepository<C> {
         nonce: Uuid,
         expires_at: DateTime<Utc>,
     ) -> AxiamResult<()> {
-        let row_id = Uuid::new_v4().to_string();
+        let row_id = new_id().to_string();
 
         let result = self
             .db

--- a/crates/axiam-db/src/repository/audit.rs
+++ b/crates/axiam-db/src/repository/audit.rs
@@ -4,6 +4,7 @@
 //! `FOR update NONE` and `FOR delete NONE`.
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::audit::{ActorType, AuditLogEntry, AuditOutcome, CreateAuditLogEntry};
 use axiam_core::repository::{AuditLogFilter, AuditLogRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -229,7 +230,7 @@ impl<C: Connection> SurrealAuditLogRepository<C> {
 
 impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
     async fn append(&self, input: CreateAuditLogEntry) -> AxiamResult<AuditLogEntry> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let metadata = input

--- a/crates/axiam-db/src/repository/ca_certificate.rs
+++ b/crates/axiam-db/src/repository/ca_certificate.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`CaCertificateRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::certificate::{
     CaCertificate, CertificateStatus, KeyAlgorithm, StoreCaCertificate,
 };
@@ -149,7 +150,7 @@ impl<C: Connection> SurrealCaCertificateRepository<C> {
 
 impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C> {
     async fn create(&self, input: StoreCaCertificate) -> AxiamResult<CaCertificate> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/certificate.rs
+++ b/crates/axiam-db/src/repository/certificate.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`CertificateRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::certificate::{
     Certificate, CertificateStatus, CertificateType, KeyAlgorithm, StoreCertificate,
 };
@@ -185,7 +186,7 @@ impl<C: Connection> SurrealCertificateRepository<C> {
 
 impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
     async fn create(&self, input: StoreCertificate) -> AxiamResult<Certificate> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/consent.rs
+++ b/crates/axiam-db/src/repository/consent.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ConsentRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{Consent, CreateConsent};
 use axiam_core::repository::ConsentRepository;
 use chrono::{DateTime, Utc};
@@ -82,7 +83,7 @@ impl<C: Connection> SurrealConsentRepository<C> {
 
 impl<C: Connection> ConsentRepository for SurrealConsentRepository<C> {
     async fn create(&self, input: CreateConsent) -> AxiamResult<Consent> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/email_config.rs
+++ b/crates/axiam-db/src/repository/email_config.rs
@@ -791,6 +791,8 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
         let override_cfg = self.get_tenant_override(tenant_id).await?;
         let effective = match override_cfg {
             None => org_cfg,
+            // Not `new_id()`: the merged view is computed, never persisted, so
+            // this id names no record and gains nothing from being sortable.
             Some(ov) => axiam_core::models::email::effective_email_config(
                 &org_cfg,
                 &ov,

--- a/crates/axiam-db/src/repository/email_verification_token.rs
+++ b/crates/axiam-db/src/repository/email_verification_token.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`EmailVerificationTokenRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::email_verification::{
     CreateEmailVerificationToken, EmailVerificationToken,
 };
@@ -98,7 +99,7 @@ impl<C: Connection> EmailVerificationTokenRepository
         &self,
         input: CreateEmailVerificationToken,
     ) -> AxiamResult<EmailVerificationToken> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/erasure_proof.rs
+++ b/crates/axiam-db/src/repository/erasure_proof.rs
@@ -4,6 +4,7 @@
 //! erasure occurred. They contain no PII — only a pseudonym and timestamp.
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{CreateErasureProof, ErasureProof};
 use axiam_core::repository::ErasureProofRepository;
 use chrono::{DateTime, Utc};
@@ -49,7 +50,7 @@ impl<C: Connection> SurrealErasureProofRepository<C> {
 
 impl<C: Connection> ErasureProofRepository for SurrealErasureProofRepository<C> {
     async fn create(&self, input: CreateErasureProof) -> AxiamResult<ErasureProof> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/export_job.rs
+++ b/crates/axiam-db/src/repository/export_job.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ExportJobRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{CreateExportJob, ExportJob, ExportJobStatus};
 use axiam_core::repository::ExportJobRepository;
 use chrono::{DateTime, Utc};
@@ -126,7 +127,7 @@ impl<C: Connection> SurrealExportJobRepository<C> {
 
 impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
     async fn create(&self, input: CreateExportJob) -> AxiamResult<ExportJob> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/federation_config.rs
+++ b/crates/axiam-db/src/repository/federation_config.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`FederationConfigRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::federation::{
     CreateFederationConfig, FederationConfig, FederationProtocol, UpdateFederationConfig,
 };
@@ -202,7 +203,7 @@ impl<C: Connection> SurrealFederationConfigRepository<C> {
 
 impl<C: Connection> FederationConfigRepository for SurrealFederationConfigRepository<C> {
     async fn create(&self, input: CreateFederationConfig) -> AxiamResult<FederationConfig> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let protocol = protocol_to_string(&input.protocol);
         let attribute_map = input.attribute_map.unwrap_or_else(|| serde_json::json!({}));
 

--- a/crates/axiam-db/src/repository/federation_link.rs
+++ b/crates/axiam-db/src/repository/federation_link.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`FederationLinkRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::federation::{CreateFederationLink, FederationLink};
 use axiam_core::repository::FederationLinkRepository;
 use chrono::{DateTime, Utc};
@@ -97,7 +98,7 @@ impl<C: Connection> SurrealFederationLinkRepository<C> {
 
 impl<C: Connection> FederationLinkRepository for SurrealFederationLinkRepository<C> {
     async fn create(&self, input: CreateFederationLink) -> AxiamResult<FederationLink> {
-        let id = Uuid::new_v4();
+        let id = new_id();
 
         let result = self
             .db

--- a/crates/axiam-db/src/repository/federation_login_state.rs
+++ b/crates/axiam-db/src/repository/federation_login_state.rs
@@ -6,6 +6,7 @@
 //! caller check and can be swept by `cleanup_expired`.
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::repository::{FederationLoginState, FederationLoginStateRepository};
 use chrono::{DateTime, Utc};
 use surrealdb::{Connection, Surreal};
@@ -50,7 +51,7 @@ impl<C: Connection> SurrealFederationLoginStateRepository<C> {
 
 impl<C: Connection> FederationLoginStateRepository for SurrealFederationLoginStateRepository<C> {
     async fn insert(&self, row: &FederationLoginState) -> AxiamResult<()> {
-        let row_id = Uuid::new_v4().to_string();
+        let row_id = new_id().to_string();
 
         let result = self
             .db

--- a/crates/axiam-db/src/repository/group.rs
+++ b/crates/axiam-db/src/repository/group.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`GroupRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
 use axiam_core::models::user::{User, UserStatus};
 use axiam_core::repository::{GroupRepository, PaginatedResult, Pagination};
@@ -129,7 +130,7 @@ impl<C: Connection> SurrealGroupRepository<C> {
 
 impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
     async fn create(&self, input: CreateGroup) -> AxiamResult<Group> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/notification_rule.rs
+++ b/crates/axiam-db/src/repository/notification_rule.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`NotificationRuleRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::notification_rule::{
     CreateNotificationRule, NotificationEventType, NotificationRule, UpdateNotificationRule,
 };
@@ -114,7 +115,7 @@ impl<C: Connection> SurrealNotificationRuleRepository<C> {
 
 impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleRepository<C> {
     async fn create(&self, input: CreateNotificationRule) -> AxiamResult<NotificationRule> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let events_str: Vec<String> = input.events.iter().map(|e| e.to_db_string()).collect();
 
         let result = self

--- a/crates/axiam-db/src/repository/oauth2_auth_code.rs
+++ b/crates/axiam-db/src/repository/oauth2_auth_code.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`AuthorizationCodeRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{AuthorizationCode, CreateAuthorizationCode};
 use axiam_core::repository::AuthorizationCodeRepository;
 use chrono::{DateTime, Utc};
@@ -84,7 +85,7 @@ impl<C: Connection> SurrealAuthorizationCodeRepository<C> {
 
 impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepository<C> {
     async fn create(&self, input: CreateAuthorizationCode) -> AxiamResult<AuthorizationCode> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/oauth2_client.rs
+++ b/crates/axiam-db/src/repository/oauth2_client.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`OAuth2ClientRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{CreateOAuth2Client, OAuth2Client, UpdateOAuth2Client};
 use axiam_core::repository::{OAuth2ClientRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -88,7 +89,7 @@ impl<C: Connection> SurrealOAuth2ClientRepository<C> {
 
 impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> {
     async fn create(&self, input: CreateOAuth2Client) -> AxiamResult<(OAuth2Client, String)> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/oauth2_refresh_token.rs
+++ b/crates/axiam-db/src/repository/oauth2_refresh_token.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`RefreshTokenRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{CreateRefreshToken, RefreshToken};
 use axiam_core::repository::RefreshTokenRepository;
 use chrono::{DateTime, Utc};
@@ -87,7 +88,7 @@ impl<C: Connection> SurrealRefreshTokenRepository<C> {
 
 impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> {
     async fn create(&self, input: CreateRefreshToken) -> AxiamResult<RefreshToken> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let user_id_str = input.user_id.map(|u| u.to_string());

--- a/crates/axiam-db/src/repository/organization.rs
+++ b/crates/axiam-db/src/repository/organization.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`OrganizationRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::organization::{CreateOrganization, Organization, UpdateOrganization};
 use axiam_core::repository::{OrganizationRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -61,7 +62,7 @@ impl<C: Connection> SurrealOrganizationRepository<C> {
 
 impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> {
     async fn create(&self, input: CreateOrganization) -> AxiamResult<Organization> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let metadata = input

--- a/crates/axiam-db/src/repository/password_history.rs
+++ b/crates/axiam-db/src/repository/password_history.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PasswordHistoryRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::password_history::{CreatePasswordHistoryEntry, PasswordHistoryEntry};
 use axiam_core::repository::PasswordHistoryRepository;
 use chrono::{DateTime, Utc};
@@ -74,7 +75,7 @@ impl<C: Connection> SurrealPasswordHistoryRepository<C> {
 
 impl<C: Connection> PasswordHistoryRepository for SurrealPasswordHistoryRepository<C> {
     async fn create(&self, input: CreatePasswordHistoryEntry) -> AxiamResult<PasswordHistoryEntry> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/password_reset_token.rs
+++ b/crates/axiam-db/src/repository/password_reset_token.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PasswordResetTokenRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::password_reset::{CreatePasswordResetToken, PasswordResetToken};
 use axiam_core::repository::PasswordResetTokenRepository;
 use chrono::{DateTime, Utc};
@@ -91,7 +92,7 @@ impl<C: Connection> SurrealPasswordResetTokenRepository<C> {
 
 impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRepository<C> {
     async fn create(&self, input: CreatePasswordResetToken) -> AxiamResult<PasswordResetToken> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/permission.rs
+++ b/crates/axiam-db/src/repository/permission.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PermissionRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::permission::{
     CreatePermission, Permission, PermissionGrant, UpdatePermission,
 };
@@ -138,7 +139,7 @@ impl<C: Connection> SurrealPermissionRepository<C> {
 
 impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
     async fn create(&self, input: CreatePermission) -> AxiamResult<Permission> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/pgp_key.rs
+++ b/crates/axiam-db/src/repository/pgp_key.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PgpKeyRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::pgp_key::{
     PgpKey, PgpKeyAlgorithm, PgpKeyPurpose, PgpKeyStatus, StorePgpKey,
 };
@@ -157,7 +158,7 @@ impl<C: Connection> SurrealPgpKeyRepository<C> {
 
 impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
     async fn create(&self, input: StorePgpKey) -> AxiamResult<PgpKey> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/resource.rs
+++ b/crates/axiam-db/src/repository/resource.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ResourceRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::resource::{CreateResource, Resource, UpdateResource};
 use axiam_core::repository::{PaginatedResult, Pagination, ResourceRepository};
 use chrono::{DateTime, Utc};
@@ -95,7 +96,7 @@ impl<C: Connection> SurrealResourceRepository<C> {
 
 impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
     async fn create(&self, input: CreateResource) -> AxiamResult<Resource> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
         let parent_id_str = input.parent_id.map(|p| p.to_string());

--- a/crates/axiam-db/src/repository/role.rs
+++ b/crates/axiam-db/src/repository/role.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`RoleRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::role::{CreateRole, Role, RoleAssignment, UpdateRole};
 use axiam_core::repository::{PaginatedResult, Pagination, RoleRepository};
 use chrono::{DateTime, Utc};
@@ -120,7 +121,7 @@ impl<C: Connection> SurrealRoleRepository<C> {
 
 impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
     async fn create(&self, input: CreateRole) -> AxiamResult<Role> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/saml_replay.rs
+++ b/crates/axiam-db/src/repository/saml_replay.rs
@@ -6,6 +6,7 @@
 //! replayed assertions (D-09).
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::repository::AssertionReplayRepository;
 use chrono::{DateTime, Utc};
 use surrealdb::{Connection, Surreal};
@@ -46,7 +47,7 @@ impl<C: Connection> AssertionReplayRepository for SurrealAssertionReplayReposito
         assertion_id: &str,
         expires_at: DateTime<Utc>,
     ) -> AxiamResult<()> {
-        let row_id = Uuid::new_v4().to_string();
+        let row_id = new_id().to_string();
         let assertion_id_owned = assertion_id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/scope.rs
+++ b/crates/axiam-db/src/repository/scope.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ScopeRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::scope::{CreateScope, Scope, UpdateScope};
 use axiam_core::repository::ScopeRepository;
 use chrono::{DateTime, Utc};
@@ -66,7 +67,7 @@ impl<C: Connection> SurrealScopeRepository<C> {
 
 impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
     async fn create(&self, input: CreateScope) -> AxiamResult<Scope> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
         let resource_id_str = input.resource_id.to_string();

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ServiceAccountRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::service_account::{
     CreateServiceAccount, ServiceAccount, UpdateServiceAccount,
 };
@@ -116,7 +117,7 @@ impl<C: Connection> SurrealServiceAccountRepository<C> {
 
 impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository<C> {
     async fn create(&self, input: CreateServiceAccount) -> AxiamResult<(ServiceAccount, String)> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/session.rs
+++ b/crates/axiam-db/src/repository/session.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`SessionRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::session::{CreateSession, Session};
 use axiam_core::repository::SessionRepository;
 use chrono::{DateTime, Utc};
@@ -96,7 +97,7 @@ impl<C: Connection> SurrealSessionRepository<C> {
 
 impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
     async fn create(&self, input: CreateSession) -> AxiamResult<Session> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/tenant.rs
+++ b/crates/axiam-db/src/repository/tenant.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`TenantRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::tenant::{CreateTenant, Tenant, TenantStatus, UpdateTenant};
 use axiam_core::repository::{PaginatedResult, Pagination, TenantRepository};
 use chrono::{DateTime, Utc};
@@ -103,7 +104,7 @@ impl<C: Connection> SurrealTenantRepository<C> {
 
 impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
     async fn create(&self, input: CreateTenant) -> AxiamResult<Tenant> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let org_id_str = input.organization_id.to_string();
         let metadata = input

--- a/crates/axiam-db/src/repository/user.rs
+++ b/crates/axiam-db/src/repository/user.rs
@@ -6,6 +6,7 @@
 
 use axiam_auth::password;
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::user::{CreateUser, UpdateUser, User, UserStatus};
 use axiam_core::repository::{PaginatedResult, Pagination, UserRepository};
 use chrono::{DateTime, Utc};
@@ -244,7 +245,7 @@ impl<C: Connection> SurrealUserRepository<C> {
 
 impl<C: Connection> UserRepository for SurrealUserRepository<C> {
     async fn create(&self, input: CreateUser) -> AxiamResult<User> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 
@@ -719,9 +720,9 @@ impl<C: Connection> SurrealUserRepository<C> {
         ip_address: Option<String>,
         user_agent: Option<String>,
     ) -> AxiamResult<User> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
-        let consent_id = Uuid::new_v4().to_string();
+        let consent_id = new_id().to_string();
         let tenant_id_str = input.tenant_id.to_string();
         // SECHRD-12/T-24-93 (RESEARCH Pitfall 5): admin-created users go
         // through this write path, so their initial password must be seeded
@@ -731,7 +732,7 @@ impl<C: Connection> SurrealUserRepository<C> {
         // work against for these users. Federated-user creation paths
         // (oidc.rs/saml.rs) have no local password and are intentionally
         // left untouched.
-        let ph_id_str = Uuid::new_v4().to_string();
+        let ph_id_str = new_id().to_string();
 
         let password_hash = password::hash_password(&input.password, self.pepper.as_deref())
             .map_err(|e| classify_write_error(e, "user"))?;

--- a/crates/axiam-db/src/repository/webauthn_credential.rs
+++ b/crates/axiam-db/src/repository/webauthn_credential.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`WebauthnCredentialRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::webauthn_credential::{
     CreateWebauthnCredential, WebauthnCredential, WebauthnCredentialType,
 };
@@ -105,7 +106,7 @@ impl<C: Connection> SurrealWebauthnCredentialRepository<C> {
 
 impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRepository<C> {
     async fn create(&self, input: CreateWebauthnCredential) -> AxiamResult<WebauthnCredential> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/webhook.rs
+++ b/crates/axiam-db/src/repository/webhook.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`WebhookRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::webhook::{CreateWebhook, RetryPolicy, UpdateWebhook, Webhook};
 use axiam_core::repository::{PaginatedResult, Pagination, WebhookRepository};
 use chrono::{DateTime, Utc};
@@ -108,7 +109,7 @@ impl<C: Connection> SurrealWebhookRepository<C> {
 
 impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
     async fn create(&self, input: CreateWebhook) -> AxiamResult<Webhook> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let retry = input.retry_policy.unwrap_or_default();
         let result = self
             .db

--- a/crates/axiam-federation/src/oidc.rs
+++ b/crates/axiam-federation/src/oidc.rs
@@ -557,6 +557,9 @@ where
             .clone()
             .unwrap_or_else(|| format!("{}.{}@federated.local", claims.sub, config_id));
 
+        // Deliberately v4, not `new_id()`: a non-usable password must still be
+        // unguessable, and v7 trades randomness for a sortable timestamp.
+        // See `axiam_core::id` — v7 is for identifiers, never for secrets.
         let random_password = Uuid::new_v4().to_string();
 
         let create_user = CreateUser {

--- a/crates/axiam-federation/src/saml.rs
+++ b/crates/axiam-federation/src/saml.rs
@@ -264,6 +264,9 @@ where
 
         let idp = self.fetch_idp_metadata(metadata_url).await?;
 
+        // Deliberately v4, not `new_id()`: the AuthnRequest ID is echoed back
+        // in `InResponseTo` and gates replay detection, so it must not be
+        // predictable from the request's timing.
         let authn_request_id = format!("_{}", Uuid::new_v4());
         let authn_request = AuthnRequest {
             id: authn_request_id.clone(),
@@ -711,6 +714,11 @@ where
 
         // Federated users get a random non-usable password since they
         // authenticate through the external IdP.
+        //
+        // Deliberately v4, not `new_id()`: this value must be unguessable, and
+        // a v7 id spends 48 bits on a timestamp that an attacker can bound from
+        // the user's creation time. See `axiam_core::id` — v7 is for
+        // identifiers, never for secrets.
         let random_password = Uuid::new_v4().to_string();
 
         let create_user = CreateUser {

--- a/crates/axiam-pki/src/pgp.rs
+++ b/crates/axiam-pki/src/pgp.rs
@@ -1,6 +1,7 @@
 //! OpenPGP key management — generation, audit signing, and encryption.
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::audit::AuditLogEntry;
 use axiam_core::models::pgp_key::{
     CreatePgpKey, EncryptedExport, GeneratedPgpKey, PgpKey, PgpKeyAlgorithm, PgpKeyPurpose,
@@ -187,7 +188,7 @@ impl<R: PgpKeyRepository> PgpService<R> {
         .map_err(|e| AxiamError::Internal(format!("spawn_blocking join error: {e}")))??;
 
         Ok(SignedAuditBatch {
-            batch_id: Uuid::new_v4(),
+            batch_id: new_id(),
             tenant_id,
             signing_key_id: signing_key.id,
             entry_ids: entry_ids_clone,

--- a/crates/axiam-server/src/cleanup.rs
+++ b/crates/axiam-server/src/cleanup.rs
@@ -575,6 +575,10 @@ impl<C: Connection + Send + Sync + 'static> CleanupTask<C> {
             .map_err(|e| AxiamError::Internal(format!("export encrypt failed: {e}")))?;
 
         // (d) Generate single-use 24h download token (D-13).
+        //
+        // Deliberately v4, not `new_id()`: this token is the sole bearer
+        // credential for the export download, so it must stay maximally random.
+        // See `axiam_core::id` — v7 is for identifiers, never for secrets.
         let raw_download_token = Uuid::new_v4().to_string();
         let token_hash = {
             use sha2::{Digest, Sha256};


### PR DESCRIPTION
Every repository writes rows as `CREATE type::record('<table>', $id)`, so
the UUID is the primary key in SurrealDB's ordered KV engine (`surrealkv:`
in compose, `file:`/RocksDB in the k8s StatefulSet). With v4 the key is
uniformly random, so consecutive inserts scatter across the whole keyspace:
each insert dirties a different page, a write burst's working set is the
entire index rather than its tail, and compaction repeatedly rewrites
overlapping ranges. UUIDv7 puts a 48-bit big-endian millisecond timestamp
in the high bits, so time-adjacent inserts stay physically adjacent and
append to the tail.

Adds `axiam_core::id::new_id()` as the single entry point, with tests
pinning the two properties the rationale depends on rather than assuming
them: the hyphenated *string* form (the form actually handed to
`type::record`) sorts in generation order, and ids are monotonic within a
single millisecond via the crate's per-millisecond counter.

Applied to every persisted entity id across the repositories plus the
bootstrap transaction, webhook delivery ids and PGP audit batch ids.

Deliberately NOT applied to secrets, each pinned with a comment so the
choice survives future refactors: federated placeholder passwords, the
SAML AuthnRequest ID, and the GDPR export download token. v4 spends 122
bits on randomness; v7 spends 48 on a timestamp and, because of the
monotonic counter, two ids minted in the same millisecond can share ~90 of
their 128 bits. That is ample for uniqueness and useless for secrecy. JWT
`jti` values with no backing session row also stay v4 — they are
uniqueness markers inside an already-signed token, not record ids.

Identifier disclosure was checked, not assumed: entity ids are not
capabilities here (every repository read is tenant-scoped and every route
is authz-checked), the unauthenticated GDPR routes are keyed by dedicated
tokens rather than ids, and the creation time a v7 id reveals is already
public via `created_at` and the JWT `iat` claim.

Verified: workspace clippy clean, `cargo fmt --check` clean, 632 workspace
lib tests pass, the full axiam-db integration suite passes, and the
api-rest bootstrap/webhook integration tests pass.