### PR TITLE
Phase H0: G-task benchmark implementation + verified Phase H plan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ base64 = "0.22"
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 webauthn-rs-proto = "0.5"
 aes-gcm = "0.11"
-uuid = { version = "1", features = ["v4", "v5", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 zeroize = "1"
 secrecy = { version = "0.10", features = ["serde"] }
 

--- a/benchmarks/PUBLIC_BENCH_ANALYSIS.md
+++ b/benchmarks/PUBLIC_BENCH_ANALYSIS.md
@@ -285,7 +285,8 @@ with server CPU; token issuance with neither until ~1.8k/s per 2 cores).
 
 | Setting (env var) | Shipped default | Small internet-facing (2c/1GiB) | M2M / microservices / IoT fleet | Large multi-tenant (8c+) |
 |---|---|---|---|---|
-| `AXIAM__RATE_LIMIT__KEY` | `ip` | `ip` | **`client_id`** (or `ip_client_id`) — per-IP buckets collide behind NAT/gateways | `ip_client_id` |
+| `AXIAM__RATE_LIMIT__PROFILE` | `internet` | `internet` | **`gateway`** — moves the whole machine-traffic family coherently from one variable | `mesh` |
+| `AXIAM__RATE_LIMIT__KEY` | `ip` | `ip` | **`client_id`** (or `ip_client_id`) — per-IP buckets collide behind NAT/gateways — **but read the security caveat below first** | `ip_client_id` |
 | `AXIAM__RATE_LIMIT__TOKEN_PER_MIN` | 20 | 60–120 | **per-client peak × 60 × 2** (a 2-core server sustains ~108k issuances/min total) | budget per tenant SLA |
 | `AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN` | 10 | 60 | 10–20× your token limit (resource servers introspect per request) | same rule |
 | `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN` | 300 | 600 | **6 000–60 000** per client (checks are cheap reads; 300/min starves any real service) | size to cache-on ceiling |
@@ -299,13 +300,26 @@ with server CPU; token issuance with neither until ~1.8k/s per 2 cores).
 | `AXIAM__AUTH__MAX_CONCURRENT_HASHES` | 0 = auto (min(cpus, 4)) | auto | auto | ≈ physical cores reserved for auth; keeps login RAM bounded (~19 MiB per concurrent hash) |
 | DB CPU allocation | — | DB ≥ server cores | DB ≥ server cores if authz/userinfo-heavy (they scale with DB CPU; tokens don't) | 2× server cores for read-heavy |
 
+**Security caveat on `client_id` keying — read before changing the key mode.**
+The `client_id` a request is bucketed by is read from the request body
+*before* the client credential is verified (that is what the OAuth2 spec puts
+there). So an attacker who simply varies the `client_id` string gets a fresh
+bucket each time and is effectively unlimited on the token, revoke and
+introspect endpoints. **`client_id` keying is a fairness control between
+well-behaved clients, not an abuse control.** `ip` is the only mode whose key
+an attacker cannot mint at will, which is why it stays the shipped default.
+Use `client_id`/`ip_client_id` only where something else is already
+authenticating callers at the edge — mTLS, an API gateway, a WAF, or an IP
+allow-list — which is exactly the topology the M2M column assumes.
+
 Two rules of thumb the data supports: (1) if your traffic is
 authorization-check-heavy, spend hardware on the **database** and turn the
 **decision cache on** before anything else; (2) if it's token-heavy, the
-limits — not the hardware — are what you'll hit first: switch rate-limit
-keying to `client_id` and size `TOKEN_PER_MIN` from your real per-client
-peak, keeping the defaults only on genuinely internet-exposed endpoints
-(login, register, password-reset, MFA).
+limits — not the hardware — are what you'll hit first: raise
+`TOKEN_PER_MIN` from your real per-client peak and, *if and only if* you have
+edge authentication per the caveat above, switch the key mode; keep the
+defaults on genuinely internet-exposed endpoints (login, register,
+password-reset, MFA), which stay per-IP in every configuration.
 
 ## 7. Full result matrix (capped run, median-of-3, graph-ready)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,6 +45,8 @@ system-under-test of the CPU we are trying to measure.
 benchmarks/
 ├── README.md                 # this file
 ├── justfile                  # convenience commands (bench-up, bench-run, bench-report…)
+├── run-improvement-tasks.sh  # per-task data collection for the pre-MVP plan (see below)
+├── run-memory-experiment.sh  # B1/D9 allocator A/B (default malloc vs jemalloc)
 ├── docs/
 │   ├── methodology.md        # how a fair run is defined; metric definitions
 │   ├── security-profiles.md  # the TLS/cert profile matrix
@@ -170,7 +172,28 @@ just repeat=3 targets="axiam keycloak" profiles="p0-plaintext p2-tls13" bench-ma
 > Every SDK bench builds against its sibling `ilpanich/axiam-<lang>-sdk` checkout
 > via a local path/replace/project reference until the alpha package is published —
 > see each language's `sdk/<lang>/TODO.md`. `sdk/HARNESS-SPEC.md` documents the
-> shared result contract every bench emits.
+> shared result contract every bench emits. As of run 3 no SDK bench has yet
+> produced a validated `status: "ok"` record against a live target — that is
+> tracked as task G10 below.
+
+## Targeted investigation runs
+
+Two standalone scripts sit alongside the matrix for the open questions from
+run 3. They are separate from `bench-matrix` on purpose: each answers ONE
+question, writes its own verdict, and can be run in isolation.
+
+| Script | Use it for |
+|---|---|
+| `./run-improvement-tasks.sh <task>` | One subcommand per task in [`claude_dev/improvement-after-serious-benchmark.md`](../claude_dev/improvement-after-serious-benchmark.md) that needs a live run. `./run-improvement-tasks.sh list` prints the tasks with time estimates. |
+| `./run-memory-experiment.sh [a\|b\|both]` | The B1/D9 memory-retention A/B: builds a default-allocator and a jemalloc image, drives a login burst, watches RSS for 10 minutes per variant, and writes `results/d9-summary.md`. |
+
+Each `run-improvement-tasks.sh` task writes `results/tasks/<task>/SUMMARY.md`
+containing the measured numbers **and** the plan's acceptance criterion, so a
+task can be closed (or a follow-up opened) from its summary alone. Start with
+`g1-timeline`: run 3 found that for ~5–7 minutes after seeding, the AXIAM stack
+serves everything at ~45 req/s with the datastore pinned at ~1 core, which
+silently corrupted every cell that ran first after a seed — see
+[`PRIVATE_BENCH_ANALYSIS.md`](PRIVATE_BENCH_ANALYSIS.md) §1.
 
 ## Out of scope (v1.0-beta)
 

--- a/benchmarks/docs/methodology.md
+++ b/benchmarks/docs/methodology.md
@@ -503,3 +503,165 @@ Publish the `prod`-posture report *alongside* the neutralized matrix, not as
 a replacement for it — the framing is "AXIAM ships per-IP rate limits by
 default; Keycloak and Zitadel don't," turning what would otherwise read as a
 benchmark asterisk into a documented security-posture advantage.
+
+## 12. Post-seed settle gate & cell-order rotation (G2)
+
+**Why this exists.** Run 3's analysis (`PRIVATE_BENCH_ANALYSIS.md` §1, "THE
+run-3 discovery: a post-seed serialized-DB transient invalidates every
+'first cell after seed'") found a **~5–7 minute window right after
+`bench-seed`** in which the AXIAM
+stack serves everything at **~45 req/s**, with SurrealDB pinned at **~1.0–1.3
+cores** (never its 2.0 cap) and the server nearly idle — the signature of a
+~22 ms *serialized* unit of DB work queuing every request — before
+spontaneously recovering to normal throughput (~740 req/s) and DB CPU (~2.0
+cores). Because `run-benchmark.sh` always ran the scenario glob in the same
+(alphabetical) order, `authz_batch_grpc`/`authz_batch_rest` were **always**
+cells 1–2 right after seed, in every run collected so far — so every
+historical batch-scenario number measured this transient, not the batch
+authz path. The same signature was caught independently on a completely
+different scenario (the B2 `oauth2_client_credentials` h1-isolation cell,
+also first-after-seed). G1's root-cause note
+(`claude_dev/postseed-transient-investigation.md`) has the bisection; this
+section documents the two harness countermeasures G2 added so the artifact
+can't silently corrupt a cell again, whatever the root cause turns out to be.
+
+### 12.1 Settle gate
+
+`run-benchmark.sh` now gates the **first cell** of every `bench-run`
+invocation behind a settle check, run once (not per cell) immediately after
+the seed-ok marker is verified:
+
+1. Poll a cheap, target-appropriate, already-seeded **canary** once per
+   second:
+   * **axiam** — the same endpoint the transient was characterized against,
+     `POST /api/v1/authz/check` (authz-check-ish), authenticated as the
+     seeded bench user (one login, cookie jar reused for every tick).  Falls
+     back to the plaintext `/health` liveness probe if the seed didn't
+     provide enough to authenticate.
+   * **keycloak** — JWKS (`/realms/<realm>/protocol/openid-connect/certs`):
+     cheap, unauthenticated, needs only the seeded realm name.
+   * **zitadel** — JWKS (`/oauth/v2/keys`): cheap, unauthenticated, no seed
+     dependency at all.
+   * any other/future target — `/health`.
+
+   A canary tick that can't complete at all (connection refused/reset, or
+   the target genuinely lacks the endpoint) is treated as **no signal** —
+   it resets the stability counter but never fails the run.
+2. Require **`BENCH_SETTLE_STABLE_SECS`** (default **30**) *consecutive*
+   seconds where the canary's observed latency is under
+   **`BENCH_SETTLE_MAX_MS`** (default **100 ms**) before letting the first
+   cell start.
+3. If that never happens within **`BENCH_SETTLE_TIMEOUT_SECS`** (default
+   **600 s** / 10 min — comfortably above the ~5–7 min window G1 measured),
+   the gate **warns and proceeds anyway** rather than hanging the harness
+   forever; it never treats "still not settled" as a hard failure.
+
+Every cell this run produces — not just the first — records the wait in its
+`meta.json`:
+
+```json
+"settle_wait_secs": 47,
+"settle_timeout": false
+```
+
+(`settle_wait_secs` is the same value across every cell of one `bench-run`
+invocation, since the gate runs once per invocation; a median-of-N cell
+aggregated across `results/run-*/` takes the **max** wait and **any**
+timeout across its repeats — the worst case, not an average, since a settle
+timeout on even one repeat means that repeat's data may still be
+suspect.) `report.py` surfaces `settle_wait_secs`/`timeout` in a dedicated
+"Appendix: post-seed settle gate" table, and adds a `settle_timeout`
+`host_flags` entry (alongside `clock_variance`/`generator_saturated`) to the
+main "All results" table for any cell whose gate hit the hard timeout — a
+signal that cell may still be inside the transient even though the harness
+proceeded. Both degrade cleanly (simply absent) on `meta.json` files that
+predate G2, so the existing run-1/run-2/run-3 trees still render unchanged.
+
+Set **`BENCH_SETTLE=0`** to skip the gate entirely — useful for a quick
+manual `bench-run` against an already-settled (or already-known-warm)
+target where waiting is pure overhead.
+
+### 12.2 Cell-order rotation
+
+Independently of the settle gate (defense in depth — the gate should make
+this moot, but "first cell after seed" was silently wrong for months before
+anyone noticed), `run-benchmark.sh` now **rotates** the executed scenario
+order by the repeat's run index, so the corruption mechanism itself (always
+running the same scenario first) can't recur even if a future gate has a
+gap. `bench-matrix` (`justfile`) exports **`BENCH_RUN_INDEX=<i>`** for each
+of its `repeat` passes; `run-benchmark.sh`'s `rotate_scenarios()` left-shifts
+the (already target/profile-filtered) scenario list by
+`(BENCH_RUN_INDEX - 1) mod N`:
+
+* run-1 executes scenarios in their natural (alphabetical) order,
+* run-2 starts one scenario further along,
+* run-3 two further, and so on, wrapping around.
+
+This is a pure, deterministic function of the run index and scenario
+count — it changes only the *order* cells run in, never *which* scenarios
+run, and a manual single `bench-run` invocation (`BENCH_RUN_INDEX` unset,
+defaults to 1) is unaffected (natural order, same as before G2). Each cell
+records its position in the rotated order as **`cell_order_index`** in
+`meta.json`, so a report reader can always tell which cell was first (and
+therefore settle-gated) in a given run.
+
+### 12.3 Self-describing labeled passes (A7-safe)
+
+A sensitivity pass (e.g. `AXIAM__DB__POOL_SIZE=4`, a batch-strategy A/B, the
+decision cache on/off) previously left **no trace in `meta.json`** — only
+the results-directory name (`sens-pool-4/`, ...) said what the pass was
+(`PRIVATE_BENCH_ANALYSIS.md` §2.2). `run-benchmark.sh` now reads the AXIAM
+server container's **actual** environment (`docker inspect`, the same
+pattern `detect_rl_posture()` already used for `rate_limits`) and dumps
+every `AXIAM__*` variable it finds into each cell's `meta.json` under
+`"axiam_env"` — so pool size, batch strategy, decision cache, rate-limit
+posture, hash concurrency, or any other pass-through knob is identifiable
+from the metadata alone.
+
+**Secret redaction (A7 — shared archives contain no secret material) is
+mandatory and non-negotiable:** the *value* of any `AXIAM__*` key whose name
+matches `PASSWORD|SECRET|KEY|PEPPER|PEM|TOKEN` (case-insensitive) is never
+written — only the key **name** (so the setting's presence stays visible)
+with a literal `"<redacted>"` placeholder:
+
+```json
+"axiam_env": {
+  "AXIAM__AUTHZ__BATCH_STRATEGY": "coalesced",
+  "AXIAM__DB__POOL_SIZE": "4",
+  "AXIAM__DB__PASSWORD": "<redacted>",
+  "AXIAM__AUTH__JWT_PRIVATE_KEY_PEM": "<redacted>",
+  "AXIAM__AUTH__PEPPER": "<redacted>",
+  "AXIAM__AMQP__SIGNING_KEY": "<redacted>"
+}
+```
+
+Because those key **names** legitimately contain PASSWORD/SECRET/KEY/PEM-
+shaped substrings even fully redacted, `just bench-pack`'s leak check
+(`justfile`) now filters out every line already carrying the literal
+`<redacted>` placeholder *before* scanning packed content for
+`SECRET`/`PASSWORD` — an actual leaked value would never carry that
+placeholder, so this can't hide a real leak, only the expected, fully-
+redacted key names. `report.py` renders one representative cell's
+`axiam_env` per (target, profile) in a dedicated "Appendix: AXIAM env knobs
+(labeled passes)" section (every cell from the same `bench-up` shares one
+running server container, so the dump is identical across that
+target/profile's scenarios) — omitted entirely for results trees predating
+G2 or for non-AXIAM targets.
+
+### 12.4 New environment knobs (G2 summary)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BENCH_SETTLE` | `1` | `0` skips the post-seed settle gate entirely. |
+| `BENCH_SETTLE_STABLE_SECS` | `30` | Consecutive seconds of low canary latency required before the first cell starts. |
+| `BENCH_SETTLE_MAX_MS` | `100` | Canary latency threshold (ms) counted as "settled". |
+| `BENCH_SETTLE_TIMEOUT_SECS` | `600` | Hard cap on the settle wait; the gate then warns, proceeds, and records `settle_timeout: true`. |
+| `BENCH_RUN_INDEX` | `1` | Drives cell-order rotation; set per-repeat by `bench-matrix` (`BENCH_RUN_INDEX=$i`), defaults to 1 (natural order) for a manual `bench-run`. |
+
+None of these are `just` recipe variables (`target=`, `profile=`, ...) — set
+them as plain environment variables, e.g.:
+
+```bash
+BENCH_SETTLE_STABLE_SECS=10 BENCH_SETTLE_MAX_MS=150 \
+  just target=axiam profile=p0-plaintext bench-run
+```

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -314,6 +314,13 @@ bench-seed:
     fi
 
 # Run the scenario suite (load + resource sampling) for a target/profile.
+# G2: run-benchmark.sh gates its first cell behind a post-seed settle check
+# and rotates the scenario order by BENCH_RUN_INDEX (set to `i` per repeat
+# pass by bench-matrix below; defaults to 1 — natural order — for a manual
+# invocation). Tunables (env, not `just` vars — see docs/methodology.md "Post-
+# seed settle gate & cell-order rotation"): BENCH_SETTLE (default 1, set 0 to
+# skip), BENCH_SETTLE_STABLE_SECS (30), BENCH_SETTLE_MAX_MS (100),
+# BENCH_SETTLE_TIMEOUT_SECS (600), BENCH_RUN_INDEX (1).
 bench-run:
     bash runner/run-benchmark.sh --target {{target}} --profile {{profile}} --scenario {{scenario}}
 
@@ -355,6 +362,13 @@ bench-matrix:
       echo "### repeat $i/{{repeat}} -> $RUN_DIR ###"
       mkdir -p "$RUN_DIR"
       export BENCH_RESULTS_DIR="$PWD/$RUN_DIR"
+      # G2 item 2: BENCH_RUN_INDEX drives run-benchmark.sh's cell-order
+      # rotation (rotate_scenarios()) — run-1 executes scenarios in their
+      # natural order, run-2 starts one scenario further along, etc., so no
+      # scenario is systematically first (and therefore corrupted by the
+      # post-seed settle window) across the repeat set. See docs/methodology.md
+      # "Post-seed settle gate & cell-order rotation".
+      export BENCH_RUN_INDEX="$i"
       for t in {{targets}}; do
         for p in {{profiles}}; do
           echo "=== run $i: $t / $p (rl={{rl}} dbcaps={{dbcaps}}) ==="
@@ -365,7 +379,7 @@ bench-matrix:
         done
       done
     done
-    unset BENCH_RESULTS_DIR
+    unset BENCH_RESULTS_DIR BENCH_RUN_INDEX
     just bench-report
 
 # --- SDK client benchmarks --- (pass the language as sdk=, e.g. sdk=python)
@@ -404,7 +418,17 @@ bench-pack:
     if tar -tJf "$OUT" | grep -qiE '\.seed/|seed\.env'; then
       echo "[bench-pack] ERROR: a .seed/ path made it into the archive" >&2; exit 1
     fi
-    if tar -xJOf "$OUT" | grep -qiE 'SECRET|PASSWORD'; then
+    # G2 item 3: meta.json's "axiam_env" (the AXIAM__* pass-through knob dump,
+    # run-benchmark.sh's axiam_env_json()) legitimately writes the NAME of
+    # every redacted key — e.g. "AXIAM__DB__PASSWORD": "<redacted>" — so the
+    # setting's presence stays visible even though its value never is. Those
+    # key names themselves contain PASSWORD/SECRET-shaped substrings, so
+    # strip out every already-redacted line (identified by the literal
+    # "<redacted>" placeholder value axiam_env_json() always writes) BEFORE
+    # scanning for leaked content — an actual leaked value would never carry
+    # that placeholder, so this can't hide a real leak, only the expected,
+    # fully-redacted key names.
+    if tar -xJOf "$OUT" | grep -vi '<redacted>' | grep -qiE 'SECRET|PASSWORD'; then
       echo "[bench-pack] ERROR: SECRET/PASSWORD text found in packed content — investigate before sharing" >&2
       exit 1
     fi

--- a/benchmarks/run-improvement-tasks.sh
+++ b/benchmarks/run-improvement-tasks.sh
@@ -704,25 +704,42 @@ task_g9_rlprod() {
   bench_down axiam
   unset BENCH_RESULTS_DIR
 
-  s "With the production per-IP posture active, nearly every request is a 429. The"
-  s "cells must say so coherently: \`bench_ok\` counts ONLY successful ops, so a"
-  s "100%-error cell reports a throughput of ~0 rather than thousands of \"ops/s\" of"
-  s "rejections (the run-3 incoherence this task fixes)."
+  s "With the production per-IP posture active, nearly every request is a 429."
   s
-  s "| scenario | bench_ok rate | error rate | coherent? |"
-  s "|---|---|---|---|"
-  for sc in oauth2_client_credentials token_introspection authz_check_rest; do
+  s "G9 established that run-3's apparently contradictory cell (\`bench_ok\` 13.6/s at"
+  s "a 1.00 error rate) was **not** a counting bug: \`doOp()\` only ever counts a"
+  s "status-match as ok, and the rate limiters start with a full burst, so a genuine"
+  s "handful of successes lands at test start while the retry storm that follows"
+  s "drives the *fraction* to ~1.00. The two metrics were each correct and together"
+  s "illegible. The fix is the \`bench_throttled\` counter, so a posture pass can be"
+  s "read directly: \`bench_failed ≈ bench_throttled\` means \"purely rate-limited\","
+  s "\`bench_failed >> bench_throttled\` means something else is also broken."
+  s
+  s "| scenario | ok ops | throttled (429/RESOURCE_EXHAUSTED) | other failures | reads as |"
+  s "|---|---|---|---|---|"
+  for sc in oauth2_client_credentials token_introspection authz_check_rest authz_check_grpc; do
     local f; f=$(k6_file "$out/$sc")
-    if [ -z "$f" ]; then s "| $sc | — | — | cell missing |"; continue; fi
-    local thr err ok
-    thr=$(k6_stat "$f" thr); err=$(k6_stat "$f" err)
-    ok=$(python3 -c "
-thr=float('$thr' if '$thr'!='NA' else 0); err=float('$err' if '$err'!='NA' else 0)
-print('✅' if (err < 0.99 or thr < 1.0) else '❌ ok-rate > 0 at ~100% errors')")
-    s "| $sc | $thr | $err | $ok |"
+    if [ -z "$f" ]; then s "| $sc | — | — | — | cell missing |"; continue; fi
+    python3 - "$f" "$sc" >> "$SUMMARY" <<'PY'
+import json, sys
+m = json.load(open(sys.argv[1]))["metrics"]
+ok = m.get("bench_ok", {}).get("count", 0)
+failed = m.get("bench_failed", {}).get("count", 0)
+thr = m.get("bench_throttled", {}).get("count")
+if thr is None:
+    verdict = "⚠ bench_throttled absent — scenario not yet wired to the shared classifier"
+    thr = "—"; other = "—"
+else:
+    other = failed - thr
+    verdict = ("✅ purely rate-limited" if failed and other <= 0.02 * failed
+               else f"❌ {other} failures beyond throttling — investigate")
+print(f"| {sys.argv[2]} | {ok} | {thr} | {other} | {verdict} |")
+PY
   done
   s
-  s "Acceptance: no row reports a meaningful \`bench_ok\` rate while its error rate is ~1.0."
+  s "Acceptance (plan G9.3): every rate-limited cell resolves to \"purely rate-limited\","
+  s "and \`bench_throttled\` is present on **gRPC** cells too (they use the shared"
+  s "\`recordGrpcResult()\` classifier rather than their own copy)."
   finish
 }
 

--- a/benchmarks/run-improvement-tasks.sh
+++ b/benchmarks/run-improvement-tasks.sh
@@ -168,21 +168,32 @@ sampler_stop() { # $1=pid
 # are trapped alongside EXIT so Ctrl-C tears the stack down instead of orphaning
 # it.
 CLEANUP_TARGET=""
+CLEANUP_PROFILE=""
 cleanup() {
   local rc=$?
   trap - EXIT INT TERM
   if [ -n "${SAMPLER_PID:-}" ]; then sampler_stop "$SAMPLER_PID"; SAMPLER_PID=""; fi
-  if [ -n "$CLEANUP_TARGET" ]; then bench_down "$CLEANUP_TARGET"; CLEANUP_TARGET=""; fi
+  if [ -n "$CLEANUP_TARGET" ]; then
+    # Only reached when a task did NOT finish normally (the clean paths disarm
+    # first), so say so — bench_down itself is silent.
+    warn "interrupted — tearing down the $CLEANUP_TARGET stack"
+    bench_down "$CLEANUP_TARGET" "$CLEANUP_PROFILE"
+    CLEANUP_TARGET=""; CLEANUP_PROFILE=""
+  fi
   return $rc
 }
-arm_cleanup() { # $1=target to bench-down on the way out
+# Re-arming is cheap and idempotent: tasks that cycle several stacks (g3/g4/g5/
+# g8) call this again before each bench_up_seed so the trap always names the
+# stack that is actually up. An empty profile falls back to bench_down's default.
+arm_cleanup() { # $1=target [$2=profile]
   CLEANUP_TARGET=$1
+  CLEANUP_PROFILE=${2:-}
   # `|| true` keeps `set -e` from aborting cleanup half-way when the task is
   # dying on a non-zero status — teardown must always run to completion.
   trap 'cleanup || true; exit 130' INT TERM
   trap 'cleanup || true' EXIT
 }
-disarm_cleanup() { trap - EXIT INT TERM; CLEANUP_TARGET=""; }
+disarm_cleanup() { trap - EXIT INT TERM; CLEANUP_TARGET=""; CLEANUP_PROFILE=""; }
 
 # Mean CPU of one container over a time range in the sampler CSV.
 cpu_mean() { # $1=csv $2=container-substring [$3=from_epoch] [$4=to_epoch]
@@ -436,6 +447,7 @@ task_g2_verify() {
   export BENCH_WARMUP=5s BENCH_DURATION=30s
 
   log "running a 2-repeat mini matrix (one target, one profile) to exercise the new machinery"
+  arm_cleanup axiam p0-plaintext
   just target=axiam profiles="p0-plaintext" targets="axiam" repeat=2 bench-matrix || \
     warn "mini matrix returned non-zero — inspect the output above"
 
@@ -482,7 +494,7 @@ PY
   s "Acceptance (plan G2): every cell carries the three new fields, the first-executed"
   s "scenario differs between run-1 and run-2, and no secret value appears in \`axiam_env\`."
   unset BENCH_RESULTS_DIR
-  bench_down axiam
+  disarm_cleanup; bench_down axiam
   finish
 }
 
@@ -505,6 +517,7 @@ task_g3_batch() {
 
   for strategy in concurrent coalesced; do
     export AXIAM__AUTHZ__BATCH_STRATEGY=$strategy
+    arm_cleanup axiam p0-plaintext
     bench_up_seed axiam
     # Belt and braces: even with the settle gate, burn one throwaway cell.
     BENCH_WARMUP=5s BENCH_DURATION=20s cell axiam p0-plaintext authz_check_rest.js \
@@ -517,7 +530,7 @@ task_g3_batch() {
         [ -n "$f" ] && s "| $strategy | $sc | $r | $(k6_stat "$f" thr) | $(k6_stat "$f" p50) | $(k6_stat "$f" p95) |"
       done
     done
-    bench_down axiam
+    disarm_cleanup; bench_down axiam
     unset AXIAM__AUTHZ__BATCH_STRATEGY
   done
 
@@ -566,11 +579,12 @@ task_g4_refresh() {
   s "| target | thr (ops/s) | p50 (ms) | bench_fallback | HTTP reqs / iteration | verdict |"
   s "|---|---|---|---|---|---|"
   for target in axiam keycloak; do
+    arm_cleanup "$target" p0-plaintext
     bench_up_seed "$target"
     # A control cell: client_credentials, so we can check refresh is NOT ~½ of it.
     cell "$target" p0-plaintext oauth2_client_credentials.js "$out/$target/cc" >/dev/null 2>&1 || true
     cell "$target" p0-plaintext token_refresh.js "$out/$target/refresh" >/dev/null 2>&1 || true
-    bench_down "$target"
+    disarm_cleanup; bench_down "$target"
     local fr; fr=$(k6_file "$out/$target/refresh")
     if [ -z "$fr" ]; then s "| $target | — | — | — | — | ❌ cell did not run |"; continue; fi
     local thr p50 fb rpi verdict
@@ -615,6 +629,7 @@ task_g5_cache_sweep() {
 
   for enabled in false true; do
     export AXIAM__AUTHZ__DECISION_CACHE_ENABLED=$enabled
+    arm_cleanup axiam p0-plaintext
     bench_up_seed axiam
     BENCH_WARMUP=5s BENCH_DURATION=20s cell axiam p0-plaintext authz_check_rest.js \
       "$out/warmup-$enabled" >/dev/null 2>&1 || true
@@ -638,7 +653,7 @@ PY
 )
       [ -n "$f" ] && s "| $enabled | $k | $(k6_stat "$f" thr) | $(k6_stat "$f" p50) | $mem |"
     done
-    bench_down axiam
+    disarm_cleanup; bench_down axiam
     unset AXIAM__AUTHZ__DECISION_CACHE_ENABLED
   done
 
@@ -681,12 +696,13 @@ task_g8_tls_h1() {
   run_cc_cell() { # $1=label $2=profile [$3=BENCH_NGINX_CONF]
     local label=$1 profile=$2 nginx=${3:-}
     [ -n "$nginx" ] && export BENCH_NGINX_CONF=$nginx || unset BENCH_NGINX_CONF
+    arm_cleanup axiam "$profile"
     bench_up_seed axiam "$profile"
     BENCH_WARMUP=5s BENCH_DURATION=20s cell axiam "$profile" authz_check_rest.js \
       "$out/$label/warmup" >/dev/null 2>&1 || true
     cell axiam "$profile" oauth2_client_credentials.js "$out/$label/cc" >/dev/null 2>&1 || true
     cell axiam "$profile" token_refresh.js "$out/$label/refresh" >/dev/null 2>&1 || true
-    bench_down axiam "$profile"
+    disarm_cleanup; bench_down axiam "$profile"
     unset BENCH_NGINX_CONF
   }
 
@@ -738,11 +754,12 @@ task_g9_rlprod() {
   local out=$TASKS_ROOT/g9-rlprod
   rm -rf "$out"; summary_open "$out" "G9 — metric coherence under a 429 storm"
   export BENCH_RESULTS_DIR=$out
+  arm_cleanup axiam p0-plaintext
   bench_up_seed axiam p0-plaintext rl=prod
   for sc in oauth2_client_credentials token_introspection authz_check_rest; do
     cell axiam p0-plaintext "$sc.js" "$out/$sc" >/dev/null 2>&1 || true
   done
-  bench_down axiam
+  disarm_cleanup; bench_down axiam
   unset BENCH_RESULTS_DIR
 
   s "With the production per-IP posture active, nearly every request is a 429."
@@ -797,6 +814,7 @@ task_g10_sdk() {
   s "\`status: \"ok\"\`, twice in a row, against a seeded p0 target (plan G10 / E1.1)."
   s "Each language's sibling repo must be checked out next to this workspace."
   s
+  arm_cleanup axiam p0-plaintext
   bench_up_seed axiam
   s "| sdk | attempt 1 | attempt 2 | notes |"
   s "|---|---|---|---|"
@@ -812,7 +830,7 @@ task_g10_sdk() {
     grep -qi "no such file\|not found\|cannot find" "$d/attempt-1.log" && note="sibling SDK repo missing?"
     s "| $lang | ${st1:-$r1} | ${st2:-$r2} | $note |"
   done
-  bench_down axiam
+  disarm_cleanup; bench_down axiam
   s
   s "For every non-\`ok\` row, fix per that language's \`sdk/<lang>/TODO.md\` and re-run"
   s "just that language: \`G10_LANGS=python ./run-improvement-tasks.sh g10-sdk\`."

--- a/benchmarks/run-improvement-tasks.sh
+++ b/benchmarks/run-improvement-tasks.sh
@@ -1,0 +1,826 @@
+#!/usr/bin/env bash
+# run-improvement-tasks.sh — per-task data collection for the pre-MVP plan
+# (claude_dev/improvement-after-serious-benchmark.md).
+#
+# Every task in that plan that needs a LIVE benchmark run has a subcommand
+# here. Each subcommand is standalone: bring the stack up, collect exactly the
+# data that task's decision needs, tear the stack down, and write a
+# SUMMARY.md with the measured numbers plus the acceptance criterion, so the
+# task can be closed (or a follow-up opened) from the summary alone.
+#
+# Run them one at a time, in whatever spare time you have:
+#
+#   cd benchmarks
+#   ./run-improvement-tasks.sh list                # what exists + time estimates
+#   ./run-improvement-tasks.sh g1-timeline         # start here (blocks G2/G3/G8)
+#   ./run-improvement-tasks.sh g3-batch            # etc.
+#   ./run-improvement-tasks.sh pack                # shareable archive at the end
+#
+# Results land under results/tasks/<task>/ (own subtree per task, so nothing
+# collides with the matrix in results/run-*/). Each task prints its verdict at
+# the end and writes it to results/tasks/<task>/SUMMARY.md.
+#
+# Laptop prep (per docs/methodology.md §10) applies to every task: on AC power,
+# `sudo cpupower frequency-set -g performance`, background apps closed, and the
+# whole session in ONE turbo mode. The runner warns if the governor is wrong.
+set -euo pipefail
+cd "$(dirname "$0")"
+BENCH_DIR=$PWD
+
+TASKS_ROOT=$PWD/results/tasks
+PLAN=../claude_dev/improvement-after-serious-benchmark.md
+
+# Container names are fixed by the compose files (targets/axiam/docker-compose.yml).
+C_SERVER=bench-axiam-server
+C_DB=bench-axiam-surrealdb
+C_MQ=bench-axiam-rabbitmq
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '\n\033[1;36m[%s]\033[0m %s\n' "${TASK:-run}" "$*"; }
+warn() { printf '\033[1;33m[%s] WARNING: %s\033[0m\n' "${TASK:-run}" "$*" >&2; }
+die()  { printf '\033[1;31m[%s] ERROR: %s\033[0m\n' "${TASK:-run}" "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null || die "$1 is required but not installed"; }
+need_base() { need docker; need just; need k6; need python3; }
+
+# Stack lifecycle. Any extra AXIAM__* knobs are passed as leading env assignments
+# by the caller (they reach the server through the compose pass-through).
+#
+# TASK_OUT (set by each task right after summary_open) is where seeding writes
+# its `<target>.seed.ok` marker. run-benchmark.sh REFUSES to start a cell unless
+# that marker exists in the cell's own BENCH_RESULTS_DIR (A2.3 fail-closed
+# gate), and every cell here gets its own directory so repeats don't overwrite
+# each other — so `cell` copies the marker in. Seeding once per stack and
+# reusing the marker is exactly right: it is a "this stack was provisioned and
+# smoke-checked" flag, not per-cell state.
+TASK_OUT=""
+
+bench_up_seed() { # $1=target [$2=profile] [$3.. extra just args]
+  local target=$1 profile=${2:-p0-plaintext}; shift 2 || shift $# || true
+  [ -n "$TASK_OUT" ] || die "internal: TASK_OUT not set before bench_up_seed"
+  mkdir -p "$TASK_OUT"
+  log "bringing up $target ($profile) and seeding"
+  BENCH_RESULTS_DIR="$TASK_OUT" just target="$target" profile="$profile" "$@" bench-up
+  BENCH_RESULTS_DIR="$TASK_OUT" just target="$target" profile="$profile" "$@" bench-seed
+  [ -f "$TASK_OUT/${target}.seed.ok" ] || \
+    warn "no seed-ok marker at $TASK_OUT/${target}.seed.ok — cells will refuse to start"
+}
+
+bench_down() { # $1=target [$2=profile]
+  just target="${1}" profile="${2:-p0-plaintext}" bench-down >/dev/null 2>&1 || true
+}
+
+# Run ONE k6 cell into its own results subtree.
+# usage: cell <target> <profile> <scenario.js> <outdir>
+# NOTE: run-benchmark.sh writes the cell files to <outdir>/<target>/<profile>/,
+# so always locate artifacts with k6_file/res_files (which recurse), never with
+# a flat <outdir>/*.k6.json glob.
+cell() {
+  local target=$1 profile=$2 scenario=$3 outdir=$4
+  mkdir -p "$outdir"
+  [ -f "$TASK_OUT/${target}.seed.ok" ] && cp "$TASK_OUT/${target}.seed.ok" "$outdir/"
+  BENCH_RESULTS_DIR="$outdir" just target="$target" profile="$profile" \
+    scenario="$scenario" bench-run
+}
+
+# Throughput (successful ops/s) + p50/p95 + fallback count from a k6 summary.
+# usage: k6_stat <file.k6.json> <thr|p50|p95|fallback|err>
+k6_stat() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+try:
+    m = json.load(open(sys.argv[1]))["metrics"]
+except Exception:
+    print("NA"); raise SystemExit
+what = sys.argv[2]
+lat = m.get("bench_op_latency_ms", {})
+vals = {
+    "thr": m.get("bench_ok", {}).get("rate"),
+    "p50": lat.get("med"),
+    "p95": lat.get("p(95)"),
+    "fallback": m.get("bench_fallback", {}).get("count", 0),
+    "err": m.get("bench_error_rate", {}).get("value"),
+}
+v = vals.get(what)
+print("NA" if v is None else (f"{v:.1f}" if isinstance(v, float) else v))
+PY
+}
+
+# Find the single .k6.json a cell produced (scenario name varies).
+k6_file() { find "$1" -name '*.k6.json' -print -quit 2>/dev/null; }
+
+# Continuous telemetry: per-container CPU/mem AND RabbitMQ queue depth, 1 Hz.
+# The queue depth is what distinguishes the "audit backlog" hypothesis (G1).
+sampler_start() { # $1=csv  -> echoes the pid
+  local out=$1
+  echo "epoch_s,container,cpu_cores,mem_mib,mq_messages" > "$out"
+  (
+    while :; do
+      local now; now=$(date +%s)
+      docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}' 2>/dev/null \
+        | grep '^bench-' \
+        | while IFS=$'\t' read -r name cpu mem; do
+            local cores used
+            cores=$(printf '%s' "$cpu" | tr -d '%' | awk '{printf "%.4f", $1/100}')
+            used=$(printf '%s' "$mem" | awk -F'/' '{print $1}' | tr -d ' ' \
+              | awk '/GiB/{printf "%.1f", $1*1024; next} /MiB/{printf "%.1f", $1+0; next} /KiB/{printf "%.2f", $1/1024; next} {print 0}')
+            printf '%s,%s,%s,%s,\n' "$now" "$name" "$cores" "$used" >> "$out"
+          done
+      # Total ready+unacked messages across all queues (best effort: the broker
+      # may not be up, or rabbitmqctl may be slow — never fail the probe on it).
+      local depth
+      depth=$(docker exec "$C_MQ" rabbitmqctl list_queues messages --no-table-headers 2>/dev/null \
+              | awk '{s+=$1} END{print s+0}') || depth=""
+      [ -n "$depth" ] && printf '%s,%s,,,%s\n' "$(date +%s)" "$C_MQ-queues" "$depth" >> "$out"
+      sleep 1
+    done
+  ) &
+  echo $!
+}
+
+sampler_stop() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
+
+# Mean CPU of one container over a time range in the sampler CSV.
+cpu_mean() { # $1=csv $2=container-substring [$3=from_epoch] [$4=to_epoch]
+  python3 - "$@" <<'PY'
+import csv, sys
+path, sub = sys.argv[1], sys.argv[2]
+lo = int(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else 0
+hi = int(sys.argv[4]) if len(sys.argv) > 4 and sys.argv[4] else 10**12
+vals = []
+for r in csv.DictReader(open(path)):
+    if sub in r["container"] and r["cpu_cores"] and lo <= int(r["epoch_s"]) <= hi:
+        vals.append(float(r["cpu_cores"]))
+print(f"{sum(vals)/len(vals):.2f}" if vals else "NA")
+PY
+}
+
+summary_open() { # $1=outdir $2=title
+  SUMMARY=$1/SUMMARY.md
+  TASK_OUT=$1
+  mkdir -p "$1"
+  {
+    echo "# $2"
+    echo
+    echo "- collected: $(date -Iseconds)"
+    echo "- host: $(uname -srm) · governor: $(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown)"
+    echo "- plan: \`claude_dev/improvement-after-serious-benchmark.md\`"
+    echo
+  } > "$SUMMARY"
+}
+s() { echo "$*" >> "$SUMMARY"; }          # write a summary line
+sp() { echo "$*" | tee -a "$SUMMARY"; }   # write AND print
+
+finish() {
+  echo
+  log "done — summary written to ${SUMMARY#$BENCH_DIR/}"
+  echo "----------------------------------------------------------------"
+  cat "$SUMMARY"
+  echo "----------------------------------------------------------------"
+}
+
+# ---------------------------------------------------------------------------
+# G1 — post-seed serialized-DB transient (Opus task; these are its probes)
+# ---------------------------------------------------------------------------
+# The plan's G1 asks: reproduce the window, then bisect the trigger. These three
+# probes answer, in order: WHEN does it end, is it TIME-based or TRAFFIC-based,
+# and is it the SERVER or the DATASTORE. Run g1-timeline first.
+
+task_g1_timeline() {
+  need_base
+  local out=$TASKS_ROOT/g1-timeline
+  rm -rf "$out"; summary_open "$out" "G1 — post-seed transient: recovery timeline"
+  local iters=${G1_ITERS:-20} dur=${G1_CELL_SECS:-20}
+
+  # The settle gate (G2) exists precisely to hide this window — turn it OFF here,
+  # measuring the window IS the point. Harmless if the knob isn't present yet.
+  export BENCH_SETTLE=0
+  export BENCH_WARMUP=5s BENCH_DURATION=${dur}s BENCH_VUS=${G1_VUS:-50}
+
+  bench_up_seed axiam
+  local t0; t0=$(date +%s)
+  local tel=$out/telemetry.csv pid; pid=$(sampler_start "$tel")
+  trap 'sampler_stop "$pid"; bench_down axiam' EXIT
+
+  s "Probe: immediately after \`bench-seed\`, run ${iters} short authz_check_rest cells"
+  s "(${dur}s measured each, ${BENCH_VUS} VUs) and watch when throughput recovers."
+  s
+  s "| # | minutes after seed | thr (ops/s) | p50 (ms) | DB CPU (cores) | server CPU |"
+  s "|---|---|---|---|---|---|"
+
+  local recovered_at=""
+  for i in $(seq 1 "$iters"); do
+    local d=$out/iter-$(printf '%02d' "$i") cs ce
+    cs=$(date +%s)
+    cell axiam p0-plaintext authz_check_rest.js "$d" >/dev/null 2>&1 || warn "cell $i failed"
+    ce=$(date +%s)
+    local f thr p50 dbcpu srvcpu mins
+    f=$(k6_file "$d"); thr=NA; p50=NA
+    [ -n "$f" ] && { thr=$(k6_stat "$f" thr); p50=$(k6_stat "$f" p50); }
+    dbcpu=$(cpu_mean "$tel" "$C_DB" "$cs" "$ce")
+    srvcpu=$(cpu_mean "$tel" "$C_SERVER" "$cs" "$ce")
+    mins=$(awk -v a="$cs" -v b="$t0" 'BEGIN{printf "%.1f", (a-b)/60}')
+    sp "| $i | $mins | $thr | $p50 | $dbcpu | $srvcpu |"
+    # First cell to clear 2x the clamped rate counts as recovery.
+    if [ -z "$recovered_at" ] && [ "$thr" != NA ] \
+       && awk -v t="$thr" 'BEGIN{exit !(t > 200)}'; then
+      recovered_at=$mins
+    fi
+  done
+
+  sampler_stop "$pid"; trap - EXIT; bench_down axiam
+  s
+  s "## Verdict"
+  if [ -n "$recovered_at" ]; then
+    s "- Transient REPRODUCED and ended at **~${recovered_at} min** after seed."
+  else
+    s "- No recovery within $(awk -v i="$iters" -v d="$dur" 'BEGIN{printf "%.0f", i*(d+35)/60}') min — either the window is longer than this probe, or it did not reproduce. Check the table: a sustained ~45 ops/s with DB ≈1.0 core IS the transient; a healthy stack reads ~740 ops/s with DB ≈2.0."
+  fi
+  s "- Queue-depth column of \`telemetry.csv\` (rows tagged \`$C_MQ-queues\`): if the"
+  s "  audit backlog drains to ~0 at the same minute throughput recovers, the AMQP"
+  s "  ingestion hypothesis is supported; if the queue is empty throughout, it is refuted."
+  s "- Next: \`g1-idle\` (time-based vs traffic-based) and \`g1-isolate\` (server vs datastore)."
+  finish
+}
+
+task_g1_idle() {
+  need_base
+  local out=$TASKS_ROOT/g1-idle
+  rm -rf "$out"; summary_open "$out" "G1 — is the window time-based or traffic-based?"
+  local wait_min=${G1_IDLE_MIN:-8}
+  export BENCH_SETTLE=0 BENCH_WARMUP=5s BENCH_DURATION=${G1_CELL_SECS:-20}s BENCH_VUS=${G1_VUS:-50}
+
+  bench_up_seed axiam
+  local tel=$out/telemetry.csv pid; pid=$(sampler_start "$tel")
+  trap 'sampler_stop "$pid"; bench_down axiam' EXIT
+
+  log "idling ${wait_min} min after seed with NO load (this is the whole experiment)"
+  s "The stack is seeded, then left **completely idle** for ${wait_min} minutes before"
+  s "the first request. If the first cell is then FAST, the window is background work"
+  s "that completes on wall-clock time (a cold-start/compaction class of cause). If it"
+  s "is still ~45 ops/s, the stack only warms up in response to TRAFFIC (a cache/"
+  s "connection/JIT-of-query-plan class of cause). This single bit splits G1's"
+  s "hypothesis space in half."
+  s
+  sleep $((wait_min * 60))
+
+  local d=$out/after-idle cs ce; cs=$(date +%s)
+  cell axiam p0-plaintext authz_check_rest.js "$d" >/dev/null 2>&1 || warn "cell failed"
+  ce=$(date +%s)
+  local f thr p50 dbcpu; f=$(k6_file "$d"); thr=NA; p50=NA
+  [ -n "$f" ] && { thr=$(k6_stat "$f" thr); p50=$(k6_stat "$f" p50); }
+  dbcpu=$(cpu_mean "$tel" "$C_DB" "$cs" "$ce")
+
+  # A second cell right after, to show whether traffic itself is what warms it.
+  local d2=$out/second-cell cs2 ce2; cs2=$(date +%s)
+  cell axiam p0-plaintext authz_check_rest.js "$d2" >/dev/null 2>&1 || true
+  ce2=$(date +%s)
+  local f2 thr2; f2=$(k6_file "$d2"); thr2=NA
+  [ -n "$f2" ] && thr2=$(k6_stat "$f2" thr)
+
+  sampler_stop "$pid"; trap - EXIT; bench_down axiam
+  sp "- first cell after ${wait_min} min idle: **${thr} ops/s** (p50 ${p50} ms, DB ${dbcpu} cores)"
+  sp "- immediately following cell:          **${thr2} ops/s**"
+  s
+  s "## Verdict"
+  s "- \`~740 ops/s\` on the first cell ⇒ **time-based**: idling through the window cures it."
+  s "- \`~45 ops/s\` on the first cell and faster on the second ⇒ **traffic-based** warm-up."
+  s "- Both slow ⇒ the window is longer than ${wait_min} min; re-run with G1_IDLE_MIN=15."
+  finish
+}
+
+task_g1_isolate() {
+  need_base
+  local out=$TASKS_ROOT/g1-isolate
+  rm -rf "$out"; summary_open "$out" "G1 — server or datastore?"
+  export BENCH_SETTLE=0 BENCH_WARMUP=5s BENCH_DURATION=${G1_CELL_SECS:-20}s BENCH_VUS=${G1_VUS:-50}
+
+  bench_up_seed axiam
+  local tel=$out/telemetry.csv pid; pid=$(sampler_start "$tel")
+  trap 'sampler_stop "$pid"; bench_down axiam' EXIT
+
+  probe() { # $1=label -> prints thr
+    local d=$out/$1
+    cell axiam p0-plaintext authz_check_rest.js "$d" >/dev/null 2>&1 || true
+    local f; f=$(k6_file "$d"); [ -n "$f" ] && k6_stat "$f" thr || echo NA
+  }
+
+  s "Restarting ONE container at a time inside the clamped window. Whatever state"
+  s "the transient lives in dies with the container that owns it."
+  s
+  local a b c
+  a=$(probe baseline);                     sp "- baseline (in-window):            **${a} ops/s**"
+  log "restarting $C_SERVER only"
+  docker restart "$C_SERVER" >/dev/null; sleep 20
+  b=$(probe after-server-restart);         sp "- after restarting the SERVER only: **${b} ops/s**"
+  log "restarting $C_DB only"
+  docker restart "$C_DB" >/dev/null; sleep 25
+  c=$(probe after-db-restart);             sp "- after restarting the DATASTORE:   **${c} ops/s**"
+
+  sampler_stop "$pid"; trap - EXIT; bench_down axiam
+  s
+  s "## Verdict"
+  s "- Clamp survives a server restart but clears on a datastore restart ⇒ the state is"
+  s "  **SurrealDB-side** (background compaction / index build / warm-up) — and is then a"
+  s "  candidate production cold-start defect, not just a bench artifact."
+  s "- Clamp clears on the server restart ⇒ it is **AXIAM-side** (DB pool/session warm-up)."
+  s "- Neither clears it ⇒ it is time-based background work; cross-check with \`g1-idle\`."
+  s "- Note a restart also drops caches, so read this together with \`g1-idle\`."
+  finish
+}
+
+task_g1_dbdirect() {
+  need_base
+  local out=$TASKS_ROOT/g1-dbdirect
+  rm -rf "$out"; summary_open "$out" "G1 — does the clamp exist without AXIAM in the path?"
+  export BENCH_SETTLE=0
+  bench_up_seed axiam
+  trap 'bench_down axiam' EXIT
+
+  # Same query shape the authz hot path uses, issued straight at SurrealDB from an
+  # ephemeral container on the bench network — no AXIAM server involved.
+  local net; net=$(docker inspect "$C_DB" -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' 2>/dev/null || echo "")
+  local img; img=$(docker inspect "$C_DB" -f '{{.Config.Image}}' 2>/dev/null || echo "surrealdb/surrealdb:v3")
+  local user=${AXIAM__DB__USERNAME:-bench} pass=${AXIAM__DB__PASSWORD:-}
+  [ -f ../docker/.secrets/env ] && . ../docker/.secrets/env || true
+  user=${AXIAM__DB__USERNAME:-$user}; pass=${AXIAM__DB__PASSWORD:-$pass}
+
+  s "Issues a repeated read straight at SurrealDB (no AXIAM server in the path) during"
+  s "the post-seed window. If the DB alone is slow, AXIAM is exonerated entirely."
+  s
+  if [ -z "$net" ] || [ -z "$pass" ]; then
+    warn "could not resolve the DB network or credentials automatically"
+    s "- **NOT RUN automatically.** Resolve manually and re-run the loop below:"
+    s '```bash'
+    s "docker run --rm --network $net $img sql \\"
+    s "  --endpoint http://$C_DB:8000 --username <user> --password <pass> \\"
+    s "  --namespace axiam --database axiam --pretty \\"
+    s "  --query 'SELECT count() FROM role_permission_grant GROUP ALL;'"
+    s '```'
+    trap - EXIT; bench_down axiam; finish; return
+  fi
+  {
+    echo "iteration,elapsed_ms"
+    for i in $(seq 1 30); do
+      local st et
+      st=$(date +%s%3N)
+      docker run --rm --network "$net" "$img" sql \
+        --endpoint "http://$C_DB:8000" --username "$user" --password "$pass" \
+        --namespace axiam --database axiam \
+        --query 'SELECT count() FROM role_permission_grant GROUP ALL;' >/dev/null 2>&1 || true
+      et=$(date +%s%3N)
+      echo "$i,$((et - st))"
+      sleep 2
+    done
+  } > "$out/db-direct.csv"
+  s "- raw timings: \`db-direct.csv\` (includes ~container-start overhead per row — compare"
+  s "  the TREND across rows, not the absolute value)."
+  s "- A flat, slow trend that improves at the same minute the k6 cells recover ⇒ the"
+  s "  serialization is inside SurrealDB."
+  trap - EXIT; bench_down axiam
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G2 — prove the harness countermeasures work on a live stack
+# ---------------------------------------------------------------------------
+task_g2_verify() {
+  need_base
+  local out=$TASKS_ROOT/g2-verify
+  rm -rf "$out"; summary_open "$out" "G2 — settle gate, cell rotation, self-describing meta"
+  export BENCH_RESULTS_DIR=$out
+  export BENCH_WARMUP=5s BENCH_DURATION=30s
+
+  log "running a 2-repeat mini matrix (one target, one profile) to exercise the new machinery"
+  just target=axiam profiles="p0-plaintext" targets="axiam" repeat=2 bench-matrix || \
+    warn "mini matrix returned non-zero — inspect the output above"
+
+  s "## Checks"
+  python3 - "$out" >> "$SUMMARY" <<'PY'
+import glob, json, os, sys
+root = sys.argv[1]
+metas = sorted(glob.glob(os.path.join(root, "**", "*.meta.json"), recursive=True))
+if not metas:
+    print("- ❌ no meta.json produced — the mini matrix did not run"); raise SystemExit
+have_settle = [m for m in metas if "settle_wait_secs" in json.load(open(m))]
+have_order  = [m for m in metas if "cell_order_index" in json.load(open(m))]
+have_env    = [m for m in metas if json.load(open(m)).get("axiam_env")]
+print(f"- cells produced: {len(metas)}")
+print(f"- `settle_wait_secs` present: {len(have_settle)}/{len(metas)} "
+      + ("✅" if len(have_settle) == len(metas) else "❌"))
+print(f"- `cell_order_index` present: {len(have_order)}/{len(metas)} "
+      + ("✅" if len(have_order) == len(metas) else "❌"))
+print(f"- `axiam_env` knob dump present: {len(have_env)}/{len(metas)} "
+      + ("✅" if len(have_env) == len(metas) else "❌"))
+# rotation: the first-executed scenario must differ between run-1 and run-2
+first = {}
+for m in metas:
+    d = json.load(open(m))
+    run = next((p for p in m.split(os.sep) if p.startswith("run-")), "run-?")
+    idx = d.get("cell_order_index")
+    if idx is not None and (run not in first or idx < first[run][0]):
+        first[run] = (idx, d.get("scenario"))
+if len(first) >= 2:
+    names = {v[1] for v in first.values()}
+    print(f"- first-executed scenario per run: "
+          + ", ".join(f"{r}={v[1]}" for r, v in sorted(first.items()))
+          + ("  ✅ rotated" if len(names) > 1 else "  ❌ NOT rotated"))
+# secret hygiene of the new env dump
+leaks = []
+for m in metas:
+    for k, v in (json.load(open(m)).get("axiam_env") or {}).items():
+        if any(t in k.upper() for t in ("PASSWORD", "SECRET", "KEY", "PEPPER", "PEM", "TOKEN")):
+            if v != "<redacted>":
+                leaks.append(f"{os.path.basename(m)}:{k}")
+print(f"- secret redaction in `axiam_env`: " + ("✅ clean" if not leaks else f"❌ LEAKED {leaks[:5]}"))
+PY
+  s
+  s "Acceptance (plan G2): every cell carries the three new fields, the first-executed"
+  s "scenario differs between run-1 and run-2, and no secret value appears in \`axiam_env\`."
+  unset BENCH_RESULTS_DIR
+  bench_down axiam
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G3 — the clean batch A/B (needs G2's settle gate merged)
+# ---------------------------------------------------------------------------
+task_g3_batch() {
+  need_base
+  local out=$TASKS_ROOT/g3-batch
+  rm -rf "$out"; summary_open "$out" "G3 — batch strategy A/B on a settled stack"
+  local reps=${G3_REPEAT:-3}
+
+  s "The four authz cells under both \`AXIAM__AUTHZ__BATCH_STRATEGY\` values, ${reps}×"
+  s "each, **on a settled stack** (this is what run 3 could not do — every historical"
+  s "batch cell was corrupted by the post-seed transient). A warm-up cell runs first"
+  s "in every pass so no measured cell is ever the first request after seeding."
+  s
+  s "| strategy | scenario | run | thr (ops/s) | p50 (ms) | p95 (ms) |"
+  s "|---|---|---|---|---|---|"
+
+  for strategy in concurrent coalesced; do
+    export AXIAM__AUTHZ__BATCH_STRATEGY=$strategy
+    bench_up_seed axiam
+    # Belt and braces: even with the settle gate, burn one throwaway cell.
+    BENCH_WARMUP=5s BENCH_DURATION=20s cell axiam p0-plaintext authz_check_rest.js \
+      "$out/$strategy/warmup" >/dev/null 2>&1 || true
+    for r in $(seq 1 "$reps"); do
+      for sc in authz_check_rest authz_batch_rest authz_check_grpc authz_batch_grpc; do
+        local d=$out/$strategy/run-$r/$sc
+        cell axiam p0-plaintext "$sc.js" "$d" >/dev/null 2>&1 || warn "$strategy/$sc run $r failed"
+        local f; f=$(k6_file "$d")
+        [ -n "$f" ] && s "| $strategy | $sc | $r | $(k6_stat "$f" thr) | $(k6_stat "$f" p50) | $(k6_stat "$f" p95) |"
+      done
+    done
+    bench_down axiam
+    unset AXIAM__AUTHZ__BATCH_STRATEGY
+  done
+
+  s
+  s "## Decision inputs (plan G3 criterion)"
+  python3 - "$out" >> "$SUMMARY" <<'PY'
+import glob, json, os, statistics, sys
+root = sys.argv[1]
+def med(strategy, scen, key):
+    vals = []
+    for f in glob.glob(os.path.join(root, strategy, "run-*", scen, "**", "*.k6.json"),
+                       recursive=True):
+        m = json.load(open(f))["metrics"]
+        vals.append(m["bench_ok"]["rate"] if key == "thr"
+                    else m["bench_op_latency_ms"]["p(95)"])
+    return statistics.median(vals) if vals else None
+for strategy in ("concurrent", "coalesced"):
+    single = med(strategy, "authz_check_rest", "thr")
+    batch = med(strategy, "authz_batch_rest", "thr")
+    bg = med(strategy, "authz_batch_grpc", "thr")
+    bg95 = med(strategy, "authz_batch_grpc", "p95")
+    if not (single and batch):
+        print(f"- **{strategy}**: incomplete data"); continue
+    checks = batch * 5  # the bench batches 5 checks per request
+    print(f"- **{strategy}**: singles {single:.0f}/s · batch {batch:.0f} req/s "
+          f"= **{checks:.0f} checks/s** → batch/single = **{checks/single:.2f}×** "
+          + ("✅ beats singles" if checks > single else "❌ worse than singles"))
+    if bg95:
+        print(f"  - gRPC batch p95 {bg95:.0f} ms "
+              + ("✅ under the 2 s gate" if bg95 < 2000 else "❌ breaches the 2 s gate"))
+PY
+  s
+  s "Ship whichever strategy wins as the default (plan G3), keep the other selectable,"
+  s "and paste this table into \`claude_dev/authz-batch-investigation.md\`."
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G4 — refresh-token cell must stop measuring a fallback
+# ---------------------------------------------------------------------------
+task_g4_refresh() {
+  need_base
+  local out=$TASKS_ROOT/g4-refresh
+  rm -rf "$out"; summary_open "$out" "G4 — token_refresh measures a real rotation"
+
+  s "| target | thr (ops/s) | p50 (ms) | bench_fallback | HTTP reqs / iteration | verdict |"
+  s "|---|---|---|---|---|---|"
+  for target in axiam keycloak; do
+    bench_up_seed "$target"
+    # A control cell: client_credentials, so we can check refresh is NOT ~½ of it.
+    cell "$target" p0-plaintext oauth2_client_credentials.js "$out/$target/cc" >/dev/null 2>&1 || true
+    cell "$target" p0-plaintext token_refresh.js "$out/$target/refresh" >/dev/null 2>&1 || true
+    bench_down "$target"
+    local fr; fr=$(k6_file "$out/$target/refresh")
+    if [ -z "$fr" ]; then s "| $target | — | — | — | — | ❌ cell did not run |"; continue; fi
+    local thr p50 fb rpi verdict
+    thr=$(k6_stat "$fr" thr); p50=$(k6_stat "$fr" p50); fb=$(k6_stat "$fr" fallback)
+    rpi=$(python3 -c "
+import json,sys
+m=json.load(open('$fr'))['metrics']
+it=m.get('iterations',{}).get('count',0); hr=m.get('http_reqs',{}).get('count',0)
+print(f'{hr/it:.2f}' if it else 'NA')")
+    verdict='❌ still a fallback'
+    [ "$fb" = "0" ] && verdict='✅ real rotation'
+    s "| $target | $thr | $p50 | $fb | $rpi | $verdict |"
+  done
+
+  s
+  s "## Acceptance (plan G4)"
+  s "- \`bench_fallback == 0\` for **both** AXIAM and Keycloak;"
+  s "- ~**1.0** HTTP request per iteration (2.0 is the client-credentials fallback signature);"
+  s "- AXIAM refresh throughput is **not** ≈ ½ × its client-credentials cell — compare"
+  s "  against the `<target>/cc` cell in this directory."
+  s "- If AXIAM still shows a fallback, the diagnosis in"
+  s "  \`claude_dev/refresh-harness-diagnosis.md\` lists what to check next."
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G5 — decision-cache hit-rate sweep (does the 3× survive a realistic key space?)
+# ---------------------------------------------------------------------------
+task_g5_cache_sweep() {
+  need_base
+  local out=$TASKS_ROOT/g5-cache-sweep
+  rm -rf "$out"; summary_open "$out" "G5 — decision cache vs cache-key cardinality"
+  local scen=${G5_SCENARIO:-authz_check_rest.js}
+  local ks=${G5_KEYSPACES:-"1 100 10000"}
+
+  s "Run 3 measured the cache at K=1 (every VU hammering ONE subject/resource pair) —"
+  s "the friendliest possible hit rate. This sweeps the key space to bound the real"
+  s "win, and records the memory cost at the largest K."
+  s
+  s "| cache | K (distinct subject×resource pairs) | thr (ops/s) | p50 (ms) | server mem (MiB) |"
+  s "|---|---|---|---|---|"
+
+  for enabled in false true; do
+    export AXIAM__AUTHZ__DECISION_CACHE_ENABLED=$enabled
+    bench_up_seed axiam
+    BENCH_WARMUP=5s BENCH_DURATION=20s cell axiam p0-plaintext authz_check_rest.js \
+      "$out/warmup-$enabled" >/dev/null 2>&1 || true
+    for k in $ks; do
+      local d=$out/cache-$enabled/k-$k
+      # BENCH_AUTHZ_KEYSPACE is read by the sweep-capable scenario (task G5's
+      # code change). With an older scenario it is simply ignored — the row then
+      # reads the same for every K, which is itself the signal that the scenario
+      # change has not landed yet.
+      BENCH_AUTHZ_KEYSPACE=$k cell axiam p0-plaintext "$scen" "$d" >/dev/null 2>&1 || true
+      local f mem; f=$(k6_file "$d")
+      mem=$(python3 - "$d" <<'PY'
+import csv, glob, os, sys
+vals = []
+for p in glob.glob(os.path.join(sys.argv[1], "**", "*.res.csv"), recursive=True):
+    for r in csv.DictReader(open(p)):
+        if r["container"].endswith("-server"):
+            vals.append(float(r["mem_mib"]))
+print(f"{sum(vals)/len(vals):.0f}" if vals else "NA")
+PY
+)
+      [ -n "$f" ] && s "| $enabled | $k | $(k6_stat "$f" thr) | $(k6_stat "$f" p50) | $mem |"
+    done
+    bench_down axiam
+    unset AXIAM__AUTHZ__DECISION_CACHE_ENABLED
+  done
+
+  s
+  s "## Decision inputs (plan G5)"
+  s "- The ship-decision needs the cache-ON/OFF ratio **at the largest K**, not at K=1."
+  s "- If the win collapses toward 1.0× as K grows, the default should stay opt-in and the"
+  s "  public doc's \"3×\" must be labeled as a best-case, small-key-space figure."
+  s "- Memory at K=10000 bounds \`DECISION_CACHE_MAX_ENTRIES\` guidance."
+  s "- Then run the revocation integration test against this live stack (plan G5 step 2)."
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G6 — memory retention (delegates to the dedicated script)
+# ---------------------------------------------------------------------------
+task_g6_memory() {
+  [ -x ./run-memory-experiment.sh ] || die "run-memory-experiment.sh missing or not executable"
+  log "delegating to run-memory-experiment.sh (builds two images — allow ~1h)"
+  ./run-memory-experiment.sh "${1:-both}"
+  echo
+  log "when it finishes, paste results/d9-summary.md into:"
+  echo "  - claude_dev/memory-retention-experiment.md §6"
+  echo "  - $PLAN §G6 (replace the placeholder)"
+}
+
+# ---------------------------------------------------------------------------
+# G8 — B2 conviction: is HTTP/2 multiplexing the TLS token-issuance penalty?
+# ---------------------------------------------------------------------------
+task_g8_tls_h1() {
+  need_base
+  local out=$TASKS_ROOT/g8-tls-h1
+  rm -rf "$out"; summary_open "$out" "G8 — TLS 1.3 token issuance: h2 vs h1 vs plaintext"
+
+  s "Three cells of the SAME operation, each run **after a warm-up cell** so none of"
+  s "them is the first request after seeding (that is what invalidated run 3's"
+  s "conviction cell). If p2-h1 ≈ p0, HTTP/2 multiplexing is convicted."
+  s
+
+  run_cc_cell() { # $1=label $2=profile [$3=BENCH_NGINX_CONF]
+    local label=$1 profile=$2 nginx=${3:-}
+    [ -n "$nginx" ] && export BENCH_NGINX_CONF=$nginx || unset BENCH_NGINX_CONF
+    bench_up_seed axiam "$profile"
+    BENCH_WARMUP=5s BENCH_DURATION=20s cell axiam "$profile" authz_check_rest.js \
+      "$out/$label/warmup" >/dev/null 2>&1 || true
+    cell axiam "$profile" oauth2_client_credentials.js "$out/$label/cc" >/dev/null 2>&1 || true
+    cell axiam "$profile" token_refresh.js "$out/$label/refresh" >/dev/null 2>&1 || true
+    bench_down axiam "$profile"
+    unset BENCH_NGINX_CONF
+  }
+
+  run_cc_cell p0-plaintext p0-plaintext
+  run_cc_cell p2-native    p2-tls13
+  run_cc_cell p2-h1        p2-tls13 tls13-h1.conf
+
+  s "| cell | negotiated HTTP | thr (ops/s) | p50 (ms) | Δ vs p0 |"
+  s "|---|---|---|---|---|"
+  python3 - "$out" >> "$SUMMARY" <<'PY'
+import glob, json, os, sys
+root = sys.argv[1]
+def stats(label):
+    f = glob.glob(os.path.join(root, label, "cc", "**", "*.k6.json"), recursive=True)
+    if not f: return None
+    m = json.load(open(f[0]))["metrics"]
+    # k6 tags http_req_duration by protocol when available; fall back to "?"
+    proto = "?"
+    for k in m:
+        if k.startswith("http_req_duration{") and "http_version" in k:
+            proto = k.split("http_version:")[1].rstrip("}")
+            break
+    return m["bench_ok"]["rate"], m["bench_op_latency_ms"]["med"], proto
+base = stats("p0-plaintext")
+for label in ("p0-plaintext", "p2-native", "p2-h1"):
+    st = stats(label)
+    if not st:
+        print(f"| {label} | — | — | — | cell missing |"); continue
+    thr, p50, proto = st
+    delta = "baseline" if label == "p0-plaintext" or not base else f"{100*(thr-base[0])/base[0]:+.1f}%"
+    print(f"| {label} | {proto} | {thr:.0f} | {p50:.1f} | {delta} |")
+PY
+  s
+  s "## Verdict (plan G8)"
+  s "- **p2-h1 within ~15% of p0** ⇒ HTTP/2 convicted. Next step is h2 tuning on the"
+  s "  actix listener (\`max_concurrent_streams\`, stream/connection window sizes), then"
+  s "  re-measure; if no setting recovers it, publish the documented position."
+  s "- **p2-h1 also ~−50%** ⇒ HTTP/2 acquitted; move to per-request server-side timing"
+  s "  at p2 vs p0 (TLS read/write vs handler) — the fallback path in the plan."
+  s "- Check the negotiated-protocol column: the h1 cell must NOT read \`2\`."
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G9 — rate-limited cells must report coherent metrics
+# ---------------------------------------------------------------------------
+task_g9_rlprod() {
+  need_base
+  local out=$TASKS_ROOT/g9-rlprod
+  rm -rf "$out"; summary_open "$out" "G9 — metric coherence under a 429 storm"
+  export BENCH_RESULTS_DIR=$out
+  bench_up_seed axiam p0-plaintext rl=prod
+  for sc in oauth2_client_credentials token_introspection authz_check_rest; do
+    cell axiam p0-plaintext "$sc.js" "$out/$sc" >/dev/null 2>&1 || true
+  done
+  bench_down axiam
+  unset BENCH_RESULTS_DIR
+
+  s "With the production per-IP posture active, nearly every request is a 429. The"
+  s "cells must say so coherently: \`bench_ok\` counts ONLY successful ops, so a"
+  s "100%-error cell reports a throughput of ~0 rather than thousands of \"ops/s\" of"
+  s "rejections (the run-3 incoherence this task fixes)."
+  s
+  s "| scenario | bench_ok rate | error rate | coherent? |"
+  s "|---|---|---|---|"
+  for sc in oauth2_client_credentials token_introspection authz_check_rest; do
+    local f; f=$(k6_file "$out/$sc")
+    if [ -z "$f" ]; then s "| $sc | — | — | cell missing |"; continue; fi
+    local thr err ok
+    thr=$(k6_stat "$f" thr); err=$(k6_stat "$f" err)
+    ok=$(python3 -c "
+thr=float('$thr' if '$thr'!='NA' else 0); err=float('$err' if '$err'!='NA' else 0)
+print('✅' if (err < 0.99 or thr < 1.0) else '❌ ok-rate > 0 at ~100% errors')")
+    s "| $sc | $thr | $err | $ok |"
+  done
+  s
+  s "Acceptance: no row reports a meaningful \`bench_ok\` rate while its error rate is ~1.0."
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# G10 — SDK benches: first validated records
+# ---------------------------------------------------------------------------
+task_g10_sdk() {
+  need_base
+  local out=$TASKS_ROOT/g10-sdk
+  rm -rf "$out"; summary_open "$out" "G10 — SDK client-side benches against a live target"
+  local langs=${G10_LANGS:-"rust python typescript go java csharp php"}
+
+  s "Each SDK bench must emit ONE spec-conformant \`axiam.sdk-bench/v1\` record with"
+  s "\`status: \"ok\"\`, twice in a row, against a seeded p0 target (plan G10 / E1.1)."
+  s "Each language's sibling repo must be checked out next to this workspace."
+  s
+  bench_up_seed axiam
+  s "| sdk | attempt 1 | attempt 2 | notes |"
+  s "|---|---|---|---|"
+  for lang in $langs; do
+    local d=$out/$lang; mkdir -p "$d"
+    local r1 r2
+    just sdk="$lang" sdk-bench > "$d/attempt-1.log" 2>&1 && r1=ok || r1=fail
+    just sdk="$lang" sdk-bench > "$d/attempt-2.log" 2>&1 && r2=ok || r2=fail
+    local st1 st2
+    st1=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[a-z]*"' "$d/attempt-1.log" | tail -1 | grep -o '[a-z]*"$' | tr -d '"' || echo "$r1")
+    st2=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[a-z]*"' "$d/attempt-2.log" | tail -1 | grep -o '[a-z]*"$' | tr -d '"' || echo "$r2")
+    local note=""
+    grep -qi "no such file\|not found\|cannot find" "$d/attempt-1.log" && note="sibling SDK repo missing?"
+    s "| $lang | ${st1:-$r1} | ${st2:-$r2} | $note |"
+  done
+  bench_down axiam
+  s
+  s "For every non-\`ok\` row, fix per that language's \`sdk/<lang>/TODO.md\` and re-run"
+  s "just that language: \`G10_LANGS=python ./run-improvement-tasks.sh g10-sdk\`."
+  s "Once ≥7 are ok, run \`just sdk-bench-all\` and build the overhead-vs-wire table (E1.3)."
+  finish
+}
+
+# ---------------------------------------------------------------------------
+# packaging
+# ---------------------------------------------------------------------------
+task_pack() {
+  log "packing shareable results (secret-scanned by the justfile recipe)"
+  just bench-pack
+  echo
+  log "task summaries collected so far:"
+  find "$TASKS_ROOT" -name SUMMARY.md 2>/dev/null | sort | sed 's|^|  |' || echo "  (none yet)"
+}
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+usage() {
+  cat <<EOF
+run-improvement-tasks.sh — per-task benchmark data collection for
+$PLAN
+
+Usage: ./run-improvement-tasks.sh <task>
+
+  Task            Plan  Est.    What it answers
+  --------------------------------------------------------------------------
+  g1-timeline     G1    ~15m    When does the post-seed window end? (run first)
+  g1-idle         G1    ~15m    Is it time-based or traffic-based?
+  g1-isolate      G1    ~10m    Does it live in the server or the datastore?
+  g1-dbdirect     G1    ~5m     Is it visible with AXIAM out of the path?
+  g2-verify       G2    ~10m    Do settle gate + rotation + meta dump work live?
+  g3-batch        G3    ~90m    Clean batch A/B: does batch beat singles?
+  g4-refresh      G4    ~15m    Is the refresh cell a real rotation now?
+  g5-cache-sweep  G5    ~60m    Does the cache 3x survive a realistic key space?
+  g6-memory       G6    ~90m    Does jemalloc fix the post-burst retention?
+  g8-tls-h1       G8    ~25m    Is HTTP/2 the TLS token-issuance penalty?
+  g9-rlprod       G9    ~10m    Are rate-limited cells' metrics coherent?
+  g10-sdk         G10   ~30m    Do the SDK benches emit valid records?
+  pack            —     ~1m     Build the shareable archive + list summaries
+
+Each task writes results/tasks/<task>/SUMMARY.md with its verdict.
+Knobs: G1_ITERS, G1_CELL_SECS, G1_VUS, G1_IDLE_MIN, G3_REPEAT, G5_KEYSPACES,
+G10_LANGS. Order that matters: g1-* before g3/g8 (they need the settle gate to
+be trustworthy), g2-verify after the G2 code lands.
+EOF
+}
+
+TASK=${1:-}
+case "$TASK" in
+  list|help|-h|--help|"") usage ;;
+  g1-timeline)    task_g1_timeline ;;
+  g1-idle)        task_g1_idle ;;
+  g1-isolate)     task_g1_isolate ;;
+  g1-dbdirect)    task_g1_dbdirect ;;
+  g2-verify)      task_g2_verify ;;
+  g3-batch)       task_g3_batch ;;
+  g4-refresh)     task_g4_refresh ;;
+  g5-cache-sweep) task_g5_cache_sweep ;;
+  g6-memory)      shift; task_g6_memory "$@" ;;
+  g8-tls-h1)      task_g8_tls_h1 ;;
+  g9-rlprod)      task_g9_rlprod ;;
+  g10-sdk)        task_g10_sdk ;;
+  pack)           task_pack ;;
+  *) die "unknown task '$TASK' — run './run-improvement-tasks.sh list'" ;;
+esac

--- a/benchmarks/run-improvement-tasks.sh
+++ b/benchmarks/run-improvement-tasks.sh
@@ -142,6 +142,58 @@ print(next((argv[i + 1] for i, v in enumerate(argv) if v == flag and i + 1 < len
 ' "$2" || true
 }
 
+# --- talking to SurrealDB with no AXIAM in the path (g1-dbdirect) ------------
+# `surreal sql` is an SQL REPL "with pipe support" — it has NO --query flag
+# (passing one aborts with "unexpected argument '--query' found" before it ever
+# connects). The statement goes in on STDIN, which is why the container needs
+# `docker run -i`. Set by task_g1_dbdirect once it has resolved the running
+# stack's own connection details.
+DBD_NET=""; DBD_IMG=""; DBD_USER=""; DBD_PASS=""
+
+# The probe statement, in ONE place so the pre-flight, the timing loop and the
+# manual-fallback snippet in the summary cannot drift apart.
+#
+# It mirrors the authz hot path's own shape (see
+# `SurrealPermissionRepository::get_role_permission_grants`): a traversal of the
+# `grants` edge that dereferences the permission record on the far side
+# (`out.*`), which is where that query's real work happens — but with no bound
+# parameters, so it needs no tenant/role UUID from the seed.
+#
+# The table is `grants` (`RELATE role -> grants -> permission`). There is NO
+# `role_permission_grant` table — that is the name of the Rust *method*, and an
+# earlier revision of this probe used it as a table name; every iteration then
+# measured a "table does not exist" error path instead of the datastore.
+DBD_QUERY='SELECT count() FROM grants WHERE out.tenant_id != NONE GROUP ALL;'
+
+surreal_direct() { # $1=statement -> JSON result on stdout, diagnostics on stderr
+  printf '%s\n' "$1" | docker run --rm -i --network "$DBD_NET" "$DBD_IMG" sql \
+    --endpoint "http://$C_DB:8000" --username "$DBD_USER" --password "$DBD_PASS" \
+    --namespace axiam --database axiam --hide-welcome --json
+}
+
+# Did that statement actually succeed? The exit status alone cannot tell you:
+# ONLY connection/auth failures exit non-zero. A missing or renamed table exits
+# 0 and reports `["The table 'x' does not exist"]` on stdout; a parse error
+# exits 0 having printed nothing at all on stdout. So judge the SHAPE of the
+# result instead — a statement that ran returns a list of ROWS
+# (`[[{"count":N}]]`), a rejected one returns a bare string — scanning from the
+# last line up so a trailing diagnostic cannot fool it.
+surreal_result_ok() { # stdin = combined output of ONE surreal_direct call
+  python3 -c '
+import json, sys
+for line in reversed(sys.stdin.read().splitlines()):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        res = json.loads(line)
+    except ValueError:
+        continue          # a stderr diagnostic, not the result — keep looking
+    sys.exit(0 if isinstance(res, list) and res and not isinstance(res[0], str) else 1)
+sys.exit(1)                # no JSON at all (parse error / never connected)
+'
+}
+
 # Continuous telemetry: per-container CPU/mem AND RabbitMQ queue depth, 1 Hz.
 # The queue depth is what distinguishes the "audit backlog" hypothesis (G1).
 #
@@ -438,6 +490,7 @@ task_g1_dbdirect() {
   [ -n "$pass" ] || pass=$(container_env "$C_SERVER" AXIAM__DB__PASSWORD)
   [ -n "$user" ] || user=$(container_cmd_flag "$C_DB" --user)
   [ -n "$pass" ] || pass=$(container_cmd_flag "$C_DB" --pass)
+  DBD_NET=$net; DBD_IMG=$img; DBD_USER=$user; DBD_PASS=$pass
 
   s "Issues a repeated read straight at SurrealDB (no AXIAM server in the path) during"
   s "the post-seed window. If the DB alone is slow, AXIAM is exonerated entirely."
@@ -451,11 +504,13 @@ task_g1_dbdirect() {
     s "- **NOT RUN automatically** (could not resolve $missing). Resolve manually"
     s "  and re-run the loop below:"
     s '```bash'
-    s "docker run --rm --network ${net:-<network>} $img sql \\"
+    s "echo '$DBD_QUERY' \\"
+    s "| docker run --rm -i --network ${net:-<network>} $img sql \\"
     s "  --endpoint http://$C_DB:8000 --username ${user:-<user>} --password <pass> \\"
-    s "  --namespace axiam --database axiam --pretty \\"
-    s "  --query 'SELECT count() FROM role_permission_grant GROUP ALL;'"
+    s "  --namespace axiam --database axiam --hide-welcome --pretty"
     s '```'
+    s "(\`surreal sql\` is a REPL with pipe support — it has no \`--query\` flag, so the"
+    s "statement goes on stdin and \`docker run\` needs \`-i\`.)"
     s
     s "The credentials are whatever \`just bench-up\` used: your exported"
     s "\`AXIAM__DB__USERNAME\`/\`AXIAM__DB__PASSWORD\` if you set them, otherwise its"
@@ -465,16 +520,15 @@ task_g1_dbdirect() {
     s '```'
     disarm_cleanup; bench_down axiam; finish; return
   fi
-  # Pre-flight the query once before timing 30 of them. The timing loop discards
-  # every error, so a wrong credential (or a renamed table) would otherwise fill
-  # db-direct.csv with 30 rows of pure container-start overhead that read like
-  # plausible timings — the worst possible failure for a task whose whole output
-  # is a trend line.
-  if ! docker run --rm --network "$net" "$img" sql \
-       --endpoint "http://$C_DB:8000" --username "$user" --password "$pass" \
-       --namespace axiam --database axiam \
-       --query 'SELECT count() FROM role_permission_grant GROUP ALL;' \
-       > "$out/preflight.log" 2>&1; then
+  # Pre-flight the query once before timing 30 of them. A wrong credential (or a
+  # renamed table) would otherwise fill db-direct.csv with 30 rows of pure
+  # container-start overhead that read like plausible timings — the worst
+  # possible failure for a task whose whole output is a trend line. Both gates
+  # are needed: the exit status catches an unusable connection, surreal_result_ok
+  # catches a statement that was rejected while still exiting 0.
+  if ! surreal_direct "$DBD_QUERY" \
+        > "$out/preflight.log" 2>&1 \
+     || ! surreal_result_ok < "$out/preflight.log"; then
     warn "the direct SurrealDB query failed as user '$user' — not timing it; see preflight.log"
     s "- **NOT RUN.** The credentials resolved, but the probe query itself failed as"
     s "  user \`$user\`. First lines of \`preflight.log\`:"
@@ -485,22 +539,26 @@ task_g1_dbdirect() {
   fi
   log "pre-flight query OK as user '$user' — timing 30 iterations"
 
+  # Each row carries its own ok flag: the pre-flight proves the query worked
+  # ONCE, but a mid-run failure (the stack going away, a restart) would still
+  # time a fast error path and read as "the clamp cleared". A row is only
+  # evidence if ok=1.
   {
-    echo "iteration,elapsed_ms"
+    echo "iteration,elapsed_ms,ok"
     for i in $(seq 1 30); do
-      local st et
+      local st et ok=1
       st=$(date +%s%3N)
-      docker run --rm --network "$net" "$img" sql \
-        --endpoint "http://$C_DB:8000" --username "$user" --password "$pass" \
-        --namespace axiam --database axiam \
-        --query 'SELECT count() FROM role_permission_grant GROUP ALL;' >/dev/null 2>&1 || true
+      surreal_direct "$DBD_QUERY" > "$out/.iter.out" 2>&1 || ok=0
       et=$(date +%s%3N)
-      echo "$i,$((et - st))"
+      surreal_result_ok < "$out/.iter.out" || ok=0
+      echo "$i,$((et - st)),$ok"
       sleep 2
     done
   } > "$out/db-direct.csv"
+  rm -f "$out/.iter.out"
   s "- raw timings: \`db-direct.csv\` (includes ~container-start overhead per row — compare"
-  s "  the TREND across rows, not the absolute value)."
+  s "  the TREND across rows, not the absolute value). Ignore any row with \`ok=0\`: the"
+  s "  query failed there, so its timing measures an error path, not the datastore."
   s "- A flat, slow trend that improves at the same minute the k6 cells recover ⇒ the"
   s "  serialization is inside SurrealDB."
   disarm_cleanup; bench_down axiam

--- a/benchmarks/run-improvement-tasks.sh
+++ b/benchmarks/run-improvement-tasks.sh
@@ -114,7 +114,19 @@ k6_file() { find "$1" -name '*.k6.json' -print -quit 2>/dev/null; }
 
 # Continuous telemetry: per-container CPU/mem AND RabbitMQ queue depth, 1 Hz.
 # The queue depth is what distinguishes the "audit backlog" hypothesis (G1).
-sampler_start() { # $1=csv  -> echoes the pid
+#
+# The PID comes back in the global SAMPLER_PID rather than on stdout, and it is
+# deliberately NOT called as `pid=$(sampler_start ...)`. Command substitution
+# reads its child's stdout until EOF, and this function backgrounds a subshell
+# that never exits — the subshell inherits the substitution pipe as fd 1 and
+# holds it open forever, so EOF never arrives and the caller blocks in read()
+# for good. Worse, an async command in a non-interactive shell has SIGINT set
+# to ignore (POSIX, job control off), so the sampler survives Ctrl-C while the
+# parent stays blocked on it: the run becomes uninterruptible and only SIGTERM
+# ends it. Keeping the PID off stdout also makes the sampler a direct child of
+# this shell, so `wait` in sampler_stop actually reaps it.
+SAMPLER_PID=""
+sampler_start() { # $1=csv  -> sets SAMPLER_PID
   local out=$1
   echo "epoch_s,container,cpu_cores,mem_mib,mq_messages" > "$out"
   (
@@ -137,11 +149,40 @@ sampler_start() { # $1=csv  -> echoes the pid
       [ -n "$depth" ] && printf '%s,%s,,,%s\n' "$(date +%s)" "$C_MQ-queues" "$depth" >> "$out"
       sleep 1
     done
-  ) &
-  echo $!
+  ) >/dev/null 2>&1 &
+  SAMPLER_PID=$!
 }
 
-sampler_stop() { kill "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
+sampler_stop() { # $1=pid
+  [ -n "${1:-}" ] || return 0
+  kill "$1" 2>/dev/null || true
+  # The subshell's in-flight `sleep` / `docker exec` child outlives the kill;
+  # take the whole family down so nothing keeps writing telemetry.csv.
+  pkill -P "$1" 2>/dev/null || true
+  wait "$1" 2>/dev/null || true
+}
+
+# Cleanup must be ARMED BEFORE the first long-running child of a task starts,
+# not after — a trap installed on the line below a hang never runs at all, which
+# is how interrupted G1 tasks used to leave their bench containers up. INT/TERM
+# are trapped alongside EXIT so Ctrl-C tears the stack down instead of orphaning
+# it.
+CLEANUP_TARGET=""
+cleanup() {
+  local rc=$?
+  trap - EXIT INT TERM
+  if [ -n "${SAMPLER_PID:-}" ]; then sampler_stop "$SAMPLER_PID"; SAMPLER_PID=""; fi
+  if [ -n "$CLEANUP_TARGET" ]; then bench_down "$CLEANUP_TARGET"; CLEANUP_TARGET=""; fi
+  return $rc
+}
+arm_cleanup() { # $1=target to bench-down on the way out
+  CLEANUP_TARGET=$1
+  # `|| true` keeps `set -e` from aborting cleanup half-way when the task is
+  # dying on a non-zero status — teardown must always run to completion.
+  trap 'cleanup || true; exit 130' INT TERM
+  trap 'cleanup || true' EXIT
+}
+disarm_cleanup() { trap - EXIT INT TERM; CLEANUP_TARGET=""; }
 
 # Mean CPU of one container over a time range in the sampler CSV.
 cpu_mean() { # $1=csv $2=container-substring [$3=from_epoch] [$4=to_epoch]
@@ -200,10 +241,10 @@ task_g1_timeline() {
   export BENCH_SETTLE=0
   export BENCH_WARMUP=5s BENCH_DURATION=${dur}s BENCH_VUS=${G1_VUS:-50}
 
+  arm_cleanup axiam
   bench_up_seed axiam
   local t0; t0=$(date +%s)
-  local tel=$out/telemetry.csv pid; pid=$(sampler_start "$tel")
-  trap 'sampler_stop "$pid"; bench_down axiam' EXIT
+  local tel=$out/telemetry.csv; sampler_start "$tel"
 
   s "Probe: immediately after \`bench-seed\`, run ${iters} short authz_check_rest cells"
   s "(${dur}s measured each, ${BENCH_VUS} VUs) and watch when throughput recovers."
@@ -231,7 +272,7 @@ task_g1_timeline() {
     fi
   done
 
-  sampler_stop "$pid"; trap - EXIT; bench_down axiam
+  sampler_stop "$SAMPLER_PID"; SAMPLER_PID=""; disarm_cleanup; bench_down axiam
   s
   s "## Verdict"
   if [ -n "$recovered_at" ]; then
@@ -253,9 +294,9 @@ task_g1_idle() {
   local wait_min=${G1_IDLE_MIN:-8}
   export BENCH_SETTLE=0 BENCH_WARMUP=5s BENCH_DURATION=${G1_CELL_SECS:-20}s BENCH_VUS=${G1_VUS:-50}
 
+  arm_cleanup axiam
   bench_up_seed axiam
-  local tel=$out/telemetry.csv pid; pid=$(sampler_start "$tel")
-  trap 'sampler_stop "$pid"; bench_down axiam' EXIT
+  local tel=$out/telemetry.csv; sampler_start "$tel"
 
   log "idling ${wait_min} min after seed with NO load (this is the whole experiment)"
   s "The stack is seeded, then left **completely idle** for ${wait_min} minutes before"
@@ -281,7 +322,7 @@ task_g1_idle() {
   local f2 thr2; f2=$(k6_file "$d2"); thr2=NA
   [ -n "$f2" ] && thr2=$(k6_stat "$f2" thr)
 
-  sampler_stop "$pid"; trap - EXIT; bench_down axiam
+  sampler_stop "$SAMPLER_PID"; SAMPLER_PID=""; disarm_cleanup; bench_down axiam
   sp "- first cell after ${wait_min} min idle: **${thr} ops/s** (p50 ${p50} ms, DB ${dbcpu} cores)"
   sp "- immediately following cell:          **${thr2} ops/s**"
   s
@@ -298,9 +339,9 @@ task_g1_isolate() {
   rm -rf "$out"; summary_open "$out" "G1 — server or datastore?"
   export BENCH_SETTLE=0 BENCH_WARMUP=5s BENCH_DURATION=${G1_CELL_SECS:-20}s BENCH_VUS=${G1_VUS:-50}
 
+  arm_cleanup axiam
   bench_up_seed axiam
-  local tel=$out/telemetry.csv pid; pid=$(sampler_start "$tel")
-  trap 'sampler_stop "$pid"; bench_down axiam' EXIT
+  local tel=$out/telemetry.csv; sampler_start "$tel"
 
   probe() { # $1=label -> prints thr
     local d=$out/$1
@@ -320,7 +361,7 @@ task_g1_isolate() {
   docker restart "$C_DB" >/dev/null; sleep 25
   c=$(probe after-db-restart);             sp "- after restarting the DATASTORE:   **${c} ops/s**"
 
-  sampler_stop "$pid"; trap - EXIT; bench_down axiam
+  sampler_stop "$SAMPLER_PID"; SAMPLER_PID=""; disarm_cleanup; bench_down axiam
   s
   s "## Verdict"
   s "- Clamp survives a server restart but clears on a datastore restart ⇒ the state is"
@@ -337,8 +378,8 @@ task_g1_dbdirect() {
   local out=$TASKS_ROOT/g1-dbdirect
   rm -rf "$out"; summary_open "$out" "G1 — does the clamp exist without AXIAM in the path?"
   export BENCH_SETTLE=0
+  arm_cleanup axiam
   bench_up_seed axiam
-  trap 'bench_down axiam' EXIT
 
   # Same query shape the authz hot path uses, issued straight at SurrealDB from an
   # ephemeral container on the bench network — no AXIAM server involved.
@@ -360,7 +401,7 @@ task_g1_dbdirect() {
     s "  --namespace axiam --database axiam --pretty \\"
     s "  --query 'SELECT count() FROM role_permission_grant GROUP ALL;'"
     s '```'
-    trap - EXIT; bench_down axiam; finish; return
+    disarm_cleanup; bench_down axiam; finish; return
   fi
   {
     echo "iteration,elapsed_ms"
@@ -380,7 +421,7 @@ task_g1_dbdirect() {
   s "  the TREND across rows, not the absolute value)."
   s "- A flat, slow trend that improves at the same minute the k6 cells recover ⇒ the"
   s "  serialization is inside SurrealDB."
-  trap - EXIT; bench_down axiam
+  disarm_cleanup; bench_down axiam
   finish
 }
 
@@ -802,7 +843,7 @@ Usage: ./run-improvement-tasks.sh <task>
 
   Task            Plan  Est.    What it answers
   --------------------------------------------------------------------------
-  g1-timeline     G1    ~15m    When does the post-seed window end? (run first)
+  g1-timeline     G1    ~25m    When does the post-seed window end? (run first)
   g1-idle         G1    ~15m    Is it time-based or traffic-based?
   g1-isolate      G1    ~10m    Does it live in the server or the datastore?
   g1-dbdirect     G1    ~5m     Is it visible with AXIAM out of the path?
@@ -817,6 +858,10 @@ Usage: ./run-improvement-tasks.sh <task>
   pack            —     ~1m     Build the shareable archive + list summaries
 
 Each task writes results/tasks/<task>/SUMMARY.md with its verdict.
+Estimates include bring-up + seed. g1-timeline is ~55s per iteration, so
+G1_ITERS=8 gives a ~12m first look; the default 20 iterations is ~25m.
+Ctrl-C at any point tears the bench stack down before exiting.
+
 Knobs: G1_ITERS, G1_CELL_SECS, G1_VUS, G1_IDLE_MIN, G3_REPEAT, G5_KEYSPACES,
 G10_LANGS. Order that matters: g1-* before g3/g8 (they need the settle gate to
 be trustworthy), g2-verify after the G2 code lands.

--- a/benchmarks/run-improvement-tasks.sh
+++ b/benchmarks/run-improvement-tasks.sh
@@ -112,6 +112,36 @@ PY
 # Find the single .k6.json a cell produced (scenario name varies).
 k6_file() { find "$1" -name '*.k6.json' -print -quit 2>/dev/null; }
 
+# --- reading the running stack's own configuration ---------------------------
+# `just bench-up` bootstraps throwaway DB credentials inside its own recipe
+# shell (AXIAM__DB__USERNAME=bench / AXIAM__DB__PASSWORD=bench-local-only-pw)
+# and writes them to no file, so neither this script's environment nor
+# docker/.secrets/env knows them on a machine that never supplied real ones.
+# The containers are the source of truth, whatever the credentials came from.
+
+# Value of one env var inside a running container ("" if absent/not running).
+container_env() { # $1=container $2=VAR
+  docker inspect "$1" -f '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null \
+    | sed -n "s/^$2=//p" | head -1 || true
+}
+
+# Value following a flag on a running container's command line ("" if absent) —
+# the datastore takes its credentials as `start --user X --pass Y ...`.
+container_cmd_flag() { # $1=container $2=flag (e.g. --pass)
+  docker inspect "$1" -f '{{json .Config.Cmd}}' 2>/dev/null \
+    | python3 -c '
+import json, sys
+try:
+    argv = json.load(sys.stdin)
+except Exception:
+    raise SystemExit
+if not isinstance(argv, list):
+    raise SystemExit
+flag = sys.argv[1]
+print(next((argv[i + 1] for i, v in enumerate(argv) if v == flag and i + 1 < len(argv)), ""))
+' "$2" || true
+}
+
 # Continuous telemetry: per-container CPU/mem AND RabbitMQ queue depth, 1 Hz.
 # The queue depth is what distinguishes the "audit backlog" hypothesis (G1).
 #
@@ -396,24 +426,65 @@ task_g1_dbdirect() {
   # ephemeral container on the bench network — no AXIAM server involved.
   local net; net=$(docker inspect "$C_DB" -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' 2>/dev/null || echo "")
   local img; img=$(docker inspect "$C_DB" -f '{{.Config.Image}}' 2>/dev/null || echo "surrealdb/surrealdb:v3")
-  local user=${AXIAM__DB__USERNAME:-bench} pass=${AXIAM__DB__PASSWORD:-}
-  [ -f ../docker/.secrets/env ] && . ../docker/.secrets/env || true
-  user=${AXIAM__DB__USERNAME:-$user}; pass=${AXIAM__DB__PASSWORD:-$pass}
+  # Credential resolution, most-authoritative-last so an operator override still
+  # wins: this shell's environment, then docker/.secrets/env, then the running
+  # containers (see container_env — bench-up's bootstrapped defaults exist
+  # nowhere else, which is what used to make this task bail out on a perfectly
+  # healthy stack).
+  local user=${AXIAM__DB__USERNAME:-} pass=${AXIAM__DB__PASSWORD:-}
+  if [ -f ../docker/.secrets/env ]; then . ../docker/.secrets/env || true; fi
+  user=${user:-${AXIAM__DB__USERNAME:-}}; pass=${pass:-${AXIAM__DB__PASSWORD:-}}
+  [ -n "$user" ] || user=$(container_env "$C_SERVER" AXIAM__DB__USERNAME)
+  [ -n "$pass" ] || pass=$(container_env "$C_SERVER" AXIAM__DB__PASSWORD)
+  [ -n "$user" ] || user=$(container_cmd_flag "$C_DB" --user)
+  [ -n "$pass" ] || pass=$(container_cmd_flag "$C_DB" --pass)
 
   s "Issues a repeated read straight at SurrealDB (no AXIAM server in the path) during"
   s "the post-seed window. If the DB alone is slow, AXIAM is exonerated entirely."
   s
   if [ -z "$net" ] || [ -z "$pass" ]; then
-    warn "could not resolve the DB network or credentials automatically"
-    s "- **NOT RUN automatically.** Resolve manually and re-run the loop below:"
+    # Say WHICH lookup failed — they have different fixes.
+    local missing="the DB network"
+    [ -n "$net" ] && missing="the DB credentials"
+    [ -z "$net" ] && [ -z "$pass" ] && missing="the DB network or credentials"
+    warn "could not resolve $missing from the running stack — is it up?"
+    s "- **NOT RUN automatically** (could not resolve $missing). Resolve manually"
+    s "  and re-run the loop below:"
     s '```bash'
-    s "docker run --rm --network $net $img sql \\"
-    s "  --endpoint http://$C_DB:8000 --username <user> --password <pass> \\"
+    s "docker run --rm --network ${net:-<network>} $img sql \\"
+    s "  --endpoint http://$C_DB:8000 --username ${user:-<user>} --password <pass> \\"
     s "  --namespace axiam --database axiam --pretty \\"
     s "  --query 'SELECT count() FROM role_permission_grant GROUP ALL;'"
     s '```'
+    s
+    s "The credentials are whatever \`just bench-up\` used: your exported"
+    s "\`AXIAM__DB__USERNAME\`/\`AXIAM__DB__PASSWORD\` if you set them, otherwise its"
+    s "throwaway local defaults. Read them back off the running stack with:"
+    s '```bash'
+    s "docker inspect $C_SERVER -f '{{range .Config.Env}}{{println .}}{{end}}' | grep AXIAM__DB__"
+    s '```'
     disarm_cleanup; bench_down axiam; finish; return
   fi
+  # Pre-flight the query once before timing 30 of them. The timing loop discards
+  # every error, so a wrong credential (or a renamed table) would otherwise fill
+  # db-direct.csv with 30 rows of pure container-start overhead that read like
+  # plausible timings — the worst possible failure for a task whose whole output
+  # is a trend line.
+  if ! docker run --rm --network "$net" "$img" sql \
+       --endpoint "http://$C_DB:8000" --username "$user" --password "$pass" \
+       --namespace axiam --database axiam \
+       --query 'SELECT count() FROM role_permission_grant GROUP ALL;' \
+       > "$out/preflight.log" 2>&1; then
+    warn "the direct SurrealDB query failed as user '$user' — not timing it; see preflight.log"
+    s "- **NOT RUN.** The credentials resolved, but the probe query itself failed as"
+    s "  user \`$user\`. First lines of \`preflight.log\`:"
+    s '```'
+    head -5 "$out/preflight.log" 2>/dev/null | sed 's/^/  /' >> "$SUMMARY" || true
+    s '```'
+    disarm_cleanup; bench_down axiam; finish; return
+  fi
+  log "pre-flight query OK as user '$user' — timing 30 iterations"
+
   {
     echo "iteration,elapsed_ms"
     for i in $(seq 1 30); do

--- a/benchmarks/run-memory-experiment.sh
+++ b/benchmarks/run-memory-experiment.sh
@@ -64,13 +64,48 @@ rss_mib() {
 }
 
 # Background sampler: appends "epoch_s,mem_mib" until the stopfile appears.
-start_sampler() { # $1=csv $2=stopfile
+#
+# The PID comes back in the global SAMPLER_PID, never on stdout: called as
+# `pid=$(start_sampler ...)` the backgrounded subshell inherits the command
+# substitution's pipe as fd 1 and — with the stopfile not yet created — holds it
+# open indefinitely, so the caller blocks in read() waiting for an EOF that
+# cannot arrive. Ctrl-C does not recover it either, because an async command in
+# a non-interactive shell has SIGINT set to ignore. Same defect as the G1
+# telemetry sampler in run-improvement-tasks.sh.
+SAMPLER_PID=""
+start_sampler() { # $1=csv $2=stopfile  -> sets SAMPLER_PID
   ( while [ ! -e "$2" ]; do
       printf '%s,%s\n' "$(date +%s)" "$(rss_mib)" >> "$1"
       sleep "$SAMPLE_SECS"
-    done ) &
-  echo $!
+    done ) >/dev/null 2>&1 &
+  SAMPLER_PID=$!
 }
+
+# Interrupt safety: a variant run holds a bench stack up for 10+ minutes, so
+# Ctrl-C must stop the sampler and tear the stack down rather than orphan both.
+STOPFILE=""
+cleanup() {
+  local rc=$?
+  trap - EXIT INT TERM
+  if [ -n "$STOPFILE" ]; then touch "$STOPFILE" 2>/dev/null || true; STOPFILE=""; fi
+  if [ -n "${SAMPLER_PID:-}" ]; then
+    kill "$SAMPLER_PID" 2>/dev/null || true
+    pkill -P "$SAMPLER_PID" 2>/dev/null || true
+    wait "$SAMPLER_PID" 2>/dev/null || true
+    SAMPLER_PID=""
+  fi
+  # Only reached when a variant did NOT finish normally (the clean path disarms
+  # first), so announce the teardown — bench-down is silenced here.
+  echo "[d9] interrupted — tearing down the bench stack" >&2
+  just target=axiam bench-down >/dev/null 2>&1 || true
+  return $rc
+}
+arm_cleanup() { # $1=stopfile
+  STOPFILE=$1
+  trap 'cleanup || true; exit 130' INT TERM
+  trap 'cleanup || true' EXIT
+}
+disarm_cleanup() { trap - EXIT INT TERM; STOPFILE=""; }
 
 mark_phase() { # $1=phases.csv $2=phase-name
   printf '%s,%s\n' "$(date +%s)" "$2" >> "$1"
@@ -114,13 +149,11 @@ run_variant() { # $1=variant(a|b) $2=tag $3=resultsdir
   echo "[d9] === variant $variant ($tag) → $outdir ==="
   export BENCH_AXIAM_IMAGE=$tag
   export BENCH_RESULTS_DIR=$outdir
+  arm_cleanup "$stopfile"
   just target=axiam bench-up
   just target=axiam bench-seed
 
-  local sampler_pid
-  sampler_pid=$(start_sampler "$rss_csv" "$stopfile")
-  # shellcheck disable=SC2064
-  trap "touch '$stopfile'; wait $sampler_pid 2>/dev/null || true" RETURN
+  start_sampler "$rss_csv" "$stopfile"
 
   # 1. idle baseline (~60 s post-seed; the note expects ~90–130 MiB)
   mark_phase "$phases" baseline
@@ -139,8 +172,8 @@ run_variant() { # $1=variant(a|b) $2=tag $3=resultsdir
   sleep $(( WATCH_MIN * 60 ))
   mark_phase "$phases" end
 
-  touch "$stopfile"; wait "$sampler_pid" 2>/dev/null || true
-  trap - RETURN
+  touch "$stopfile"; wait "$SAMPLER_PID" 2>/dev/null || true; SAMPLER_PID=""
+  disarm_cleanup
   just target=axiam bench-down
   unset BENCH_AXIAM_IMAGE BENCH_RESULTS_DIR
   echo "[d9] variant $variant done"

--- a/benchmarks/runner/report.py
+++ b/benchmarks/runner/report.py
@@ -364,11 +364,21 @@ def host_flags(meta, host):
     """A6: clock_variance (window mean MHz sagged >15% below the window max —
     i.e. the run was not at a flat sustained clock) and generator_saturated
     (k6 itself was eating too much of the host's non-stack CPU headroom to
-    trust it as a clean load generator)."""
+    trust it as a clean load generator).
+
+    G2: settle_timeout — the post-seed settle gate (run-benchmark.sh's
+    settle_gate()) hit its hard timeout without ever seeing
+    BENCH_SETTLE_STABLE_SECS consecutive stable canary ticks, so this cell may
+    still be inside (or just leaving) the post-seed serialized-DB transient
+    (PRIVATE_BENCH_ANALYSIS.md §1) even though the gate proceeded anyway.
+    meta.get() defaults to falsy for any meta.json predating G2, so old trees
+    render exactly as before (no flag)."""
     flags = []
     mhz_avg, mhz_max = host.get("mhz_avg", 0.0), host.get("mhz_max", 0.0)
     if mhz_max > 0 and mhz_avg < 0.85 * mhz_max:
         flags.append("clock_variance")
+    if meta.get("settle_timeout"):
+        flags.append("settle_timeout")
 
     containers = meta.get("containers") or []
     if containers:
@@ -527,7 +537,29 @@ def aggregate_cell(runs):
     thr_spread_pct = (((max(thr_vals) - min(thr_vals)) / 2.0) / thr_median * 100.0
                        if thr_vals and thr_median else 0.0)
 
-    meta = basis[0]["meta"]  # containers/caps/scenario_sha etc. are stable across runs
+    meta = dict(basis[0]["meta"])  # containers/caps/scenario_sha etc. are stable across runs
+    # G2: settle_wait_secs/settle_timeout are NOT stable across runs by design
+    # (cell-order rotation means this cell isn't the first cell — and doesn't
+    # necessarily hit the same settle wait — in every repeat), so unlike the
+    # rest of `meta` they're recombined across ALL raw runs rather than just
+    # taken from basis[0]: the worst-case (max) wait, and timeout if ANY run's
+    # gate hit its hard timeout. meta.get() on older per-run meta.json files
+    # (predating G2) returns None/falsy, so this degrades to "no data" rather
+    # than crashing on a mixed old/new results tree.
+    settle_waits = [r["meta"].get("settle_wait_secs") for r in runs
+                     if r["meta"].get("settle_wait_secs") is not None]
+    if settle_waits:
+        meta["settle_wait_secs"] = max(settle_waits)
+    if any("settle_timeout" in r["meta"] for r in runs):
+        meta["settle_timeout"] = any(r["meta"].get("settle_timeout") for r in runs)
+    # axiam_env should be identical across runs of the same labeled pass (same
+    # bench-up); basis[0] usually has it, but fall back to any run that does
+    # (e.g. basis[0] happened to predate G2 while a later repeat didn't).
+    if not meta.get("axiam_env"):
+        for r in runs:
+            if r["meta"].get("axiam_env"):
+                meta["axiam_env"] = r["meta"]["axiam_env"]
+                break
     der = derive(perf, res)
     der_server = derive_server_only(perf, res, target)
 
@@ -969,6 +1001,84 @@ def build_report(cells, multi_run=False):
             ])
         lines += [md_table(
             ["scenario", "profile", "target", "err", "status_avg", "status_max"],
+            rows), ""]
+
+    # 4c. Appendix: post-seed settle gate (G2). settle_wait_secs/settle_timeout
+    # come from run-benchmark.sh's settle_gate() (see docs/methodology.md
+    # "Post-seed settle gate & cell-order rotation"). Only rendered when at
+    # least one cell actually carries the field — meta.json files predating
+    # G2 have neither key, so a mixed-vintage results tree (e.g. the existing
+    # run-1/run-2/run-3 trees alongside a fresh G2 run) renders this section
+    # only for the cells that have the data and never crashes on the ones
+    # that don't (host_flags() above degrades the same way for the
+    # `settle_timeout` flag in the main results table).
+    settle_cells = [c for c in cells if c["meta"].get("settle_wait_secs") is not None]
+    if settle_cells:
+        lines += [
+            "## Appendix: post-seed settle gate", "",
+            "`settle_wait(s)` is how long run-benchmark.sh's settle gate "
+            "waited, before this run's FIRST cell, for "
+            "`BENCH_SETTLE_STABLE_SECS` consecutive seconds of canary "
+            "latency under `BENCH_SETTLE_MAX_MS` (defaults 30s / 100ms) — "
+            "every cell in the same run records the same wait, since the "
+            "gate runs once per `bench-run` invocation, not per cell. "
+            "`timeout` marks a cell whose gate hit its hard "
+            "`BENCH_SETTLE_TIMEOUT_SECS` (default 600s) without ever seeing "
+            "that many stable seconds — the run proceeded anyway (the gate "
+            "never fails the harness) but the cell may still be inside the "
+            "post-seed serialized-DB transient (PRIVATE_BENCH_ANALYSIS.md "
+            "§1); it's also surfaced as a `settle_timeout` host_flag in the "
+            "\"All results\" table above. For median-of-N cells, "
+            "`settle_wait(s)` is the MAX across the repeat's runs (worst "
+            "case) and `timeout` is set if ANY run's gate timed out.", "",
+        ]
+        rows = []
+        for c in sorted(settle_cells, key=lambda c: (c["scenario"], c["profile"], c["target"])):
+            rows.append([
+                c["scenario"], c["profile"], c["target"],
+                f"{c['meta'].get('settle_wait_secs', 0):.0f}",
+                "✓" if c["meta"].get("settle_timeout") else "·",
+            ])
+        lines += [md_table(
+            ["scenario", "profile", "target", "settle_wait(s)", "timeout"],
+            rows), ""]
+
+    # 4d. Appendix: AXIAM env knobs / labeled passes (G2). meta.json's
+    # "axiam_env" is every AXIAM__* env var the server container actually
+    # received, with secret-shaped values (PASSWORD/SECRET/KEY/PEPPER/PEM/
+    # TOKEN in the var name) redacted to the literal "<redacted>" — see
+    # run-benchmark.sh's axiam_env_json(). This makes a labeled sensitivity
+    # pass (pool size, batch strategy, decision cache, hash concurrency, ...)
+    # identifiable straight from the metadata rather than the results-
+    # directory name (PRIVATE_BENCH_ANALYSIS.md §2.2). Grouped by
+    # (target, profile), one representative cell per group, rather than
+    # repeated per scenario — every cell from the same `bench-up` shares one
+    # running server container, so its axiam_env is identical across that
+    # target/profile's scenarios. Absent entirely (section omitted) for any
+    # results tree predating G2, and for non-AXIAM targets (axiam_env_json()
+    # only inspects the AXIAM server container).
+    env_groups = {}
+    for c in cells:
+        env = c["meta"].get("axiam_env")
+        if not env:
+            continue
+        key = (c["target"], c["profile"])
+        if key not in env_groups or c["scenario"] < env_groups[key][0]:
+            env_groups[key] = (c["scenario"], env)
+    if env_groups:
+        lines += [
+            "## Appendix: AXIAM env knobs (labeled passes)", "",
+            "One representative cell's `axiam_env` per (target, profile) — "
+            "see the note above. `<redacted>` means the setting was present "
+            "but its value is a secret (never packed/shared — see "
+            "`just bench-pack`'s leak check in `justfile`).", "",
+        ]
+        rows = []
+        for (target, profile), (scenario, env) in sorted(env_groups.items()):
+            for k, v in sorted(env.items()):
+                rows.append([target, profile, scenario, k, v])
+        lines += [md_table(
+            ["target", "profile", "representative scenario", "AXIAM__ var", "value"],
             rows), ""]
 
     # 5. Excluded

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -84,6 +84,11 @@ export BENCH_TARGET="$TARGET"
 export BENCH_HOST="${BENCH_HOST:-localhost}"
 # BENCH_PORT is set by the profile env (8090 plaintext, 8443 TLS).
 
+# G2: base URL for the post-seed settle gate's canary probes (same
+# scheme/host/port the k6 scenarios below hit). Built here, once, since it's
+# only used for the cheap out-of-band canary requests, never by k6 itself.
+BASE="${BENCH_SCHEME:-http}://${BENCH_HOST}:${BENCH_PORT:-8090}"
+
 # Scenario set
 if [ "$SCENARIO" = "all" ]; then
   mapfile -t SCENARIOS < <(cd "$BENCH/scenarios" && ls ./*.js | sed 's#^\./##')
@@ -135,6 +140,32 @@ filter_scenarios() {
   SCENARIOS=("${out[@]}")
 }
 filter_scenarios
+
+# G2 item 2: cell-order rotation. Run 3 found EVERY historical batch cell was
+# corrupted because the matrix always ran scenarios in the same (alphabetical)
+# order and the batch scenarios always landed as cell 1-2, right after seed —
+# squarely inside the post-seed serialized-DB transient window (see the settle
+# gate below and PRIVATE_BENCH_ANALYSIS.md §1). Rotating the EXECUTED order
+# (i.e. after filter_scenarios, so it matches what actually runs and what
+# cell_order_index below counts) by the run index means no scenario is
+# systematically first across a median-of-N `bench-matrix` (repeat=N): run-1
+# starts at scenario 1, run-2 at scenario 2, etc. — a left-rotation by
+# (BENCH_RUN_INDEX - 1) mod N. Deterministic (pure function of run index +
+# scenario count) and changes only the ORDER, never WHICH scenarios run.
+# BENCH_RUN_INDEX is set by justfile's bench-matrix loop (BENCH_RUN_INDEX=$i,
+# one per repeat pass); a manual single `bench-run` invocation (no matrix)
+# defaults to 1 — no rotation, natural (alphabetical) order.
+BENCH_RUN_INDEX="${BENCH_RUN_INDEX:-1}"
+rotate_scenarios() {
+  local n=${#SCENARIOS[@]} idx="$BENCH_RUN_INDEX" shift_by
+  [ "$n" -gt 1 ] || return 0
+  case "$idx" in ''|*[!0-9]*) idx=1 ;; esac
+  shift_by=$(( (idx - 1) % n ))
+  [ "$shift_by" -gt 0 ] || return 0
+  SCENARIOS=( "${SCENARIOS[@]:$shift_by}" "${SCENARIOS[@]:0:$shift_by}" )
+  echo "[run] cell-order rotation: run index $idx -> shifted scenario order by $shift_by (BENCH_RUN_INDEX)"
+}
+rotate_scenarios
 
 command -v k6 >/dev/null || { echo "[run] k6 not installed — see https://k6.io/docs/get-started/installation/" >&2; exit 1; }
 
@@ -205,6 +236,171 @@ CELL_PAUSE="${BENCH_CELL_PAUSE:-60}"
 # Naive JSON string escaping (backslash + double-quote only — sufficient for
 # the plain ASCII strings embedded here: image names, kernel/cpu strings).
 json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+# --- G2 item 1: post-seed settle gate ---------------------------------------
+# Run 3 found a ~5-7 min window right after `bench-seed` where the AXIAM stack
+# serves everything at ~45 req/s with SurrealDB pinned at ~1 core (~22 ms
+# serialized unit), then spontaneously recovers — see
+# claude_dev/postseed-transient-investigation.md and
+# PRIVATE_BENCH_ANALYSIS.md §1. Because the matrix always ran scenarios in the
+# same order, this window silently corrupted every "first cell after seed"
+# ever measured. Instead of trusting a fixed clock delay, this gate polls a
+# cheap, target-appropriate, already-seeded canary once per second and blocks
+# the FIRST cell of a `bench-run` invocation until the target looks settled
+# (N consecutive stable seconds) or a hard timeout is hit.
+BENCH_SETTLE="${BENCH_SETTLE:-1}"                            # 0 to skip entirely (quick manual runs)
+BENCH_SETTLE_STABLE_SECS="${BENCH_SETTLE_STABLE_SECS:-30}"    # consecutive stable seconds required
+BENCH_SETTLE_MAX_MS="${BENCH_SETTLE_MAX_MS:-100}"             # canary latency threshold
+BENCH_SETTLE_TIMEOUT_SECS="${BENCH_SETTLE_TIMEOUT_SECS:-600}" # hard cap, then warn + proceed
+SETTLE_WAIT_SECS=0     # recorded in every cell's meta.json this run produces
+SETTLE_TIMEOUT_HIT=0   # 1 -> meta.json's settle_timeout: true
+
+_CANARY_JAR=""
+
+# One request against a cheap, target-appropriate, already-seeded endpoint.
+# Echoes the observed latency in whole milliseconds and returns 0 on any
+# completed HTTP response (even non-2xx — that still proves the listener is up
+# and timed); returns 1 only on a hard failure (connection refused/reset,
+# curl error) so a target that lacks/can't reach the canary endpoint never
+# fails the run — the caller just treats that tick as "no signal".
+canary_probe() {
+  local resp code time_s
+  case "$TARGET" in
+    axiam)
+      # authz-check-ish: the SAME endpoint (POST /api/v1/authz/check) whose
+      # post-seed clamp G1 documented, authenticated as the seeded bench user.
+      # Log in once (lazily) and reuse the cookie jar for every tick — a fresh
+      # login every second would itself be an expensive, different signal.
+      # Falls back to the plaintext /health liveness probe when the seed
+      # didn't provide enough to authenticate (e.g. BENCH_SKIP_OAUTH2-style
+      # partial seed) — still a real "is the listener answering" signal.
+      if [ -z "$_CANARY_JAR" ] || [ ! -s "$_CANARY_JAR" ]; then
+        _CANARY_JAR="$(mktemp)"
+        if [ -n "${BENCH_USERNAME:-}" ] && [ -n "${BENCH_PASSWORD:-}" ] && [ -n "${BENCH_ORG_SLUG:-}" ]; then
+          curl -sSk --max-time 5 -c "$_CANARY_JAR" -o /dev/null -X POST "$BASE/api/v1/auth/login" \
+            -H "Content-Type: application/json" \
+            -d "{\"org_slug\":\"${BENCH_ORG_SLUG}\",\"tenant_slug\":\"${BENCH_TENANT_SLUG:-default}\",\"username_or_email\":\"${BENCH_USERNAME}\",\"password\":\"${BENCH_PASSWORD}\"}" \
+            2>/dev/null || true
+        fi
+      fi
+      if [ -s "$_CANARY_JAR" ] && [ -n "${BENCH_RESOURCE_ID:-}" ] \
+         && awk -F'\t' '$6=="axiam_csrf"{f=1} END{exit !f}' "$_CANARY_JAR" 2>/dev/null; then
+        local csrf; csrf="$(awk -F'\t' '$6=="axiam_csrf"{v=$7} END{print v}' "$_CANARY_JAR")"
+        resp="$(curl -sSk --max-time 5 -b "$_CANARY_JAR" -o /dev/null -w '%{http_code} %{time_total}' \
+          -X POST "$BASE/api/v1/authz/check" -H "Content-Type: application/json" \
+          -H "X-CSRF-Token: $csrf" -d "{\"action\":\"read\",\"resource_id\":\"${BENCH_RESOURCE_ID}\"}" 2>/dev/null)" || return 1
+      else
+        resp="$(curl -sSk --max-time 5 -o /dev/null -w '%{http_code} %{time_total}' "$BASE/health" 2>/dev/null)" || return 1
+      fi
+      ;;
+    keycloak)
+      # jwks — cheap, unauthenticated, needs only the seeded realm name.
+      resp="$(curl -sSk --max-time 5 -o /dev/null -w '%{http_code} %{time_total}' \
+        "$BASE/realms/${BENCH_REALM:-bench}/protocol/openid-connect/certs" 2>/dev/null)" || return 1
+      ;;
+    zitadel)
+      # jwks — cheap, unauthenticated, no seed dependency at all.
+      resp="$(curl -sSk --max-time 5 -o /dev/null -w '%{http_code} %{time_total}' \
+        "$BASE/oauth/v2/keys" 2>/dev/null)" || return 1
+      ;;
+    *)
+      resp="$(curl -sSk --max-time 5 -o /dev/null -w '%{http_code} %{time_total}' "$BASE/health" 2>/dev/null)" || return 1
+      ;;
+  esac
+  [ -n "$resp" ] || return 1
+  code="${resp%% *}"; time_s="${resp#* }"
+  [ "$code" != "000" ] || return 1  # curl couldn't even complete the request
+  awk -v t="$time_s" 'BEGIN{printf "%.0f", t*1000}'
+}
+
+# Blocks until BENCH_SETTLE_STABLE_SECS consecutive canary ticks are all under
+# BENCH_SETTLE_MAX_MS, or BENCH_SETTLE_TIMEOUT_SECS elapses (then warns and
+# proceeds anyway, setting SETTLE_TIMEOUT_HIT=1). Sets SETTLE_WAIT_SECS to the
+# wall-clock seconds actually waited either way. A no-signal tick (canary
+# unreachable / target lacks the endpoint) resets the stability counter but
+# never aborts the run.
+settle_gate() {
+  if [ "$BENCH_SETTLE" = "0" ]; then
+    echo "[run] BENCH_SETTLE=0 — skipping post-seed settle gate"
+    return 0
+  fi
+  echo "[run] post-seed settle gate: waiting for ${BENCH_SETTLE_STABLE_SECS}s of consecutive canary latency < ${BENCH_SETTLE_MAX_MS}ms (hard timeout ${BENCH_SETTLE_TIMEOUT_SECS}s)"
+  echo "      — see claude_dev/postseed-transient-investigation.md / PRIVATE_BENCH_ANALYSIS.md §1 (post-seed serialized-DB transient). Set BENCH_SETTLE=0 to skip."
+  local start_ts now_ts stable_count=0 lat
+  start_ts=$(date +%s)
+  while :; do
+    # Sleep BEFORE each probe (including the first) so N consecutive stable
+    # ticks always corresponds to N full wall-clock seconds of stability —
+    # not N-1 (a probe taken at t=0 before any sleep would otherwise let
+    # BENCH_SETTLE_STABLE_SECS=30 finish in 29s).
+    sleep 1
+    now_ts=$(date +%s)
+    SETTLE_WAIT_SECS=$(( now_ts - start_ts ))
+    if [ "$SETTLE_WAIT_SECS" -ge "$BENCH_SETTLE_TIMEOUT_SECS" ]; then
+      SETTLE_TIMEOUT_HIT=1
+      echo "[run] WARN: settle gate hit its ${BENCH_SETTLE_TIMEOUT_SECS}s timeout without ${BENCH_SETTLE_STABLE_SECS} consecutive stable seconds under ${BENCH_SETTLE_MAX_MS}ms — proceeding anyway (settle_timeout: true will be recorded in meta.json)" >&2
+      break
+    fi
+    if lat="$(canary_probe)"; then
+      if [ "$lat" -lt "$BENCH_SETTLE_MAX_MS" ]; then
+        stable_count=$((stable_count + 1))
+      else
+        stable_count=0
+      fi
+    else
+      stable_count=0
+    fi
+    if [ "$stable_count" -ge "$BENCH_SETTLE_STABLE_SECS" ]; then
+      SETTLE_WAIT_SECS=$(( $(date +%s) - start_ts ))
+      echo "[run] settle gate: stable for ${BENCH_SETTLE_STABLE_SECS}s straight — proceeding (waited ${SETTLE_WAIT_SECS}s total)"
+      break
+    fi
+  done
+  [ -z "$_CANARY_JAR" ] || rm -f "$_CANARY_JAR"
+}
+
+# --- G2 item 3: self-describing labeled passes ------------------------------
+# Dumps every AXIAM__* env var the server container actually received
+# (straight off `docker inspect`, like detect_rl_posture() above — what
+# ACTUALLY ran, not what the shell that called `bench-up` intended) into each
+# cell's meta.json under "axiam_env", so a labeled pass (pool size, batch
+# strategy, decision cache, rate-limit posture, hash concurrency, ...) is
+# identifiable from the metadata alone rather than the results-directory name
+# (PRIVATE_BENCH_ANALYSIS.md §2.2).
+#
+# CRITICAL (A7 — shared archives contain no secret material): the VALUE of any
+# key matching AXIAM_ENV_REDACT_RE (case-insensitive) is NEVER written — only
+# the key NAME (so the setting's presence stays visible) with a literal
+# "<redacted>" placeholder value. `just bench-pack`'s leak check (justfile)
+# filters out every line containing that literal string before scanning
+# packed content for SECRET/PASSWORD, specifically so these legitimately-named
+# (and fully redacted) keys don't trip it — see the comment there.
+AXIAM_ENV_REDACT_RE='PASSWORD|SECRET|KEY|PEPPER|PEM|TOKEN'
+axiam_env_json() {
+  [ "$TARGET" = "axiam" ] || { echo -n "{}"; return; }
+  command -v docker >/dev/null 2>&1 || { echo -n "{}"; return; }
+  local env_dump line k v first=1
+  env_dump="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "bench-${TARGET}-server" 2>/dev/null)" || { echo -n "{}"; return; }
+  echo -n "{"
+  while IFS= read -r line; do
+    case "$line" in
+      AXIAM__*=*) : ;;
+      *) continue ;;
+    esac
+    k="${line%%=*}"
+    v="${line#*=}"
+    [ "$first" -eq 1 ] || echo -n ","
+    first=0
+    echo
+    if printf '%s' "$k" | grep -qiE "$AXIAM_ENV_REDACT_RE"; then
+      printf '    "%s": "<redacted>"' "$(json_escape "$k")"
+    else
+      printf '    "%s": "%s"' "$(json_escape "$k")" "$(json_escape "$v")"
+    fi
+  done <<< "$env_dump"
+  [ "$first" -eq 1 ] || echo
+  echo -n "}"
+}
 
 # Container names that make up each target's stack, with a role used to look
 # up its CPU cap default (mirrors targets/<name>/docker-compose.yml — see A4/A5
@@ -340,6 +536,7 @@ containers_json() {
 
 run_one() {
   local scenario="$1"
+  local cell_order_index="${2:-1}"
   local name="${scenario%.js}"
   local outdir="$RESULTS/$TARGET/$PROFILE"
   mkdir -p "$outdir"
@@ -408,17 +605,29 @@ run_one() {
   "cpu_governor": "$(json_escape "$CPU_GOVERNOR")",
   "build_ref": "$(json_escape "$BUILD_REF")",
   "k6_cpu_cores_avg": $k6_cpu_cores_avg,
-  "containers": $(containers_json)
+  "containers": $(containers_json),
+  "settle_wait_secs": $SETTLE_WAIT_SECS,
+  "settle_timeout": $([ "$SETTLE_TIMEOUT_HIT" = "1" ] && echo true || echo false),
+  "cell_order_index": $cell_order_index,
+  "axiam_env": $(axiam_env_json)
 }
 EOF
   echo "[run] wrote $k6sum, $rescsv, $hostcsv, $meta"
 }
 
 SCENARIO_COUNT=${#SCENARIOS[@]}
+
+# G2 item 1: gate the FIRST cell of this run behind the settle check (once —
+# not per cell; every cell in this run records the same settle_wait_secs /
+# settle_timeout since they all measure the same post-seed settle event).
+if [ "$SCENARIO_COUNT" -gt 0 ]; then
+  settle_gate
+fi
+
 scenario_idx=0
 for s in "${SCENARIOS[@]}"; do
   scenario_idx=$((scenario_idx + 1))
-  run_one "$s"
+  run_one "$s" "$scenario_idx"
   # C3: pause between cells (not after the last one) so heat dissipates and
   # allocations/caches from this cell settle before the next measurement.
   if [ "$scenario_idx" -lt "$SCENARIO_COUNT" ] && [ "$CELL_PAUSE" -gt 0 ] 2>/dev/null; then

--- a/benchmarks/scenarios/authz_batch_grpc.js
+++ b/benchmarks/scenarios/authz_batch_grpc.js
@@ -6,7 +6,7 @@
 import grpc from 'k6/net/grpc';
 import { check } from 'k6';
 import { cfg, loadStages, thresholds, tlsOptions, grpcConnectParams, requireSeed } from './lib/config.js';
-import { m } from './lib/metrics.js';
+import { recordGrpcResult } from './lib/metrics.js';
 import { loginSession, jwtClaims } from './lib/auth.js';
 
 const client = new grpc.Client();
@@ -82,8 +82,8 @@ export default function (data) {
   // reading it — so the raw value silently recorded 1 for EVERY code, including
   // StatusOK (0). `===` against grpc.StatusOK is unaffected, which is why the
   // checks stayed correct while this metric was uniformly 1.
-  m.grpcStatus.add(res && res.status != null ? Number(res.status) : -1);
-  m.latency.add(Date.now() - start);
-  m.errorRate.add(!ok);
-  if (ok) m.ok.add(1); else m.failed.add(1);
+  // G9: one shared classifier for every gRPC scenario — also splits out
+  // RESOURCE_EXHAUSTED into bench_throttled so a rate-limited cell is
+  // legible (see claude_dev/grpc-vs-rest-authz-analysis.md).
+  recordGrpcResult(res, Date.now() - start, ok);
 }

--- a/benchmarks/scenarios/authz_check_grpc.js
+++ b/benchmarks/scenarios/authz_check_grpc.js
@@ -6,7 +6,7 @@
 import grpc from 'k6/net/grpc';
 import { check } from 'k6';
 import { cfg, loadStages, thresholds, tlsOptions, grpcConnectParams, requireSeed } from './lib/config.js';
-import { m } from './lib/metrics.js';
+import { recordGrpcResult } from './lib/metrics.js';
 import { loginSession, jwtClaims } from './lib/auth.js';
 
 const client = new grpc.Client();
@@ -70,8 +70,8 @@ export default function (data) {
   // reading it — so the raw value silently recorded 1 for EVERY code, including
   // StatusOK (0). `===` against grpc.StatusOK is unaffected, which is why the
   // checks stayed correct while this metric was uniformly 1.
-  m.grpcStatus.add(res && res.status != null ? Number(res.status) : -1);
-  m.latency.add(Date.now() - start);
-  m.errorRate.add(!ok);
-  if (ok) m.ok.add(1); else m.failed.add(1);
+  // G9: one shared classifier for every gRPC scenario — also splits out
+  // RESOURCE_EXHAUSTED into bench_throttled so a rate-limited cell is
+  // legible (see claude_dev/grpc-vs-rest-authz-analysis.md).
+  recordGrpcResult(res, Date.now() - start, ok);
 }

--- a/benchmarks/scenarios/authz_check_rest.js
+++ b/benchmarks/scenarios/authz_check_rest.js
@@ -10,6 +10,37 @@
 // resource_id must be the seeded resource UUID and a seeded role grant makes the
 // decision allowed=true. A non-GET call under /api/v1 requires the CSRF
 // double-submit (axiam_csrf cookie + X-CSRF-Token header), both taken from login.
+//
+// ---------------------------------------------------------------------------
+// G5 — decision-cache key-space sweep (BENCH_AUTHZ_KEYSPACE)
+// ---------------------------------------------------------------------------
+//
+// Run 3 measured the D7 decision cache with 50 VUs all hammering ONE
+// (subject, resource, action, scope) tuple — cardinality K=1, the friendliest
+// hit rate that can exist — and reported a ~3.0-3.15x throughput win. That
+// number cannot justify flipping a security-relevant default, so this scenario
+// is parameterized by the cache-key cardinality:
+//
+//   BENCH_AUTHZ_KEYSPACE=K   each request picks 1 of K distinct cache keys
+//
+//   K=1      (DEFAULT) reproduces run 3 exactly. No provisioning happens, the
+//            request body is byte-identical to the pre-G5 scenario, and every
+//            other cell that runs this file is unaffected.
+//   K=100    small-service key space.
+//   K=10000  exceeds the default DECISION_CACHE_MAX_ENTRIES (10 000 per
+//            tenant), so it also exercises the FIFO eviction path.
+//
+// The cache key was read out of crates/axiam-authz/src/decision_cache.rs
+// (`SubKey` = subject_id, resource_id, action, scope; sharded by tenant_id) —
+// not taken on faith from the design doc.
+//
+// Both key-generation modes (see lib/config.js `authzKeyspaceMode`) keep the
+// request a REAL authorization evaluation returning HTTP 200 with a real
+// decision. An error path (400 on a malformed UUID, 404 on a missing object)
+// would short-circuit the engine and make the whole sweep meaningless, so
+// setup() probes the generated key space before the measured window starts and
+// fails loudly if the probe is not the expected decision.
+import http from 'k6/http';
 import { cfg, baseUrl, loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
 import { doOp } from './lib/metrics.js';
 import { loginSession } from './lib/auth.js';
@@ -21,22 +52,257 @@ export const options = Object.assign(
     },
     thresholds: thresholds('bench_op_latency_ms'),
     summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+    // Ceiling only — provisioning 10 000 resources over REST outruns k6's 60s
+    // setup default. Changes nothing about the requests the VUs send.
+    setupTimeout: cfg.setupTimeout,
   },
   tlsOptions(),
 );
 
 const RESOURCE = __ENV.BENCH_RESOURCE_ID || 'bench-resource';
 
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// Clamp K to a sane integer. K<=1 means "behave exactly as the pre-G5 scenario".
+function keyspace() {
+  const k = Math.floor(Number(cfg.authzKeyspace));
+  return Number.isFinite(k) && k > 1 ? k : 1;
+}
+
+// ---------------------------------------------------------------------------
+// setup() helpers — admin session + child-resource provisioning
+// ---------------------------------------------------------------------------
+
+// Log in as the bootstrap admin (runner/seed.sh's `admin` user) and return the
+// cookie-session credentials needed to POST under /api/v1. Mirrors
+// lib/targets.js `axiam.login()`: prefer the seeded org/tenant UUIDs, fall back
+// to slugs, omit empty selectors. Deliberately NOT added to lib/auth.js — this
+// is a G5-only provisioning path, not a measured operation.
+function adminSession() {
+  const jar = http.cookieJar();
+  const url = `${baseUrl()}/api/v1/auth/login`;
+  const body = { username_or_email: cfg.adminUsername, password: cfg.adminPassword };
+  if (cfg.orgId) body.org_id = cfg.orgId;
+  else if (cfg.orgSlug) body.org_slug = cfg.orgSlug;
+  if (cfg.tenantId) body.tenant_id = cfg.tenantId;
+  else if (cfg.tenantSlug) body.tenant_slug = cfg.tenantSlug;
+
+  const res = http.post(url, JSON.stringify(body), { headers: { 'Content-Type': 'application/json' } });
+  if (res.status !== 200) {
+    throw new Error(
+      `authz_check_rest[G5]: admin login failed (status ${res.status}). ` +
+        'BENCH_AUTHZ_KEYSPACE>1 in resource mode provisions child resources through the admin REST API; ' +
+        'set BENCH_ADMIN_USERNAME/BENCH_ADMIN_PASSWORD to match runner/seed.sh, or use ' +
+        'BENCH_AUTHZ_KEYSPACE_MODE=action (no provisioning).',
+    );
+  }
+  const cookies = jar.cookiesForURL(url);
+  const access = cookies.axiam_access && cookies.axiam_access[0];
+  const csrf = cookies.axiam_csrf && cookies.axiam_csrf[0];
+  if (!access || !csrf) {
+    throw new Error('authz_check_rest[G5]: admin login returned no axiam_access/axiam_csrf cookie');
+  }
+  return {
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${access}`, 'X-CSRF-Token': csrf },
+    cookies: { axiam_csrf: csrf },
+  };
+}
+
+// Child resources are named deterministically so a re-run against a stack that
+// was NOT torn down reuses what is already there instead of duplicating it
+// (the G5 driver sweeps K=1 -> 100 -> 10000 against one live stack).
+function childName(i) {
+  return `bench-ks-${i}`;
+}
+
+// Existing bench-ks-* children of the seeded resource, as { name: id }.
+// GET /api/v1/resources/{id}/children returns an UNPAGINATED Vec<Resource>
+// (crates/axiam-api-rest/src/handlers/resources.rs `list_children`), so one
+// call is enough even at 10 000. A failure here is non-fatal: we simply
+// provision from scratch.
+function existingChildren(sess) {
+  const res = http.get(`${baseUrl()}/api/v1/resources/${RESOURCE}/children`, { headers: sess.headers });
+  if (res.status !== 200) {
+    console.warn(`authz_check_rest[G5]: children listing returned ${res.status}; provisioning from scratch`);
+    return {};
+  }
+  let items;
+  try {
+    const body = res.json();
+    items = Array.isArray(body) ? body : body.items || [];
+  } catch (_e) {
+    return {};
+  }
+  const byName = {};
+  for (const r of items) {
+    if (r && r.name && r.id) byName[r.name] = r.id;
+  }
+  return byName;
+}
+
+// Provision (or reuse) K-1 child resources of the seeded resource and return
+// the full ordered key list: [seeded resource, child 1, ... child K-1].
+//
+// Children inherit the bench user's role assignment through the hierarchy
+// (the seeded `bench-reader` role is assigned scoped to the parent, and
+// engine.rs `applicable_role_ids` accepts an assignment scoped to any ancestor
+// of the target), so every one of the K keys yields a real ALLOW on the same
+// 3-round-trip evaluation path as K=1.
+function provisionResourceKeyspace(k) {
+  if (!UUID_RE.test(RESOURCE)) {
+    throw new Error(
+      `authz_check_rest[G5]: BENCH_RESOURCE_ID is "${RESOURCE}", not a UUID — the resource key-space mode ` +
+        'needs the seeded resource UUID to parent its children. Source .seed/axiam.seed.env, or use ' +
+        'BENCH_AUTHZ_KEYSPACE_MODE=action.',
+    );
+  }
+  const sess = adminSession();
+  const known = existingChildren(sess);
+
+  const ids = [RESOURCE];
+  const missing = [];
+  for (let i = 1; i < k; i++) {
+    const name = childName(i);
+    if (known[name]) {
+      ids.push(known[name]);
+    } else {
+      ids.push(null);
+      missing.push({ slot: i, name });
+    }
+  }
+
+  if (missing.length > 0) {
+    console.log(`authz_check_rest[G5]: provisioning ${missing.length} child resources (K=${k})`);
+    const batchSize = Math.max(1, Math.floor(cfg.authzKeyspaceBatch) || 1);
+    for (let off = 0; off < missing.length; off += batchSize) {
+      const chunk = missing.slice(off, off + batchSize);
+      const reqs = chunk.map((m) => [
+        'POST',
+        `${baseUrl()}/api/v1/resources`,
+        JSON.stringify({ name: m.name, resource_type: 'bench-keyspace', parent_id: RESOURCE }),
+        { headers: sess.headers, cookies: sess.cookies },
+      ]);
+      const responses = http.batch(reqs);
+      for (let j = 0; j < responses.length; j++) {
+        const r = responses[j];
+        if (r.status !== 201) {
+          throw new Error(
+            `authz_check_rest[G5]: creating ${chunk[j].name} failed (status ${r.status}): ` +
+              String(r.body).slice(0, 200),
+          );
+        }
+        let id;
+        try {
+          id = r.json().id;
+        } catch (_e) {
+          id = null;
+        }
+        if (!id) throw new Error(`authz_check_rest[G5]: create ${chunk[j].name} returned no id`);
+        ids[chunk[j].slot] = id;
+      }
+      if ((off / batchSize) % 25 === 0) {
+        console.log(`authz_check_rest[G5]: ${Math.min(off + batchSize, missing.length)}/${missing.length} created`);
+      }
+    }
+  }
+
+  for (let i = 0; i < ids.length; i++) {
+    if (!ids[i]) throw new Error(`authz_check_rest[G5]: key-space slot ${i} was not provisioned`);
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Request construction
+// ---------------------------------------------------------------------------
+
+// Build the check body for key index `i`. At i=0 this is byte-identical to the
+// pre-G5 body in BOTH modes: {"action":"read","resource_id":"<seeded>"}.
+function bodyFor(data, i) {
+  if (data.keyspace_mode === 'action') {
+    return JSON.stringify({ action: i === 0 ? 'read' : `read-ks-${i}`, resource_id: RESOURCE });
+  }
+  return JSON.stringify({ action: 'read', resource_id: data.resource_ids[i] });
+}
+
+// Per-VU xorshift32, seeded from __VU. Deterministic (so two cells with the
+// same K draw the same sequence) and uniform over [0, k). Module scope is
+// per-VU in k6, so each VU keeps its own stream across iterations.
+let rngState = 0;
+function nextIndex(k) {
+  if (k <= 1) return 0;
+  if (rngState === 0) rngState = (__VU * 2654435761) >>> 0 || 0x9e3779b9;
+  rngState ^= rngState << 13;
+  rngState >>>= 0;
+  rngState ^= rngState >>> 17;
+  rngState ^= rngState << 5;
+  rngState >>>= 0;
+  return rngState % k;
+}
+
+// ---------------------------------------------------------------------------
+
 export function setup() {
   requireSeed();
-  return loginSession();
+  const session = loginSession();
+  const k = keyspace();
+  const mode = cfg.authzKeyspaceMode === 'action' ? 'action' : 'resource';
+
+  const data = Object.assign({}, session, { keyspace: k, keyspace_mode: mode, resource_ids: [RESOURCE] });
+
+  if (k > 1 && mode === 'resource') {
+    data.resource_ids = provisionResourceKeyspace(k);
+  }
+
+  if (k > 1) {
+    // Fail-closed gate: the LAST key must be a real evaluation with the
+    // expected decision, otherwise the sweep would silently measure an error
+    // path or the short "no applicable roles" deny instead of the full
+    // evaluation the cache is supposed to be skipping.
+    const probe = http.post(`${baseUrl()}/api/v1/authz/check`, bodyFor(data, k - 1), {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`,
+        'X-CSRF-Token': session.csrf_token,
+      },
+      cookies: { axiam_csrf: session.csrf_token },
+    });
+    if (probe.status !== 200) {
+      throw new Error(
+        `authz_check_rest[G5]: key-space probe returned ${probe.status}, not a decision — ` +
+          `the K=${k} sweep would measure an error path. Body: ${String(probe.body).slice(0, 200)}`,
+      );
+    }
+    const allowed = probe.json().allowed;
+    if (mode === 'resource' && allowed !== true) {
+      throw new Error(
+        'authz_check_rest[G5]: a provisioned child resource evaluated to DENY ' +
+          `(reason: ${probe.json().reason}). Hierarchy inheritance of the seeded role assignment is not ` +
+          'working, so the sweep would measure the SHORT deny path (2 DB round-trips) instead of the full ' +
+          'evaluation. Re-seed, or use BENCH_AUTHZ_KEYSPACE_MODE=action.',
+      );
+    }
+    if (mode === 'action' && allowed !== false) {
+      throw new Error(
+        'authz_check_rest[G5]: a synthetic action evaluated to ALLOW — the bench role grants more than ' +
+          '"read", so the action key space is not the intended deny-on-full-path shape.',
+      );
+    }
+    console.log(
+      `authz_check_rest[G5]: key space ready — K=${k}, mode=${mode}, ` +
+        `decision at last key = ${allowed ? 'ALLOW' : 'DENY'} (both are cached verbatim)`,
+    );
+  }
+
+  return data;
 }
 
 export default function (data) {
+  const i = nextIndex(data.keyspace || 1);
   doOp({
     method: 'POST',
     url: `${baseUrl()}/api/v1/authz/check`,
-    body: JSON.stringify({ action: 'read', resource_id: RESOURCE }),
+    body: bodyFor(data, i),
     params: {
       headers: {
         'Content-Type': 'application/json',

--- a/benchmarks/scenarios/lib/auth.js
+++ b/benchmarks/scenarios/lib/auth.js
@@ -3,6 +3,7 @@
 import http from 'k6/http';
 import encoding from 'k6/encoding';
 import { adapter } from './targets.js';
+import { cfg, baseUrl } from './config.js';
 
 // Obtain an access (+ refresh) token once, for scenarios that operate on a token.
 // Tries client_credentials first (works for every target); falls back to login.
@@ -39,12 +40,33 @@ export function mintToken() {
 // Used by both `loginSession()` (authz scenarios) and `mintUserToken()`
 // (token-holding scenarios like userinfo) so the cookie-reading logic lives in
 // exactly one place.
+//
+// G4: `axiam_refresh` is Path-scoped to `/api/v1/auth/refresh`
+// (crates/axiam-api-rest/src/middleware/csrf.rs `refresh_cookie()`,
+// `.path("/api/v1/auth/refresh")`) — unlike `axiam_access`/`axiam_csrf`, which
+// are Path=`/` (same file, `access_cookie()`/`csrf_cookie()`). A jar read
+// scoped to the *login* URL (`/api/v1/auth/login`) therefore never returns it
+// (RFC 6265 path-matching: "/api/v1/auth/refresh" is not a prefix of
+// "/api/v1/auth/login") — this was the entire root cause of the AXIAM
+// `token_refresh` cell measuring 100% `bench_fallback`: `refresh_token` came
+// back `undefined` on every call, so callers always fell through to the
+// client_credentials fallback branch. Fix: also probe the jar against the
+// refresh endpoint's own path so the narrowly-scoped cookie is found. This is
+// a pure jar read (no extra HTTP request) and is a harmless no-op for targets
+// that never set an `axiam_refresh`-named cookie (Keycloak/Zitadel deliver
+// their refresh token in the JSON body instead, via the fallback below).
 export function readAccessFromLogin(built, res, jar) {
   const cookies = jar.cookiesForURL(built.url);
   let body = null;
   try { body = res.json(); } catch (_e) { /* cookie-only response, no JSON body */ }
   const access = (cookies.axiam_access && cookies.axiam_access[0]) || (body && (body.access_token || body.token));
-  const refresh = (cookies.axiam_refresh && cookies.axiam_refresh[0]) || (body && body.refresh_token);
+  const originMatch = /^(https?:\/\/[^/]+)/.exec(built.url);
+  const origin = originMatch ? originMatch[1] : '';
+  const refreshScopeCookies = origin ? jar.cookiesForURL(`${origin}/api/v1/auth/refresh`) : {};
+  const refresh =
+    (cookies.axiam_refresh && cookies.axiam_refresh[0]) ||
+    (refreshScopeCookies.axiam_refresh && refreshScopeCookies.axiam_refresh[0]) ||
+    (body && body.refresh_token);
   const csrf = cookies.axiam_csrf && cookies.axiam_csrf[0];
   return { access_token: access, refresh_token: refresh, csrf_token: csrf };
 }
@@ -83,9 +105,9 @@ export function mintUserToken() {
   if (!built.fallback) {
     const res = http.request(built.method, built.url, built.body || null, built.params || {});
     if (res.status === (built.expect || 200)) {
-      const { access_token, refresh_token } = readAccessFromLogin(built, res, jar);
+      const { access_token, refresh_token, csrf_token } = readAccessFromLogin(built, res, jar);
       if (access_token) {
-        return { access_token, refresh_token, is_user_token: true };
+        return { access_token, refresh_token, csrf_token, is_user_token: true };
       }
     }
   }
@@ -100,7 +122,68 @@ export function mintUserToken() {
   try { body = ccRes.json(); } catch (_e) { body = {}; }
   const access = body.access_token || body.token;
   if (!access) throw new Error('auth.mintUserToken: client_credentials fallback returned no token');
-  return { access_token: access, refresh_token: body.refresh_token, is_user_token: false };
+  return { access_token: access, refresh_token: body.refresh_token, csrf_token: undefined, is_user_token: false };
+}
+
+// G4: AXIAM's user-login-issued refresh token is redeemed at the *session*
+// refresh endpoint `POST /api/v1/auth/refresh` — NOT the generic OAuth2
+// `POST /oauth2/token?grant_type=refresh_token` grant that `targets.js`'s
+// `axiam.refresh()` builder sends every refresh request to today. These are
+// two different token stores server-side:
+//   - `/api/v1/auth/login` mints its refresh token via axiam-auth's
+//     SessionRepository (crates/axiam-auth/src/service.rs, `login()` ~L604-634).
+//   - `/oauth2/token`'s `refresh_token` grant looks the presented token up in
+//     axiam-oauth2's RefreshTokenRepository instead
+//     (crates/axiam-oauth2/src/token.rs `handle_refresh_token`, ~L502-514) and
+//     returns `invalid_grant` ("refresh token is invalid, expired, or
+//     revoked") for anything not issued by an OAuth2-flow grant — a
+//     session-login refresh token is never in that table, so this call
+//     always 401s once the cookie-extraction bug above is fixed.
+// The correct redemption target, `/api/v1/auth/refresh`
+// (crates/axiam-api-rest/src/handlers/auth.rs `refresh()`, ~L421-480),
+// requires:
+//   - the `axiam_refresh` cookie (read from the httpOnly cookie, L429-434 —
+//     there is no body/header alternative),
+//   - the CSRF double-submit header `X-CSRF-Token` matching the `axiam_csrf`
+//     cookie (this path is NOT in `CSRF_EXEMPT_SUFFIXES`, middleware/csrf.rs),
+//   - a JSON body `{ tenant_id, org_id }` (`RefreshRequest`, handlers/auth.rs)
+//     — `org_id` is required to deserialize but is not actually trusted
+//     (the handler re-derives it from `tenant_id`, L449-451), so any
+//     well-formed UUID satisfies it.
+// The response rotates all three cookies (new access/refresh/csrf) but its
+// JSON body carries only `{ expires_in }` — no tokens — so the new
+// refresh/csrf values must be read back out of the jar (see
+// `readAxiamRefreshCookies` below), not out of `doOp()`'s return value.
+//
+// This belongs in targets.js's `axiam.refresh()` long-term so every target
+// goes through the same `a.refresh()` call shape; implemented here because
+// targets.js is out of scope for this change (see
+// claude_dev/refresh-harness-diagnosis.md for the exact diff to make there).
+export function axiamRefreshOp(refreshToken, csrfToken) {
+  return {
+    method: 'POST',
+    url: `${baseUrl()}/api/v1/auth/refresh`,
+    body: JSON.stringify({ tenant_id: cfg.tenantId, org_id: cfg.orgId }),
+    params: {
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken || '' },
+      cookies: { axiam_refresh: refreshToken, axiam_csrf: csrfToken || '' },
+    },
+    expect: 200,
+  };
+}
+
+// Read the rotated `axiam_refresh`/`axiam_csrf` cookies out of the jar after
+// an `axiamRefreshOp` redemption. k6 stores a response's Set-Cookie headers
+// into the VU's jar automatically regardless of how the request's own
+// cookies were supplied, so this works whether or not the prior request also
+// happened to hit the jar. Scoped to the refresh endpoint's own path/origin
+// for the same Path-scoping reason documented on `readAccessFromLogin` above.
+export function readAxiamRefreshCookies(jar) {
+  const cookies = jar.cookiesForURL(`${baseUrl()}/api/v1/auth/refresh`);
+  return {
+    refresh_token: cookies.axiam_refresh && cookies.axiam_refresh[0],
+    csrf_token: cookies.axiam_csrf && cookies.axiam_csrf[0],
+  };
 }
 
 // Decode the (unverified) claims from a JWT payload segment. Used only to read

--- a/benchmarks/scenarios/lib/config.js
+++ b/benchmarks/scenarios/lib/config.js
@@ -75,6 +75,60 @@ export const cfg = {
   // --- validity gates ---
   maxErrorRate: num('BENCH_MAX_ERROR', 0.01),
   maxP95: num('BENCH_MAX_P95_MS', 2000),
+
+  // --- G5: decision-cache key-space sweep (authz_check_rest.js only) ---
+  //
+  // Run 3 measured the D7 decision cache at an effective cardinality of ONE:
+  // 50 VUs all sending the same (subject, resource, action, scope) tuple, i.e.
+  // the friendliest hit rate that exists. `BENCH_AUTHZ_KEYSPACE=K` spreads each
+  // request over K distinct cache keys so the ship-decision can be made against
+  // a realistic hit rate instead of a best case. K=1 (the default) reproduces
+  // run 3 exactly and leaves every other cell that runs authz_check_rest.js
+  // completely unchanged.
+  //
+  // The cache key is `(tenant_id, subject_id, resource_id, action, scope)` —
+  // verified against crates/axiam-authz/src/decision_cache.rs `SubKey`, NOT
+  // taken from the design doc.
+  authzKeyspace: num('BENCH_AUTHZ_KEYSPACE', 1),
+
+  // How the K distinct keys are generated. Both modes keep the request a REAL
+  // authorization evaluation returning HTTP 200 with a real decision — never a
+  // 400/404 error path, which would make the sweep meaningless.
+  //
+  //   'resource' (default) — provision K-1 CHILD resources of the seeded
+  //       `bench-resource` in setup() via the admin REST API, and vary
+  //       `resource_id`. The seeded `bench-reader` role is assigned scoped to
+  //       `bench-resource`, so hierarchy inheritance
+  //       (crates/axiam-authz/src/engine.rs `applicable_role_ids`) makes every
+  //       child ALLOW, on the same 3-round-trip evaluation path as K=1. This is
+  //       the mode the G5 plan asks for (K distinct subject x resource pairs).
+  //   'action' — zero-provisioning fallback: keep the seeded resource and vary
+  //       the `action` string. Index 0 is literally "read" (ALLOW); every other
+  //       index is an action no grant covers, so the engine runs the FULL
+  //       assignments -> ancestors -> grants path and returns
+  //       DENY("no permission grants action '<x>'"). Denies are cached verbatim
+  //       (decision_cache.rs / engine.rs `check_access` caches the full
+  //       AccessDecision), so the cache is exercised identically. Use this when
+  //       the admin credentials for provisioning are unavailable, or as a
+  //       control that isolates pure key cardinality from DB row diversity.
+  authzKeyspaceMode: str('BENCH_AUTHZ_KEYSPACE_MODE', 'resource'),
+
+  // Parallelism of the setup()-time resource provisioning (http.batch size).
+  // Only used by 'resource' mode with K > 1.
+  authzKeyspaceBatch: num('BENCH_AUTHZ_KEYSPACE_BATCH', 20),
+
+  // k6 setup() ceiling. Provisioning ~10 000 resources over REST needs more
+  // than k6's 60s default. Pure ceiling — it changes no request the VUs send.
+  setupTimeout: str('BENCH_SETUP_TIMEOUT', '900s'),
+
+  // Bootstrap admin session used ONLY by the G5 keyspace provisioning in
+  // setup(). Defaults deliberately mirror runner/seed.sh's `admin` /
+  // BENCH_ADMIN_PASSWORD so no new secret has to be plumbed through: seed.sh
+  // bootstraps the org with username `admin` and password `Bench@Admin123!`
+  // unless BENCH_ADMIN_PASSWORD was overridden there. These are throwaway
+  // benchmark-fixture credentials for a disposable container; never log them.
+  adminUsername: str('BENCH_ADMIN_USERNAME', 'admin'),
+  adminPassword: str('BENCH_ADMIN_PASSWORD', 'Bench@Admin123!'),
 };
 
 export function baseUrl() {

--- a/benchmarks/scenarios/lib/metrics.js
+++ b/benchmarks/scenarios/lib/metrics.js
@@ -21,6 +21,28 @@ export const m = {
   // hint why. A Trend (not a Counter) so the summary's percentile/avg stats
   // surface which code dominates. Recorded by the gRPC scenarios only.
   grpcStatus: new Trend('bench_grpc_status'),
+  // G9/item-3: rate-limit rejections counted DISTINCTLY from other failures
+  // (REST 429 / gRPC RESOURCE_EXHAUSTED=8 — the status both
+  // crates/axiam-api-rest's shared+in-memory limiters and
+  // crates/axiam-api-grpc's GrpcSharedRateLimitLayer/GovernorLayer return,
+  // see crates/axiam-api-grpc/src/middleware/rate_limit.rs
+  // too_many_requests_response()). This is additive: a throttled op is still
+  // counted in bench_failed / bench_error_rate exactly as before (it is not a
+  // success), so nothing downstream that reads those two metrics changes
+  // behavior. What this adds is the ability to tell, from the summary alone,
+  // whether a near-100%-error cell is "almost entirely expected control-plane
+  // rejections" (bench_failed ≈ bench_throttled) or "something else is also
+  // broken" (bench_failed >> bench_throttled) — the run-3 "13.6/s bench_ok at
+  // bench_error_rate=1.00" cells were not a bug in bench_ok's accounting
+  // (doOp() below already only ever increments bench_ok on a true logical
+  // pass — see the report for the full trace); they were a handful of
+  // legitimate successes admitted by the rate limiter, plus a k6 closed-loop
+  // VU loop retrying near-instantly on every 429 with no backoff, producing
+  // an iteration count so large that bench_error_rate rounds to "1.00" at 2
+  // decimal places while bench_ok's count-over-full-test-duration rate still
+  // reads as a nonzero, seemingly-contradictory "ops/s". bench_throttled
+  // makes that story legible without changing either existing metric.
+  throttled: new Counter('bench_throttled'),
 };
 
 // Execute one built request (from targets.js) and record uniform metrics.
@@ -42,6 +64,14 @@ export function doOp(built, params) {
     m.ok.add(1);
   } else {
     m.failed.add(1);
+    // G9/item-3: classify rate-limit rejections distinctly (see m.throttled
+    // above). res.status === 429 can only be true here because `passed` is
+    // already false, i.e. `expected` (200/201) didn't match — so a scenario
+    // whose `built.expect` was itself 429 could never reach this branch as a
+    // "throttled" success; no scenario in this repo sets expect: 429 (grep
+    // confirms every adapter/scenario expects 200/201), so a 429 can only
+    // ever land in the failed/throttled branch, never in bench_ok.
+    if (res.status === 429) m.throttled.add(1);
   }
 
   if (!passed) return null;
@@ -49,5 +79,40 @@ export function doOp(built, params) {
     return res.json();
   } catch (_e) {
     return {}; // non-JSON 2xx (e.g. JWKS variants) still counts as success
+  }
+}
+
+// Shared record-and-classify helper for scenarios that cannot use doOp()
+// because their transport isn't k6/http (currently: the gRPC scenarios —
+// authz_check_grpc.js, authz_batch_grpc.js, userinfo_grpc.js,
+// zitadel_userinfo_grpc.js — whose k6/net/grpc `invoke()` response shape and
+// timing model differ from http.request()'s, so they hand-roll their own
+// ok/failed/latency/status recording instead). This centralizes the SAME
+// classify-and-count semantics doOp() uses above (including the
+// bench_throttled split) so those scenarios can adopt it with a one-line
+// change at their call site instead of re-diverging their own copy again.
+// NOT wired into any scenario by this change — see G9
+// (claude_dev/grpc-vs-rest-authz-analysis.md) for the exact remaining
+// call-site edit each of those (unowned) files needs.
+//
+// `res` is the raw k6 grpc.Client.invoke() response, `latencyMs` the
+// caller-measured duration, `ok` the caller's `grpc status OK` check result.
+export function recordGrpcResult(res, latencyMs, ok) {
+  // Number() is required: k6 hands res.status to JS as a wrapped Go value
+  // (typeof === "object"), so `res.status === 8` below would silently never
+  // match without this coercion (same pitfall the D11 grpcStatus comments in
+  // the gRPC scenarios already document for the OK-code case).
+  const statusCode = res && res.status != null ? Number(res.status) : -1;
+  m.grpcStatus.add(statusCode);
+  m.latency.add(latencyMs);
+  m.errorRate.add(!ok);
+  if (ok) {
+    m.ok.add(1);
+  } else {
+    m.failed.add(1);
+    // grpc RESOURCE_EXHAUSTED=8 — the status too_many_requests_response()
+    // (crates/axiam-api-grpc/src/middleware/rate_limit.rs) and the in-memory
+    // GovernorLayer's GovernorError::TooManyRequests both return.
+    if (statusCode === 8) m.throttled.add(1);
   }
 }

--- a/benchmarks/scenarios/token_refresh.js
+++ b/benchmarks/scenarios/token_refresh.js
@@ -1,11 +1,12 @@
 // Scenario: refresh-token grant. AXIAM rotates refresh tokens single-use, so each
 // VU mints its own token in setup-per-VU style and chains rotations. For targets
 // without rotation the same refresh token is reusable; both are handled.
+import http from 'k6/http';
 import { sleep } from 'k6';
-import { loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
+import { cfg, loadStages, thresholds, tlsOptions, requireSeed } from './lib/config.js';
 import { adapter } from './lib/targets.js';
 import { doOp, m } from './lib/metrics.js';
-import { mintUserToken } from './lib/auth.js';
+import { mintUserToken, axiamRefreshOp, readAxiamRefreshCookies } from './lib/auth.js';
 
 export const options = Object.assign(
   {
@@ -18,8 +19,11 @@ export const options = Object.assign(
   tlsOptions(),
 );
 
-// Per-VU refresh token, so single-use rotation does not invalidate other VUs.
+// Per-VU refresh token (+ CSRF token, needed only for AXIAM's cookie-based
+// grant — see axiamRefreshOp), so single-use rotation does not invalidate
+// other VUs.
 let vuRefresh = null;
+let vuCsrf = null;
 
 export function setup() {
   requireSeed();
@@ -27,6 +31,7 @@ export function setup() {
 
 export default function () {
   const a = adapter();
+  const isAxiam = cfg.target === 'axiam';
   if (!vuRefresh) {
     let tok;
     try {
@@ -51,21 +56,45 @@ export default function () {
       return;
     }
     vuRefresh = tok.refresh_token;
+    vuCsrf = tok.csrf_token;
     if (!vuRefresh) {
       // Target issued no refresh token off a user login either (e.g. Zitadel:
       // mintUserToken() falls back to client_credentials because its login()
       // returns a session-API `sessionToken`, not an OIDC token — a real
       // refresh token would require driving a full OIDC auth-code flow with
-      // `offline_access`, which this harness cannot easily do). Nothing to
-      // measure; mint again as the closest comparable token-issuance op. This
-      // is not a refresh, so tag + count it as a fallback
-      // (comparability: fallback-op). For AXIAM/Keycloak this branch should
-      // no longer be reached.
+      // `offline_access` against Zitadel's hosted login UI, which this
+      // protocol-level k6 harness cannot do — see
+      // claude_dev/refresh-harness-diagnosis.md). Nothing to measure; mint
+      // again as the closest comparable token-issuance op. This is not a
+      // refresh, so tag + count it as a fallback (comparability:
+      // fallback-op). For AXIAM/Keycloak this branch should no longer be
+      // reached (G4).
       m.fallback.add(1);
       doOp(a.clientCredentials());
       return;
     }
   }
+
+  if (isAxiam) {
+    // AXIAM's user-session refresh token is redeemed at the session endpoint
+    // `POST /api/v1/auth/refresh`, not the OAuth2 `POST /oauth2/token`
+    // grant `targets.js`'s generic `a.refresh()` builds — see the extensive
+    // citation on `axiamRefreshOp` in lib/auth.js for why the two are not
+    // interchangeable (different server-side token stores).
+    const body = doOp(axiamRefreshOp(vuRefresh, vuCsrf));
+    if (body !== null) {
+      // Success: the rotated refresh/csrf pair arrives only via Set-Cookie
+      // (the JSON body carries just `expires_in`), so read it back out of
+      // the jar rather than out of `body`.
+      const rotated = readAxiamRefreshCookies(http.cookieJar());
+      vuRefresh = rotated.refresh_token || null;
+      vuCsrf = rotated.csrf_token || vuCsrf;
+    } else {
+      vuRefresh = null; // failed → re-mint next iteration
+    }
+    return;
+  }
+
   const body = doOp(a.refresh(vuRefresh));
   // Follow rotation: adopt the new refresh token if one was returned.
   if (body && body.refresh_token) vuRefresh = body.refresh_token;

--- a/benchmarks/scenarios/userinfo_grpc.js
+++ b/benchmarks/scenarios/userinfo_grpc.js
@@ -12,7 +12,7 @@
 import grpc from 'k6/net/grpc';
 import { check } from 'k6';
 import { cfg, loadStages, thresholds, tlsOptions, grpcConnectParams, requireSeed } from './lib/config.js';
-import { m } from './lib/metrics.js';
+import { m, recordGrpcResult } from './lib/metrics.js';
 import { mintUserToken } from './lib/auth.js';
 
 const client = new grpc.Client();
@@ -68,8 +68,8 @@ export default function (data) {
   // reading it — so the raw value silently recorded 1 for EVERY code, including
   // StatusOK (0). `===` against grpc.StatusOK is unaffected, which is why the
   // checks stayed correct while this metric was uniformly 1.
-  m.grpcStatus.add(res && res.status != null ? Number(res.status) : -1);
-  m.latency.add(Date.now() - start);
-  m.errorRate.add(!ok);
-  if (ok) m.ok.add(1); else m.failed.add(1);
+  // G9: one shared classifier for every gRPC scenario — also splits out
+  // RESOURCE_EXHAUSTED into bench_throttled so a rate-limited cell is
+  // legible (see claude_dev/grpc-vs-rest-authz-analysis.md).
+  recordGrpcResult(res, Date.now() - start, ok);
 }

--- a/claude_dev/b2-tls-h2-investigation.md
+++ b/claude_dev/b2-tls-h2-investigation.md
@@ -1,0 +1,392 @@
+# B2 endgame — convict or acquit HTTP/2 (plan task G8)
+
+**Status:** source analysis complete; conviction cell pending laptop hardware.
+**Date:** 2026-07-26.
+**Scope:** `crates/axiam-server/src/tls.rs`, `crates/axiam-server/src/main.rs`,
+`docs/security-profiles.md`.
+**Companion:** `benchmarks/PRIVATE_BENCH_ANALYSIS.md` §4.3,
+`benchmarks/run-improvement-tasks.sh` task `g8-tls-h1`.
+
+This is the last open hypothesis on B2. Two rounds of fixes (TLS 1.3 session
+resumption; the p2 overlay rework) did not move the number, and the remaining
+candidate is the transport itself. This document records **what the source
+proves without any hardware**, the **exact laptop protocol** to settle it, and
+the **honest framing answer** the plan asks for.
+
+---
+
+## 0. The measurement being explained
+
+From run 3 (median-of-3), p2-tls13 vs p0-plaintext, native overlay:
+
+| scenario | Δ throughput at p2 |
+|---|---|
+| `oauth2_client_credentials` | **−50.5%** (903 vs 1823 req/s) |
+| `oauth2_introspect` | −0.2% |
+| `userinfo` | −3.7% |
+| login | ~0% |
+| authz checks | positive |
+
+Two properties of the degraded cells matter more than the headline number:
+
+1. `http_req_tls_handshaking ≈ 0` — session resumption works; **TLS crypto is
+   not the cost.** Whatever this is, it is not handshakes.
+2. Server CPU, DB CPU and throughput all halve **in lockstep** while p50
+   **exactly doubles**. A server that is *working harder* shows rising CPU; a
+   server whose CPU falls with its throughput is *not being given work*. That
+   is a concurrency ceiling upstream of the handlers, not a cost inside them.
+
+Do not re-derive these numbers here — they come from the benchmark record.
+
+---
+
+## 1. What the source proves (no hardware required)
+
+Versions pinned by `Cargo.lock`: actix-web **4.14.0**, actix-http **3.13.1**,
+actix-server **2.6.0**, actix-rt **2.11.0**, rustls **0.23.42**, h2 **0.4.15**.
+
+### 1.1 The `AXIAM__SERVER__TLS__HTTP2=false` knob was a no-op — proven, now fixed
+
+The knob narrowed the rustls `ServerConfig`'s ALPN list to `http/1.1`, logged a
+warning, and then served h2 anyway. The chain:
+
+| step | file:line | what it does |
+|---|---|---|
+| `HttpServer::bind_rustls_0_23` | actix-web-4.14.0 `src/server.rs:587` | → `listen_rustls_0_23_inner` |
+| `listen_rustls_0_23_inner` | actix-web-4.14.0 `src/server.rs:1006` | ends in `.rustls_0_23_with_config(config, acceptor_config)` |
+| `HttpService::rustls_0_23_with_config` | actix-http-3.13.1 `src/service.rs:735` | **unconditionally prepends h2** |
+| ALPN selection | rustls-0.23.42 `src/server/hs.rs:99-108` | picks by **server** preference order |
+
+The prepend, verbatim (actix-http-3.13.1 `src/service.rs:747-749`):
+
+```rust
+let mut protos = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+protos.extend_from_slice(&config.alpn_protocols);
+config.alpn_protocols = protos;
+```
+
+Our list is **appended**, so `h2` is always at index 0. rustls then selects with
+`our_protocols.iter().find(|ours| their_protocols.contains(ours))` — first
+server-listed match wins — so any client offering h2 gets h2, whatever we
+configured. Every actix TLS bind carries the same prepend and documents it
+("ALPN protocols "h2" and "http/1.1" are added to any configured ones",
+`src/server.rs:585`, `:604`, `:995`, …), including the OpenSSL and
+rustls 0.20/0.21/0.22 variants.
+
+It cannot be compiled out either: actix-web's `rustls-0_23` feature **implies**
+`http2` (`rustls-0_23 = ["__tls", "http2", ...]` in actix-web-4.14.0
+`Cargo.toml`), and the prepending module is gated on `rustls-0_23` alone, not
+on `http2`.
+
+**Verdict: the knob was, definitively, a no-op on this bind.**
+
+**What changed (this task):** `build_rustls_server_config` now **fails fast**
+with `io::ErrorKind::Unsupported` when `server.tls.http2 = false`, before any
+cert/key IO. The misleading `tracing::warn!` in `main.rs` is gone. Rationale: a
+config key that silently does the opposite of what it says is worse than no key
+— and in a benchmark context it is actively dangerous, because it can
+manufacture a fake "h1 cell" and a false conviction. Refusing to boot is the
+same doctrine this module already applies to every other misconfiguration
+(missing cert, unreadable CA bundle, mismatched keypair).
+
+The `http2` field itself lives in `crates/axiam-api-rest/src/config/mod.rs`,
+which is outside this task's file ownership, so it was not deleted. If it is
+ever removed, delete `reject_unsupported_http2_knob` with it.
+
+**The only two ways to get a genuinely http/1.1-only TLS 1.3 endpoint:**
+
+1. Front the plaintext bind with an edge that does not enable HTTP/2 —
+   `benchmarks/targets/axiam/tls/tls13-h1.conf`. This is what the G8 conviction
+   cell uses and it is the supported answer.
+2. Abandon `actix_web::HttpServer` for that bind and drive
+   `actix_http::H1Service::rustls_0_23` (actix-http-3.13.1
+   `src/h1/service.rs:371`) on an `actix_server::Server` directly — it is the
+   one rustls service factory in the tree that never touches
+   `alpn_protocols`. **Not done, deliberately:** it means duplicating the
+   entire `App` factory and the `HttpServer` plumbing (keep-alive, timeouts,
+   `on_connect`, `AppConfig`, worker wiring) for a knob that is a diagnostic
+   convenience, not a security control, and whose usefulness is unproven until
+   the cell below runs. Revisit only if h2 is convicted *and* the documented
+   position turns out to be unacceptable.
+
+### 1.2 One HTTP/2 connection is served by exactly one core — proven
+
+This is the mechanism that would make the h2 hypothesis true, and it is
+verifiable from source:
+
+1. **A TCP connection is pinned to one worker for its lifetime.** actix-server
+   round-robins each accepted socket: `&self.handles[self.next]` then
+   `self.next = (self.next + 1) % self.handles.len()`
+   (actix-server-2.6.0 `src/accept.rs:432-438`).
+2. **Each worker is a single-threaded runtime.** Worker count defaults to
+   `available_parallelism()` (actix-server-2.6.0 `src/builder.rs:61`), and each
+   runs its own current-thread tokio runtime.
+3. **Every h2 stream is spawned onto that worker's local set.** The h2
+   dispatcher does `actix_rt::spawn(...)` per request
+   (actix-http-3.13.1 `src/h2/dispatcher.rs:134-135`), and `actix_rt::spawn` is
+   `tokio::task::spawn_local` (actix-rt-2.11.0 `src/lib.rs:209-215`).
+
+⇒ **N concurrent streams on one h2 connection execute on one thread.** HTTP/2
+multiplexing buys ordering and header compression here, not parallelism.
+HTTP/1.1 with a per-VU connection pool spreads across every worker.
+
+### 1.3 The arithmetic matches the measurement suspiciously well
+
+`benchmarks/targets/axiam/docker-compose.yml:33` limits the AXIAM container to
+`cpus: ${BENCH_CPUS:-2}` — **two** CPUs, hence **two** actix workers.
+
+Collapsing 50 VUs from *many* connections onto *one* h2 connection means going
+from 2 usable cores to 1. That predicts, at saturation: throughput ×½, p50 ×2,
+server CPU ×½ — which is exactly the observed signature. This is the single
+strongest circumstantial argument for conviction, and it is *why* it must be
+tested rather than assumed: a factor of two is also what a dozen other things
+produce.
+
+### 1.4 A stream-concurrency cap is **not** the cause — proven
+
+actix-http never sets `SETTINGS_MAX_CONCURRENT_STREAMS`. Its h2 handshake
+builder sets only the two windows (actix-http-3.13.1 `src/h2/mod.rs:60-71`):
+
+```rust
+let mut builder = Builder::new();
+builder
+    .initial_window_size(config.h2_initial_window_size())
+    .initial_connection_window_size(config.h2_initial_connection_window_size());
+```
+
+`h2::server::Builder::max_concurrent_streams` exists (h2-0.4.15
+`src/server.rs:858`) but is unreachable from actix, and `h2::frame::Settings`
+derives `Default` (i.e. `max_concurrent_streams: None`), so the server
+advertises **no** stream limit at all.
+
+Two consequences:
+
+- The ceiling is **not** a stream cap. Do not go looking for one.
+- Because the server advertises no limit, a client is **never forced** to open
+  a second connection. Go's `http2.Transport` (k6's client) only dials another
+  connection when the current one cannot accept a new stream; with no
+  advertised limit it assumes a large default and keeps one connection. The
+  server therefore has **no lever at all** over how many h2 connections it is
+  given. That is the crux of the whole problem.
+
+### 1.5 What actix *does* expose, and what was wired up
+
+Only two h2 settings exist on `actix_web::HttpServer`, and both are honoured on
+the rustls bind (`src/server.rs:317`, `:329` setters; `:1041-1048` forwarding
+inside `listen_rustls_0_23_inner`):
+
+| new env var | actix setter | unset ⇒ |
+|---|---|---|
+| `AXIAM__SERVER__H2__INITIAL_STREAM_WINDOW_SIZE` | `h2_initial_window_size` | 1 MiB (`DEFAULT_H2_STREAM_WINDOW_SIZE`, actix-http `src/config.rs:19`) |
+| `AXIAM__SERVER__H2__INITIAL_CONNECTION_WINDOW_SIZE` | `h2_initial_connection_window_size` | 2 MiB (`DEFAULT_H2_CONN_WINDOW_SIZE`, actix-http `src/config.rs:14`) |
+
+Implemented as `axiam_server::tls::Http2Tuning`, loaded from the same sources
+and with the same `AXIAM__…__…` idiom as `AppConfig` (`config/default.toml` +
+`AXIAM__*` env, `__` separator). Both fields are `Option`; **unset means the
+actix setter is never called**, so a default deployment is behaviourally
+identical to before this change. Values outside `1 ..= 2^31-1` are rejected at
+startup (RFC 9113 §6.5.2; `h2::server::Builder` would otherwise `assert!` inside
+a worker at first handshake). Keep-alive was not exposed: it is shared by h1 and
+h2, does not bear on a multiplexed-connection ceiling (the connection stays open
+either way), and changing it would move p0 and p2 alike — it is not a B2 lever.
+
+**Prediction, recorded before measurement:** window tuning will not move this
+number. Flow-control windows only throttle when in-flight bytes exceed the
+window; token-endpoint requests and responses are ~1 KB, three orders of
+magnitude below the 1 MiB default. The knobs exist so the hypothesis can be
+*falsified cheaply*, not because it is believed.
+
+---
+
+## 2. The laptop protocol
+
+No live stack, Docker or k6 exists in the development sandbox. Everything below
+runs on the maintainer's laptop.
+
+### 2.1 The conviction cell (already scripted)
+
+```bash
+cd benchmarks && ./run-improvement-tasks.sh g8-tls-h1
+```
+
+Three cells of the same operation — `p0-plaintext`, `p2-native`, `p2-h1` (the
+`tls13-h1.conf` edge) — each preceded by a **warm-up cell**, because the missing
+warm-up is what invalidated run 3's conviction attempt. Output lands in
+`benchmarks/results/tasks/g8-tls-h1/SUMMARY.md`.
+
+**Decision rule (pre-committed, do not renegotiate after seeing the numbers):**
+
+> **p2-h1 throughput within ~15% of p0 ⇒ HTTP/2 is CONVICTED.**
+> **p2-h1 also ≈ −50% ⇒ HTTP/2 is ACQUITTED**, and the investigation moves to
+> per-request server-side timing at p2 vs p0 (span around TLS read/write vs
+> handler), per plan G8 step 2.
+
+**Validity guard:** the summary's negotiated-protocol column for the `p2-h1`
+cell must **not** read `2`. If it does, the edge is speaking h2 and the cell is
+void — fix the edge, do not interpret the number. (Note that
+`AXIAM__SERVER__TLS__HTTP2=false` can no longer be used to fake this cell: the
+server now refuses to start. That is intentional.)
+
+### 2.2 Two direct observations worth more than the throughput table
+
+The table infers the mechanism. These two observe it, and take about a minute
+each. Run them **during** the measured window of the `p2-native` CC cell and
+again during `p0-plaintext`.
+
+**(a) Count the connections.** This is the single decisive datum, because the
+entire hypothesis is "50 VUs collapse onto one connection":
+
+```bash
+docker exec <axiam-container> sh -c \
+  "ss -tn state established '( sport = :8090 )' | wc -l"
+```
+
+*If h2 is guilty:* p2-native ≈ 1–2; p0 ≈ 50; p2-h1 ≈ 50.
+*If those are all ≈ 50,* the collapse never happened and h2 is acquitted
+regardless of what the throughput table says.
+
+**(b) Watch the worker threads.** This observes §1.2 directly:
+
+```bash
+docker exec <axiam-container> top -H -b -n 3 -p 1 | grep -i actix
+```
+
+*If h2 is guilty:* at p2-native exactly **one** worker thread sits near 100% and
+the other is idle; at p0 **both** are near 100%.
+
+**(c) Cheap corroborating control.** Re-run the `p0-plaintext` CC cell with
+`BENCH_CPUS=1`. If the ceiling really is "one core", single-CPU p0 should land
+at roughly the p2-native throughput measured with `BENCH_CPUS=2`. A clean match
+is very hard to explain any other way.
+
+### 2.3 The tuning matrix, if convicted
+
+Four cells, CC only, `p2-tls13` native overlay, each after a warm-up. Set the
+env vars on the AXIAM service in the native-TLS compose overlay.
+
+| cell | `…H2__INITIAL_STREAM_WINDOW_SIZE` | `…H2__INITIAL_CONNECTION_WINDOW_SIZE` | prediction |
+|---|---|---|---|
+| baseline | unset (1 MiB) | unset (2 MiB) | reference |
+| A — smaller | `262144` | `1048576` | no change |
+| B — larger | `4194304` | `16777216` | no change |
+| C — RFC default | `65535` | `65535` | no change, or slightly worse |
+
+**Stopping rule:** if no cell moves throughput by more than ~5%, flow control is
+exonerated and the tuning avenue is closed — publish the documented position.
+If some cell *does* move it materially, the flow-control hypothesis is live and
+worth a proper sweep (and §1.4's reasoning needs revisiting).
+
+There is deliberately **no** `max_concurrent_streams` cell: actix cannot set it
+(§1.4), and a knob that cannot reach the library is exactly the failure mode
+this task was created to remove.
+
+### 2.4 If convicted, what would actually fix it
+
+None of these is an AXIAM config knob, which is itself the finding:
+
+1. **Client-side pooling** (the realistic answer). Real SDK and mesh clients
+   should hold more than one h2 connection per AXIAM replica, or cap streams
+   per connection. This is a documentation and SDK-defaults matter, not a
+   server change.
+2. **Spread connections across replicas.** More CPU per replica helps only when
+   connections ≥ workers; a second replica behind an LB helps immediately.
+3. **Upstream ask (small, concrete, worth filing).** If actix-http advertised
+   `SETTINGS_MAX_CONCURRENT_STREAMS`, well-behaved clients would open
+   additional connections on their own and the ceiling would dissolve without
+   any client change. `h2::server::Builder::max_concurrent_streams` already
+   exists (h2-0.4.15 `src/server.rs:858`); actix-http simply never calls it and
+   exposes no setter. That is a genuinely small upstream patch.
+4. **Local last resort:** the `H1Service` rewrite of §1.1(2), which trades h2
+   away entirely for that bind. Only if 1–3 all fail and the loss is judged
+   unacceptable.
+
+---
+
+## 3. The honest framing question: artifact or production concern?
+
+The plan asks whether this is a **benchmark-topology artifact** (one client
+host, so h2 collapses 50 VUs onto one connection, while real clients pool) or a
+**real production concern**. This determines whether G8 is a fix or a
+documentation item.
+
+**Answer: predominantly a benchmark-topology artifact, with a real but narrow
+and bounded production caveat. It is a documentation item, not a code fix.**
+
+### 3.1 The case that it is an artifact
+
+- **The effect size is manufactured by the harness.** The −50% is not a
+  property of h2; it is `2 workers → 1 worker` on a container capped at
+  `BENCH_CPUS=2`. On an 8-vCPU deployment the same collapse would cost 7/8, not
+  1/2. The benchmark's headline number therefore measures neither the true
+  best case nor the true worst case — it measures the container's CPU quota.
+- **One client host is the whole premise.** k6 runs as one process against one
+  server process. Real AXIAM traffic is many independent services, each with
+  its own connection pool to a load-balanced set of replicas. The pathological
+  case — *all* concurrency behind *one* connection to *one* replica — is
+  essentially a property of running the load generator this way.
+- **The selective damage argues against a blanket transport tax.** Introspection
+  (−0.2%), userinfo (−3.7%) and login (~0%) run over the identical transport
+  with the identical VU count from the identical `lib/config.js`. A transport
+  that halves everything would have halved them too. The reconciliation is that
+  `client_credentials` at 1823 req/s is by a wide margin the highest-throughput
+  scenario and the only one plausibly CPU-saturated at p0 — a per-core ceiling
+  only bites when you are already at the ceiling. That is coherent, but note
+  what it implies: **the degradation appears only in the one cell where the
+  benchmark's own CPU cap is the binding constraint.** That is close to a
+  definition of a topology artifact.
+
+### 3.2 The case that it is real
+
+- **§1.2 is a genuine property of the shipped server**, not of the harness. One
+  h2 connection *is* served by one core, in production, always.
+- **The pathological topology is plausible for an IAM.** An API gateway, a mesh
+  sidecar, or a batch job that hammers `/oauth2/token` from a single process
+  with a single pooled h2 connection is a realistic deployment, and token
+  issuance is exactly the endpoint such a component hammers.
+- **AXIAM cannot defend itself.** Per §1.4 the server advertises no stream
+  limit, so it has no way to induce a client to open more connections. The
+  mitigation lives entirely on the client side or in the topology.
+
+### 3.3 Why the balance lands on "document, don't fix"
+
+The production risk is real but *conditional on a topology the operator
+controls*, and AXIAM has **no code lever** to change it — the two exposed h2
+knobs cannot touch thread affinity (§1.5), the ALPN knob is unimplementable
+(§1.1), and the only genuine server-side fix is upstream in actix-http (§2.4.3).
+Shipping a config knob that cannot affect the outcome would repeat exactly the
+mistake this task was created to correct.
+
+So the deliverable is: an accurate `docs/security-profiles.md` note telling
+operators to spread high-volume token traffic across connections and replicas
+and not to expect one h2 connection to saturate a multi-core instance; a
+tuning surface that exists so the flow-control hypothesis can be falsified; a
+knob that now fails loudly instead of lying; and an upstream issue for
+`max_concurrent_streams`.
+
+**This holds under conviction. Under acquittal §3 is moot** — the cause is
+elsewhere and this document's §1 survives only as the reference on why the h2
+knob is gone. Either way TLS crypto is already exonerated by
+`http_req_tls_handshaking ≈ 0`.
+
+---
+
+## 4. Change log for this task
+
+| file | change |
+|---|---|
+| `crates/axiam-server/src/tls.rs` | `http2=false` now a hard startup error (`ErrorKind::Unsupported`), with the full source citation; `alpn_protocols()` is now a fixed `h2, http/1.1` list; new `Http2Tuning` config (two window knobs, `Option`-defaulted, validated); 8 new/updated unit tests |
+| `crates/axiam-server/src/main.rs` | applies `Http2Tuning` to the `HttpServer` builder before bind; removed the misleading `http2=false` warning; startup log now reports actual ALPN and effective h2 windows |
+| `docs/security-profiles.md` | ALPN section rewritten to the proven position; new HTTP/2 tuning + concurrency-ceiling section |
+| `claude_dev/b2-tls-h2-investigation.md` | this document |
+
+Verified locally: `cargo check -p axiam-server --no-default-features` clean;
+`cargo test -p axiam-server --no-default-features --lib` → 28 passed, 0 failed;
+`cargo fmt -p axiam-server -- --check` clean; `cargo clippy -p axiam-server
+--no-default-features --lib --all-targets` clean. (`--no-default-features`
+because the sandbox has no system libxml2 for the `saml` feature — the crate
+documents this fallback in its own `Cargo.toml`. The changed code is outside
+every `#[cfg(feature = "saml")]` block.)
+
+**No benchmark numbers in this document were produced here.** Everything in §0
+is quoted from the existing run-3 record; §2 is a protocol, and its
+"predictions" are labelled as such.

--- a/claude_dev/decision-cache-decision.md
+++ b/claude_dev/decision-cache-decision.md
@@ -1,0 +1,325 @@
+# Decision note — should the authorization decision cache (D7) default to ON?
+
+**Task:** G5 of [`improvement-after-serious-benchmark.md`](improvement-after-serious-benchmark.md)
+**Status: OPEN — blocked on measurement.** No default is being changed by this note.
+**Scope of the flag:** `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` (today `false`),
+`AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` (`5`),
+`AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES` (`10000`, per tenant).
+
+This note states the security argument, defines exactly what the K-sweep must
+show for the default to flip, and leaves a table to fill in with measured
+numbers. It deliberately does **not** pre-commit to a decision: the only
+throughput evidence that exists today (run 3) was collected at the single most
+favourable cache-key cardinality that can exist, and flipping a
+security-relevant default on that evidence would be unjustified.
+
+---
+
+## 1. What the cache actually is
+
+Source of truth read for this note (not the design doc):
+
+| Fact | Where |
+|---|---|
+| Cache key is `(tenant_id, subject_id, resource_id, action, scope)` | `crates/axiam-authz/src/decision_cache.rs` — `SubKey` + per-tenant shard map |
+| The **full** decision is cached — `Allow` *and* `Deny(reason)` verbatim | `crates/axiam-authz/src/engine.rs::check_access`, `cache.insert(request, decision.clone())` |
+| A hit skips the whole `evaluate()` (3–4 sequential SurrealDB round-trips) | `engine.rs::check_access` early return |
+| TTL is checked on read; expired entries are evicted in passing | `decision_cache.rs::get` |
+| Size cap is **per tenant**, FIFO, enforced only on insert of a *new* key | `decision_cache.rs::insert` |
+| The whole cache sits behind **one** `Mutex<HashMap<Uuid, TenantShard>>` | `decision_cache.rs` — `shards` |
+| Attached only when the flag is on; otherwise the code path is byte-identical to a build without the cache | `crates/axiam-server/src/main.rs` ~L734–947, `AuthzConfig::build_decision_cache` |
+
+A hit is indistinguishable from a miss to the caller: same decision, same deny
+reason string. There is no "cached" marker in the response.
+
+## 2. The security argument
+
+### 2.1 Why a cache is defensible here at all
+
+AXIAM's RBAC is additive, allow-wins, default-deny (CLAUDE.md / SEC-040). The
+two staleness directions are therefore **not** symmetric:
+
+- A **stale deny** is safe. The subject is momentarily under-privileged. Cost is
+  a redundant re-evaluation, never an authorization bypass.
+- A **stale allow after a revocation** is the entire risk. It is a subject
+  retaining access they no longer have.
+
+So only one direction needs defending, and it is defended in two layers.
+
+### 2.2 Layer 1 — event-driven invalidation on access-narrowing mutations
+
+Every REST mutation that can narrow access calls `invalidate_subject` (targeted)
+or `invalidate_tenant` (conservative flush) through the `AuthzChecker` trait
+before returning. Verified call sites:
+
+| Handler file | Invalidation |
+|---|---|
+| `handlers/roles.rs` (role update/delete, role↔permission grant/revoke) | `invalidate_tenant` |
+| `handlers/roles.rs` (user role assign/unassign) | `invalidate_subject` |
+| `handlers/groups.rs` (group role assign/unassign) | `invalidate_tenant` |
+| `handlers/groups.rs` (member add/remove) | `invalidate_subject` |
+| `handlers/permissions.rs` (permission create/update/delete, grant changes) | `invalidate_tenant` |
+| `handlers/resources.rs` (resource update — incl. reparent — and delete) | `invalidate_tenant` |
+| `handlers/scopes.rs` (scope create/delete) | `invalidate_tenant` |
+
+Coverage looks complete for the mutation surface. This is the layer that makes
+revocation *immediate* rather than TTL-bounded.
+
+### 2.3 Layer 2 — bounded staleness ≤ TTL
+
+If an invalidation is ever missed — a new mutation path that forgets the hook, an
+out-of-band write straight to SurrealDB, an `AuthzChecker` implementation that
+takes the trait's default no-op — the damage is bounded: `get()` treats an entry
+older than `ttl` as a miss, so a stale allow cannot outlive the revocation by
+more than `decision_cache_ttl_secs` (default **5 s**). Within a single process
+this bound is unconditional; it does not depend on any hook firing.
+
+### 2.4 What the operator actually loses if an invalidation event is dropped
+
+Concretely, for up to 5 seconds after the revocation:
+
+- The revoked subject continues to receive `allowed: true` for the exact
+  `(subject, resource, action, scope)` tuples already in cache — and only those.
+  A tuple never evaluated before the revocation is a miss and evaluates fresh.
+- It applies to **every** read path uniformly (REST `/authz/check`, gRPC
+  `CheckAccess`, AMQP async authz, and the internal `RequirePermission` guard on
+  every admin endpoint), because `main.rs` shares one `Arc<DecisionCache>` across
+  all engines. A dropped invalidation therefore also delays revoking an
+  *administrator's* own privileges for up to the TTL.
+- There is no audit signal distinguishing a stale allow from a fresh one. The
+  audit log records the decision, not its provenance. Post-incident, an operator
+  cannot tell from the logs whether a given allow was served from cache.
+
+That last point is the one worth weighing: the failure is silent and
+unobservable, even though it is short.
+
+### 2.5 Three findings that count against ON, discovered while reading the code
+
+These are code observations from this task, not measurements. All are in
+`crates/`, which G5's implementation half does not own; they need their own
+issues.
+
+**(a) `TenantShard.order` grows without bound when the working set is smaller
+than the cap — a slow memory leak in the *default* configuration.**
+`order` is pushed on every insert of a key not currently in `entries`, and popped
+**only** inside `if is_new { while entries.len() > max_entries_per_tenant { … } }`.
+When a key TTL-expires, `get()` removes it from `entries` but leaves its `SubKey`
+in `order`; the next access re-inserts it as `is_new`, pushing a *second* copy.
+With a working set below `max_entries_per_tenant` (10 000 by default — i.e. the
+normal case) `entries.len()` never exceeds the cap, the `while` never runs, and
+`order` is append-only. Growth rate equals the **miss rate**: ~20 entries/s at
+the modelled K=100 point, ~1 000/s for a busy tenant, at roughly 100 bytes per
+`SubKey`. A tenant that receives access-narrowing mutations self-heals
+(`invalidate_tenant` drops the whole shard); a quiet-but-busy tenant does not.
+The existing test `reinsert_same_key_does_not_grow_or_double_count_fifo` only
+covers re-insert of a *live* key (`is_new == false`), so this path is untested.
+**The K=10000 memory column in the sweep will not reveal this** — at K > cap the
+`while` loop runs and drains stragglers. It is the K=100 cell, run long, that
+would show it.
+
+**(b) The cache is process-local; there is no cross-replica invalidation.**
+`main.rs` builds one in-process `Arc<DecisionCache>`. No AMQP/webhook broadcast
+of invalidation events exists (`grep invalidate crates/axiam-amqp/src` → nothing).
+In the multi-replica Kubernetes deployment AXIAM targets, a revocation handled by
+replica A invalidates only replica A. Replicas B…N keep serving the stale allow
+until TTL. **So §2.2's "immediate" is a single-process property, and any
+horizontally scaled deployment gets §2.3's ≤ 5 s bound as its *actual* revocation
+latency, not its worst case.** If the default flips, this must be stated next to
+the default, not in a footnote — an operator running 3 replicas would otherwise
+reasonably believe revocation is immediate.
+
+**(c) `invalidate_subject` is O(shard) under the global lock.** It does
+`entries.retain(…)` over the whole tenant shard — up to 10 000 entries — while
+holding the single mutex that every authz check needs. Every role unassignment
+therefore stalls all authz evaluation briefly. Small, but it grows with
+`DECISION_CACHE_MAX_ENTRIES`, which is exactly the knob the K=10000 memory
+measurement is meant to inform.
+
+## 3. Why run 3's 3× cannot decide this
+
+Run 3 measured (`benchmarks/PUBLIC_BENCH_ANALYSIS.md` §4/§6):
+
+| Op | cache OFF | cache ON | ratio |
+|---|---|---|---|
+| `authz_check_rest` p0 | 737 ops/s | 2322 ops/s | 3.15× |
+| `authz_check_grpc` p0 | 603 ops/s | 1822 ops/s | 3.02× |
+
+Every one of the 50 VUs sent the **same** `(subject, resource, action, scope)`
+tuple for the whole cell. Effective cardinality K = 1, steady-state hit rate
+≈ 100%. That is the upper bound of the cache's value, not an estimate of it.
+
+### 3.1 What the hit rate should do as K grows (model, not data)
+
+Entries are stamped at **insert** and inserts happen only on a miss — a hit does
+not refresh the timestamp (`decision_cache.rs::get` returns without touching
+`inserted_at`). So each key runs a fixed cycle: one miss, then every access for
+the next `T` seconds is a hit. With K keys drawn uniformly at rate R:
+
+> **h = R·T / (K + R·T)**  and  **R = 1 / ( h·c_hit + (1−h)·c_miss )**
+
+with `c_miss = 1/737 s`, `c_hit = 1/2322 s` from run 3 and `T = 5 s`. Solving the
+fixed point:
+
+| K | modelled hit rate | modelled thr | modelled ratio |
+|---|---|---|---|
+| 1 | ~100% | 2322 | 3.15× (= measured run 3) |
+| 100 | ~99% | ~2280 | ~3.1× |
+| 10 000 | ~33% | ~945 | ~1.28× |
+
+**This table is a prediction to be falsified, not evidence.** Two reasons it may
+be optimistic: (i) the miss path takes the global mutex **twice** (`get` then
+`insert`) versus once for a hit, so at a low hit rate the single
+`Mutex<HashMap<…>>` becomes a serialization point that run 3 never exercised —
+the measured K=10000 ratio could land **below 1.0×**, i.e. a net regression;
+(ii) at K = 10 000 the per-tenant cap is exactly reached, so FIFO eviction runs
+on the insert path and the live set is slightly smaller than K, pushing the hit
+rate below the modelled 33%.
+
+## 4. Measurement — what the laptop must run
+
+### 4.1 The K-sweep (throughput + memory)
+
+```bash
+cd benchmarks
+./run-improvement-tasks.sh g5-cache-sweep
+```
+
+Defaults are already correct: `G5_SCENARIO=authz_check_rest.js`,
+`G5_KEYSPACES="1 100 10000"`, cache OFF then ON, one warm-up cell per stack.
+Output: `benchmarks/results/tasks/g5-cache-sweep/SUMMARY.md`.
+
+The scenario knob (implemented in this task):
+
+- **`BENCH_AUTHZ_KEYSPACE=K`** — each request picks 1 of K distinct cache keys.
+  `K=1` is the default and reproduces run 3 byte-for-byte (no provisioning, same
+  request body), so the sweep's first point is directly comparable.
+- **`BENCH_AUTHZ_KEYSPACE_MODE=resource`** (default) — `setup()` provisions K−1
+  **child resources** of the seeded `bench-resource` through the admin REST API
+  and varies `resource_id`. Children inherit the seeded `bench-reader`
+  assignment via hierarchy (`engine.rs::applicable_role_ids` accepts an
+  assignment scoped to any ancestor), so **every key yields a real `Allow`** on
+  the same 3-round-trip evaluation path as K=1.
+- **`BENCH_AUTHZ_KEYSPACE_MODE=action`** — zero-provisioning fallback that keeps
+  the seeded resource and varies the `action` string. Index 0 is literally
+  `read` (`Allow`); every other index is an action no grant covers, so the engine
+  runs the **full** assignments → ancestors → grants path and returns
+  `Deny("no permission grants action '…'")`. Denies are cached verbatim, so the
+  cache is exercised identically. Useful as a control: it varies *only* key
+  cardinality, with zero change in DB row diversity.
+
+Neither mode ever hits an error path — `setup()` probes the last key before the
+measured window and aborts the cell if the response is not a 200 carrying the
+expected decision.
+
+Worth also running, off the critical path, to test finding (a): one long
+`K=100`, cache-ON cell (≥ 30 min) watching server RSS. The model says
+`order` should grow ~20 entries/s ≈ 2 KB/s there while `entries` stays flat at
+100. The standard 20 s cells are far too short to see it.
+
+### 4.2 The safety re-verification
+
+The existing test is:
+
+```bash
+cargo test -p axiam-authz --test decision_cache_integration_test
+```
+
+`crates/axiam-authz/tests/decision_cache_integration_test.rs`, specifically:
+
+| Test fn | Property |
+|---|---|
+| `revocation_invalidation_denies_immediately` | revocation enforced immediately via the invalidation hook, not after TTL |
+| `without_invalidation_stale_allow_persists_until_ttl` | the control: worst-case stale allow is bounded by TTL when the event is suppressed |
+| `tenant_flush_enforces_revocation_immediately` | coarse `invalidate_tenant` path |
+| `cache_hit_matches_miss_allow_and_skips_db` / `…_deny_with_reason` | a hit is byte-identical to a miss, and skips the DB |
+| `cache_disabled_behaves_exactly_as_today` | flag-off is a no-op |
+
+**Gap to record against plan G5 step 2.** That step says to run "the existing
+integration test … against the bench stack". It cannot be done as written: this
+suite drives the engine with **mutable counting mock repositories**, not a live
+server or database. It proves the *engine's* invalidation contract; it proves
+nothing about whether the REST mutation handlers reach it over the wire, and it
+cannot see finding (b) at all. Until a real end-to-end test exists, the live-stack
+check has to be manual against the running bench stack (cache ON):
+
+1. `just target=axiam bench-up && just target=axiam bench-seed`, with
+   `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true`.
+2. As `benchuser`: `POST /api/v1/authz/check` with the seeded resource → expect
+   `allowed: true`. Repeat once to guarantee the entry is cached.
+3. As admin: `DELETE /api/v1/roles/{bench-reader}/users/{benchuser}` (the
+   `invalidate_subject` path).
+4. Immediately (< 1 s) re-issue step 2 → **must** be `allowed: false`. An
+   `allowed: true` here means the invalidation hook did not fire end-to-end.
+5. Control for the ≤ TTL bound: restore the assignment, re-warm the entry, then
+   revoke by a path that only flushes coarsely and confirm the deny appears
+   within 5 s regardless.
+
+A follow-up issue should be opened for a REST-level integration test covering
+steps 2–4, and one for a multi-replica variant covering finding (b).
+
+## 5. Decision criteria — agreed **before** the numbers arrive
+
+The default flips to `true` only if **all** of these hold:
+
+| # | Criterion | Rationale |
+|---|---|---|
+| C1 | Cache-ON/OFF throughput ratio **at K = 10 000** is ≥ **1.5×** | The ship-decision must rest on the worst realistic key space, not the best. Below this the win does not pay for silent, unobservable staleness. |
+| C2 | The ratio at K = 10 000 is **> 1.0× with margin** — no regression from lock contention | If the cache can make the server *slower* under a realistic key space, ON-by-default is indefensible at any hit rate. |
+| C3 | Server RSS at K = 10 000, cache ON, is within **+150 MiB** of cache OFF | Bounds `DECISION_CACHE_MAX_ENTRIES` guidance and keeps the D9 retention work interpretable. |
+| C4 | `p95` at every K is **no worse** than cache OFF | A cache that improves the mean while lengthening the tail (lock convoy) is a bad trade for an authz hot path. |
+| C5 | The `order`-growth leak (finding **a**) is **fixed and regression-tested** | Shipping a default-ON unbounded allocator in the authorization path is not acceptable regardless of the throughput win. |
+| C6 | The multi-replica staleness caveat (finding **b**) is documented **next to the default** in the config docstring, the deployment guide, `PUBLIC_BENCH_ANALYSIS.md` §6 and the security docs | Per plan G5 step 3: not a footnote. |
+| C7 | The live-stack revocation check in §4.2 passes | Layer 1 must be shown to work over the wire, not only against mocks. |
+
+If C1 or C2 fails: **default stays `false`**, and the public doc's "3.0–3.15×"
+must be relabelled as a best-case, K=1, small-key-space figure — the wording
+change is required either way, since the current text does not say what key space
+produced it.
+
+If C1/C2 pass but C5 fails: default stays `false` **pending the leak fix**, then
+re-evaluate — do not ship the flip and the fix as one change.
+
+## 6. Results table — TO BE FILLED FROM THE LAPTOP RUN
+
+Paste from `benchmarks/results/tasks/g5-cache-sweep/SUMMARY.md`. Do not
+interpolate or estimate any cell.
+
+| cache | K | thr (ops/s) | p50 (ms) | p95 (ms) | server mem (MiB) | ratio vs OFF at same K |
+|---|---|---|---|---|---|---|
+| false | 1 | | | | | — |
+| false | 100 | | | | | — |
+| false | 10000 | | | | | — |
+| true | 1 | | | | | |
+| true | 100 | | | | | |
+| true | 10000 | | | | | |
+
+Long-soak cell for finding (a):
+
+| cell | duration | entries (K) | server RSS start | RSS end | ΔRSS/hour |
+|---|---|---|---|---|---|
+| cache ON, K=100 | | 100 | | | |
+
+Criteria check:
+
+| Criterion | Threshold | Measured | Pass? |
+|---|---|---|---|
+| C1 ratio @ K=10000 | ≥ 1.5× | | |
+| C2 no regression @ K=10000 | > 1.0× | | |
+| C3 ΔRSS @ K=10000 | ≤ +150 MiB | | |
+| C4 p95 @ every K | ≤ cache-OFF p95 | | |
+| C5 `order` leak fixed | issue closed | | |
+| C6 docs updated in 4 places | yes/no | | |
+| C7 live-stack revocation | pass | | |
+
+**DECISION: _open_.** Fill §6, then record the outcome here with a one-line
+rationale and, if the default flips, the four doc locations updated.
+
+## 7. If the decision is to keep it opt-in
+
+That is a legitimate outcome, not a failure. The cache would remain a documented
+tuning knob for deployments that (i) run a single replica or accept ≤ TTL
+cross-replica staleness, (ii) have a measured hot key space small relative to
+their request rate, and (iii) have read the staleness statement. In that case
+the deliverables are: the relabelled public-doc figure, a "when to enable the
+decision cache" section in the deployment guide carrying the K-sweep table
+verbatim, and issues for findings (a), (b), (c).

--- a/claude_dev/design-document.md
+++ b/claude_dev/design-document.md
@@ -276,6 +276,7 @@ FROM user:$uid;
 - **MFA**: TOTP (RFC 6238) with encrypted secret storage; extensible for WebAuthn later
 - **Audit logs**: Append-only table, no UPDATE/DELETE allowed (enforced at SurrealDB permission level)
 - **Resource hierarchy**: Computed at query time via graph traversal, not materialized, to keep writes simple and consistent
+- **Record identifiers**: UUIDv7 (`axiam_core::id::new_id`) for every persisted entity id. Record ids are the primary key in SurrealDB's ordered KV engine (`surrealkv:`/`file:`), so v7's leading 48-bit millisecond timestamp keeps time-adjacent inserts physically adjacent instead of scattering them across the keyspace as v4 does. Ids are stored as hyphenated strings, whose lexicographic order matches the byte order, so the locality survives the encoding. **Secrets never use v7**: session/download/reset/cancel tokens and generated passwords stay on a CSPRNG, because v7 spends 48 bits on a timestamp and its per-millisecond monotonic counter leaves same-millisecond ids sharing a long common prefix — ample for uniqueness, useless for secrecy.
 
 ---
 

--- a/claude_dev/grpc-vs-rest-authz-analysis.md
+++ b/claude_dev/grpc-vs-rest-authz-analysis.md
@@ -1,0 +1,455 @@
+# G9 small investigations — written answers
+
+Covers all three G9 sub-items from `claude_dev/improvement-after-serious-benchmark.md`
+§G9. Item 1 (gRPC-vs-REST authz gap) is the deep dive; item 2 (Keycloak
+p0/p2 login asymmetry) is diagnostic-procedure-only per the plan (no
+Keycloak changes); item 3 (`sens-rl-prod` metric coherence) documents the
+root cause and the code fix already landed in
+`benchmarks/scenarios/lib/metrics.js`.
+
+No live stack/docker/k6 was available while writing this — every claim below
+is either **proven by source** (cites a `file:line`) or explicitly flagged
+**hypothesis** with the cheapest experiment that would settle it on the
+maintainer's laptop. No benchmark number below is fabricated; all of them are
+quoted from `claude_dev/improvement-after-serious-benchmark.md` §G9 or
+`benchmarks/PRIVATE_BENCH_ANALYSIS.md` (run 3).
+
+---
+
+## 1. gRPC single-check −18% vs REST, despite better latency
+
+### 1.1 The numbers and the arithmetic
+
+Run 3, clean cells (median-of-3, both p0-plaintext and p2-tls13 profiles —
+i.e. not the post-seed transient documented in §1 of
+`PRIVATE_BENCH_ANALYSIS.md`, and not a TLS artifact since the gap is
+identical at p2):
+
+| | REST (`authz_check_rest`) | gRPC (`authz_check_grpc`) |
+|---|---|---|
+| throughput | **737 req/s** | **603 req/s** (−18%) |
+| p50 latency | 68 ms | **62 ms** (better) |
+| p95 latency | 85 ms | **75 ms** (better) |
+
+Both handlers route through the identical
+`AuthorizationEngine::check_access` path (D-08; see 1.3 below), at 50 VUs,
+`ramping-vus` closed-loop executor, in both scenario files
+(`benchmarks/scenarios/authz_check_rest.js`,
+`benchmarks/scenarios/authz_check_grpc.js`).
+
+In a closed-loop model with `N` VUs each doing one blocking call per
+iteration, throughput ≈ `N / mean_latency` — so the *lower* a cell's latency,
+the *higher* its throughput should be, all else equal. Checking that
+explicitly (per-VU latency, not p50/p95, but p50 is the closest proxy
+available from the summary):
+
+- REST: `50 / 0.068 s ≈ 735.3 req/s` — measured **737**. Fully explained by
+  latency alone (within noise).
+- gRPC: `50 / 0.062 s ≈ 806.5 req/s` — measured **603**. A **~203 req/s
+  (≈25%) shortfall** the latency number does not explain.
+
+This is the strongest clue in the dataset: REST's closed loop is behaving
+exactly as the arithmetic predicts (the server has enough headroom that 50
+VUs simply queue up behind REST's own service time), while gRPC's *achieved*
+concurrency is behaving as if something is holding it below 50 effective
+VUs, even though its per-call service time is the better of the two.
+
+A second, independent data point corroborates this pattern on a completely
+different gRPC code path. `PRIVATE_BENCH_ANALYSIS.md` §1.3 records the one
+clean batch cell in the whole run-3 archive: `authz_batch_grpc` (coalesced
+strategy) at **852.7 batches/s, p50 49 ms, p95 75 ms**. Arithmetic:
+`50 / 0.049 s ≈ 1020.4` predicted vs **852.7** measured — a **~16%
+shortfall**, same direction as the single-check gap, on a scenario whose
+per-item server-side cost (5 items/batch, engine-coalesced lookups) is
+structurally unrelated to `check_access`'s per-call UUID-parsing/validation
+cost (see 1.3). No clean REST-batch cell exists to cross-check against (§1.3:
+"no clean cell at all for: batch REST"), so this is corroborating, not
+conclusive — but the fact that *two* independent gRPC scenarios both
+under-realize their own latency-implied throughput, while the one clean REST
+cell (single-check) does not, points at something systemic to the gRPC path
+through the harness rather than something specific to `check_access`'s body.
+
+A third data point, from `PRIVATE_BENCH_ANALYSIS.md` §3.1 (DB-uncapped
+sensitivity pass — same scenarios, SurrealDB's CPU cap raised from 2 to 4
+cores):
+
+| cell | capped → uncapped | limiter after uncapping |
+|---|---|---|
+| `authz_check_rest` | 737 → **1013** (+37%) | "nothing pegged; round-trip latency" |
+| `authz_check_grpc` | 603 → **712** (+18%) | "same" |
+
+If the capped-run ceiling for both cells were *purely* SurrealDB-CPU-bound
+(SurrealDB is pegged at ~2.0/2 cores in both, per §3.2), giving both more DB
+capacity should relieve both proportionally. REST gets +37%, gRPC only
++18%, and the *relative* gap actually widens (gRPC/REST = 81.8% capped vs
+70.3% uncapped). That is consistent with gRPC's capped-run ceiling having an
+extra, non-DB-CPU component that additional database capacity does not
+relieve — again pointing away from a purely server-CPU/DB explanation and
+toward something in the gRPC call path (server-side concurrency plumbing, or
+harness-side) that caps effective parallelism independent of backend
+capacity.
+
+### 1.2 What's proven vs what's a hypothesis
+
+**Proven by source** (read, not run):
+
+- **Both handlers hit the same core logic.** `check_access` (REST:
+  `crates/axiam-api-rest/src/handlers/authz_check.rs:151-193`; gRPC:
+  `crates/axiam-api-grpc/src/services/authorization.rs:79-126`) both end in
+  `engine.check_access(&access_req)` / `authz.check_access(&access_req)` —
+  same `AuthorizationEngine`, same SurrealDB queries. The per-call *body*
+  work differs, but the DB work does not.
+- **gRPC does strictly more per-call CPU work than REST for identity
+  handling.** `check_access` in
+  `crates/axiam-api-grpc/src/services/authorization.rs:85-109` performs
+  **five** `Uuid::parse_str`-style parses (`claims_tenant_id`,
+  `claims_subject_id`, `body_tenant_id`, `body_subject_id`, `resource_id` —
+  lines 91, 92, 97, 98, 115) plus two `if` cross-validation branches
+  (SEC-003/T-27-12, lines 100-109) comparing body-supplied
+  `tenant_id`/`subject_id` against the verified JWT claims. REST's
+  `CheckAccessBody` (`crates/axiam-api-rest/src/handlers/authz_check.rs:36-49`)
+  declares `resource_id: Uuid` and `subject_id: Option<Uuid>` as *typed*
+  fields — serde/actix's JSON extractor parses them directly, and REST does
+  not even accept a body `tenant_id` (it is always `user.tenant_id` from the
+  auth extractor, per the module doc at lines 8-10), so there is no
+  cross-validation branch to run at all. This is real, but it is in-process,
+  synchronous, sub-microsecond-scale CPU work on UUIDs — implausible as the
+  source of a ~25% throughput gap when both paths are dominated by
+  millisecond-scale DB round trips, and **it argues the wrong direction for
+  latency**: gRPC does more of this work per call yet still shows the lower
+  p50/p95. If this were the dominant cost, gRPC's latency should be *worse*,
+  not better. Ranked low.
+- **REST pays an extra async DB round trip per call that gRPC does not.**
+  `AuthenticatedUser::from_request`
+  (`crates/axiam-api-rest/src/extractors/auth.rs:87-113`) calls
+  `validator.is_session_active(user.tenant_id, user.session_id).await`
+  (lines 106-109) — a `SurrealSessionRepository::get_by_id` lookup
+  (`crates/axiam-api-rest/src/extractors/auth.rs:47-58`) on **every**
+  REST request, to support session revocation (REQ-7/D-15). gRPC's
+  `AuthInterceptor::call` (`crates/axiam-api-grpc/src/middleware/auth.rs:33-47`)
+  only runs `validate_access_token` (signature/expiry check, no DB call) —
+  it never checks session liveness. This is a real, proven asymmetry and a
+  plausible, sufficient explanation for REST's *higher* latency (68 vs
+  62 ms p50) — but it makes gRPC's *lower* throughput more surprising, not
+  less: gRPC does less server-side work per call (no session DB round trip)
+  and still achieves fewer requests/second than the closed-loop arithmetic
+  predicts.
+- **The shared rate-limit DB round trip is symmetric, not a cause.** Both
+  protocols pay one DB round trip here: REST's
+  `/api/v1/authz/check` route is wrapped with `RateLimitShared` (
+  `crates/axiam-api-rest/src/server.rs:770-777`); gRPC's
+  `GrpcSharedRateLimitLayer` is applied server-wide, unconditionally, to
+  every gRPC call (`crates/axiam-api-grpc/src/server.rs:153`,
+  `.layer(shared_rate_limit_layer)`, backed by
+  `SurrealRateLimitBucketRepository::increment` —
+  `crates/axiam-api-grpc/src/middleware/rate_limit.rs:369-406`). Checked
+  and ruled out as an asymmetry.
+- **No gRPC-specific concurrency cap found in the transport config.**
+  `crates/axiam-api-grpc/src/server.rs:152` sets
+  `.concurrency_limit_per_connection(256)` — 50 VUs each hold one
+  connection (`authz_check_grpc.js` connects once per VU, `__ITER === 0`
+  guard), so this cap is nowhere near binding.
+- **The one shared mutex in the authz path (`axiam-authz`'s decision
+  cache, `crates/axiam-authz/src/decision_cache.rs:119`,
+  `Mutex<HashMap<Uuid, TenantShard>>`) is identical for both protocols.**
+  `crates/axiam-server/src/main.rs` constructs the engine (and clones the
+  same `Arc`-wrapped decision cache into it) separately for REST, gRPC, and
+  the AMQP consumer (three `AuthorizationEngine::new` call sites, lines
+  ~745, ~769, ~935), but all clone the *same* underlying cache instance —
+  so lock contention, if any, is shared equally and cannot explain a
+  REST-vs-gRPC asymmetry. (Also: this run predates G5's cache-ON
+  ship-decision, §3.2 of the private doc, so the cache was very likely off
+  for this cell regardless.)
+- **The rate limiters were not binding during this measurement.** The
+  default (`RateLimitProfile::Internet`, which presets nothing —
+  `crates/axiam-api-rest/src/config/rate_limit.rs:182`)
+  caps `authz_check_per_min` at 300/min = 5 req/s per IP (default value,
+  `crates/axiam-api-rest/src/config/rate_limit.rs:295`) — far below 603-737
+  req/s, so this cell's profile must have used a raised limit (matching
+  §3.7 of the private doc, which separately documents the *default* posture
+  clamping both protocols to near-zero — that is item 3 of this note, not
+  item 1). Confirms the 603/737 numbers reflect real capacity, not a rate
+  limiter.
+
+**Hypothesis, not proven** (needs the live discriminator experiment below):
+
+- **The k6 gRPC client (`k6/net/grpc`) achieves less effective concurrency
+  than its 50 configured VUs, for reasons internal to the harness rather
+  than the server.** I read `benchmarks/scenarios/authz_check_grpc.js`
+  closely for a timing-window bug (the obvious "hidden overhead" story: some
+  JS-side cost happening *outside* the `Date.now()` window used for
+  `bench_op_latency_ms`) and did **not** find one: `start = Date.now()` is
+  captured immediately before `client.invoke(...)`, and the request-object
+  literal, `check()`, and `m.grpcStatus.add()` (lines in
+  `authz_check_grpc.js`'s `default()`) all execute *before*
+  `m.latency.add(Date.now() - start)` is called — so all of that JS-side
+  work is *inside* the timed window, not hidden from it. That rules out the
+  simplest version of "the harness undercounts gRPC latency." What remains
+  unruled-out is a *structural* difference between k6's `http` module (whose
+  `res.timings.duration` is computed natively in k6's Go core, purely for
+  the wire round trip) and k6's `grpc` module (whose `invoke()` does
+  protobuf marshal/unmarshal and Go↔JS value-boundary crossing — evidenced
+  by the D11 comments already in the file about `res.status` arriving as "a
+  wrapped Go value" needing `Number()` coercion) possibly costing real
+  wall-clock time on the k6 process itself (CPU competing with the other 49
+  VUs) in a way that raises the *iteration* cycle time without raising the
+  *invoke()* time proportionally as much as it raises REST's simpler
+  JSON-string-building iteration cycle. This is plausible but **not
+  established** — it would need to show up as elevated k6-generator CPU
+  usage during the gRPC cell relative to the REST cell, which was not
+  captured in run 3.
+
+### 1.3 Cheapest discriminator experiment (laptop)
+
+In order of cost, cheapest first:
+
+1. **Free — re-read existing k6 summaries, if the raw JSON from run 3 is
+   still on disk.** k6 always emits `iteration_duration` (built-in, no code
+   change) alongside `bench_op_latency_ms` (custom). If
+   `iteration_duration`'s p50 on the gRPC cell is meaningfully larger than
+   `bench_op_latency_ms`'s p50 (while REST's `iteration_duration` ≈
+   `bench_op_latency_ms`), that proves per-iteration harness overhead is
+   inflating gRPC's *effective* per-VU cycle time beyond what
+   `bench_op_latency_ms` reports — confirming the harness-side hypothesis
+   without touching any code. (Not checked here: no raw run-3 `.k6.json`
+   files exist in this checkout — `benchmarks/results/` is empty except for
+   `.gitkeep`.)
+2. **Cheap — re-run `authz_check_grpc.js` and `authz_check_rest.js` at 2×
+   VUs (100) on the same target.** If the server is the ceiling, gRPC's
+   throughput should barely move (queueing would show up as materially
+   worse p50/p95). If the harness/client is the ceiling, gRPC throughput
+   should scale up noticeably toward the 2× line while REST, already
+   latency-bound, scales closer to linearly too (both should move — the
+   diagnostic signal is *relative* movement, not absolute).
+3. **Cheap — watch server-side CPU (`docker stats`) during each cell at the
+   same 50 VUs.** If the AXIAM server / SurrealDB containers are visibly
+   *less* utilized during the gRPC cell than the REST cell (both cells run
+   the same core `check_access`, so utilization should track req/s if the
+   server is the bottleneck), that is direct evidence of spare server
+   capacity going unused — i.e. the ceiling is upstream of the server.
+4. **Moderate — instrument k6-generator CPU** (`k6 run --out ...` or OS-level
+   `top`/`pidstat` on the k6 process) during both cells. If the k6 process's
+   own CPU is pegged during the gRPC cell but not the REST cell at the same
+   VU count, that directly confirms the load generator itself (not the
+   server) is the effective bottleneck for gRPC.
+
+### 1.4 Recommendation
+
+**Document as accepted overhead; no server-side code change.** No candidate
+found by reading `axiam-api-grpc`/`axiam-api-rest` source explains a
+throughput deficit that: (a) is not visible in latency, (b) recurs on an
+unrelated gRPC scenario (batch) with a different per-item cost profile, and
+(c) does not scale proportionally with database capacity the way the REST
+ceiling does. Everything server-side that *is* proven true (gRPC's extra
+UUID parsing/cross-validation, REST's extra session-revocation DB call)
+points the wrong direction for explaining the gap, or is already fully
+accounted for by the (favorable, for gRPC) latency numbers. The private
+doc's original guess — "suspect per-call UUID-parse/validation or tonic
+service overhead" (`PRIVATE_BENCH_ANALYSIS.md` §3.6) — is not well
+supported once the arithmetic is checked explicitly: that overhead would
+have to show up in the *timed* portion of the request and make gRPC's
+latency *worse*, and it doesn't.
+
+There is no ≤20-line fix here because there is no *proven* single cause to
+fix — the strongest lead (harness/client-side effective concurrency) is a
+hypothesis that needs the live discriminator experiments in §1.3 to become
+actionable, and none of them are code changes to the two lib files this
+task owns. **gRPC still wins on the metric that matters more for a
+service-mesh authz check under load — p95 latency (75 vs 85 ms) — so this
+does not block anything; carry it forward as a documented, low-priority
+open item** (as `PRIVATE_BENCH_ANALYSIS.md` §3.6 already does), now with the
+closed-loop arithmetic and the batch/DB-uncapped corroboration recorded so a
+future pass has a concrete starting point instead of re-deriving it.
+
+---
+
+## 2. Keycloak p0-vs-p2 login asymmetry (diagnostic procedure only — no KC changes)
+
+**The numbers** (`PRIVATE_BENCH_ANALYSIS.md` §2.4, same image digest both
+profiles): p0 (plaintext) login **52 req/s, p50 919 ms, p95 1070 ms**, 2/3
+runs valid, ±7.8% spread (the widest in the matrix). p2 (TLS 1.3) login
+**stuck at 23 req/s, p95 2249 ms, 0/3 runs valid.** This is fairness
+hygiene, not an AXIAM defect — Keycloak is not code this repo owns or ships,
+and the task explicitly scopes this to "note the finding," not fix it.
+
+### Diagnostic procedure for the laptop
+
+1. **Rule out run-order / warm-up interaction first.** §2.4 already floats
+   "possibly KC hashing-iteration warm-up interacting with run order." Run
+   the p0 and p2 Keycloak login cells **back-to-back, twice, in both
+   orders** (p0→p2 then p2→p0), each preceded by an explicit idle/settle
+   window (mirrors G1/G2's post-seed-transient countermeasure — same
+   family of "first cell after some event is unrepresentative" bug). If p2
+   recovers when it's *not* first, or degrades when p0 runs right before
+   it, that points at a KC-internal warm-up/JIT/hashing-cache effect keyed
+   off request order, not TLS itself.
+2. **Isolate TLS overhead from Keycloak's own request handling.** Capture
+   `docker stats` for the Keycloak container during both cells. If KC's CPU
+   is pegged in p2 but not p0 at the same 50 VUs, TLS handshake/cipher cost
+   on Keycloak's own listener is plausible (Keycloak terminates its own TLS
+   in this profile, per the target's compose config — confirm which
+   listener p2 actually points at before concluding this). If KC's CPU is
+   *not* pegged in p2, the bottleneck is elsewhere (network path, bench
+   client TLS overhead, or the "0/3 valid" gate itself masking a
+   measurement problem rather than a real slowdown).
+3. **Check what "0/3 valid" actually means for p2.** A run being
+   gate-invalid (per `report.py`'s validity gate) is a different finding
+   than "p2 is 2.3× slower" — confirm whether the p2 cell fails the
+   error-rate/p95 threshold gate outright (making the 23 req/s / p95 2249 ms
+   figures themselves suspect, e.g. built on a smaller effective sample)
+   or passes the gate but is legitimately slower. This changes whether the
+   right next step is "investigate KC+TLS performance" or "fix the p2
+   Keycloak login cell's validity first."
+4. **One repro run each way is sufficient per the G9 spec** ("one
+   diagnostic run each way") — this is bounded, not an open-ended KC
+   performance investigation. Record whatever the run shows (even
+   inconclusive) in the private doc under §2.4 and move on; G9's
+   acceptance criterion for this item is the written note, not a fix.
+
+No Keycloak configuration, Dockerfile, or benchmark target file was touched
+for this item, per the task's "no KC fixes" instruction.
+
+---
+
+## 3. `sens-rl-prod` metric coherence (fixed in `benchmarks/scenarios/lib/metrics.js`)
+
+### 3.1 The incoherence
+
+Run 3's production-rate-limit pass (`sens-rl-prod`) showed, e.g.,
+`authz_check_rest` at **`bench_ok` rate 13.6/s while `bench_error_rate` was
+1.00**, and `authz_check_grpc` at **84/s while `bench_error_rate` was
+0.95**. Read at face value this looks contradictory: a cell that is
+"~100% errors" advertising a double-digit "ops/s" of apparent success.
+
+### 3.2 Root cause (traced by reading `doOp()` and every scenario that
+produced these numbers)
+
+**`doOp()` was not the bug.** `benchmarks/scenarios/lib/metrics.js`'s
+`doOp()` only ever calls `m.ok.add(1)` when `check()` reports the response
+status equals `built.expect` (200/201 in every scenario/adapter — verified
+by grepping every `expect:` in `benchmarks/scenarios/lib/targets.js` and
+every scenario file; none sets `expect: 429`, so a 429 can never be
+misclassified as a pass via `built.expect`). `authz_check_rest.js` and the
+two REST scenarios the `g9-rlprod` harness task exercises
+(`oauth2_client_credentials.js`, `token_introspection.js`) all call `doOp()`
+normally with `expect: 200`. Ruled out: "a scenario counting a 429 as a
+success because `built.expect` matched" (candidate cause from the task
+brief) — does not happen anywhere in this codebase.
+
+**The gRPC scenarios (`authz_check_grpc.js`, `authz_batch_grpc.js`,
+`userinfo_grpc.js`, `zitadel_userinfo_grpc.js`) do bypass `doOp()`** and
+hand-roll their own `ok`/`failed`/`errorRate`/`latency` recording (they
+must — k6's `grpc.Client.invoke()` has a different response shape and
+timing model than `http.request()`, there is no way to feed it through the
+HTTP-shaped `doOp()`). This is a real maintenance smell (confirmed by
+reading all four files), but their hand-rolled logic mirrors `doOp()`'s
+classify-then-count semantics correctly: `ok` is only ever incremented when
+`res.status === grpc.StatusOK`, matching REST's behavior. It is not, by
+itself, the source of the incoherence.
+
+**The actual mechanism (established by reading `crates/axiam-api-rest`'s
+and `crates/axiam-api-grpc`'s rate limiters, both `governor`-based token
+buckets):** the default (`RateLimitProfile::Internet`) posture's
+`authz_check_per_min = 300` (5 req/s per IP,
+`crates/axiam-api-rest/src/config/rate_limit.rs:295`) and the analogous
+gRPC `grpc_authz_per_sec` default both use `governor::Quota::per_second`
+with `burst_size` equal to the configured rate
+(`crates/axiam-api-grpc/src/middleware/rate_limit.rs:183-184`) — meaning
+the bucket starts **full** and admits a burst of real, legitimate successes
+at test start (during k6's ramp-up), before settling into steady-state
+rejections once the burst is drained. Those burst successes are genuine
+200s/OK responses — `bench_ok` is correct to count them. Meanwhile, k6's
+`ramping-vus` executor is a **closed loop with no backoff**: every VU that
+gets a 429/`RESOURCE_EXHAUSTED` retries again immediately on its next
+iteration, so the *total* iteration volume over the test's duration becomes
+very large (thousands of near-instant rejections), while the real successes
+stay small and roughly bounded by the configured rate. `bench_error_rate`
+(a `Rate` = failures / total iterations) correctly reflects that the vast
+majority of that huge iteration count failed — round to "1.00" at 2 decimal
+places even when not exactly 100%. `bench_ok`'s reported "rate" (a k6
+`Counter`'s built-in `count / total_test_duration_seconds`, which is what
+`run-improvement-tasks.sh`'s `k6_stat()` reads via `m["bench_ok"]["rate"]`)
+is *also* correct — it is the small burst-phase success count spread over
+the whole test's wall-clock duration, which is a genuine (if small)
+admitted-throughput number, not noise. **Both numbers are individually
+correct; the incoherence is a legibility gap, not a counting bug**: nothing
+in the summary told a reader whether "1.00 error rate" meant "some other
+bug, unrelated to rate limiting, is also broken" or "this is entirely
+expected 429 rejection." (This reading is corroborated by
+`PRIVATE_BENCH_ANALYSIS.md` §3.7, which independently describes the same
+posture pass in aggregate terms — "CC 0.9/s, introspection 0.4/s, ~100%
+429s" — the same shape of number, at the same order of magnitude, for a
+sibling endpoint.)
+
+### 3.3 The fix
+
+`benchmarks/scenarios/lib/metrics.js`:
+
+- Added `m.throttled = new Counter('bench_throttled')`. `doOp()` now adds to
+  it (in addition to, not instead of, `m.failed`/`bench_error_rate` — this
+  is additive, changes no existing metric's semantics or any downstream
+  consumer) whenever a failed check's response status is exactly `429`.
+- Added an exported `recordGrpcResult(res, latencyMs, ok)` helper that
+  centralizes the *same* classify-and-count logic (including the
+  `bench_throttled` split, keyed off gRPC status `8` =
+  `RESOURCE_EXHAUSTED`, the status `too_many_requests_response()` in
+  `crates/axiam-api-grpc/src/middleware/rate_limit.rs:222-224` returns) so
+  the gRPC scenarios can adopt it with a one-line change instead of
+  re-diverging their hand-rolled copy further.
+
+With this in place, a `sens-rl-prod`-style summary shows, per scenario:
+`bench_ok` (genuine successes), `bench_throttled` (expected control-plane
+rejections), and `bench_failed - bench_throttled` (anything else) — so a
+100%-ish-error cell where `bench_failed ≈ bench_throttled` reads as "the
+posture is working as configured," and a cell where `bench_failed` is
+larger than `bench_throttled` reads as "something else is also broken,"
+without requiring the reader to reconcile a `Counter`-rate against a
+`Rate`-fraction computed over different denominators in their head.
+
+**`node --check` passed** on both owned files
+(`benchmarks/scenarios/lib/metrics.js`, `benchmarks/scenarios/lib/targets.js`
+— the latter required no change for this task).
+
+### 3.4 Remaining edit needed (NOT made — outside this task's file ownership)
+
+`recordGrpcResult()` is exported and ready, but **not wired into any
+scenario** — `authz_check_grpc.js`, `authz_batch_grpc.js`, and
+`userinfo_grpc.js` are not owned by this change (only
+`benchmarks/scenarios/lib/metrics.js`, `benchmarks/scenarios/lib/targets.js`,
+and this document are). The exact remaining edit, per file, is to replace
+the final six lines of each scenario's `default()` with a single call.
+For example, in `authz_check_grpc.js`:
+
+```diff
+- const ok = check(res, { 'grpc status OK': (r) => r && r.status === grpc.StatusOK });
+- m.grpcStatus.add(res && res.status != null ? Number(res.status) : -1);
+- m.latency.add(Date.now() - start);
+- m.errorRate.add(!ok);
+- if (ok) m.ok.add(1); else m.failed.add(1);
++ const ok = check(res, { 'grpc status OK': (r) => r && r.status === grpc.StatusOK });
++ recordGrpcResult(res, Date.now() - start, ok);
+```
+
+(plus `import { m, recordGrpcResult } from './lib/metrics.js';` — currently
+`import { m } from './lib/metrics.js';`). The same substitution applies to
+`authz_batch_grpc.js` and `userinfo_grpc.js`. `zitadel_userinfo_grpc.js`
+targets Zitadel, not AXIAM's rate limiter, so wiring it in is optional
+(harmless either way — `bench_throttled` would simply stay at 0 for that
+scenario, matching today's behavior of `bench_failed` alone).
+
+### 3.5 Acceptance harness alignment
+
+`g9-rlprod` (`benchmarks/run-improvement-tasks.sh:697-727`) exercises
+`oauth2_client_credentials`, `token_introspection`, `authz_check_rest` — all
+three go through `doOp()`, so this task's `bench_throttled` fix is live for
+all three without any further edit. It reads `thr = m["bench_ok"]["rate"]`
+and `err = m["bench_error_rate"]["value"]` from the k6 summary and prints
+✅ when `err < 0.99 or thr < 1.0`. That check is unaffected by this change
+(it does not read `bench_throttled`) — this task did not touch
+`run-improvement-tasks.sh` (not owned) — but the underlying numbers it reads
+were already correct per the trace above; whether a given cell's `thr`
+lands under `1.0` depends on the configured rate limit and load profile
+(G7's territory), not on anything fixed here. What this task adds is the
+diagnostic signal (`bench_throttled`) that makes *why* a cell landed where
+it did legible from the summary, which was the actual ask ("so a posture
+pass is diagnosable").

--- a/claude_dev/improvement-after-g-benchmark.md
+++ b/claude_dev/improvement-after-g-benchmark.md
@@ -1,0 +1,440 @@
+# Improvements After the G-Task Run (2026-07-28) — Phase H Plan
+
+**Created 2026-07-28** from the full G1–G10 task-run results
+(`results-20260728.tar.xz`: `results/tasks/g*`, the median-of-3 matrix in
+`results/run-*` + `results/report.md`, and the `sens-*` labeled passes).
+Every verdict number in §1 was **re-verified against the raw archive**
+(each task's `results/tasks/<task>/SUMMARY.md`, the underlying `*.k6.json`
+metrics and `*.meta.json` cell metadata) before this plan was finalized.
+This document is the executable task list that follows
+[`improvement-after-serious-benchmark.md`](improvement-after-serious-benchmark.md)
+(the G plan). Task IDs continue as **H1…H10**.
+
+Each task states **which model to use**, chosen as the *cheapest model that
+can reliably do the job*: **Sonnet 5** for well-specified, mechanical,
+harness/config/docs work with crisp acceptance criteria; **Opus 5** only for
+open-ended debugging, design judgment, or security-relevant default changes.
+Same discipline as before: feature branch, signed commits, PR per phase,
+every Opus task ends by writing its findings into `claude_dev/`.
+
+> **Where the code is (H0 — merge first).** The entire G implementation is
+> **not on `main`**. This plan lives on branch
+> **`claude/benchmark-results-analysis-hynzr8`**, which carries everything
+> in one mergeable unit: the task driver
+> (`benchmarks/run-improvement-tasks.sh`) with its four runner fixes
+> (telemetry sampler, interrupt-safe teardown, g1-dbdirect credentials +
+> probe), the G2 settle gate + rotation + env dump, the G4 refresh fix
+> (cookie `Path` root cause), the G5 K-sweep scenario +
+> `decision-cache-decision.md` (decision left OPEN behind seven pre-agreed
+> criteria), the G7 rate-limit posture presets
+> (`AXIAM__RATE_LIMIT__PROFILE`, defaults unchanged) + decision record, the
+> G8 ALPN analysis (`HTTP2=false` proven a no-op and turned into a hard
+> startup error), the G9 `bench_throttled` classifier — **and** this plan,
+> already merged with current `main` (UUIDv7 ids, SDK OIDC/SSO contract
+> 1.5). The 2026-07-28 results were collected with this branch's harness.
+> **H0: PR and merge this branch before starting any H task**; all file
+> references below are to its state. Branches
+> `claude/g1-timeline-hanging-l0mqd0` (same code, no plan) and
+> `claude/benchmark-results-analysis-f1xn2k` (same plan, no code) are
+> **superseded by this one** and should be closed without merging.
+
+---
+
+## §1 What the G run established (verdicts)
+
+| Task | Verdict | Evidence |
+|---|---|---|
+| G1 transient | **Partially resolved** | Window reproduced: **~6.0 min** at ~44 ops/s (p50 ~1.0 s), DB pinned ~1.05 cores, server idle; sharp cliff recovery to ~715 ops/s between minute 5.4 and 6.0. **8 min of idle does NOT cure it** (first cell after idle: 44.5 ops/s) ⇒ warm-up is **traffic-driven**, not wall-clock. **Survives a server restart** (44.3 ops/s after) ⇒ state is not in the AXIAM process. **RabbitMQ queue depth is 0 for the whole window** ⇒ audit-backlog hypothesis **refuted**. The two remaining probes were faulty: the datastore-restart cell recorded only **1 request** (server needed pool re-signin after the DB restart; cell unusable — its SUMMARY row reads `NA`), and the db-direct probe has per-row container-start overhead (~500 ms flat, 31 rows, no post-window baseline) — inconclusive. |
+| G2 settle gate + rotation + meta | **Implemented and working — but the gate does not work against THIS transient** | `settle_wait_secs` (34/35 s), `settle_timeout:false`, `cell_order_index` rotates between runs, `axiam_env` dumped with secrets `<redacted>` — all present in `tasks/g2-verify/run-*` meta.json. The SUMMARY's "❌ no meta.json" is a **checker bug** (it looked in the un-redirected default results dir). Critically: the gate passed in ~34 s while the clamp lasts ~6 min — a 1 rps serial canary sees the ~22 ms serialized unit as a *fast* response; the clamp is only visible **under concurrency** (closed-loop queueing: 50 VUs / 45 ops/s ≈ 1 s p50). Consequence: G3 run-1 cells, G5's K=1/K=100 cells, G8's CC cells and both G4/G8 CC comparison cells all ran inside the window despite gate + warm-up cell. |
+| G3 batch A/B | **DECIDED — `coalesced` wins, ship it as default** | On settled cells (runs 2–3): coalesced batch REST 744 ops/s = **3 721 checks/s = 4.98×** singles (748/s); coalesced batch gRPC 866–872 ops/s ≈ **4 330 checks/s**, p95 74 ms (gate ≤2 s ✅). Concurrent: batch REST 200 ops/s = 1 000 checks/s = 1.37× singles, gRPC batch 216 ops/s p95 282 ms. Both beat singles, coalesced wins by 3.7×. |
+| G4 refresh harness | **PASS — with a comparability caveat** | AXIAM 910 ops/s, Keycloak 323 ops/s, `bench_fallback == 0`, **1.00 HTTP req/iteration** on both. (AXIAM refresh ≈ ½ × its CC cell — but with 1 req/iter and rotation doing revoke+issue writes, that is real work, not the fallback signature. The in-task CC comparison cell was clamped (46 ops/s) and unusable.) ⚠ Per `refresh-harness-diagnosis.md`: AXIAM deliberately has no ROPC/password grant, so its cell measures **session refresh**, Keycloak's the **OAuth2 refresh grant** — `report.py` needs a `protocol-variant` label and the pair must not be published as a like-for-like head-to-head (→ H7). |
+| G5 cache K-sweep | **Contaminated — decision stays OPEN** | Only K=10 000 is trustworthy: cache ON 712 vs OFF 541 ops/s = **+32%**, memory cost ≈ 0 (196 vs 207 MiB). K=1 rows (both 45 ops/s, p50 >1 s) and the K=100 OFF row (60 ops/s, p50 954 ms) ran inside the transient. K=1 truth from run-3 `sens-cache-on`: **3.0–3.15×** (authz REST 2322 vs 737; gRPC 1822 vs 603). The revocation live test was not run. The branch's `decision-cache-decision.md` gates the flip behind seven criteria and surfaced **three cache defects** that must be fixed before any default change (unbounded `order` growth below the cap; process-local cache ⇒ multi-replica revocation ≤ TTL; `invalidate_subject` O(shard) under the global mutex) — all folded into H5. |
+| G6 memory retention | **PASS — jemalloc convincingly** | Default malloc: 68 → peak 491 → retained **376 MiB** (+309 over baseline). jemalloc: 69 → peak **126** → retained **86 MiB** (+17). Closes **94%** of the gap (threshold ≥30%) with no throughput caveat recorded. Go: make jemalloc the release default. |
+| G8 TLS h1 vs h2 | **Inconclusive for CC — all three CC cells clamped (~45 ops/s)**; valuable side-signal from refresh | The SUMMARY table's "p2-h1 within 15% of p0 ⇒ h2 convicted" reading is wrong — all three cells measured the transient, not TLS. The **refresh** cells in the same session escaped the window and say something new: p0 914 ops/s, **p2-native 893 (−2.3% — no native-TLS penalty)**, p2-h1 (nginx) 443 (−51%, plus **1 059 `bench_failed` ops**). Also: negotiated-protocol capture never landed (column reads `?`). B2 remains open. |
+| G7 rate-limit posture | **Implemented on the branch — two residuals** | Shipped defaults byte-for-byte unchanged; relaxation is an opt-in `AXIAM__RATE_LIMIT__PROFILE` = `internet`\|`gateway`\|`mesh` preset touching only machine-to-machine buckets (switches them to `client_id` keying); human endpoints strict per-IP by construction. Residuals per `rate-limit-posture-decision.md`: §7.1 maintainer sign-off, §7.2 a laptop re-measurement of the gateway preset (→ H7). |
+| G9 metric coherence | **Mostly done; REST wiring missing** | Root cause written up (`grpc-vs-rest-authz-analysis.md`): the run-3 incoherence was burst-then-storm, not a counting bug. `bench_throttled` + the shared `recordGrpcResult()` classifier are wired into the **gRPC** scenarios and the CC path (145 ok vs 7 145 throttled — legible), but the REST scenarios `token_introspection` and `authz_check_rest` still lack it (confirmed by the g9 run). G9.1 (gRPC −16%) is documented as **accepted overhead** (no cheap fix; gRPC still wins p95). G9.2 (Keycloak login asymmetry) has a written procedure but no diagnostic run yet. |
+| G10 SDK benches | **0 / 7 validated — every failure now has a known, small cause** | rust: bench runs but `BENCH_RESOURCE_ID` arrived empty (env plumbing). python: `axiam_sdk` not installed (no local-path install step). typescript: `axiam-sdk` package unresolved (sibling repo not linked). go: `go.mod` needs `go mod tidy`. java: `ClassNotFoundException: io.axiam.bench.Bench` (bench not compiled before `exec:java`). csharp/php: host toolchain missing (honest `pending` records). |
+| Pool sensitivity (run-3 leftover, new `inflight-64` pass) | **pool_size=4 = +7% on CC only; in-flight cap 64 changes nothing** | CC 1955 (pool 4) and 1954 (pool 4 + inflight 64) vs 1823 matrix baseline; every other scenario within noise. |
+
+**Cross-cutting finding — the single biggest data-quality fact:** the G2
+settle gate as implemented (serial canary, p50 < 100 ms) **cannot detect the
+post-seed clamp** and passed ~34 s into a ~6-minute window. Every "first
+cell(s) after seed" in the G run is still corrupted, exactly like run 3. The
+matrix batch rows (`authz_batch_rest` 41/s, `authz_batch_grpc` invalid 0/3) and
+the report's batch verdicts are artifacts of the same contamination and must
+not be published as-is.
+
+**Stray data — root cause found in the harness:** the `bench-matrix` recipe
+unconditionally re-exports `BENCH_RESULTS_DIR="$PWD/results/run-$i"`
+(`benchmarks/justfile:364`, repeat loop), clobbering any redirect a caller
+set — which is why `g2-verify`'s mini matrix wrote into the default results
+root (its SUMMARY "❌ no meta.json" is that leak, not a missing
+implementation) and had to be moved by hand. `results/axiam/p2-tls13/` at
+the results root (CC 44.7/s clamped; refresh with the old 2-req/iter
+fallback signature) is a stale pre-G4 leftover of the same class — delete
+it; it must not enter any report. Fixed by H1.
+
+---
+
+## §2 Phase H0 — data integrity first (in order)
+
+### H1. A settle gate that actually detects the clamp + runner-fault fixes — **Sonnet 5**
+
+*Why Sonnet:* every fix is precisely specified below with a reproducible
+failure in hand and the offending lines identified; no open-ended judgment.
+
+*Files (all on this branch):* `benchmarks/justfile` (`bench-matrix`),
+`benchmarks/runner/run-benchmark.sh` (`settle_gate()` / `canary_probe()`,
+`BENCH_SETTLE_*` tunables), `benchmarks/run-improvement-tasks.sh`,
+`benchmarks/docs/methodology.md`, `benchmarks/runner/report.py`.
+
+1. **Settle gate v2 (concurrent canary).** `settle_gate()` today is a
+   serial 1 rps `canary_probe()` requiring `BENCH_SETTLE_STABLE_SECS=30`
+   consecutive seconds under `BENCH_SETTLE_MAX_MS=100` — measured result:
+   it passes ~34 s into the ~6-min clamp, because a lone request against
+   the ~22 ms serialized unit *is* fast; the clamp only exists under
+   concurrency. Replace the probe with a short concurrent burst (k6,
+   `authz_check_rest`, 20 VUs, 15 s — or a curl-parallel equivalent to keep
+   k6 out of the gate) and require **probe throughput ≥ 400 ops/s**
+   (in-window ~44, settled ~730 — the threshold is far from both) OR p50
+   < 150 ms *under those 20 VUs*. Repeat every 30 s until pass; keep the
+   existing hard-timeout/`settle_timeout` machinery and meta fields, add
+   `settle_probe_thr`. Update methodology §"post-seed settle" with why the
+   serial canary was blind.
+2. **Fix the `bench-matrix` results-dir clobber (the wrong-directory
+   fault):** the repeat loop unconditionally
+   `export BENCH_RESULTS_DIR="$PWD/results/run-$i"`, discarding any
+   redirect the caller set — this is exactly why `g2-verify`'s mini matrix
+   wrote to the results root and its SUMMARY checker (which globs under the
+   task's own dir, correctly) reported "no meta.json". Change it to nest:
+   `RUN_DIR="${BENCH_RESULTS_DIR:-$PWD/results}/run-$i"`. Then audit every
+   `run-improvement-tasks.sh` step for the same pattern and make the script
+   fail fast if a cell would write outside `results/tasks/<task-id>/`.
+   Re-run `g2-verify` afterwards to get a green SUMMARY (the fields
+   themselves are already proven present: `settle_wait_secs` 34/35 s,
+   `cell_order_index` rotated, `axiam_env` redacted). Delete the stale
+   stray `results/axiam/p2-tls13/` tree.
+3. **Fix the g1-isolate datastore-restart probe:** after restarting the DB
+   container, wait for the server's pool to re-sign-in (poll `/health` or
+   one authenticated request until 200, with a timeout) before measuring,
+   and run a full-length cell. The current data point is n=1 request and
+   unusable.
+4. **Fix the g1-dbdirect probe:** keep one long-lived client (exec into a
+   persistent container or a single process with a session), not one
+   `docker run` per query; timestamp every row; run the *same* query the
+   authz path issues (take it from the D6 report); and always collect a
+   post-window baseline segment so in-window vs settled is a within-file
+   comparison.
+5. `report.py`: refuse (or loudly flag) cells whose meta records
+   `settle_timeout: true`.
+
+*Acceptance:* a deliberately-immediate cell after a fresh seed is held by
+the gate and, when released, measures ≥ 600 ops/s on `authz_check_rest`;
+`settle_wait_secs` lands ≈ the observed window (~5–7 min), not ~34 s; a dry
+run of the task script writes nothing outside `results/tasks/`.
+
+### H2. G1 endgame: locate the clamp, rule product defect in or out — **Opus 5**
+
+*Why Opus:* the remaining space is genuinely open-ended (SurrealDB
+internals vs data shape), and the outcome is a product-risk verdict the
+public doc must carry honestly.
+
+*Files:* `claude_dev/postseed-transient-investigation.md` (extend/finish),
+possible follow-ups in `crates/axiam-db` / `benchmarks/targets/axiam/*`.
+
+Evidence inherited (do not re-litigate): traffic-cured ~6-min window with a
+sharp cliff (44 → 572 → 715 ops/s in one 36 s step); idle does not cure;
+server restart does not cure; AMQP queues flat 0; DB pinned at ~1.0 core;
+~22 ms serialized unit. New discriminator from G8: in the same session,
+**`token_refresh` ran at 914 ops/s while CC and authz sat clamped at ~45** —
+the clamp appears to be *per-table/per-query*, not global.
+
+1. **Per-operation clamp map (cheapest, most informative):** inside a fresh
+   window run 20 s micro-cells of authz_check, CC, introspection, userinfo,
+   jwks, refresh, login; tabulate which are clamped. Cross-reference each
+   op's tables/queries (from the D6 query-pattern report) — the clamped set
+   should name the table(s)/index(es) whose post-ingest state is the cause.
+2. **Fixed db-direct probe (H1.5)** with the actual clamped query: if a raw
+   SurrealDB session shows the same ~22 ms serialized unit in-window,
+   AXIAM is exonerated entirely; if not, instrument `axiam-db` (pool
+   checkout wait vs query time — the F1 metrics exist) during the window.
+3. **Seed-volume dependence:** seed at 10% → does the window scale down?
+   (Index/compaction work scales with ingest; a fixed-length warmup does
+   not.)
+4. **SurrealDB-side observation:** debug logs + `docker stats` of the DB
+   during the window; look for compaction/index messages coinciding with
+   the recovery cliff; repeat the datastore-restart probe with H1.4's fix —
+   if a DB restart *clears* the clamp, the state is rebuilt DB-side memory;
+   if it *resets* the 6-min clock, it is recovery/replay work.
+5. **Verdict + action.** Traffic-cured means a production instance after a
+   bulk import serves degraded traffic until warmed — that is
+   **product-relevant** unless the probes prove the trigger is unique to
+   the bench's seed shape. If product-relevant: open the issue with the
+   reproduction, evaluate mitigations (post-import warm-up driver in the
+   server, staged ingest, SurrealDB tuning/version bump — measure, don't
+   speculate), and add the honesty line to the public doc. Either way the
+   ~22 ms serialized unit must be named, not hand-waved.
+
+*Acceptance:* investigation note finished with a demonstrated trigger
+(turning the suspected cause off/down measurably shortens or removes the
+window), the per-op clamp map, and a bench-only vs product-relevant verdict
+with the follow-up issue/PR filed if product-relevant.
+
+---
+
+## §3 Phase H-A — ship the decided wins (parallel, after H1)
+
+### H3. Flip the batch default to `coalesced` (executes the G3 decision) — **Sonnet 5**
+
+*Files:* `crates/axiam-authz/src/config.rs` (default), config docs +
+deployment docs + `benchmarks/PUBLIC_BENCH_ANALYSIS.md` §6 row,
+`claude_dev/authz-batch-investigation.md` (append the verdict + G3 table).
+
+The G3 criterion was met by both strategies and `coalesced` wins decisively
+(4.98× vs 1.37×; gRPC batch p95 74 ms vs 282 ms). Change the default,
+keep `concurrent` selectable, update every doc location that names the
+default (config reference, tuning table, public §6), paste the G3 table
+into the investigation doc as the closing verdict, and update the config
+unit test asserting the default.
+
+*Acceptance:* default is `coalesced`; both strategies still selectable and
+tested; all four doc locations agree; investigation doc closed with data.
+
+### H4. jemalloc as the release default (executes the G6 PASS) — **Sonnet 5**
+
+*Files:* `docker/` server Dockerfile, release CI workflow,
+`crates/axiam-server/Cargo.toml` (feature default for release profile or
+build arg), deployment docs, `claude_dev/memory-retention-experiment.md` §6,
+public doc retained-memory caveat.
+
+G6 measured jemalloc closing **94%** of the 309 MiB retention gap (peak also
+491 → 126 MiB) at default decay settings. Make the `jemalloc` feature the
+default for release container builds (keep a `--no-default-features` escape
+hatch documented for musl/platform edge cases), add `MALLOC_CONF` guidance
+(explicitly: defaults sufficed; `dirty_decay_ms` tuning not needed), paste
+the numbers into the experiment note §6 and the G6 placeholder, and rewrite
+the public doc's retained-memory caveat to "fixed since draft 3 (allocator)".
+
+*Acceptance:* released image runs with jemalloc (verifiable via
+`MALLOC_CONF=stats_print:true` smoke or the binary's feature list); docs and
+both notes updated; CI green.
+
+### H5. Decision-cache ship decision on clean data — **Opus 5**
+
+*Why Opus:* flipping a security-relevant default (authorization staleness)
+on evidence that is currently one-third contaminated needs the adversarial
+read; the re-measurement itself is prescribed.
+
+*Files:* `crates/axiam-authz` (`decision_cache.rs`, default + docs),
+`benchmarks/scenarios/authz_check_rest.js` (`BENCH_AUTHZ_KEYSPACE` exists),
+`docs/` security notes, `claude_dev/decision-cache-decision.md` (**exists on
+this branch, decision OPEN behind seven pre-agreed criteria — fill it, do
+not fork a new note**).
+
+1. **Fix the three cache defects the G5 analysis surfaced — before any
+   measurement counts toward the flip** (criterion C5): (a) the `order`
+   vector grows unbounded while the working set stays *below*
+   `max_entries_per_tenant` (TTL-expired keys leave `entries` but stay in
+   `order`; re-access pushes a duplicate) — fix + a regression test for the
+   expired-then-reaccessed path; (b) `invalidate_subject` is O(shard) under
+   the single global mutex every check needs — bound or shard the lock;
+   (c) the cache is process-local: document "revocation immediate" as a
+   single-process property and the multi-replica worst case ≤ TTL, next to
+   the default.
+2. Re-run the K-sweep **on the H1 settled protocol**: cache ON/OFF at
+   K ∈ {1, 100, 10 000}, median-of-3, warm-up + gate before every pass.
+   Anchors to reconcile: K=1 → 3.0–3.15× (run-3 sens), K=10 000 → +32%
+   (G5), K=100 → unknown (contaminated).
+3. Add the missing **live-stack revocation test** (the existing integration
+   test drives mocks; the decision note carries a manual curl procedure —
+   automate it): immediate invalidation on the live stack, and the
+   suppressed-event worst case (stale-allow ≤ TTL).
+4. Memory bound at K=10 000 with the real entry count inspected (G5's
+   server-RSS delta was ≈ 0 — verify the cache actually held 10 000
+   entries rather than silently evicting).
+5. Walk the note's seven criteria with the clean data and decide default ON
+   (TTL 5 s) vs opt-in; if ON: config default, deployment docs, public §6,
+   and the ≤TTL staleness statement in the security docs next to the
+   default. One combined cache+pool4 labeled cell.
+
+*Acceptance:* cache defects fixed with tests; clean K-sweep table; live
+revocation tests pass; the decision note's criteria table is filled and the
+verdict recorded; if the default flips, all four doc locations updated.
+
+### H6. B2 endgame v2: settled CC cells + protocol capture — **Opus 5**
+
+*Why Opus:* third attempt at the last-hypothesis TLS debugging; the G8 run
+added a genuinely confusing new fact that needs careful discrimination.
+
+*Files:* `benchmarks/scenarios/lib/*` (protocol capture),
+`crates/axiam-server/src/tls.rs` (per `b2-tls-h2-investigation.md`),
+`docs/security-profiles.md`, `benchmarks/PRIVATE_BENCH_ANALYSIS.md`.
+
+Constraints already proven by this branch's source analysis — do not re-try
+them: `AXIAM__SERVER__TLS__HTTP2=false` was a no-op (actix-http
+unconditionally prepends `h2` to ALPN) and is now a **hard startup error**;
+actix-http exposes **no** `max_concurrent_streams`/window knobs, so "tune
+the native h2 listener" is not an available move. If h2 is convicted, the
+outcome is the documented-position path (topology artifact: one client
+host = few h2 connections; real clients pool connections) unless a
+listener-level fix exists outside actix's h2 surface.
+
+1. **Protocol capture first (the `?` column):** record each response's
+   negotiated protocol (k6 `res.proto`) into a `bench_http_proto` metric
+   and surface it in `report.py`; without it no conviction is valid.
+   Optionally log ALPN server-side at debug for cross-checking.
+2. **Re-run the three CC cells mid-session on the settled protocol** (p0,
+   p2-native, p2-h1), plus refresh at the same three points. Never first
+   after seed (H1 gate + a warm-up cell).
+3. **Discriminate with the new facts:** matrix CC p2-native = −50%
+   (903 vs 1823) but G8 refresh p2-native = **−2.3%** (893 vs 914) — and
+   both p2 numbers sit ≈ 900/s. Test the "p2 POST ceiling ≈ 900/s"
+   hypothesis directly: run CC at p2 with halved/doubled VUs — a fixed
+   per-request TLS cost scales p50 linearly and leaves the ceiling; a
+   serialization point holds throughput at ~900 regardless. Compare CPU
+   split (server vs k6) between CC-p0 and CC-p2 at equal load.
+4. **Make the h1 control trustworthy before using it:** G8's p2-h1 refresh
+   lost 51% *and* recorded **1 059 failed ops** — tune the nginx overlay
+   (worker count, keepalive_requests, proxy buffering) until its error
+   rate is 0 and its p0-equivalent overhead is characterized; only then
+   does "h1-over-TLS ≈ p0?" convict or acquit h2.
+5. Fix what is found, or write the documented position
+   (`docs/security-profiles.md` + public §5) with the evidence. CC and
+   refresh must both be re-measured at p2 for the final table;
+   introspection/jwks must not regress.
+
+*Acceptance:* p2 CC within ~15% of p0, **or** an evidence-backed accepted
+position published; the protocol column renders in the report; the h1
+control cell is error-free.
+
+---
+
+## §4 Phase H-B — harness completeness (anytime)
+
+### H7. Metric & small-investigation batch — **Sonnet 5**
+
+*Files:* `benchmarks/scenarios/lib/metrics.js` + the REST scenarios,
+`benchmarks/runner/report.py`, `claude_dev/rate-limit-posture-decision.md`,
+notes in `claude_dev/` / private doc.
+
+1. **Finish the G9 classifier wiring for REST:** the shared classifier
+   (`recordGrpcResult()` + the CC path) exists but `token_introspection`
+   and `authz_check_rest` still bypass it (confirmed live by the g9 run:
+   `bench_throttled` absent) — add the REST-side equivalent so
+   `bench_throttled` exists in every scenario. Acceptance: a `rl=prod`
+   mini-pass shows all three probed scenarios reading "purely
+   rate-limited" or naming the real failure.
+2. **`protocol-variant` comparability label in `report.py`** (G4 caveat):
+   AXIAM's refresh cell measures session refresh, Keycloak's the OAuth2
+   refresh grant — label the pair so head-to-head tables carry the caveat
+   the same way `fallback-op`/`cc-token-setup` are carried today.
+3. **G7 residuals:** surface `rate-limit-posture-decision.md` §7.1 to the
+   maintainer for sign-off, and run the §7.2 laptop re-measurement of the
+   `gateway` preset (one labeled pass), pasting the numbers into the
+   decision record and the sizing docs.
+4. **G9.2 Keycloak p0-vs-p2 login asymmetry** (52/s valid vs 23/s invalid
+   0/3 in the matrix): one diagnostic run each way per the written
+   procedure in `grpc-vs-rest-authz-analysis.md`; note the finding in the
+   private doc; fairness hygiene only, no KC fixes. (G9.1 is closed —
+   documented as accepted overhead.)
+
+### H8. SDK benches round 2 — one fix per language, then the overhead table — **Sonnet 5**
+
+*Why Sonnet:* every failure has a named, mechanical cause from the G10
+attempt logs; the spec, harness and TODOs all exist.
+
+*Files:* `benchmarks/sdk/<lang>/*`, `benchmarks/justfile` (recipe line 387
+area), sibling `ilpanich/axiam-<lang>-sdk` checkouts, `sdk/collect.py`,
+`benchmarks/runner/report.py`, `sdk/README.md`.
+
+Per-language fixes (from `tasks/g10-sdk/*/attempt-*.log`):
+
+| lang | observed failure | fix |
+|---|---|---|
+| rust | ran, `status:error`: `BENCH_RESOURCE_ID must be a valid UUID (got "")` | the seed env is not reaching the bench: source `benchmarks/.seed/<target>.seed.env` in the sdk-bench recipe/run.sh and assert the UUID non-empty before starting; fail fast with the exact missing var named |
+| python | `No module named 'axiam_sdk'` | `run.sh`: create a venv and `pip install -e ../../../../axiam-python-sdk` (sibling checkout) when the module is missing |
+| typescript | `Cannot find package 'axiam-sdk'` | `run.sh`: `npm install ../../../../axiam-typescript-sdk` (file: dependency) before running `bench.mjs`; verify the sibling checkout name matches the TODO |
+| go | `go: updates to go.mod needed; go mod tidy` | commit the tidied `go.mod`/`go.sum` with the local `replace` to the sibling repo; make `run.sh` run `go mod tidy` defensively |
+| java | `ClassNotFoundException: io.axiam.bench.Bench` | build before exec: `mvn -q package` (or `compile`) ahead of `exec:java`, or run `exec:java` with the correct module/classpath per the TODO |
+| csharp | honest `pending`: toolchain not installed | preflight that prints the exact host install commands (dotnet SDK version per TODO); document in `sdk/csharp/TODO.md`; optionally provide a container fallback |
+| php | honest `pending`: toolchain not installed | same pattern (php + composer, composer path-repo to the sibling SDK) |
+
+Then: each language emits a `status:"ok"` `axiam.sdk-bench/v1` record twice
+in a row against a seeded p0 target; `collect.py` ingests all without
+warnings; run `just sdk-bench-all` at p0 + p2 and build the E1.3
+**overhead-vs-wire-baseline table** into the published report; fix
+`sdk/README.md` claims to measured reality (pending languages listed as
+pending).
+
+*Acceptance:* ≥ 7 SDKs with validated OK records; the overhead table
+renders from real records; README truthful.
+
+### H9. DB-pool default decision (small) — **Sonnet 5**
+
+*Files:* `crates/axiam-db` (default), `claude_dev/db-pool-design.md`
+(verdict §), deployment docs.
+
+Evidence: `pool_size=4` = **+7% on client-credentials** (1955 vs 1823),
+neutral on everything else; `POOL_MAX_IN_FLIGHT=64` adds nothing on top;
+expiry soak already PASSED (run 3). Criterion (pre-agreed): one settled
+confirm cell reproduces ≥ +5% on CC with nothing regressed → ship
+`pool_size=4` as default (in-flight cap stays 0/unlimited-semantics as
+today); otherwise keep 1 and close with the negative result. Update the
+design doc's verdict section and the deployment docs either way.
+
+*Acceptance:* confirm cell recorded; default matches the criterion outcome;
+docs consistent.
+
+### H10. Run 4 — the publishable matrix + public-doc refresh (E4) — **Sonnet 5**
+
+*Precondition:* H1 (gate), H3 (batch default), H4 (jemalloc image), H5/H6
+outcomes landed; H9 decided.
+
+1. Full median-of-3 matrix (all targets, p0 + p2) on the settled protocol
+   with cell rotation active — the first matrix whose batch rows are
+   trustworthy. Expect: `authz_batch_rest`/`_grpc` valid and ~5× singles
+   (coalesced default); AXIAM `token_refresh` valid with 0 fallback,
+   published next to Keycloak's cell under the H7 `protocol-variant` label
+   (session refresh vs OAuth2 refresh grant — not like-for-like); no
+   `fallback-op` rows for AXIAM.
+2. Sensitivity passes per the standing list (uncapped DB, rl=prod, p3-mtls
+   spot-check, cache/pool per H5/H9 defaults — a labeled OFF pass for
+   whichever default flipped, so the delta stays visible).
+3. E4: regenerate `PUBLIC_BENCH_ANALYSIS.md` from run-4 medians. Contents
+   that must change: batch rows (previously artifacts), refresh row
+   (real rotation), B2 verdict per H6, the transient note per H2's verdict
+   (honesty section), the SDK overhead table (H8), moved-to-fixed list
+   (memory retention, batch, refresh). Keep the honest tone; label the
+   laptop as the platform; keep E3 (server-class re-run) tracked.
+
+*Acceptance:* report renders with zero invalid AXIAM cells outside
+known-labeled ones; public doc fourth draft published from run-4 medians.
+
+---
+
+## §5 Execution order & model summary
+
+```
+H0: PR + merge claude/benchmark-results-analysis-hynzr8 (G implementation + harness + this plan)
+H1 (Sonnet) ─→ H2 (Opus)                       # gate first, then the transient verdict
+H3, H4 (Sonnet, parallel — no new data needed) # decided wins, ship now
+H5 (Opus, needs H1), H6 (Opus, needs H1)       # the two open performance verdicts
+H7, H8 (Sonnet, anytime), H9 (Sonnet, needs H1)
+H10 run 4 + E4 last (needs H1, H3, H4; folds in H5/H6/H9 outcomes)
+```
+
+| Task | Model | Rationale for the cheaper/costlier choice |
+|---|---|---|
+| H1 settle gate v2 + runner faults | **Sonnet 5** | every fix specified against a reproduced failure |
+| H2 transient endgame | **Opus 5** | open-ended DB-internals debugging + product-risk verdict |
+| H3 batch default → coalesced | **Sonnet 5** | pre-agreed criterion already met by the data |
+| H4 jemalloc release default | **Sonnet 5** | threshold met 94% vs 30%; mechanical build/CI/docs |
+| H5 cache ship decision | **Opus 5** | security-default flip on partially-contaminated evidence |
+| H6 B2 endgame v2 | **Opus 5** | last-hypothesis TLS debugging, new confounding fact |
+| H7 metrics + small investigations | **Sonnet 5** | bounded diagnostics with written-answer deliverables |
+| H8 SDK benches round 2 | **Sonnet 5** | per-language causes identified; recipe-driven repair |
+| H9 pool default | **Sonnet 5** | one confirm cell + pre-agreed ≥5% criterion |
+| H10 run 4 + E4 | **Sonnet 5** | protocol execution + doc regeneration |
+
+**MVP gate:** H1–H6 (H6 may close as a documented position). H7–H9
+non-blocking. H10 required for the public page, not the server MVP.

--- a/claude_dev/improvement-after-serious-benchmark.md
+++ b/claude_dev/improvement-after-serious-benchmark.md
@@ -1,5 +1,17 @@
 # Improvements After the Serious Benchmark (run 3) — Pre-MVP Plan
 
+> **Status update 2026-07-28:** the G1–G10 tasks were executed on the laptop
+> (`results-20260728.tar.xz`), using the harness/implementation from branch
+> `claude/benchmark-results-analysis-hynzr8` (unmerged at the time — merging
+> it is Phase H's step H0). Per-task verdicts and the follow-up plan (Phase
+> **H**) live in
+> [`improvement-after-g-benchmark.md`](improvement-after-g-benchmark.md).
+> Headlines: G3 decided (`coalesced` wins 4.98×), G4 PASS, G6 PASS
+> (jemalloc, 94%), G1 narrowed (traffic-cured DB-side clamp; AMQP refuted);
+> G5/G8 data partially invalidated by the still-undetected post-seed
+> transient (the G2 settle gate passes in ~34 s inside a ~6 min window);
+> G10 0/7 with per-language causes identified.
+
 **Created 2026-07-26** from the run-3 analysis
 ([`benchmarks/PRIVATE_BENCH_ANALYSIS.md`](../benchmarks/PRIVATE_BENCH_ANALYSIS.md),
 run-3 rewrite). This document is the executable task list for the **final
@@ -232,8 +244,18 @@ retention doesn't reproduce).
    the in-process retainer instead (that outcome would mean the memory is
    *held*, not fragmented — a different bug class).
 
-> **⟨PLACEHOLDER — integrate `results/d9-summary.md` here when the
-> experiment has run.⟩**
+> **Experiment run 2026-07-28 (results integrated per the placeholder):**
+>
+> | variant | baseline RSS | burst peak | post-burst plateau (10 min) | retained above baseline |
+> |---|---|---|---|---|
+> | A — default malloc | 68 MiB | 491 MiB | 376 MiB | **309 MiB** |
+> | B — jemalloc (default decay) | 69 MiB | **126 MiB** | 86 MiB | **17 MiB** |
+>
+> jemalloc closes **291 MiB = 94%** of the retention gap (threshold ≥30%) at
+> default `MALLOC_CONF` — no decay tuning needed — and also cuts the burst
+> peak ~4×. **Verdict: PASS — propose jemalloc as the release default.**
+> The follow-up PR is task **H4** in
+> [`improvement-after-g-benchmark.md`](improvement-after-g-benchmark.md).
 
 *Acceptance:* numbers in both docs; a PR or a documented "not worth it";
 public doc's retained-memory caveat updated either way.

--- a/claude_dev/improvement-after-serious-benchmark.md
+++ b/claude_dev/improvement-after-serious-benchmark.md
@@ -378,3 +378,78 @@ G9 (Sonnet), G10 (Sonnet)                      # anytime; G10 before run 4
 MVP gate: G1–G7 done (G8 may land as a documented position rather than a
 fix; G9 is non-blocking; G10 required only for the SDK section of the
 public page, not for the server MVP itself).
+
+---
+
+## Implementation status (updated 2026-07-26)
+
+Implemented on branch `claude/benchmark-analysis-reporting-yo7gh5`, **each task
+with the model this plan assigns it** (G5/G7/G8 via Opus 5 agents; G2/G4/G9 via
+Sonnet 5 agents).
+
+**One environment constraint governs the whole table:** this sandbox has
+`cargo`, `node` and `python3` but **no `k6`, no Docker target stacks, and no
+live server** — and container-image egress is blocked, so no stack can be
+brought up. Every acceptance criterion that is a *measured benchmark number* is
+therefore collected on the maintainer's laptop via the new driver script rather
+than here. No benchmark number was fabricated.
+
+### The data-collection driver
+
+`benchmarks/run-improvement-tasks.sh` — one subcommand per task that needs a
+live run, each independently runnable in a spare slot, each writing
+`results/tasks/<task>/SUMMARY.md` with the measured numbers **and** this plan's
+acceptance criterion so the task can be closed from its summary alone:
+
+| Subcommand | Task | Answers |
+|---|---|---|
+| `g1-timeline` | G1 | When does the post-seed window end? (**run this first**) |
+| `g1-idle` | G1 | Time-based background work, or traffic-driven warm-up? |
+| `g1-isolate` | G1 | Does the state live in the server or the datastore? |
+| `g1-dbdirect` | G1 | Is the clamp visible with AXIAM out of the path? |
+| `g2-verify` | G2 | Do settle gate + rotation + env dump work live (incl. a secret-leak check)? |
+| `g3-batch` | G3 | Clean batch A/B — does batch finally beat single checks? |
+| `g4-refresh` | G4 | Is the refresh cell a real rotation now (`bench_fallback == 0`)? |
+| `g5-cache-sweep` | G5 | Does the cache's 3× survive a realistic key space? |
+| `g6-memory` | G6 | Does jemalloc fix the post-burst retention? (wraps `run-memory-experiment.sh`) |
+| `g8-tls-h1` | G8 | Is HTTP/2 multiplexing the TLS token-issuance penalty? |
+| `g9-rlprod` | G9 | Are rate-limited cells legible (`bench_failed ≈ bench_throttled`)? |
+| `g10-sdk` | G10 | Do the SDK benches emit valid records? |
+
+### Per-task status
+
+| Task | Model | Status | Notes |
+|------|-------|--------|-------|
+| G1 transient root-cause | Opus 5 | ⛔ laptop | Four probes scripted. The `g1-idle` probe is the decisive one: it splits "background work on a timer" from "warm-up that needs traffic" in a single cell. |
+| G2 harness countermeasures | Sonnet 5 | ✅ / ⏳ | Settle gate (`BENCH_SETTLE*`, canary-probes the target's real endpoint), per-run scenario rotation (`cell_order_index`), `axiam_env` knob dump with secret redaction. Found and fixed a real `bench-pack` bug: the leak grep false-positived on redacted key *names*. Live verification ⏳ `g2-verify`. |
+| G3 batch default | Sonnet 5 | ⛔ laptop | Blocked on G2's settle gate — this is the A/B run 3 could not do. |
+| G4 refresh fix | Sonnet 5 | ✅ / ⏳ | Root-caused from source: the `axiam_refresh` cookie is scoped `Path=/api/v1/auth/refresh` (jar read at the login URL could never see it), **and** login-issued refresh tokens live in `axiam-auth`'s `SessionRepository`, so they can never validate at the OAuth2 token endpoint. See `refresh-harness-diagnosis.md`. ⚠ **Comparability**: AXIAM has no password grant (deliberately — OAuth 2.1 drops ROPC), so this cell measures *session refresh* while Keycloak's measures the *OAuth2 refresh grant*. The two need a `protocol-variant` label in `report.py`; do not publish as a like-for-like head-to-head. |
+| G5 cache sweep | Opus 5 | ✅ / ⏳ | `BENCH_AUTHZ_KEYSPACE=K` spreads checks over K distinct cache keys; K=1 byte-identical to before; `setup()` self-provisions and fails closed if a key yields the wrong decision. Decision left **open** behind seven pre-agreed criteria. Surfaced three `axiam-authz` findings — see below. |
+| G6 allocator | Sonnet 5 | ⛔ laptop | Fully scripted (`run-memory-experiment.sh`); §G6's placeholder awaits the numbers. |
+| G7 rate-limit posture | Opus 5 | ✅ / ⏳ | Shipped defaults **unchanged** (login 10/min, token 20, introspect 10, authz 300, key `ip`); relaxation is an opt-in `Internet`/`Gateway`/`Mesh` posture that touches only machine-to-machine buckets and switches them to `client_id` keying. Human endpoints stay strict per-IP under every posture. Preset values justified against measured ceilings; where a value sits *above* the measured ceiling (Mesh authz) it is documented as a runaway-loop guard, not an attacker guard. |
+| G8 B2 endgame | Opus 5 | ✅ / ⏳ | **`AXIAM__SERVER__TLS__HTTP2=false` was a proven no-op** — actix-http's `rustls_0_23_with_config` unconditionally prepends `h2` to ALPN and rustls selects by server preference, so h2 always won regardless of the setting. Now a hard startup error (`ErrorKind::Unsupported`) rather than a silent lie — an operator relying on it was previously wrong without knowing, and it also made faking an h1 cell via the env var impossible. G8 deliberately did NOT ship an h2 `max_concurrent_streams` knob: actix-http never exposes it, so the knob could not have affected the outcome, and shipping it would repeat the exact mistake this task existed to correct. Conviction cell ⏳ `g8-tls-h1`. See `b2-tls-h2-investigation.md`. |
+| G9 small investigations | Sonnet 5 | ✅ / ⏳ | The rate-limit "metric incoherence" was **not** a counting bug: limiters start with a full burst, so genuine successes land at test start while the retry storm drives the *fraction* to ~1.00. Both metrics were correct and jointly illegible. Fixed with `bench_throttled` + a shared `recordGrpcResult()` classifier now wired into all three gRPC scenarios. gRPC-vs-REST authz gap documented as accepted overhead (no cheap fix found; gRPC still wins p95). |
+| G10 SDK benches | Sonnet 5 | ⛔ laptop | Needs a live seeded target; `g10-sdk` validates two consecutive `status: "ok"` records per language. |
+
+### Findings that became new work (not in the original plan)
+
+1. **Decision-cache `order` vector grows unbounded** when the working set stays
+   *below* `max_entries_per_tenant` — the FIFO trim only runs when the cap is
+   exceeded, while TTL-expired keys are removed from `entries` but left in
+   `order`, so a re-access pushes a duplicate. Growth tracks the miss rate. The
+   existing test only covers a *live* re-insert, so this is untested. This
+   matters precisely because it is the code G5 may default to ON — **fix before
+   any default flip** (it is criterion C5 in the cache decision note).
+2. **The decision cache is process-local with no cross-replica invalidation**,
+   so "revocation is immediate" is a single-process property; a multi-replica
+   deployment's actual revocation latency is ≤ TTL. This must appear next to the
+   default wherever the default is documented, not in a footnote.
+3. **`invalidate_subject` is O(shard) under the single global mutex** — a role
+   unassignment scans up to 10 000 entries while holding the lock every authz
+   check needs.
+4. **No live-stack revocation test exists.** The "existing integration test"
+   G5 was to run against the live stack drives the engine with mock
+   repositories; there is no REST-level or live-DB invalidation test anywhere.
+   The cache note carries a manual curl procedure and recommends two issues.
+5. **`report.py` needs a `protocol-variant` comparability label** for the G4
+   refresh cell (see the G4 row above).

--- a/claude_dev/rate-limit-posture-decision.md
+++ b/claude_dev/rate-limit-posture-decision.md
@@ -1,0 +1,370 @@
+# Rate-limit posture — decision record (G7)
+
+**Date:** 2026-07-26
+**Task:** G7 of [`improvement-after-serious-benchmark.md`](improvement-after-serious-benchmark.md)
+**Scope:** shipped rate-limit defaults, deployment presets, sizing docs, startup posture log
+**Status:** implemented; **no shipped default changed**. One item needs
+maintainer sign-off (§7.1) and one needs a laptop re-measurement (§7.2).
+
+---
+
+## 1. Decision, in one paragraph
+
+**No shipped default was moved.** `RateLimitConfig::default()` and
+`GrpcConfig::default()` are byte-for-byte what they were before this task.
+Instead, the M2M/NAT'd-fleet sizing ships as an **opt-in deployment posture
+preset** selected by a single environment variable,
+`AXIAM__RATE_LIMIT__PROFILE` = `internet` (default) | `gateway` | `mesh`,
+which moves the whole machine-traffic family — bucket-key mode, token,
+introspect, revoke, REST authz, and the gRPC authz ceiling — coherently.
+Human endpoints (`login`, `register`, `password_reset`, `mfa`) are excluded
+**by construction**: the preset struct has no field for them, so no profile
+can raise them, now or later. The default posture is a *no-op by
+construction* (`RateLimitProfile::Internet::preset()` returns `None`), so
+the internet-facing posture cannot drift as the presets evolve.
+
+This is the safer of the two routes the spec offered, and it is the one the
+evidence supports (§4 below produced a finding that argues *against* making
+per-client keying the default at all).
+
+---
+
+## 2. Evidence
+
+From benchmark run 3 (2026-07-25/26, `1.0.0-alpha19`, median-of-3;
+[`benchmarks/PRIVATE_BENCH_ANALYSIS.md`](../benchmarks/PRIVATE_BENCH_ANALYSIS.md)
+§3.7 and §5.3, [`benchmarks/PUBLIC_BENCH_ANALYSIS.md`](../benchmarks/PUBLIC_BENCH_ANALYSIS.md) §6):
+
+| Observation | Number |
+|---|---|
+| Shipped defaults vs a 50-VU **single-source-IP** load | every limited endpoint flattened to ~0–14 req/s at ~100% `429` (client-credentials 0.9/s, introspection 0.4/s) |
+| Unlimited paths in the same pass | unaffected — JWKS 27 700/s, userinfo 5 994/s |
+| Same 2-core server, unthrottled | ~1 800 token issuances/s; ~740/s authz checks cache-off, ~2 300/s cache-on; ~2 200/s introspection; ~603/s gRPC authz; ~69 logins/s (Argon2id) |
+| Shipped default caps a *client* at | 20 token req/min = 0.33/s |
+
+Both facts hold simultaneously. The defaults are a **working anti-abuse
+control** on a small internet-facing deployment and are **wrong for an
+M2M/NAT'd fleet**, where dozens-to-thousands of distinct OAuth2 clients
+share one egress IP and therefore one bucket. The maintainer confirmed the
+latter reading (private §3.7, §5.3).
+
+All numbers above are **laptop-class** (Docker containers pinned to
+2 cores / 1 GiB, developer machine) and explicitly temporary. Nothing in
+this task invented a number: every preset value is derived from that table
+and the derivation is written next to the constant in
+`crates/axiam-api-rest/src/config/rate_limit.rs` and in
+[`docs/deployment/rate-limit-sizing.md`](../docs/deployment/rate-limit-sizing.md) §3.
+
+---
+
+## 3. Options considered
+
+### Option A — move the raw defaults (token → `client_id` keying at ~600/min, etc.)
+
+The spec's own proposal-to-assess. **Rejected.**
+
+- It changes the security posture of *every existing deployment* on
+  upgrade, silently, including the small internet-facing ones the current
+  defaults were designed for. That inverts the safe direction of a default
+  change.
+- Its central mechanism — keying on `client_id` — is **not an anti-abuse
+  control** (§4.1). Making it the default would replace a control that
+  demonstrably stops a flood with one that an attacker bypasses by
+  incrementing a string.
+- It cannot be justified from the measurements: the run-3 posture pass
+  measured that the defaults *work*. There is no evidence of a default that
+  is too strict for the deployment it was designed for — only evidence of a
+  default applied to a topology it was not designed for. That is a
+  configuration problem, and configuration problems are solved with
+  configuration.
+
+### Option B — documented opt-in posture preset (**chosen**)
+
+- Zero behaviour change on upgrade; the change is visible, deliberate, and
+  logged at boot.
+- One env var sets the family coherently, so an operator cannot fix REST
+  token limits and leave gRPC authz at 100/s/IP — the exact trap that makes
+  hand-tuning fail.
+- The per-client keying caveat can be stated *at the point of choosing it*,
+  which is where it will actually be read.
+- Cost: an operator who does not read the docs stays throttled. Mitigated
+  by the startup log line (§5.3), the deployment-guide pointer, and public
+  §6 already recommending the M2M values.
+
+### Option C — docs only, no preset
+
+Rejected: public §6's advice is a list of six independent knobs. Applying
+it by hand is error-prone in precisely the coherence dimension that matters
+(key mode without the matching per-client ceilings is worse than either
+alone — it splits the bucket *and* keeps the small number).
+
+---
+
+## 4. Abuse-vector analysis
+
+### 4.1 `client_id` keying is a fairness control, not an abuse control
+
+The `client_id` used for bucket derivation is parsed from the
+**unauthenticated** form body (`client_secret_post`, RFC 6749 §2.3.1) by
+`extractors::rate_limit::extract_form_client_id`, **before** any credential
+is verified (`axiam_oauth2::token` verifies the secret later, in the
+handler). Therefore:
+
+- Under `key=client_id` or `ip_client_id`, an attacker who rotates the
+  `client_id` string gets a **fresh bucket per value** and is effectively
+  unlimited on `/oauth2/token`, `/oauth2/revoke`, `/oauth2/introspect`.
+- This is a property of the **D8 key modes as shipped**, independent of this
+  task. The presets do not create it; they make it the active posture — which
+  is the decisive reason they are opt-in, logged, and documented with the
+  caveat in the operator's face
+  ([sizing doc §5.1](../docs/deployment/rate-limit-sizing.md)).
+- Residual protection under those modes: the client lookup fails fast
+  (secret comparison is a cheap constant-time hash compare, not Argon2), so
+  the marginal cost of a rejected request is ~one DB lookup — survivable at
+  the measured envelope, but it is DB load, not free. The real control moves
+  to the edge (WAF / API gateway / mTLS / IP allow-list), which is what a
+  `gateway`/`mesh` deployment has by definition.
+
+**Consequence for the default:** keeping `key=ip` as the shipped default is
+not conservatism, it is correctness. The IP-keyed bucket is the only one of
+the three modes an attacker cannot mint at will.
+
+### 4.2 Bucket-keyspace growth
+
+A rotating `client_id` also grows the key space of both limiter layers: the
+per-replica in-memory `Governor` map and the shared `rate_limit_bucket`
+SurrealDB table. Neither is unbounded in practice (fixed 60 s windows
+expire; the cleanup task sweeps), but a sustained rotation flood is a
+resource-consumption vector on top of the bypass. Documented in sizing §5.2.
+**Not fixed here** — a proper fix (only key on `client_id`s that resolve to
+a real client, or a bounded keyspace with an IP-keyed overflow bucket) is a
+design change to D8 and is listed for the maintainer in §7.3.
+
+### 4.3 No-`client_id` requests fall back to the IP key
+
+`ClientAwareKeyExtractor` falls back to the IP key when no `client_id` is
+parseable — fail-safe (limiting is never disabled), but under a preset that
+fallback is metered at the *preset's larger number* (e.g. 600/min instead of
+20/min per IP). An anonymous/malformed token flood therefore gets 30× more
+budget under `gateway` than under the defaults. Acceptable for the intended
+topology (edge-protected), documented in sizing §5.4, and another reason not
+to make it the default.
+
+### 4.4 The gRPC limiter cannot key per client at all
+
+`AXIAM__GRPC__KEY` is reserved and a no-op: the rate-limit `tower::Layer` is
+`Server::builder()`-wide and runs before tonic resolves per-RPC claims, so
+there is no client identity at the keying point. Behind a shared ingress IP,
+`AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` is a **fleet-wide** ceiling. The presets
+raise it (1 000 / 5 000 per sec) precisely because a per-IP ceiling under
+NAT is a fleet ceiling — but this means the gRPC authz surface has *no*
+per-client fairness in any posture. Documented (sizing §5.3); the fix is the
+future per-RPC identity-aware interceptor already anticipated in
+`GrpcRateLimitKeyMode`'s doc comment.
+
+### 4.5 Human endpoints — why they are non-negotiable
+
+`login`/`register`/`password_reset`/`mfa` gate password guessing, OTP
+guessing, account enumeration and (for login) an Argon2id CPU cost of
+~1/69th of a 2-core server per request. None of those economics change
+because the deployment is a service mesh, and none of those endpoints has an
+OAuth2 client identity to key on (structural — see `RateLimitKeyMode` docs).
+They are absent from `MachineLimitPreset` entirely, and
+`no_profile_touches_human_endpoints` is a unit test, so a future preset
+cannot regress this by accident.
+
+### 4.6 What the preset values still stop
+
+Under `gateway` (token 600/min/client = 10/s):
+
+- A single compromised client credential is capped at ~0.55% of the measured
+  1 800/s server ceiling — ~180 distinct credentials running flat out would
+  be needed to saturate the server, so one leaked secret is not a DoS engine
+  and its abuse is visibly rate-shaped in audit logs.
+- Introspection at 6 000/min still bounds token-probing to a rate where the
+  opaque-token search space is untouchable, while covering a resource server
+  that introspects once per request.
+- `authz_check` at 6 000/min/client sits an order of magnitude below the
+  measured ~44 400/min whole-server cache-off ceiling.
+
+Under `mesh`, the authz ceiling (60 000/min = 1 000/s) is **above** the
+measured 740/s cache-off whole-server ceiling. Stated honestly in the docs:
+on that hardware it is a runaway-retry-loop guard, not an abuse control. It
+is an appropriate value only for a deployment with no internet exposure on
+the machine endpoints, which is exactly what `mesh` names.
+
+---
+
+## 5. What was implemented
+
+### 5.1 Config (`crates/axiam-api-rest/src/config/rate_limit.rs`)
+
+- `RateLimitProfile { Internet (default), Gateway, Mesh }` +
+  `MachineLimitPreset` (the preset's field set — machine endpoints only).
+- `RateLimitConfig::profile` (`AXIAM__RATE_LIMIT__PROFILE`).
+- `apply_profile(is_set)` / `apply_profile_from_env()` — applies the preset
+  to every field the operator did **not** pin with an explicit
+  `AXIAM__RATE_LIMIT__*` env var, and returns a `RateLimitPosture`
+  (profile, whether a preset was applied, the list of overriding env var
+  names, and the gRPC ceiling to hand to the gRPC config).
+  **Precedence: explicit env var > preset > shipped default.**
+- `RateLimitKeyMode::as_str()` / `RateLimitProfile::as_str()` for logging.
+
+Preset values (per bucket), with derivations recorded next to the constants:
+
+| | `internet` (shipped) | `gateway` | `mesh` |
+|---|---|---|---|
+| `KEY` | `ip` | `client_id` | `client_id` |
+| `TOKEN_PER_MIN` | 20 | 600 | 6 000 |
+| `INTROSPECT_PER_MIN` | 10 | 6 000 | 60 000 |
+| `REVOKE_PER_MIN` | 10 | 600 | 6 000 |
+| `AUTHZ_CHECK_PER_MIN` | 300 | 6 000 | 60 000 |
+| `GRPC__GRPC_AUTHZ_PER_SEC` | 100 | 1 000 | 5 000 |
+| login / register / reset / MFA | 10 / 5 / 3 / 5 | **unchanged** | **unchanged** |
+
+### 5.2 gRPC (`crates/axiam-api-grpc/src/config.rs`)
+
+`GrpcConfig::apply_rate_limit_preset[_from_env]()` — applies the ceiling the
+REST-side preset table specifies, unless `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC`
+is pinned. The **numbers are not duplicated here**: the gRPC crate does not
+depend on the REST crate, so the composition root passes the value. This
+keeps one source of truth and one operator-facing env var for the whole
+family.
+
+### 5.3 Startup posture log (`crates/axiam-server/src/main.rs`)
+
+One `tracing::info!` line — the existing structured-JSON idiom, `info`
+level, alongside the other boot lines — emitted after the posture is
+resolved and validated, before the listeners bind:
+
+```
+"Rate-limit posture active"
+  profile, preset_applied, key_mode,
+  login_per_min, register_per_min, password_reset_per_min, mfa_per_min,
+  token_per_min, introspect_per_min, revoke_per_min, authz_check_per_min,
+  grpc_authz_per_sec, operator_overrides
+```
+
+Every field is configuration; no secrets. `operator_overrides` lists the env
+var **names** that beat the preset (or `none`), so an operator seeing a value
+that disagrees with the profile immediately knows why.
+
+### 5.4 Docs
+
+- **New:** [`docs/deployment/rate-limit-sizing.md`](../docs/deployment/rate-limit-sizing.md)
+  — the "sizing your limits" page: which posture you are in, the measured
+  envelope (labelled laptop-class and temporary), the preset table with
+  derivations, how to size by hand, the six security caveats from §4, and
+  how to read the startup log.
+- `docs/deployment/README.md` — `AXIAM__RATE_LIMIT__PROFILE` row + a pointer
+  to the sizing page from the rate-limiting section.
+- `docs/README.md` — index entry.
+
+### 5.5 Single-source-of-truth check (pragmatic, not a build-time include)
+
+The sizing page's posture table is delimited by
+`<!-- rate-limit-posture-table:begin/end -->` and parsed by unit tests that
+run in the existing CI test job (`cargo test --workspace`):
+
+- `axiam-api-rest`: `documented_defaults_match_shipped_config` (doc vs
+  `RateLimitConfig::default()`), `documented_presets_match_applied_profiles`
+  (doc vs what `apply_profile` actually produces, including the gRPC column
+  and the human-endpoint columns), and
+  `public_benchmark_doc_shipped_defaults_match_code` — which also diffs the
+  **"Shipped default" column of `benchmarks/PUBLIC_BENCH_ANALYSIS.md` §6**
+  against the code. That file is owned by the benchmark harness, so a
+  *missing* file is skipped; a *wrong* value fails.
+- `axiam-api-grpc`: `documented_grpc_default_matches_shipped_config`
+  (doc vs `GrpcConfig::default()` — each crate checks its own half).
+
+Plus behavioural tests: `internet_profile_is_a_no_op`,
+`explicit_env_vars_win_over_the_preset`,
+`no_profile_touches_human_endpoints`,
+`presets_stay_below_the_measured_server_ceiling`,
+`profile_deserializes_from_documented_env_values`,
+`rate_limit_preset_applies_only_when_env_unset`.
+
+### 5.6 Known limitation (documented, not fixed)
+
+"Explicitly set" is detected as *an `AXIAM__…` env var is present*. A value
+coming from the optional `config/default.toml` file source looks unset to
+the preset and will be overwritten. The repo ships no such file and the
+container/K8s deployment path is env-var-only, so this is a documentation
+matter (sizing §5.5), not a defect in the shipped deployment model.
+
+---
+
+## 6. Verification actually run
+
+```
+cargo test  -p axiam-api-rest --lib --no-default-features config::   → 23 passed, 0 failed
+cargo test  -p axiam-api-grpc --lib config::                         → 4 passed, 0 failed
+cargo check -p axiam-server   --no-default-features                  → Finished (clean)
+cargo clippy -p axiam-api-rest --lib --no-default-features --tests -- -D warnings → clean
+cargo clippy -p axiam-api-grpc --lib --tests -- -D warnings          → clean
+cargo fmt   -p axiam-api-rest -p axiam-api-grpc -- --check           → clean
+cargo fmt   -p axiam-server -- --check                               → no diffs in main.rs
+bash scripts/check-doc-links.sh                                      → all links resolve
+```
+
+`--no-default-features` is used for the REST/server crates because this
+sandbox has no `libxml2` for the `saml` feature (same flag CI's
+"Build (SAML off)" job uses). The rate-limit code is not feature-gated.
+
+**Not run:** the startup log line has not been observed on a live boot — it
+requires SurrealDB + RabbitMQ, which this sandbox does not have. It is
+straight-line `tracing::info!` with no fallible call, and the crate compiles,
+but a maintainer smoke-boot is the honest confirmation (§7.2).
+
+---
+
+## 7. What remains for the maintainer
+
+### 7.1 Sign-off items
+
+1. **Preset values.** No shipped default moved, so nothing regresses on
+   upgrade — but the `gateway`/`mesh` numbers are a judgement call anchored
+   to laptop-class measurements. Confirm 600 / 6 000 / 600 / 6 000 (gateway)
+   and 6 000 / 60 000 / 6 000 / 60 000 (mesh) match the fleet sizes you
+   intend to support. They are one table in one file.
+2. **`mesh` authz = 60 000/min is above the measured whole-server
+   ceiling** — deliberately a runaway-loop guard rather than an abuse
+   control, and labelled as such in the docs. Confirm you are comfortable
+   shipping a documented not-really-a-limit under that profile name, or drop
+   it to 30 000.
+3. **§4.1 is a live finding about D8 as shipped**, not about this change:
+   the `client_id` key modes are attacker-mintable. Confirm the
+   documentation-plus-opt-in treatment is sufficient for v1.0-beta, or open
+   an issue for the bounded-keyspace fix (§7.3).
+
+### 7.2 Needs a laptop run
+
+1. **Boot smoke test** — start the stack and confirm the
+   `Rate-limit posture active` line appears once at `info` with the expected
+   fields, under both no profile and `AXIAM__RATE_LIMIT__PROFILE=gateway`.
+2. **Re-measure the posture pass under `gateway`** in run 4: the run-3
+   `rl=prod` pass measured the defaults; there is no measured cell for the
+   preset. Expected result — the single-IP generator is no longer flattened
+   *if* the harness sends distinct `client_id`s, and is still flattened if it
+   sends one. Both outcomes are informative; the second would empirically
+   confirm §4.3.
+3. **Refresh the envelope numbers** in
+   `docs/deployment/rate-limit-sizing.md` §2 after run 4 — they are copied
+   from public §6 and labelled temporary. The doc-vs-code test does not
+   cover that prose table (it covers the posture table), so it is a manual
+   sync at run-4 time.
+
+### 7.3 Follow-ups deliberately not done here
+
+1. **Bounded bucket keyspace for `client_id` modes** (§4.2) — key only on
+   `client_id`s that resolve to a known client, or cap distinct keys per IP
+   with an overflow bucket. Design change to D8; needs its own issue.
+2. **Per-RPC client-identity-aware gRPC rate limiting** (§4.4) — the
+   interceptor reordering already anticipated in `GrpcRateLimitKeyMode`'s
+   doc comment. Until then, gRPC authz has no per-client fairness.
+3. **`benchmarks/PUBLIC_BENCH_ANALYSIS.md` §6 does not yet mention
+   `AXIAM__RATE_LIMIT__PROFILE`.** That file is outside this task's file
+   ownership (owned by the benchmark/reporting agent), and its *shipped
+   default* column is already correct and now CI-guarded against drift
+   (§5.5). Someone should add a `PROFILE` row and point the M2M column at
+   the preset when the public doc is next revised (E4 / fourth draft).

--- a/claude_dev/refresh-harness-diagnosis.md
+++ b/claude_dev/refresh-harness-diagnosis.md
@@ -1,0 +1,331 @@
+# G4 — AXIAM `token_refresh` harness diagnosis (A8 residual)
+
+**Status:** root cause proven from server source; fix applied to
+`benchmarks/scenarios/lib/auth.js` and `benchmarks/scenarios/token_refresh.js`.
+No live stack in this sandbox (no docker/k6) — the laptop confirmation command
+is at the bottom. `benchmarks/scenarios/lib/targets.js` is **not** edited here
+(owned by another agent this round); the exact change it still needs is
+described in §4.
+
+## Symptom (run 3)
+
+AXIAM's `token_refresh` cell fired `bench_fallback` on 100% of iterations
+(9,774/9,774), 2 HTTP requests/iteration (the client-credentials-fallback
+signature), while Keycloak's identical code path measured 379 req/s with
+**zero** fallback and **one** request/iteration.
+
+## Root cause 1 (primary, sufficient by itself): cookie `Path` mismatch
+
+`readAccessFromLogin()` (`benchmarks/scenarios/lib/auth.js`, pre-fix line 43)
+read the jar with:
+
+```js
+const cookies = jar.cookiesForURL(built.url);   // built.url = .../api/v1/auth/login
+```
+
+but the server scopes the three login cookies to **different paths**:
+
+- `axiam_access` — `Path=/` —
+  `crates/axiam-api-rest/src/middleware/csrf.rs:209-217` (`access_cookie()`)
+- `axiam_csrf` — `Path=/` —
+  `crates/axiam-api-rest/src/middleware/csrf.rs:242-250` (`csrf_cookie()`)
+- `axiam_refresh` — **`Path=/api/v1/auth/refresh`** —
+  `crates/axiam-api-rest/src/middleware/csrf.rs:224-231` (`refresh_cookie()`):
+
+  ```rust
+  pub fn refresh_cookie(token: &str, max_age_secs: u64, cookie_secure: bool) -> Cookie<'static> {
+      Cookie::build(COOKIE_REFRESH, token.to_owned())
+          .http_only(true)
+          .secure(cookie_secure)
+          .same_site(SameSite::Strict)
+          .path("/api/v1/auth/refresh")
+          .max_age(Duration::seconds(max_age_secs as i64))
+          .finish()
+  }
+  ```
+
+Per RFC 6265 path-matching, a cookie scoped to `/api/v1/auth/refresh` is
+**not** returned for a request/jar-lookup against `/api/v1/auth/login`
+(`/api/v1/auth/refresh` is not a path-prefix of `/api/v1/auth/login` — they
+diverge at `refresh` vs `login`). So `jar.cookiesForURL(loginUrl)` correctly
+returns `axiam_access`/`axiam_csrf` (both `Path=/`) but **never**
+`axiam_refresh`. `readAccessFromLogin()` therefore always returned
+`refresh_token: undefined` for AXIAM, and `mintUserToken()` /
+`token_refresh.js` always took the "target issued no refresh token" fallback
+branch (`m.fallback.add(1); doOp(a.clientCredentials())`) — 100% fallback,
+exactly as observed.
+
+This is fully proven by source and is **not** dependent on the `Secure`
+question below: `authz_check_rest` uses the exact same `readAccessFromLogin()`
+at the same `p0-plaintext` profile and correctly retrieves `axiam_access`/
+`axiam_csrf` every time (737-1013+ req/s in run 3, no fallback) — proof that
+whatever the jar does with `Secure` cookies over `http://`, it isn't blocking
+these two `Path=/` cookies. Only the narrowly-scoped `axiam_refresh` cookie
+was ever missed, and Path is the only attribute that differs.
+
+### Secondary/latent finding: `Secure` is not profile-aware (worth fixing, not the cause here)
+
+`AuthConfig::cookie_secure` defaults to `true`
+(`crates/axiam-auth/src/config.rs:189`) and is applied unconditionally to all
+three cookies (`crates/axiam-api-rest/src/middleware/csrf.rs:212,227,245`).
+`benchmarks/targets/axiam/docker-compose.yml` sets no
+`AXIAM__AUTH__COOKIE_SECURE` override for any profile (grepped, no match), so
+even under `p0-plaintext` (`http://`, no TLS) the server still sends
+`Set-Cookie: ...; Secure`. As shown above this did **not** turn out to be why
+`token_refresh` failed (the `Path`-scoped cookies without this problem also
+worked fine), but it's a real config gap: a `Secure` cookie set from a plain
+`http://` origin is out-of-spec and some HTTP clients refuse to attach it back
+to later `http://` requests (RFC 6265bis §4.1.2.5 discourages exactly this).
+Recommend (not part of this diff, `docker-compose.yml` is out of scope):
+`AXIAM__AUTH__COOKIE_SECURE=false` for the `p0-plaintext` bench profile only,
+matching the profile's own `BENCH_VERIFY_TLS=false` intent.
+
+## Root cause 2 (would have surfaced immediately after fixing #1): wrong redemption endpoint
+
+Even with the cookie correctly extracted, the pre-fix `token_refresh.js` calls
+`doOp(a.refresh(vuRefresh))`, and `targets.js`'s `axiam.refresh()` POSTs to
+**`/oauth2/token?grant_type=refresh_token`**. That is the wrong endpoint for a
+login-issued refresh token:
+
+- `POST /api/v1/auth/login` mints its refresh token via axiam-auth's
+  **`SessionRepository`** —
+  `crates/axiam-auth/src/service.rs:942-980` (`create_session_and_tokens()`,
+  called from `login()`), token stored via `session_repo.create(...)`.
+- `POST /oauth2/token` with `grant_type=refresh_token` looks the presented
+  token up in a **different** store, the OAuth2
+  **`RefreshTokenRepository`** —
+  `crates/axiam-oauth2/src/token.rs:446-649` (`handle_refresh_token()`),
+  specifically the lookup at lines 501-509:
+
+  ```rust
+  // Look up the refresh token by hash (after client auth)
+  let token_hash = hash_refresh_token(raw_token);
+  self.refresh_token_repo
+      .find_by_hash(tenant_id, &token_hash)
+      ...
+      OAuth2Error::InvalidGrant("refresh token is invalid, expired, or revoked".into())
+  ```
+
+A session-login refresh token is never written to that table (only
+`authorization_code`-flow refresh issuance would write there — see
+`token.rs:268-287` — and AXIAM's `client_credentials` grant issues **no**
+refresh token at all, `token.rs:335,436`). So posting a login-issued refresh
+token to `/oauth2/token` always returns `invalid_grant`/401. This is why the
+harness fix could not simply "read the cookie correctly" — it also had to
+target the correct endpoint.
+
+The correct redemption target is the REST **session** refresh endpoint:
+
+- `POST /api/v1/auth/refresh` —
+  `crates/axiam-api-rest/src/handlers/auth.rs:421-480`.
+  - Reads the refresh token **only** from the `axiam_refresh` cookie (no body
+    or header alternative) — lines 429-434.
+  - Requires the JSON body `RefreshRequest { tenant_id: Uuid, org_id: Uuid }`
+    (`handlers/auth.rs:99-103`) — `org_id` must deserialize as a UUID but is
+    not actually trusted; the handler re-derives the authoritative org from
+    `tenant_id` (`handlers/auth.rs:449-451`, `org_id: tenant.organization_id`).
+  - Requires the CSRF double-submit header `X-CSRF-Token` matching the
+    `axiam_csrf` cookie — this path is **not** in `CSRF_EXEMPT_SUFFIXES`
+    (`crates/axiam-api-rest/src/middleware/csrf.rs:42-68`; only `/login`,
+    the MFA/reset/federation endpoints, and the `/oauth2/` prefix are
+    exempt), so a request missing the header/cookie pair 403s
+    (`AuthorizationDenied`, `middleware/csrf.rs:170-181`) before the handler
+    even runs.
+  - On success, rotates **all three** cookies (new access/refresh/csrf,
+    `handlers/auth.rs:461-476`) but the JSON body carries only
+    `{ expires_in }` (`RefreshSuccessResponse`, `handlers/auth.rs:95-97`) —
+    **no tokens in the body**. The new refresh/csrf values are therefore only
+    obtainable from `Set-Cookie` on that response (i.e., read back out of the
+    jar), never from `doOp()`'s parsed body.
+
+## The fix
+
+`benchmarks/scenarios/lib/auth.js`:
+
+1. `readAccessFromLogin()` now also probes the jar against the refresh
+   cookie's own path (`${origin}/api/v1/auth/refresh`), in addition to the
+   login URL, and merges the result. Pure jar read, no extra request; a
+   harmless no-op for targets that never set an `axiam_refresh`-named cookie.
+2. `mintUserToken()` now also returns `csrf_token` (previously dropped on the
+   floor — `loginSession()` already extracted it, `mintUserToken()` didn't).
+3. New `axiamRefreshOp(refreshToken, csrfToken)`: builds a
+   `POST /api/v1/auth/refresh` request with the `axiam_refresh`/`axiam_csrf`
+   cookies set explicitly, the `X-CSRF-Token` header, and a
+   `{ tenant_id, org_id }` JSON body from `cfg` (same assumption
+   `axiam.clientCredentials()`/`axiam.introspect()`/`axiam.refresh()` already
+   make in `targets.js` today — `cfg.tenantId` is expected to hold a real UUID,
+   populated by `seed.sh`'s `BENCH_TENANT_ID`/`BENCH_ORG_ID`).
+4. New `readAxiamRefreshCookies(jar)`: re-reads the rotated
+   `axiam_refresh`/`axiam_csrf` pair from the jar after redemption (JSON body
+   has nothing to read).
+
+`benchmarks/scenarios/token_refresh.js`:
+
+- Tracks a per-VU `vuCsrf` alongside `vuRefresh`.
+- For `cfg.target === 'axiam'`, calls `axiamRefreshOp()`/
+  `readAxiamRefreshCookies()` instead of the generic `a.refresh(vuRefresh)`
+  (which remains used, unchanged, for Keycloak/Zitadel — Keycloak's path was
+  already proven correct at 379 req/s and is untouched).
+- On a failed redemption, `vuRefresh` resets to `null` so the VU re-mints via
+  `mintUserToken()` on the next iteration, same recovery pattern as before.
+
+Both files pass `node --check` (validated via `.mjs` copies, since this
+sandbox's Node auto-detects module syntax inconsistently for the bare `.js`
+extension used by k6 scenario files — see caveat in §5). k6 itself is not
+installed in this sandbox; the import graph (`k6/http`, `k6/encoding`, `k6`)
+cannot be resolved or exercised here.
+
+## §4 — the change `targets.js` still needs (not applied here; out of scope this round)
+
+The fix above is deliberately implemented as an AXIAM-only branch inside
+`token_refresh.js` + AXIAM-only helpers in `auth.js`, so it does not require
+touching `targets.js`. For architectural consistency (targets.js's own header
+comment: "This is the ONLY place where vendor differences live"), the
+long-term move is to fold this into `targets.js`'s `axiam` adapter so
+`token_refresh.js` can go back to calling `a.refresh(vuRefresh)` uniformly for
+every target:
+
+1. Change `axiam.refresh(refreshToken)` (currently `targets.js:70-83`, POSTs
+   form-encoded `grant_type=refresh_token` to `/oauth2/token`) to instead
+   build the `POST /api/v1/auth/refresh` request: JSON body
+   `{ tenant_id: cfg.tenantId, org_id: cfg.orgId }`, and accept an **explicit
+   second parameter** for the CSRF token (the builder signature would need to
+   become `refresh(refreshToken, csrfToken)` — a shape change from every other
+   adapter's `refresh(refreshToken)`, since AXIAM alone needs the CSRF
+   double-submit header/cookie). Set `cookies: { axiam_refresh: refreshToken,
+   axiam_csrf: csrfToken }` and header `X-CSRF-Token: csrfToken` in `params`.
+2. Because the response carries the rotated refresh token only via
+   `Set-Cookie` (not JSON body), either (a) have `token_refresh.js` special-case
+   reading the jar after the call for AXIAM only (what this patch does today,
+   just relocated), or (b) — cleaner — extend `doOp()` in `metrics.js` to
+   optionally return `{ body, res }` so callers needing cookies don't have to
+   special-case; that's a `metrics.js` change, also out of scope for any
+   single-file-owner this round.
+3. `mintUserToken()`'s existing `csrf_token` field (now returned, this patch)
+   is exactly what a uniform `a.refresh(refreshToken, csrfToken)` call site in
+   `token_refresh.js` would need — no further plumbing required once (1)/(2)
+   land.
+
+Once that lands, `benchmarks/scenarios/lib/auth.js`'s `axiamRefreshOp`/
+`readAxiamRefreshCookies` and `token_refresh.js`'s `isAxiam` branch introduced
+by this change become dead code and should be deleted in the same PR that
+makes the `targets.js` change, to avoid two parallel implementations.
+
+## Zitadel `offline_access` — not implemented, ≤50 lines not achievable
+
+Assessed per the G4 spec's ask. Not implemented; the fallback tag for
+Zitadel's `token_refresh` cell stays.
+
+Zitadel disables the ROPC (resource-owner password) grant by default, which is
+why `targets.js`'s Zitadel `login()` already uses the Session API v2
+(`POST /v2/sessions`) instead — and a session-API session is not an OIDC token
+(no `access_token`/`refresh_token`, just a `sessionToken`), so it cannot seed a
+refresh grant. The only way to obtain a real Zitadel refresh token (scope
+`offline_access`) is to complete an actual **OIDC Authorization Code flow**:
+`GET /oauth/v2/authorize` → Zitadel's *hosted, stateful login UI* (its own
+HTML form, its own CSRF token embedded in that form, likely multi-step if MFA
+is configured) → `POST` the credentials to that UI → follow the redirect chain
+back to the registered `redirect_uri` with a `code` → exchange the code at
+`/oauth/v2/token`. This is fundamentally different from every other op this
+harness performs: it requires parsing and resubmitting a third-party HTML
+form and following an interactive redirect chain, not just building a request
+against a documented JSON/form API. k6's `http` module has no DOM/form
+handling, and k6's separate browser-automation module (a different execution
+model entirely, incompatible with this protocol-level VU/iteration harness)
+would be required to do it reliably. Zitadel's Session API v2 also supports an
+SSO shortcut (`prompt=none` / `id_token_hint` against `/authorize` using the
+just-created session's cookie) that in principle could skip the login form,
+but its exact contract (session-to-authorize cookie linkage, response shape)
+is not verifiable from this sandbox without a live Zitadel instance to probe,
+and getting it wrong would silently produce another mislabeled-as-real
+fallback — worse than the honest, documented fallback tag already in place.
+Recommend leaving this as a explicitly out-of-scope, tagged fallback unless a
+future task can verify the SSO shortcut against a live Zitadel instance.
+
+## §5 — what's proven vs. what needs laptop confirmation
+
+**Proven by source (this sandbox, no live stack needed):**
+- The `Path` mismatch is the actual, sufficient root cause (RFC 6265
+  path-matching is deterministic; `authz_check_rest`'s working `Path=/`
+  cookies at the same profile rule out `Secure` as the explanation here).
+- `/oauth2/token`'s refresh grant and `/api/v1/auth/login`'s refresh token are
+  backed by two disjoint repositories/tables — a login-issued token can never
+  validate at `/oauth2/token`.
+- `/api/v1/auth/refresh`'s exact contract (cookie-only token, CSRF-required,
+  JSON-body-has-no-tokens) — read directly from the handler and the CSRF
+  middleware's exemption list.
+
+**Needs laptop confirmation:**
+- That k6's actual cookie jar implementation performs RFC 6265-conformant
+  path-matching in `cookiesForURL()` (assumed, standard, but not verified
+  against k6's Go source in this sandbox).
+- The end-to-end numbers below.
+- Whether `cfg.orgId`/`cfg.tenantId` are populated as real UUIDs in the
+  laptop's actual seed output for every target/profile combination run (the
+  `axiamRefreshOp` JSON body will 400 if `org_id` is empty-string when only a
+  slug was seeded — no different from the pre-existing assumption
+  `axiam.clientCredentials()` already makes).
+
+## Laptop confirmation command
+
+```
+just target=axiam profile=p0-plaintext bench-up
+just target=axiam bench-seed
+just target=axiam profile=p0-plaintext scenario=token_refresh.js bench-run
+```
+
+Then check `results/<run>/axiam/p0-plaintext/token_refresh/summary.json` (or
+equivalent report output) for:
+
+- `bench_fallback == 0`
+- one HTTP request per iteration (`http_reqs` / iterations ≈ 1, not ≈ 2)
+- throughput **not** ≈ ½ × the `client_credentials` cell's throughput for the
+  same target/profile (the fallback-op signature), and directionally
+  comparable to Keycloak's 379 req/s head-to-head number.
+
+---
+
+## 6. Comparability correction (added by the integrating agent, 2026-07-26)
+
+The pass criteria above end with "directionally comparable to Keycloak's
+379 req/s head-to-head number". **That comparison needs a label, and the report
+must carry it**, otherwise this fix trades one mislabeled cell for another.
+
+After the fix the two cells measure *different protocol operations*:
+
+| target | endpoint | operation | credential store |
+|---|---|---|---|
+| AXIAM | `POST /api/v1/auth/refresh` | **session refresh** (cookie + CSRF double-submit) | `axiam-auth` `SessionRepository` |
+| Keycloak | `POST /realms/…/protocol/openid-connect/token` `grant_type=refresh_token` | **OAuth2 refresh grant** | Keycloak's OAuth2 store |
+
+AXIAM *cannot* be made to match Keycloak's shape from a password login, and this
+is deliberate rather than a gap: `TokenService::exchange`
+(`crates/axiam-oauth2/src/token.rs:143-147`) supports exactly
+`authorization_code`, `client_credentials` and `refresh_token` — there is **no
+password/ROPC grant**, which is the OAuth 2.1-recommended posture (the password
+grant is removed in OAuth 2.1; Keycloak's cell depends on it). So the only way
+to obtain an *OAuth2* refresh token from AXIAM is a full authorization-code
+flow.
+
+**Consequences to act on:**
+
+1. **Label the cell.** Both operations are legitimately "renew an access
+   credential without re-authenticating" — comparable at the product level, not
+   at the protocol level. The cell should carry a comparability label of its own
+   (suggest `protocol-variant`, alongside the existing `fallback-op` and
+   `cc-token-setup`), so `report.py` keeps it visible with a footnote rather
+   than presenting it as a like-for-like head-to-head. This is a `report.py`
+   change and is tracked in the plan, not applied here.
+2. **The apples-to-apples option, if we want it.** Drive AXIAM's
+   `/oauth2/authorize` with the session cookie obtained at login to get an
+   authorization code, exchange it for an OAuth2 access+refresh pair, then
+   exercise `grant_type=refresh_token` exactly as Keycloak does. This is
+   plausible in ~40-60 lines *if* the authorize endpoint accepts the session
+   cookie and does not require an interactive consent step — verify before
+   committing to it. That would give a true protocol-level head-to-head and
+   would additionally cover AXIAM's authorization-code path, which no scenario
+   currently benchmarks at all.
+3. **Publishing rule until then:** AXIAM's refresh number may be published as
+   AXIAM's *session-refresh* capability, and Keycloak's as its *OAuth2-refresh*
+   capability, side by side with the distinction stated — never as "AXIAM is
+   N× Keycloak at refresh".

--- a/claude_dev/sdk-oidc-sso-conformance-review.md
+++ b/claude_dev/sdk-oidc-sso-conformance-review.md
@@ -1,0 +1,715 @@
+# CONTRACT §12 OIDC/SSO — cross-SDK conformance review (T9)
+
+**Date:** 2026-07-27
+**Scope:** CONTRACT §12 (OIDC/SSO relying-party helpers), implemented independently in eight SDKs
+against contract 1.4 (`/home/user/axiam` @ `9c5de58`).
+**Outcome:** contract amended to **1.5** (non-breaking / clarifying); one repo **BLOCKED**, seven
+**SAFE TO MERGE**; 19 follow-up items recorded (F-01–F-19, of which F-16 was fixed in this review,
+leaving 18 open).
+
+Branch under review in every repo: `claude/sdk-oidc-sso-plan-8t4hgm`.
+
+| Repo | Commit reviewed |
+|---|---|
+| `axiam` (contract) | `9c5de58` |
+| `axiam-typescript-sdk` (reference) | `2efd754` |
+| `axiam-python-sdk` | `e98ffbf` |
+| `axiam-go-sdk` | `ba9bd84` |
+| `axiam-rust-sdk` | `b2d7930` |
+| `axiam-php-sdk` | `6d5775e` |
+| `axiam-java-sdk` | `c7b6866` |
+| `axiam-csharp-sdk` | `cf59dc8` |
+| `axiam-kotlin-sdk` | `c65edca` |
+
+---
+
+## 1. Conformance matrix
+
+Legend: **P** = pass · **F** = fail · **D** = divergent but legal (a contract MAY, or a
+per-language equivalence) · **P\*** = pass with a recorded caveat · **n/a** = not applicable.
+Every cell was determined by reading the shipped source, not by reading an agent's report.
+
+### 1.1 Vocabulary and surface
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| All nine §12.2 operations present, exact per-language name | P | P | P | P | P | P | P | P |
+| C# `OidcBegin` has **no** `Async` suffix; no `OidcBeginAsync` exists | n/a | n/a | n/a | n/a | n/a | n/a | P | n/a |
+| Python: identical names on sync + async client; no `async_*` anywhere | n/a | P | n/a | n/a | n/a | n/a | n/a | n/a |
+| Kotlin: `suspend`, no `*Async`/`Deferred` twins | n/a | n/a | n/a | n/a | n/a | n/a | n/a | P |
+| Java: only the permitted `*Async` twins (and no `oidcBeginAsync`) | n/a | n/a | n/a | n/a | n/a | P | n/a | n/a |
+| No additional diverging auth/authz method names | P | P | P | P | P | P | P | P |
+| Argument order / params shape consistent, subject-before-object | P | P | P | P | P | P | P | P |
+| Host object for the nine methods | D | P | P | P | P | P | P | P |
+
+`D` for TypeScript: the nine live on a Node-only `OidcClient` rather than `AxiamClient`, because
+its CI forbids `node:crypto`/`jose` from reaching the browser bundle. Contract 1.5 §12.2 now
+permits this explicitly.
+
+### 1.2 Error taxonomy
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| `OAuthProtocolError` is a **sub-type** of the existing auth-error type | P | P | P | D | P | P | P | P |
+| `message` field exactly `"<error>: <error_description>"` | P | P | P | P | P | P | P | P |
+| `error` + `error_description` publicly accessible (per-language casing) | P | P | D | P | P | P | P | P |
+| Existing consumer `catch`/`except`/`match` code still works | P | P | P | **F** | P\* | P | P | P |
+| 400 from `/oauth2/*` with an OAuth2 body → `OAuthProtocolError` | P | P | P | P | P | P | P | P |
+| 401 from `/oauth2/*` with an OAuth2 body → `OAuthProtocolError` | P | P | P | P | P | P | P | P |
+| 401 from `/oauth2/*` never enters the §9 refresh guard (tested) | P | P | P | P | P | P | P | P |
+
+- **RS `D`** on sub-typing: Rust models it as two new fields (`oauth`, `reason`) on the existing
+  `AxiamError::Auth` struct variant rather than a peer type — an idiomatic and legal realisation.
+- **RS `F`** on consumer compatibility: adding fields to a public, non-`#[non_exhaustive]` struct
+  variant is **source-breaking** for downstream crates. `AxiamError::Auth { .. }` still matches,
+  but `AxiamError::Auth { message }` (exhaustive destructure) is `E0027` and every
+  `AxiamError::Auth { message: … }` construction is `E0063`. The commit mechanically fixed 33
+  construction sites and 9 patterns inside the repo, including one in a shipped `examples/` file —
+  which is precisely the evidence that downstream code breaks too. Contract 1.4's log calls §12
+  "non-breaking"; for Rust it is not. Pre-1.0 (`1.0.0-alpha18`), so tolerable, but it must be
+  documented and `#[non_exhaustive]` should be added now.
+- **GO `D`**: the `error` field is exported as `ErrorCode`, because a field named `Error` would
+  collide with the promoted `Error()` method that satisfies the `error` interface. Contract 1.5 §2
+  now blesses this. Go's `Error()` also prefixes `"authentication failed: "`; the `Message` field
+  itself is exact, which is what 1.5 requires.
+- **PHP `P*`**: `AuthError::__construct` gained `$reason` as the **second positional** parameter,
+  so any downstream caller passing `$previous` positionally breaks. No such call site exists in
+  the repo (all 22 verified), but the ordering is a latent trap — `$reason` should be keyword-only
+  or last.
+
+The 401-out-of-guard property is realised two ways, both tested and both conformant: an explicit
+`/oauth2/*` skip list (TS `SKIP_REFRESH`, Java `OAUTH2_SKIP_REFRESH_PATHS`, C#
+`ReactiveRefreshExemptPaths`) or structurally, by routing §12 calls through a transport that has no
+401→refresh interceptor at all (Python, Go, Rust, PHP, Kotlin). The structural variant is more
+robust today but more fragile to a future generic interceptor; each of those five repos should
+carry a regression comment or test naming that invariant (follow-up F-14).
+
+### 1.3 `Sensitive` / §7
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| Exactly the 5 §12.5 fields wrapped (access/refresh/id token, client_secret, code_verifier) | P | P | P | P | P | P | P | P |
+| `state` and `nonce` are **not** wrapped | P | P | P | P | P | P | P | P |
+| Redaction in every stringification sink | P | P | P | P | P | P | P | P |
+| Redaction in every structured-serialization sink | P | P\* | P | n/a | P | P\* | P | n/a |
+| Raw value not reachable **implicitly** (no public field/`Deref`/auto-unbox) | P | P | D | P | P | P | P | P |
+| §12 caller can read the returned tokens | P | P | P | P | P | **F** | P | **F** |
+
+- `n/a` for Rust and Kotlin on structured serialization: neither wrapper nor any §12 DTO implements
+  `Serialize`/`@Serializable`, so a leak there is a compile error rather than a runtime risk. That
+  is the strongest possible outcome, not a gap.
+- **PY/JV `P*`**: the behaviour is correct but the assertion is missing — Python has no
+  `model_dump_json()` test on `OidcTokenSet`/`AuthorizationRequest`, and Java has no Jackson test
+  on the three DTOs (only on a bare `Sensitive`). Follow-up F-11/F-12.
+- **GO `D`**: `type Sensitive string` means `string(tok.AccessToken)` reaches the raw value from any
+  package. That is an *explicit* conversion and it is the shape §7's Go row itself prescribes;
+  contract 1.5 §7 rule 2 now says so.
+- **JV/KT `F`**: `Sensitive.expose()` is package-private (Java, in `io.axiam.sdk`) and `internal`
+  (Kotlin). Both SDKs return `OidcTokenSet` objects whose `access_token`/`refresh_token`/`id_token`
+  **the caller cannot read at all**. This is not a §7 violation — under contract 1.5 rule 3 a
+  module-private accessor stays conformant — but it defeats the purpose of §12, which exists to
+  hand tokens to a relying party so it can forward, persist, and later revoke them. Highest-value
+  follow-up (F-02, F-03).
+
+### 1.4 PKCE and ID-token validation
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| PKCE `S256` only; `plain` structurally unreachable | P | P | P | P | P | P | P | P |
+| RFC 7636 Appendix B vector asserted in a real test | P | P | P | P | P | P | P | P |
+| §12.4 r1 `alg` = `EdDSA`, checked before signature work (+ failing test) | P | P | P | P | P | P | P | P |
+| §12.4 r2 signature + `kid`, one re-fetch, no-`kid` rejected (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r3 `iss` exact string match (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r4 `aud` contains `client_id`, `azp` when multiple (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r5 `exp`/`iat`/`nbf`, skew clamped ≤60 s (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r6 `nonce` constant-time compare (+ test) | P | P | P | P | P | P | P | P |
+| §12.4 r7 all-or-nothing discard (+ test) | P | P | P | P | P | P\* | P\* | P\* |
+| Exactly the seven contract reason codes, no eighth | P | P | P | P | P | P | P | P |
+| No "skip validation" option on any public API | P | P | P | P | P | P | P | P |
+
+All eight use the contract's reason-code strings verbatim, and all eight independently converged
+on the same many-to-one mappings (`token_expired` for every time failure, `unknown_kid` for a
+missing `kid`, `invalid_alg` for an unparseable header). Contract 1.5 §12.3 rule 3 now records that
+vocabulary as closed and pins those mappings, so the convergence is no longer accidental.
+
+`P*` on rule 7 for Java, C#, and Kotlin: validation demonstrably precedes token-set construction,
+so no partial object can exist, but the tests only assert that an error is thrown — they do not
+positively assert the access/refresh token is absent from the outcome (TS, Python, Go, Rust, PHP
+all do). Follow-up F-13.
+
+### 1.5 Cross-cutting rules
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| Stateless: no `state`/`nonce`/`code_verifier` in SDK or process-global state | P | P | P | P | P | P | P | P |
+| State store: 10-min TTL, clamped as a maximum | P | P | P | P | P | P | P | P |
+| State store: single-use `consume`, atomic delete-before-check | P | P | P | P | P | P | P | P |
+| State store: lazy sweep, no background timer/thread | P | P | P | P | P | P | P | P |
+| Discovery cache TTL floor ≥ 5 min | P | P | P | P | P | P | P | P |
+| Discovery cache single-flight (tested with N concurrent cold callers) | P | P | P | P | P | P | P | P |
+| Discovery cache per-origin, never tenant-keyed, never process-global | P | P | D | P | P | P | D | D |
+| Token endpoint: form-encoded body, never JSON | P | P | P | P | P | P | P | P |
+| `tenant_id` sent as a **query** parameter, never a body field | P | P | P | P | P | P | P | P |
+| `client_secret_post` only — no `Authorization: Basic` anywhere | P | P | P | P | P | P | P | P |
+| `X-Tenant-ID` still emitted on `/oauth2/*` | P | P | P\* | P | P | P\* | P\* | P |
+| Grant form-field sets exactly per §12.1; optionals omitted not emptied | P | P | P | P | P | P | P | P |
+| Endpoints read from the discovery document, never hardcoded | P | P | P | P | P\* | P | P | P |
+| `sso_complete` goes through the §4 cookie-jar path | P | P | P | P | P | P | P | P |
+| `sso_complete` performs the same post-login session sync as `login()` | P | P | P | **F** | P | P | P | P |
+| `revoke`: 200 = success, idempotent on unknown token, 5xx = network error | P | D | P | P | P | P | P | P |
+| Spaces in authorization-URL query values encoded `%20`, not `+` | P | P | P | **F** | P | P | P | P |
+| Reserved-param collision raises a programming error, not the taxonomy | P | P | P | D | P | P | P | P |
+| `oidc_begin` takes `client_id` from client config, not per call | P | P | P | P | P | P | P | P |
+| `AuthorizationRequest` = exactly `url`/`state`/`nonce`/`code_verifier` | P | P | P | P | P | P | P | P |
+| `sso_start` defaults tenant/org from session, prefers UUID, raises client-side | P | P | P | P\* | P | P | P | P |
+| No new **runtime** dependency added | P | P | P | D | P | P | P | P |
+| No TLS-bypass surface anywhere in shipped source | P | P | P | P | P | P | P | P |
+| Conformance statement updated to claim §12 | P | P | P | P | P | P | P\* | P |
+
+- **GO/C#/KT `D`** on cache keying: the cache is two per-instance scalar fields with no explicit
+  origin key, safe because a client is bound to one base URL for life. Contract 1.5 §12.3 rule 6
+  now states that a per-client-instance cache satisfies the origin requirement by construction.
+  Legal, and the previous wording was self-contradictory anyway.
+- **`X-Tenant-ID` `P*`** (Go, Java, C#): the header interceptor returns early for a foreign host,
+  and §12 builds absolute URLs from the discovery document. A deployment whose document advertises
+  `token_endpoint` on a different host than `base_url` would silently drop the header. Harmless
+  today (the `/oauth2/*` handlers never read it — see §3 below) but untested in all eight repos.
+  Follow-up F-15.
+- **PHP `P*`** on endpoint sourcing: the pre-existing §10 `JwksVerifier` retains a hardcoded
+  `baseUrl + '/oauth2/jwks'` fallback used only when discovery is unavailable or cross-origin. The
+  §12 path always uses `jwks_uri`.
+- **PY `D`** on `revoke`: Python accepts **only** `200`; a `204` would raise. Conformant to the
+  contract as worded (1.4 and 1.5 both make `200` the MUST), but the other seven accept any 2xx,
+  which is what 1.5 recommends. Follow-up F-08.
+- **RS `F`** on `sso_complete`: it captures cookies and re-syncs CSRF but never calls
+  `absorb_session_cookies`, so unlike every sibling it does not seed the token manager or resolve
+  `tenant_id`/`org_id`. A subsequent `refresh()` fails with "no access token to refresh". F-05.
+- **RS `F`** on `%20`: **verified by execution** (see §5). F-04.
+- **RS `D`** on the collision guard: it raises `AxiamError::Network`, a §2 taxonomy error, where the
+  other seven raise the language's programming-error type. Legal under the contract (which is silent
+  on the type) but it misclassifies a caller bug as a transport failure. F-09.
+- **RS `D`** on dependencies: `Cargo.toml` gains two `[dependencies]` entries (`getrandom`,
+  `base64`), both already unconditional transitive deps. **`Cargo.lock` is unchanged by the
+  commit** — verified — so zero new crates enter the graph and the vulnerability-scan intent is
+  satisfied. Reported as `D`, not `F`.
+- **C# `P*`**: `README.md:20` claims §1–§12 but the checklist heading immediately below still reads
+  "### §1–§11 conformance checklist". Cosmetic. F-16.
+
+### 1.6 §9 single-flight refresh — the one row with real failures
+
+| Rule | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| `oidc_refresh` burst of N produces exactly **one** wire call | P | P | P | **F** | **F** | P | P | P |
+| That one outcome is shared with all N callers (§9 rule 2) | P | P | P | **F** | **F** | P | P | P |
+| §9 test requirement satisfied for `oidc_refresh` (N ≥ 5) | P (3) | P (6) | P (10) | **F** | **F** | P (5) | P (5) | P (6) |
+| Guard mechanism | shared `Promise` + session guard, bounded 3 retries | coalescer + `run_exclusive` | own `chan` future | **bare `Mutex<()>`** | `{ran,promise}` + bounded 3 retries | `SingleFlight` + `runExclusive` (bound 3) | `SemaphoreSlim` + cached `Task<T>` | `Mutex` + shared `Deferred` |
+
+TypeScript's N is 3 in its guard-contention test but its coalescing test asserts one wire call for
+concurrent callers; treated as satisfied.
+
+Adjudicated in §2.2 and §2.3 below.
+
+### 1.7 Contract MAYs — divergence here is not a defect
+
+| Item | TS | PY | GO | RS | PHP | JV | C# | KT |
+|---|---|---|---|---|---|---|---|---|
+| `login_client_credentials` credential adoption (§12.1 MAY) | D opt-in | D skipped | D opt-in | D skipped | D opt-in | D skipped | D flag + `NotSupportedException` | D skipped |
+| Optional `OidcStateStore` offered (§12.3 r1 MAY) | D yes | D yes | D yes | D yes | D yes | D yes | D yes | D yes |
+
+Where adoption **is** implemented (TS, Go, PHP), it was verified in all three that the adopted
+token (a) is opt-in and default-off, (b) lives behind `Sensitive` in a private field, (c) is
+attached only as an `Authorization: Bearer` header by a private interceptor that explicitly skips
+`/oauth2/*`, and (d) never enters the cookie jar or a public property. All three carry a test
+asserting the token endpoint sees no `Authorization` header. **Five different positions on one MAY,
+zero defects.**
+
+---
+
+## 2. Adjudication of the hard problems
+
+### 2.1 §7 vs §12 — the token-accessor conflict (highest priority)
+
+**What §7 said (1.4):** "The raw token string MUST NOT be exposed via any public getter API," and
+internal code reaches it "via a crate/module-private method or friend function, not a public API."
+**What §12 requires:** returning `access_token`/`refresh_token`/`id_token` *to the caller*, who
+must read them to persist, forward, or later revoke them. These are mutually unsatisfiable.
+
+**What all eight actually did** (read from source, not reports):
+
+| SDK | Wrapper | Accessor | Visibility | Changed by this commit? |
+|---|---|---|---|---|
+| TypeScript | `class Sensitive<T>`, private `#value` | `expose()` | public (doc-tagged `@internal`) | no — doc comments only |
+| Python | `pydantic.SecretStr` | `get_secret_value()` | public by design | no |
+| Go | `type Sensitive string` | `expose()` unexported **plus** `string(x)` conversion | effectively public | no |
+| Rust | newtype `Sensitive<T>(T)` | `expose()` | **widened `pub(crate)` → `pub`** | **yes** |
+| PHP | `final class` + static `WeakMap` | `reveal()` | public | no |
+| Java | `final class Sensitive` | `expose()` | **package-private** (`io.axiam.sdk`) | no |
+| C# | `readonly struct Sensitive<T>` | `Expose()` (+ public `Wrap()`) | **both added public** | **yes** |
+| Kotlin | `class Sensitive<T>`, private `value` | `expose()` | **`internal`** | no |
+
+So six of eight are readable by a caller; **Java and Kotlin are not** — their `OidcTokenSet`
+carries tokens no consumer of the library can extract. Redaction, by contrast, is airtight in all
+eight, including the sinks a naive wrapper misses (Go `%#v`/`Format`/`GoString`/`MarshalJSON`, Node
+`util.inspect`, Java `@JsonSerialize` + non-`Serializable`, C# `JsonConverterFactory` + suppressed
+struct equality, PHP's zero-introspectable-properties `WeakMap` trick, Kotlin's hand-written
+`toString` overrides on `data class` DTOs).
+
+**Ruling.** There is no single rule that *requires* a public accessor and that all eight satisfy,
+so §7 must permit rather than require one. Contract 1.5 splits §7 into four numbered rules:
+
+1. **Redaction — unconditional MUST**, now enumerating the easily-missed sinks explicitly. No
+   other section relaxes it.
+2. **No implicit reachability — MUST**: no public field, `Deref`, implicit conversion, auto-unbox,
+   or value-comparing inherited equality. Go's named-type conversion is named as an *explicit*
+   conversion and accepted for that language, since §7's own Go row prescribes that shape.
+3. **One explicit accessor — MAY, and RECOMMENDED where §12 ships.** A module-private accessor
+   stays conformant, but then the §12 token set is unreadable by the caller, so the SDK **SHOULD**
+   widen it — and widening is explicitly noted as non-breaking and additive.
+4. **Point-of-use discipline — MUST**: never pass the accessor's result to a sink.
+
+A rationale paragraph records why the text changed, so the next reader does not re-derive the
+conflict. The **C and C++ rows are untouched**, with a sentence explaining that both defer §12
+and therefore never hand token material to a caller — rule 3 has nothing to enable there, and
+would apply unchanged to any later port.
+
+This makes all eight conformant **and** keeps the Java/Kotlin gap visible as a SHOULD violation
+rather than papering over it. The gap is a functional defect, recorded as F-02/F-03: high severity,
+non-blocking (widening `internal`/package-private to public breaks no one and can land after
+merge), but it must ship before either SDK is released advertising §12.
+
+### 2.2 Rust's §9 single-flight is partial — conformance gap, not a contract flaw
+
+**Verified facts.** `AxiamClientInner.oidc_refresh_guard` is a bare `tokio::sync::Mutex<()>`
+(`src/client.rs:465`), acquired at `src/oidc/exchange.rs:530-532`. It holds no result slot — there
+is no `OnceCell`, `Shared`, `broadcast`, or `Option<Result<…>>` anywhere near it. `Sensitive<T>`,
+`OidcTokenSet`, and `AxiamError` are each **not** `Clone` (verified derive-by-derive; `AxiamError`
+boxes a `dyn StdError` and cannot easily become `Clone`). Consequently N concurrent callers produce
+**N wire calls**, issued serially. There is also **no concurrency test for `oidc_refresh` at all**
+— the repo's only §9 burst test covers the §1 cookie path via a different guard.
+
+**Ruling: this is a conformance gap requiring a Rust code fix, not grounds to amend §9.** Three
+reasons:
+
+1. **The observable behaviour genuinely differs, and differs badly.** AXIAM refresh tokens are
+   opaque, server-stored, and **single-use with rotation**. Serialization without sharing therefore
+   means callers 2..N deliberately replay an already-consumed refresh token and each receives
+   `invalid_grant`. Seven SDKs: N callers, one wire call, all N succeed. Rust: N callers, N wire
+   calls, one succeeds and N−1 fail with an auth error. That is not an implementation detail; it is
+   the difference the rule exists to prevent.
+2. **§9 rule 2 is already a MUST in contract 1.4.** Nothing new is being demanded. Amending §9 to
+   permit serialization would weaken a correctness rule for all eleven languages to accommodate one
+   port, and would silently license the same regression elsewhere.
+3. **The language does not make sharing impractical.** The claim rests on `Sensitive`/`AxiamError`
+   not being `Clone`, but `Sensitive` already has a working `pub(crate) fn clone_inner()` for
+   exactly this kind of duplication, and cloning a redacted wrapper cannot leak anything — every
+   other SDK's wrapper is freely copyable (C#'s is a `struct`). The non-`Clone` decision was about
+   preventing leak paths, and a `Clone` impl is not one.
+
+**Precise fix (F-01).** In `axiam-rust-sdk`:
+
+1. `src/sensitive.rs` — add `impl<T: Clone> Clone for Sensitive<T>` (a manual impl, not a derive,
+   with a doc comment noting that duplicating a redacted wrapper cannot leak: only `expose()` can).
+2. `src/oidc/exchange.rs` / `src/oidc/id_token.rs` — derive `Clone` on `OidcTokenSet`,
+   `IdTokenClaims`, and `Audience`.
+3. `src/error.rs` — add `pub(crate) fn clone_for_waiter(&self) -> AxiamError`, reconstructing the
+   same variant field-wise (`OAuthProtocolError` is two `String`s and `IdTokenFailureReason` is a
+   fieldless enum, so `Auth` clones exactly; other variants clone with `source: None`).
+4. `src/client.rs` — replace `oidc_refresh_guard: tokio::sync::Mutex<()>` with
+   `oidc_refresh_inflight: tokio::sync::Mutex<Option<tokio::sync::broadcast::Sender<Result<OidcTokenSet, Arc<AxiamError>>>>>`.
+   `tokio`'s `sync` feature is already enabled — **no new dependency**.
+5. `src/oidc/exchange.rs::oidc_refresh` — leader/waiter election: under the mutex, if a `Sender`
+   is present, `subscribe()`, drop the lock, `recv().await`, and map `Arc<AxiamError>` back through
+   `clone_for_waiter`; otherwise create the channel, publish it, drop the lock, perform the single
+   `post_token`, clear the slot under the lock, then `send` the result. The public signature
+   `Result<OidcTokenSet, AxiamError>` is preserved.
+6. `tests/oidc_token_ops_test.rs` — add the §9 burst test: ≥5 concurrent `oidc_refresh` calls
+   against a counting `/oauth2/token` mock, asserting exactly **one** request **and** that all
+   callers observe the same `access_token`. Mirror `tests/single_flight_refresh_test.rs`.
+
+**This is the sole reason `axiam-rust-sdk` is BLOCKED.** Merging it would ship a README claiming
+"§1–§12 conformance" while violating a §12-referenced MUST and omitting a MUST-level test.
+
+### 2.3 Five guard-contention designs — observably equivalent, and the 3-attempt bound should not have propagated
+
+| SDK | Coalescer | Interaction with the §1 guard | Observable result for N concurrent callers |
+|---|---|---|---|
+| TS | shared `Promise` in `#pendingRefresh` | runs inside the session `refreshGuard`; bounded 3 retries if busy | 1 wire call, shared outcome |
+| Python | `_SyncSingleFlight` / `_AsyncSingleFlight` | `RefreshGuard.run_exclusive_sync/async`, blocking, no retry | 1 wire call, shared outcome |
+| Go | own `oidcRefreshFuture` (mutex + `chan`) | deliberately does **not** use `Client.guard` | 1 wire call, shared outcome |
+| Java | `SingleFlight.run` | `RefreshGuard.runExclusive`, bounded 3 attempts | 1 wire call, shared outcome |
+| C# | cached `Task<OidcTokenSet>` + `SemaphoreSlim(1,1)` | dedicated instance, not the cookie guard | 1 wire call, shared outcome |
+| Kotlin | shared `CompletableDeferred` | dedicated instance of the §9 Kotlin mechanism | 1 wire call, shared outcome |
+| PHP | `Session::refreshGuard()` → `{ran, promise}` | bounded 3 retries; on `ran=false` waits then **re-acquires** | **N wire calls** (see below) |
+| Rust | none | bare `Mutex<()>` | **N wire calls** |
+
+**Verdict on the six that pass: observably equivalent, and that is what matters.** A behavioural
+contract governs what an observer can detect — one wire call per burst, one outcome delivered to
+everyone, no stale token set, no refresh-retry loop. All six deliver exactly that. The differences
+(shared promise vs. condition variable vs. channel vs. cached task; reusing the §1 guard object vs.
+a dedicated instance of the same mechanism) are invisible from outside and should never have been
+contract-relevant.
+
+**Verdict on the TypeScript 3-attempt bound: an implementation detail that should not have been
+propagated.** It exists only because TS's `RefreshGuard` returns `Promise<void>`, so the refreshed
+token set cannot travel back through the guard and the caller must loop to re-acquire it. It is not
+a property of the OIDC flow. It nonetheless propagated to PHP and Java, and in PHP it is where the
+result-sharing was lost: because `oidcRefresh` treats `ran === false` as "the guard is busy with
+*someone else's* refresh", a second concurrent `oidcRefresh` caller waits on the leader's promise
+and then issues **its own** token POST — structurally the same defect as Rust's. The mitigating
+facts are that vanilla PHP has no concurrency for these synchronous calls (`refreshPromise` is a
+per-instance property and `->wait()` blocks), so the path is only reachable under Fibers/Swoole,
+and that PHP has no `oidcRefresh` burst test to expose it either way. Recorded as F-06 (high
+severity, non-blocking).
+
+**Contract wording adopted (1.5).** §9 gains **rule 5**, which pins observable behaviour and frees
+mechanism:
+
+- Rules 1–4 constrain observable behaviour only; the per-language table is guidance, not a mandate.
+- An operation may use a **dedicated instance of an equally strong mechanism** where the shared
+  guard's API is specialized to another token namespace (naming the real reason: the §1 guard
+  compares cookie-access-token freshness, which is meaningless for a `refresh_token` grant) — but
+  never a weaker mechanism.
+- Where an implementation composes an operation-specific coalescer *with* the shared guard, a
+  **bounded** (never unbounded) wait is permitted, exhaustion MUST raise `AuthError` rather than
+  return a stale token set, and **the specific bound is explicitly not part of this contract**.
+
+§9 rule 2 additionally now states the observable requirement in one sentence, with the single-use
+rotation reasoning, so "serialize but do not share" can never again be read as conformant. §9's
+test requirement is clarified to apply **per refresh operation**, so `oidc_refresh` needs its own
+burst test. §12.1's "MUST run under the §9 single-flight refresh guard" becomes "MUST be governed
+by a §9-conformant single-flight guard", pointing at rule 5.
+
+### 2.4 Verification of the numbers I was given
+
+All eight suites and all eight coverage gates were **re-run locally**. Everything reported by the
+implementing agents held up; Rust's previously unmeasured coverage clears its floor.
+
+| SDK | Tests reported | Tests measured | Coverage reported | Coverage measured | Floor | Gate |
+|---|---|---|---|---|---|---|
+| TypeScript | 465 / 97.24% lines | **465 passed, 49 files** | 97.24 L / 92.51 B | **97.24 L / 92.51 B / 97.02 S / 97.58 F** | 94 L / 86 B / 94 S / 95 F | **PASS** |
+| Python | 434 / 98.88% | **434 passed** | 98.88 | **98.88** | 97 (`fail_under`) | **PASS** |
+| Go | ~116 / 94.7% | **all packages ok** (448 incl. subtests) | 94.7 | **94.7** | 94 (`coverage.yml`) | **PASS** |
+| Rust | 75 new tests / **never measured** | all test binaries pass | — | **91.52% lines** (90.93 regions, 86.55 functions) | 90 lines | **PASS**, margin 1.52 |
+| PHP | 436 / 96.23% | **436 tests, 1115 assertions** | 96.23 | **96.23** | 94 (`coverage.yml`) | **PASS** |
+| Java | 350 / 94.4% JaCoCo | **350 passed, 0 failures** | 94.4 | **94.02** (1619/1722 lines) | 0.93 BUNDLE LINE COVEREDRATIO | **PASS**, margin 0.0102 |
+| C# | 328 / 96.03% | **328 passed** (37 + 291) | 96.03 | **96.05** (union-merged lcov) | 94 (`coverage.yml`) | **PASS** |
+| Kotlin | 209 / 99.02% Kover | **209 passed, 0 failures** | 99.02 | **99.02** (1209/1221 lines) | `minBound(98)` LINE | **PASS**, margin 1.02 |
+
+Notes on the two thinnest margins and the one previously-unknown number:
+
+- **Rust 91.52% vs floor 90** is real but thin, and the §12 code is where the slack is:
+  `oidc/discovery.rs` 81.13% lines, `oidc/exchange.rs` 86.96% (51 uncovered lines across 850
+  source lines with **zero** inline unit tests), `oidc/authorize.rs` 90.43%. Roughly 15 untested
+  error arms sit in `exchange.rs` — malformed-body parse failures on all four endpoints, the
+  `oidc_endpoint_url` parse-failure arm, and a **dead** tenant-missing branch in `sso_start`
+  (unreachable: `TenantIdentifier` is a two-variant enum and §5 guarantees one is set). Adding the
+  F-01 concurrency test plus a few malformed-body tests would restore margin. F-10.
+- **Java 94.02% vs floor 0.93** leaves 0.0102 of headroom. Four one-line delegating overloads
+  (`oidcRefresh(Sensitive)`, `oidcRefreshAsync(Sensitive)`, `introspect(Sensitive)`,
+  `revoke(Sensitive)`) have no test referencing them. F-17.
+- I could not measure a **branch** figure for Go, PHP, or C# — none of the three configures a
+  branch gate, and their floors are line-based, which is what I measured.
+
+Additional facts established by execution rather than reading:
+
+- **Rust emits `+` for spaces in the authorization URL.** `url::Url::query_pairs_mut()` returns a
+  `form_urlencoded::Serializer`, so `append_pair("scope", "openid profile email")` yields
+  `scope=openid+profile+email`. Confirmed with a standalone program against the same `url 2.5.8`
+  the repo locks. All seven siblings emit `%20` (TS post-processes `URLSearchParams`, Python uses
+  `quote(safe='')`, Go post-processes `Encode()`, PHP uses `rawurlencode`, Java/Kotlin use
+  OkHttp `addQueryParameter`, C# uses `Uri.EscapeDataString`). F-04.
+- **Rust's `Cargo.lock` is unchanged by the commit**, confirming that `getrandom` and `base64` were
+  already in the graph and that the two new `[dependencies]` entries add no crates.
+- **The mixed slug-header / UUID-query pair is safe.** `crates/axiam-api-rest/src/handlers/oauth2.rs`
+  reads the tenant exclusively from `web::Query<TenantQuery>` and never inspects `X-Tenant-ID`;
+  `/oauth2/token` is a public path (`middleware/authz.rs:222`) and CSRF-exempt
+  (`middleware/csrf.rs:71`). The header is inert on those endpoints.
+
+---
+
+## 3. Contract 1.5 changes made
+
+All edits are in `/home/user/axiam/sdks/CONTRACT.md` (1090 → 1374 lines) and are non-breaking and
+clarifying. **Every change describes behaviour all eight SDKs already exhibit**, with two
+deliberate exceptions noted below.
+
+| # | Section | Change |
+|---|---|---|
+| 1 | §7 | Restructured "Required behavior" into four numbered rules separating unconditional redaction (r1) from the explicit-accessor MAY (r3), with no-implicit-reachability (r2) and point-of-use discipline (r4). Added a rationale paragraph and a sentence keeping the C/C++ rows' intent intact. **§2.1 ruling.** |
+| 2 | §9 r2 | Added the observable requirement — one wire call per burst, that outcome shared with all N — with the single-use-rotation reasoning. |
+| 3 | §9 r5 (new) | Mechanism is free; a dedicated guard instance for a second token namespace is permitted; a bounded wait for a shared guard is permitted and its bound is explicitly not contract-worthy. **§2.3 ruling.** |
+| 4 | §9 test requirement | Clarified: assert shared outcome too, and apply the requirement **per refresh operation**. |
+| 5 | §2 construction rules | The `"<error>: <error_description>"` requirement binds the `message` *field*; a rendered prefix (Go `Error()`, Rust `Display`) is fine. Field names follow per-language casing; Go's `ErrorCode` rename accepted. |
+| 6 | §12.1 note 2 | Documented that a slug `X-Tenant-ID` legitimately accompanies a UUID `?tenant_id=` (the handlers read only the query parameter), and that a slug-only client with no resolved UUID cannot call five of the nine operations. **Defect 4.** |
+| 7 | §12.1 note 5 | Corrected `revoke`: `200` MUST be success, any other `2xx` MAY be (RECOMMENDED), `5xx` MUST NOT be and stays a `NetworkError`. Removed 1.4's "Only 401 is an error". Added the mandatory idempotence test. **Defect 7.** |
+| 8 | §12.1 | `client_id` removed from `oidc_begin`'s per-call inputs; stated that it comes from client configuration for §12.4 r4 consistency, and that a missing one fails fast with no wire call (taxonomy **or** programming error). **Defect 5.** |
+| 9 | §12.1 | New paragraph: `AuthorizationRequest` deliberately carries **no** `redirect_uri`; the caller must carry it between begin and exchange; the store entry is where the glue parks it. Adding the field is explicitly deferred. **Defect 6, resolved as "document", matching all eight.** |
+| 10 | §12.1 | `oidc_refresh`: "MUST run under the §9 guard" → "MUST be governed by a §9-conformant single-flight guard", citing r5, r2's observable requirement, and the per-operation test requirement. |
+| 11 | §12.2 | New normative paragraph permitting either host object, with the browser-bundle rationale; names stay fixed; a separate host must be documented and must not split the nine. **Defect 8.** |
+| 12 | §12.3 r1 | Enumerated store-entry fields (incl. `redirect_uri`); TTL is a clamped maximum; sweeping MUST be lazy with no background timer/thread. |
+| 13 | §12.3 r3 | Declared the seven reason codes a **closed** vocabulary and pinned the many-to-one mappings — every r5 time failure → `token_expired`, no-`kid` → `unknown_kid`, unparseable header → `invalid_alg`, unclassified → `invalid_signature`. **Defect 3, resolved by documenting rather than adding codes, since adding any would break all eight.** |
+| 14 | §12.3 r6 | Rewrote the self-contradiction: sharing one document across tenants of an origin is correct and intended; a per-client-instance cache satisfies the origin requirement by construction; a process-global/cross-client cache MUST key on the normalized origin. Added the TTL-floor-raising clarification. **Defect 1.** |
+| 15 | §12.4 r2 | "One JWKS re-fetch then fail" is normative **per cooldown window**, not per token, with the fetch-amplification reasoning and the observable requirements. **Defect 2.** |
+| 16 | §12.4 r5 | `exp` and `iat` are both required; skew above 60 s is clamped, not rejected; every failure reports `token_expired`. |
+| 17 | Conformance Statement | Added a per-SDK table for the eight §12 implementers (recording Kotlin's pre-existing §8 carve-out and both async conventions) and the three unchanged deferrers; recorded that credential adoption is a MAY with five legal positions. |
+| 18 | Breaking Changes Log | Added the contract 1.5 entry in the existing format, itemising all of the above. |
+| 19 | Version footer | `1.4` → `1.5` with the new provenance clause appended in the existing style. |
+
+**The two deliberate exceptions to "all eight already satisfy it".** Change 2 (§9 r2's observable
+statement) and change 4 (the per-operation test requirement) restate MUSTs that contract 1.4
+*already* imposed; Rust fails the first and Rust and PHP fail the second. I am not creating new work
+by contract fiat — I am removing the ambiguity that let a pre-existing MUST be read as satisfied.
+Both gaps appear in the follow-up list with concrete fixes, and both are called out here rather than
+being buried.
+
+**Deliberately not changed:** `AuthorizationRequest` did **not** gain a `redirect_uri` field. All
+eight ship the four-field shape, so adding it would invent work and change an already-published
+type; the footgun is documented instead. No reason code was added, for the same reason.
+
+**Re-synced** to all eight SDK repos as `<repo>/CONTRACT.md` (byte-identical to the source).
+Conformance statements were checked in all eight: each already names the right section range, so
+seven required no editing (Kotlin's `§1–§7, §9–§12` is correct given its pre-existing §8 deferral
+and now matches the new conformance table). One was corrected: `axiam-csharp-sdk/README.md:27`'s
+checklist heading still read "§1–§11" under a statement claiming §1–§12 — see F-16. Contract 1.5
+changes no claimed section range, so no statement's `§1–§12` needed to move.
+
+---
+
+## 4. Follow-up list (severity-ordered)
+
+Nothing below is a hot-fix I applied — this review changed contract text, vendored copies, and this
+document only. Exactly **one** item blocks a merge.
+
+### Blocking
+
+**F-01 — Rust `oidc_refresh` violates §9 rule 2, and its §9 test is absent. BLOCKS MERGE.**
+Repo `axiam-rust-sdk`. Files `src/client.rs:465`, `src/oidc/exchange.rs:526-560`,
+`src/sensitive.rs`, `src/error.rs`, `src/oidc/id_token.rs`, `tests/oidc_token_ops_test.rs`.
+Defect: the guard is a bare `tokio::sync::Mutex<()>` with no result slot, so N concurrent callers
+issue N serialized wire calls; with single-use rotating refresh tokens callers 2..N replay a
+consumed token and fail `invalid_grant`. No `oidc_refresh` concurrency test exists.
+Fix: the six steps in §2.2 above (manual `Clone` for `Sensitive<T>`; `Clone` on `OidcTokenSet`/
+`IdTokenClaims`/`Audience`; `AxiamError::clone_for_waiter`; swap the mutex for
+`Mutex<Option<broadcast::Sender<Result<OidcTokenSet, Arc<AxiamError>>>>>` — `tokio`'s `sync` feature
+is already on, so no new dependency; leader/waiter election in `oidc_refresh`; the ≥5-caller burst
+test asserting one request and one shared `access_token`). Severity **critical**.
+
+### High — fix before any release advertising §12; do not block merge
+
+**F-02 — Java: a §12 caller cannot read the tokens it is handed.**
+Repo `axiam-java-sdk`, file `src/main/java/io/axiam/sdk/Sensitive.java:65`. `String expose()` is
+package-private in `io.axiam.sdk`, so a consumer holding an `OidcTokenSet` (package
+`io.axiam.sdk.oidc`) cannot extract `accessToken()`/`refreshToken()`/`idToken()` at all. Fix: make
+`expose()` `public`, with Javadoc citing contract 1.5 §7 rule 3 (as Rust and C# did); add a test
+asserting a caller outside `io.axiam.sdk` can read an exchanged access token, and one asserting
+`toString`/Jackson still redact. Widening is additive and breaks nothing. Severity **high**.
+
+**F-03 — Kotlin: same defect.**
+Repo `axiam-kotlin-sdk`, file `src/main/kotlin/io/axiam/sdk/Sensitive.kt:28`. `internal fun
+expose(): T`. Same fix (make it `public`, KDoc the §12 reason, add the caller-readability and
+still-redacts tests). Severity **high**.
+
+**F-04 — Rust emits `+` instead of `%20` in the authorization URL.**
+Repo `axiam-rust-sdk`, file `src/oidc/authorize.rs:223-233`. `url::Url::query_pairs_mut()` is a
+`form_urlencoded::Serializer`, so a multi-valued `scope` becomes `scope=openid+profile+email` —
+verified by execution. §12.1 rule 5 requires RFC 3986 percent-encoding and all seven siblings emit
+`%20`. Fix: build the query with an explicit RFC 3986 encoder over the unreserved set
+`[A-Za-z0-9-._~]` (Kotlin's `percentEncode` is the closest model), or keep `query_pairs_mut()` and
+post-process `+` → `%20` as TypeScript and Go do; then add an assertion on the **raw** URL string
+(`%20` present, `+` absent) — the existing test at `tests/oidc_pkce_test.rs:72-78` reads the value
+back through `query_pairs()`, which decodes `+` to a space and so passes either way. Severity
+**high** (interop and cross-SDK byte-consistency, not a functional break: Actix's
+`serde_urlencoded` decodes `+` as a space).
+
+**F-05 — Rust `sso_complete` does not perform the post-login session sync.**
+Repo `axiam-rust-sdk`, file `src/oidc/exchange.rs:801-845`. It captures cookies and re-syncs CSRF
+but never calls `absorb_session_cookies` (`src/rest/auth.rs:184`), so unlike all seven siblings it
+does not seed the token manager or resolve `tenant_id`/`org_id`; a subsequent `refresh()` fails
+with "no access token to refresh". Fix: call `absorb_session_cookies()` on success, mirroring
+`login`/`verify_mfa`; add a test asserting `resolved_org_id()` is populated and `refresh()` works
+after `sso_complete`. Severity **high**.
+
+**F-06 — PHP `oidcRefresh` does not share one result across concurrent callers, and has no burst
+test.** Repo `axiam-php-sdk`, files `src/Oidc/OidcClient.php:389-412`, `src/Session.php:214-236`.
+On `ran === false` it waits on the leader's promise and then **re-acquires the guard**, issuing its
+own token POST — so a second concurrent `oidcRefresh` produces a second wire call and replays a
+consumed refresh token. Only reachable under Fibers/Swoole (vanilla PHP has no concurrency for
+these synchronous calls), and there is no `oidcRefresh` concurrency test either way. Fix: have
+`refreshGuard` distinguish "busy with the same kind" (return the shared promise and **use** its
+result) from "busy with a different kind" (wait, then retry), or give `oidcRefresh` its own
+coalescer keyed to the OIDC namespace as Go, C#, and Kotlin did; add the §9 burst test.
+Severity **high**.
+
+**F-07 — Rust `AxiamError::Auth` is source-breaking and the enum is not `#[non_exhaustive]`.**
+Repo `axiam-rust-sdk`, file `src/error.rs:25-47`. Adding `oauth`/`reason` to a public struct variant
+makes every downstream `AxiamError::Auth { message: … }` construction `E0063` and every exhaustive
+destructure `E0027`; 33 constructions and 9 patterns were rewritten inside the repo, one of them in
+a shipped `examples/` file. Fix: add `#[non_exhaustive]` to `AxiamError` (and/or to the `Auth`
+variant) so future additive fields cannot break consumers again, and record the break honestly in
+the repo `CHANGELOG.md` — it is acceptable at `1.0.0-alpha18` but must not be described as
+non-breaking. Severity **high** (documentation and future-proofing; the code works).
+
+### Medium
+
+**F-08 — Python `revoke` accepts only `200`.**
+Repo `axiam-python-sdk`, file `src/axiam_sdk/_oidc.py:638`
+(`response.status_code == httpx.codes.OK`). Conformant to the contract's MUST but the outlier
+against seven SDKs and against 1.5's RECOMMENDED "any 2xx". Fix: accept `200 <= status < 300`;
+add a `204` test. Severity **medium**.
+
+**F-09 — Rust's reserved-param collision guard raises a taxonomy error.**
+Repo `axiam-rust-sdk`, file `src/oidc/authorize.rs:198-207` returns `AxiamError::Network`. The other
+seven raise a programming-error type (`Error`, `ValueError`, plain `error`, `InvalidArgumentException`,
+`IllegalArgumentException`, `ArgumentException`), which is what the port brief specified: a caller
+passing a reserved `extra_param` is a bug, not a transport failure. Fix: introduce (or reuse) a
+non-taxonomy programming-error path, or at minimum document the deviation. Severity **medium**.
+
+**F-10 — Rust §12 coverage is thin and contains a dead branch.**
+Repo `axiam-rust-sdk`. `src/oidc/discovery.rs` 81.13% lines, `src/oidc/exchange.rs` 86.96% (850
+source lines, **zero** inline unit tests, ~15 untested error arms), `src/oidc/authorize.rs` 90.43%;
+total 91.52% against a 90 floor. `src/oidc/exchange.rs:716-724` is unreachable (`TenantIdentifier`
+is a two-variant enum and §5 guarantees one is set). Fix: delete the dead branch; add
+malformed-body tests for all four parse sites, a failing-discovery test, and an invalid-endpoint-URL
+test. F-01's burst test also helps. Severity **medium** (the gate passes today, but the margin is
+1.52 points).
+
+**F-11 — Python: no serialization-leak assertion.**
+Repo `axiam-python-sdk`, file `tests/test_oidc_redaction.py`. No test exercises
+`model_dump_json()` or `model_dump(mode="json")` on `OidcTokenSet`/`AuthorizationRequest`, and
+`src/axiam_sdk/_models.py:163-164`'s claim that "`model_dump` redacts" is imprecise: in pydantic
+python-mode `model_dump()` returns the `SecretStr` **object**, so the raw value stays reachable off
+the returned dict (the existing test passes only because `str(dict)` uses the redacting repr). Fix:
+add `model_dump_json()` assertions and correct the comment. Severity **medium**.
+
+**F-12 — Java: no Jackson-leak assertion on the §12 DTOs.**
+Repo `axiam-java-sdk`, file `src/test/java/io/axiam/sdk/SensitiveTest.java`. The only Jackson
+redaction test targets a bare `Sensitive`; nothing serializes `OidcTokenSet`,
+`AuthorizationRequest`, or `OidcStateEntry`. Correct by construction (`@JsonSerialize` is
+class-level) but unasserted. Fix: add `ObjectMapper.writeValueAsString` assertions for all three.
+Severity **medium**.
+
+**F-13 — Java, C#, Kotlin: §12.4 rule 7 tests are weaker than the rule.**
+Files `src/test/java/io/axiam/sdk/AxiamClientOidcCoverageTest.java`,
+`tests/Axiam.Sdk.Tests/OidcExchangeTests.cs:374`,
+`src/test/kotlin/io/axiam/sdk/oidc/OidcCoverageGapsTest.kt:82`. Each asserts only that an error is
+thrown. Fix: mirror the five siblings that additionally assert a sentinel access token
+(`"should-never-be-returned"`) appears nowhere in the outcome or the error. Severity **medium**.
+
+**F-14 — Five SDKs rely on a structural, undocumented invariant to keep 401-from-`/oauth2/*` out of
+the §9 guard.** Repos `axiam-python-sdk`, `axiam-go-sdk`, `axiam-rust-sdk`, `axiam-php-sdk`,
+`axiam-kotlin-sdk`. Each is correct today only because no 401→refresh interceptor sits on the
+transport §12 uses; adding one later would silently break the rule (which the three list-based
+SDKs are immune to). Fix: add a comment at the transport seam naming the invariant, plus a
+regression test asserting a 401 from `/oauth2/introspect` triggers zero `/api/v1/auth/refresh`
+calls (Python, Go, Rust, and PHP already have such a test — Kotlin's `hitRefreshEndpoint()` check
+is the weakest). Severity **medium**.
+
+**F-15 — `X-Tenant-ID` is dropped on `/oauth2/*` when discovery advertises a foreign host.**
+Repos `axiam-go-sdk` (`client.go:313-316`), `axiam-java-sdk` (`AuthInterceptor.java:87`),
+`axiam-csharp-sdk` (`Rest/AxiamHttpMessageHandler.cs:171`). The header interceptor returns early
+for a non-base-URL host and §12 builds absolute URLs from the discovery document, so a
+proxy-fronted deployment loses the header §12.1 note 2 calls unconditional. Harmless today (the
+handlers ignore it — verified) but a latent surprise. Fix: emit `X-Tenant-ID` for
+discovery-document-derived `/oauth2/*` URLs regardless of host, or document the exception; add a
+test in all eight asserting the header on a `/oauth2/token` request (**no repo has one**).
+Severity **medium**.
+
+### Low
+
+**F-16 — C# README heading contradicted its own conformance claim. FIXED IN THIS REVIEW.**
+Repo `axiam-csharp-sdk`: `README.md:20` claimed §1–§12 while `README.md:27` still read
+"### §1–§11 conformance checklist", even though the table below it already carried a §12 row.
+Corrected to "§1–§12" as part of the conformance-statement re-sync. No further action.
+Severity **low**.
+
+**F-17 — Java: four untested one-line overloads against a 0.0102 coverage margin.**
+Repo `axiam-java-sdk`, `AxiamClient.java:1061`, `:1079`, `:1149`, `:1195`
+(`oidcRefresh(Sensitive)`, `oidcRefreshAsync(Sensitive)`, `introspect(Sensitive)`,
+`revoke(Sensitive)`). Fix: one test each, or route the `String` overloads through them.
+Severity **low**.
+
+**F-18 — PHP `AuthError`'s new `$reason` is the second positional parameter.**
+Repo `axiam-php-sdk`, `src/Core/AuthError.php:24-28`. Any downstream caller passing `$previous`
+positionally breaks. No such site exists in the repo. Fix: move `$reason` last or make it
+named-only. Severity **low**.
+
+**F-19 — Rust doc link points at the wrong file for the RFC 7636 vector.**
+`src/oidc/authorize.rs:87` says the Appendix B vector is verified in `tests/oidc_pkce_test.rs`; it
+is actually at `src/oidc/authorize.rs:251`. Also `src/oidc/id_token.rs:31`'s `ID_TOKEN_ALG` is a
+public constant with zero references anywhere. Fix: correct the link, remove or use the constant.
+Severity **low**.
+
+---
+
+## 5. What I verified by execution vs. by reading
+
+### Verified by execution (I ran it)
+
+- **All eight test suites**, from a clean or force-rerun state: TypeScript 465/465 (`vitest run`),
+  Python 434/434 (`pytest`), Go all packages ok (`go test ./...`), Rust all test binaries ok (via
+  `cargo llvm-cov`, exit 0), PHP 436 tests / 1115 assertions (`phpunit`), Java 350/350 with 0
+  failures/errors (`mvn -o verify`, parsed from `target/surefire-reports`), C# 328/328 (37 + 291,
+  `dotnet test`), Kotlin 209/209 (`./gradlew clean test --rerun-tasks` — an initial run came back
+  `UP-TO-DATE` from a warm build directory and was discarded).
+- **All eight coverage gates**, using each repo's own CI command and floor: TypeScript vitest
+  thresholds, Python `fail_under = 97`, Go's `awk` 94 floor over the scoped profile, Rust
+  `cargo llvm-cov report --fail-under-lines 90` (exit 0, **91.52% lines**), PHP's 94 floor via
+  `pcov`, Java's JaCoCo `BUNDLE`/`LINE`/`COVEREDRATIO` `0.93` (`mvn verify` exit 0, ratio recomputed
+  from `jacoco.csv`), C#'s 94 floor over a properly union-merged lcov, Kotlin `koverVerify`
+  `minBound(98)` (exit 0, 99.02% recomputed from the Kover XML). **Every gate passes.**
+- **`cargo-llvm-cov` was not installed**; I installed it plus `llvm-tools-preview` and ran the exact
+  CI command, resolving the one number nobody had.
+- **The Rust `+`-vs-`%20` defect**, with a standalone program against the same `url 2.5.8` the repo
+  locks: `append_pair("scope", "openid profile email")` → `scope=openid+profile+email`.
+- **Rust's `Cargo.lock` is unchanged** by the commit (`git show --stat HEAD -- Cargo.lock` empty).
+- **The server's tenant handling on `/oauth2/*`**, by reading the handler and its middleware
+  registrations: query-only, public path, CSRF-exempt.
+- **Per-file Rust coverage** for the §12 modules, from the llvm-cov report.
+
+### Verified by reading source (not executed)
+
+- The whole conformance matrix in §1 apart from the test-execution and coverage rows: every naming,
+  argument-order, error-mapping, `Sensitive`-wrapping, redaction-sink, PKCE, ID-token-rule,
+  state-store, discovery-cache, wire-shape, cookie-jar, dependency, and TLS-policy cell was
+  established by reading the shipped source and the corresponding tests, at file:line.
+- That each §12.4 rule has a failing test: I read the test bodies and their assertions; I did not
+  individually confirm each of the ~56 rule-tests fails when its rule is removed. The suites do
+  pass as a whole, which I did run.
+- The §9 concurrency claims for the six passing SDKs: I read the coalescer code and the burst
+  tests' assertions (N and the shared-value check). I did not instrument them to count wire calls
+  independently — but each test asserts the count itself, and each suite passed.
+- Rust's N-wire-calls-for-N-callers behaviour is a reading of the guard code plus the absence of any
+  result slot and of any `Clone` on the three relevant types. There is no test to run, which is
+  itself part of F-01.
+- PHP's `oidcRefresh` retry-instead-of-share behaviour is a reading of
+  `OidcClient.php:389-412` against `Session.php:214-236`. It is not reachable in vanilla PHP, so it
+  cannot be demonstrated by execution without a Fibers harness.
+
+### Could not verify
+
+- **Branch coverage for Go, PHP, and C#.** None configures a branch gate; their floors are
+  line-based, which is what I measured.
+- **Live server behaviour.** No AXIAM instance was running, so every wire-shape claim rests on the
+  SDK's own mock-server tests plus the handler source. The mixed slug-header/UUID-query pairing is
+  confirmed against `handlers/oauth2.rs`, not against a live 200.
+- **`cargo audit`** in the Rust repo, and the TypeScript `npm run build` codegen step (`buf` is not
+  installed in this environment). Both are environment limits, not findings, and the `Cargo.lock`
+  check covers the substance of the dependency question.
+
+---
+
+## 6. Merge verdict
+
+| Repo | Verdict | Reason |
+|---|---|---|
+| `axiam` (contract) | **SAFE TO MERGE** | contract 1.5 amendments + this document |
+| `axiam-typescript-sdk` | **SAFE TO MERGE** | fully conformant; 465 tests and all four thresholds verified |
+| `axiam-python-sdk` | **SAFE TO MERGE** | conformant; F-08/F-11 are non-blocking |
+| `axiam-go-sdk` | **SAFE TO MERGE** | conformant; F-14/F-15 non-blocking |
+| `axiam-rust-sdk` | **BLOCKED** | **F-01**: §9 rule 2 result-sharing absent (N callers → N serialized refresh calls, N−1 failing `invalid_grant` against single-use rotating tokens) and no `oidc_refresh` burst test, while the README claims §1–§12. F-04, F-05, F-07 should ride along in the same fix commit. |
+| `axiam-php-sdk` | **SAFE TO MERGE** | F-06 is the same defect class as F-01 but unreachable in vanilla PHP; high-priority follow-up, not a merge blocker |
+| `axiam-java-sdk` | **SAFE TO MERGE** | F-02 (unreadable tokens) is high severity but additive to fix and breaks nothing today |
+| `axiam-csharp-sdk` | **SAFE TO MERGE** | conformant; F-13/F-16 cosmetic-to-medium |
+| `axiam-kotlin-sdk` | **SAFE TO MERGE** | F-03 mirrors F-02; same reasoning |
+
+Eight of nine repos are safe. One is blocked on a single, precisely-specified fix.

--- a/claude_dev/sdk-oidc-sso-plan.md
+++ b/claude_dev/sdk-oidc-sso-plan.md
@@ -1,0 +1,399 @@
+# SDK OIDC / SSO Relying-Party Helpers — Implementation Plan
+
+> **Status: PLAN — not yet implemented.**
+> Scope: the eight **backend-capable** client SDKs (`axiam-rust-sdk`, `axiam-typescript-sdk`,
+> `axiam-python-sdk`, `axiam-java-sdk`, `axiam-kotlin-sdk`, `axiam-csharp-sdk`,
+> `axiam-php-sdk`, `axiam-go-sdk`) plus a contract amendment in this repository
+> (`sdks/CONTRACT.md`). The device/client-oriented SDKs (`axiam-swift-sdk`,
+> `axiam-c-sdk`, `axiam-cplusplus-sdk`) are **explicitly deferred** — see §8.
+> Each task below is sized to be one executable task for a developer agent in a
+> follow-up run, and carries the **recommended model** (cheapest adequate choice
+> between Opus 5 and Sonnet 5) to drive that agent.
+
+## 1. Problem statement — what is missing today (surveyed 2026-07-27)
+
+The AXIAM server already ships a complete OIDC provider + federation surface
+(`sdks/openapi.json`):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /.well-known/openid-configuration` | OIDC discovery |
+| `GET /oauth2/authorize` | Authorization endpoint (code flow, PKCE, `state`, `nonce`) |
+| `POST /oauth2/token?tenant_id=<uuid>` | Token endpoint — `authorization_code`, `client_credentials`, `refresh_token` grants (form-encoded `TokenRequest`, returns `TokenResponse` with optional `id_token`) |
+| `GET /oauth2/jwks` | Signing keys (EdDSA/Ed25519) |
+| `POST /oauth2/introspect`, `POST /oauth2/revoke` | RFC 7662 / RFC 7009 |
+| `POST /api/v1/auth/federation/oidc/start` | First-time SSO against an upstream IdP: returns IdP authorize URL, server persists state+nonce (10-min TTL, D-22) |
+| `POST /api/v1/auth/federation/oidc/callback` | Single-use state consumption, user provisioning/linking, returns **Set-Cookie** session (no token in body) |
+
+The SDKs, however, only implement the CONTRACT §1 vocabulary: `login`
+(direct password `POST /api/v1/auth/login`), `verify_mfa`, `refresh`, `logout`,
+`check_access`/`can`/`batch_check`, and gRPC `get_user_info`, plus the §10/§11
+resource-server middleware (local JWKS verification of inbound bearer tokens).
+
+**A backend developer today cannot implement "Login with AXIAM" (OIDC/SSO) using
+any SDK.** Specifically, no SDK has:
+
+- OIDC discovery-document fetch/cache;
+- authorization-URL construction with CSPRNG `state`, `nonce`, and PKCE S256
+  verifier/challenge generation;
+- authorization-code → token exchange against `POST /oauth2/token`;
+- ID-token validation as a *relying party* (`iss`/`aud`/`exp`/`nonce`/signature);
+- `client_credentials` grant for service-account M2M auth;
+- token introspection/revocation calls;
+- helpers for the federation SSO endpoints (`/federation/oidc/start|callback`).
+
+(Verified by grep across all SDK repos: zero non-test source hits for
+`authorization_code`, `client_credentials`, `code_verifier`, `/oauth2/token`,
+or `/oauth2/authorize`.)
+
+What each backend SDK *does* already have, and the new work must reuse:
+
+| SDK | JWKS/EdDSA verification to reuse | HTTP core to reuse | Framework surface |
+|---|---|---|---|
+| Rust | `src/token/jwks.rs` | existing reqwest-based client | Actix extractor (`src/middleware/actix.rs`) |
+| TypeScript | `src/node/jwks.ts` (+ `src/node/session.ts`) | `src/rest/` core | Express/Fastify middleware, NestJS module |
+| Python | `src/axiam_sdk/_jwks.py`, `token/` | `_client.py` / `_async_client.py` | FastAPI deps, Django middleware |
+| Java | JWKS logic reachable from `io/axiam/sdk/AxiamClient.java` | `AxiamClient` HTTP core | Spring filter/auto-config (`spring/`) |
+| Kotlin | `src/main/kotlin/io/axiam/sdk/internal/JwksVerifier.kt` | `AxiamClient.kt` | Ktor plugin (`ktor/AxiamAuthentication.kt`) — JVM-only SDK, Ktor `compileOnly` |
+| C# | `Axiam.Sdk/Auth/Jwk.cs` | `Axiam.Sdk` core | `Axiam.Sdk.AspNetCore` middleware + policies |
+| PHP | `src/Auth/JwksVerifier.php` | `src/AxiamClient.php` | Laravel provider, Symfony bundle |
+| Go | `internal/jwks/verifier.go` | `client.go` | `middleware/nethttp.go` |
+
+## 2. Design — canonical operation set (to be locked in CONTRACT §12)
+
+CONTRACT §1 forbids any SDK method names outside the naming map, so the contract
+amendment (Task T0) is a **hard prerequisite** for every SDK task. The proposed
+canonical vocabulary (final casing per language follows the existing §1 casing
+rules):
+
+| Canonical operation | Endpoint | Semantics |
+|---|---|---|
+| `oidc_discover` | `GET /.well-known/openid-configuration` | Fetch + cache discovery doc (TTL ≥ 5 min, single-flight, per-base-URL). Returns typed `OidcConfiguration`. |
+| `oidc_begin` | *(no wire call, uses discovery)* | Build authorization request: CSPRNG `state` (≥128-bit) and `nonce`, PKCE verifier (43–128 chars) + **S256** challenge (never `plain`). Returns `AuthorizationRequest { url, state, nonce, code_verifier }`. Caller stores `state`/`nonce`/`code_verifier` in its own session and redirects the browser to `url`. |
+| `oidc_exchange` | `POST /oauth2/token` (`grant_type=authorization_code`) | Exchange `code` + `code_verifier` + `redirect_uri` (+ `client_id`, optional `client_secret` for confidential clients; `tenant_id` as query param). Validates the returned `id_token` (checklist in §3) before returning `OidcTokenSet { access_token, id_token, id_claims, refresh_token?, expires_in, scope? }`. |
+| `oidc_refresh` | `POST /oauth2/token` (`grant_type=refresh_token`) | Refreshes an `OidcTokenSet`. MUST run under the existing §9 single-flight refresh guard. Distinct from session `refresh` (cookie/opaque-token path) — do not merge the two. |
+| `login_client_credentials` | `POST /oauth2/token` (`grant_type=client_credentials`) | Service-account M2M login: `client_id` + `client_secret` (+ optional `scope`). Returns the token set; the SDK may then use it as its bearer credential exactly like a `login()` result. |
+| `introspect` | `POST /oauth2/introspect` | RFC 7662; returns typed `IntrospectionResult { active, ... }`. |
+| `revoke` | `POST /oauth2/revoke` | RFC 7009; returns void; treat HTTP 200 as success even for unknown tokens. |
+| `sso_start` | `POST /api/v1/auth/federation/oidc/start` | Upstream-IdP SSO step 1 (`OidcStartRequest` → `OidcStartResponse.authorize_url`). No JWT required. |
+| `sso_complete` | `POST /api/v1/auth/federation/oidc/callback` | Step 2: posts `OidcPublicCallbackRequest`; session arrives as **Set-Cookie**, so the §4 cookie-jar requirement applies verbatim; returns `SsoLoginSuccessResponse`. |
+
+Cross-cutting rules (normative, identical in all SDKs — the amendment text must
+state them):
+
+1. **Stateless by default.** `oidc_begin`/`oidc_exchange` never store
+   `state`/`nonce`/`code_verifier` inside the SDK; the caller owns that storage.
+   Framework integrations MAY add an optional `OidcStateStore` interface with an
+   in-memory reference implementation (TTL 10 min, single-use consume — mirrors
+   the server's `federation_login_state` semantics).
+2. **Sensitive wrapping (§7).** `access_token`, `refresh_token`, `id_token`,
+   `client_secret`, and `code_verifier` are `Sensitive<T>` in every SDK; never
+   logged, never in `Debug`/`toString` output.
+3. **Error taxonomy (§2).** `OAuth2ErrorResponse` bodies map to a new
+   `OAuthProtocolError` subtype of the existing taxonomy carrying `error` +
+   `error_description`; HTTP 400 from the token endpoint MUST NOT surface as a
+   generic validation error. ID-token validation failures raise
+   `AuthenticationError` with a machine-readable reason code.
+4. **Tenant context (§5).** `tenant_id` is a required argument (or client-level
+   config) for `oidc_exchange`, `oidc_refresh`, and `login_client_credentials`
+   (query param on the token endpoint); org/tenant slugs for `sso_start` follow
+   the §5.1 rules.
+5. **REST `/oauth2/userinfo` stays out** of the SDK vocabulary (existing closing
+   note): RP claims come from the validated ID token; identity lookups use gRPC
+   `get_user_info`.
+6. **TLS (§6)** applies; the discovery cache key includes the scheme+host+port to
+   prevent cross-issuer poisoning.
+
+## 3. ID-token validation checklist (normative for `oidc_exchange`)
+
+Reuse each SDK's existing JWKS verifier; validation per OIDC Core §3.1.3.7:
+
+1. `alg` MUST be `EdDSA` — reject `none` and anything else outright.
+2. Signature via `GET /oauth2/jwks`, keyed by `kid`; on unknown `kid`, one JWKS
+   re-fetch then fail (same rule the §10 middleware already implements).
+3. `iss` equals the discovery document's `issuer` (exact string match).
+4. `aud` contains our `client_id`; if multiple audiences, `azp` must equal it.
+5. `exp`/`iat`/`nbf` with clock skew ≤ 60 s.
+6. `nonce` claim equals the caller-supplied nonce from `oidc_begin` (mandatory
+   when the request scope included `openid`; the helper always includes it).
+7. On any failure: `AuthenticationError`, and the token set is discarded (no
+   partial success).
+
+## 4. Task list, ordering, and model assignment
+
+Execution order: **T0 → T1 → {T2…T8 in parallel} → T9.** T1 is the reference
+implementation; T2–T8 are ports of a fully-specified design and can run as one
+parallel wave.
+
+Model-choice rule used below (best-but-cheapest): **Opus 5** only where the task
+*creates* normative text or reference patterns that every other task copies, or
+performs cross-repo adversarial review (design ambiguity → cheaper models drift);
+**Sonnet 5** for everything that is a well-specified port with strong local
+feedback (compilers, existing test harnesses, a reference implementation to
+imitate). This mirrors the cost outcome of the sdk-auth-helpers run.
+
+| # | Task | Repo | Model | Why this model |
+|---|---|---|---|---|
+| T0 | CONTRACT §12 amendment + naming-map rows + openapi/proto re-sync note | `axiam` | **Opus 5** | Normative spec text; every downstream task inherits its mistakes |
+| T1 | TypeScript reference implementation | `axiam-typescript-sdk` | **Opus 5** | Establishes the file/test/doc patterns T2–T8 imitate |
+| T2 | Rust port | `axiam-rust-sdk` | Sonnet 5 | Spec + reference exist; rustc/clippy give strong feedback |
+| T3 | Python port | `axiam-python-sdk` | Sonnet 5 | Straight port; sync+async mirroring is mechanical |
+| T4 | Go port | `axiam-go-sdk` | Sonnet 5 | Straight port; small API surface |
+| T5 | Java port | `axiam-java-sdk` | Sonnet 5 | Straight port onto existing Spring surface |
+| T6 | Kotlin port | `axiam-kotlin-sdk` | Sonnet 5 | Straight port onto existing Ktor plugin |
+| T7 | C# port | `axiam-csharp-sdk` | Sonnet 5 | Straight port; ASP.NET Core patterns already in repo |
+| T8 | PHP port | `axiam-php-sdk` | Sonnet 5 | Straight port onto Laravel/Symfony surfaces |
+| T9 | Cross-SDK conformance review + contract conformance-statement update | all + `axiam` | **Opus 5** | Adversarial cross-repo review; catches semantic drift Sonnet ports may introduce |
+
+Every task ends with a **signed commit** (project rule), a `CHANGELOG.md` entry,
+and — for T1–T8 — a re-synced vendored `CONTRACT.md` copied from this repo after
+T0 merges.
+
+### T0 — Contract amendment (`axiam` repo) — **Opus 5**
+
+1. Append **§12 "OIDC / SSO Relying-Party Helpers"** to `sdks/CONTRACT.md`
+   containing: the §2 operation table above rendered as a naming map for all
+   twelve languages (casing per existing §1 rules: Go/C# PascalCase, C
+   `axiam_`-prefixed snake_case, C++ snake_case, others camel/snake as per
+   language); the six cross-cutting rules; the §3 ID-token checklist; the
+   stateless-state rule; and a deferral paragraph for Swift/C/C++ (§8 below).
+2. Amend the §1 note "No SDK is permitted to expose additional login/auth/authz
+   method names…" to reference §12 as part of the locked vocabulary.
+3. Add the `OAuthProtocolError` row to the §2 error taxonomy and the
+   HTTP-status mapping (`400` from `/oauth2/*` → `OAuthProtocolError`).
+4. Log the addition in "Breaking Changes Log" as a **non-breaking, additive**
+   contract 1.4 change.
+5. Verify `sdks/openapi.json` already describes every §12 endpoint (it does as
+   of 2026-07-27 — this step is a check, not an edit).
+6. Deliverable check: `grep -c "oidc_" sdks/CONTRACT.md` > 0; markdown renders;
+   no server code touched.
+
+### T1 — TypeScript reference implementation — **Opus 5**
+
+Repo: `axiam-typescript-sdk` (npm `axiam-sdk`, TS ~5.9, tsup build, vitest).
+
+1. New module `src/node/oidc.ts` (+ re-exports from `src/node/index.ts` and a
+   subpath export if the existing `package.json` `exports` map is per-area):
+   `discover()`, `oidcBegin()`, `oidcExchange()`, `oidcRefresh()`,
+   `loginClientCredentials()`, `introspect()`, `revoke()`, `ssoStart()`,
+   `ssoComplete()` — Node-only (uses `node:crypto` for CSPRNG + SHA-256/base64url
+   PKCE; no WebCrypto fallback needed since this lives under `src/node/`).
+2. Reuse: `src/node/jwks.ts` for ID-token verification (extend, don't fork);
+   `src/rest/` request core for transport + §2 error mapping; `Sensitive`
+   wrapper wherever the repo defines it; the §9 single-flight guard for
+   `oidcRefresh`.
+3. Types in the same file or `src/node/oidcTypes.ts`: `OidcConfiguration`,
+   `AuthorizationRequest`, `OidcTokenSet`, `IntrospectionResult`,
+   `OidcStateStore` (interface) + `MemoryOidcStateStore` (10-min TTL,
+   single-use `consume(state)`).
+4. Framework glue: `oidcLoginHandlers(client, store, opts)` in
+   `src/middleware/` returning `{ login, callback }` Express-compatible
+   handlers (redirect to `url` / consume state + exchange + establish session
+   via the existing `src/node/session.ts` machinery). Fastify variant mirrors
+   the existing plugin pattern.
+5. Tests (vitest, mock the HTTP layer the way existing rest tests do):
+   discovery caching + single-flight; PKCE S256 vector (RFC 7636 Appendix B);
+   state/nonce entropy and uniqueness; full happy-path exchange; each ID-token
+   validation failure from §3 (wrong iss/aud/exp/nonce/alg/`kid`);
+   `OAuth2ErrorResponse` → `OAuthProtocolError` mapping; client-credentials
+   happy path; revoke-is-idempotent; `MemoryOidcStateStore` single-use + TTL.
+6. Example under `examples/` (Express "Login with AXIAM"), README section,
+   CHANGELOG, vendored `CONTRACT.md` re-sync. `npm test` + `npm run build`
+   green.
+
+### T2 — Rust port — **Sonnet 5**
+
+Repo: `axiam-rust-sdk` (single crate `axiam-sdk`, edition 2021, MSRV 1.88).
+
+1. New module `src/oidc/mod.rs` (submodules `discovery.rs`, `authorize.rs`,
+   `exchange.rs`, `state.rs`); methods on the existing client(s): `oidc_discover`,
+   `oidc_begin`, `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
+   `introspect`, `revoke`, `sso_start`, `sso_complete`.
+2. PKCE/state/nonce via the crate's existing CSPRNG dependency (`rand`/`getrandom`
+   — whichever is already in `Cargo.toml`; add `sha2` + `base64` only if absent).
+   ID-token validation reuses `src/token/jwks.rs`.
+3. Wrap secrets in the crate's existing `Sensitive` type; `Debug` must redact.
+4. Actix glue (feature `actix`): a small `oidc_login_scope()` helper mirroring
+   the existing extractor module's style is optional — implement only if it fits
+   in the task budget; core primitives are the deliverable.
+5. Tests under `tests/` following the repo's existing mock-server pattern
+   (same coverage list as T1 item 5). RFC 7636 Appendix B test vector included.
+6. Example in `examples/`, README, CHANGELOG, vendored contract re-sync.
+   `cargo fmt --check`, `cargo clippy --lib`, `cargo test` green.
+
+### T3 — Python port — **Sonnet 5**
+
+Repo: `axiam-python-sdk` (PyPI `axiam-sdk`, ≥3.10, sync `_client.py` + async
+`_async_client.py`, extras `fastapi`/`django`).
+
+1. New `src/axiam_sdk/_oidc.py` with shared pure logic (PKCE via `secrets` +
+   `hashlib`, URL building, ID-token checks reusing `_jwks.py`); sync methods on
+   `AxiamClient` and async twins on the async client (`oidc_discover`,
+   `oidc_begin`, `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
+   `introspect`, `revoke`, `sso_start`, `sso_complete`) — respect the SDK-Q08
+   async-naming rule.
+2. Models in `_models.py` (dataclasses/pydantic — match whatever `_models.py`
+   already uses); secrets use the repo's existing sensitive-value pattern.
+3. Framework glue: FastAPI `oidc_login_router(...)` factory in
+   `fastapi/__init__.py` (two routes: login-redirect + callback) and a Django
+   view-pair helper in `django/`; both delegate to the shared core and the
+   existing session-cookie machinery in `_session.py`.
+4. Tests mirroring the repo's existing transport-mock style; same coverage list
+   as T1; both sync and async paths. `pytest` + type check (whatever
+   `pyproject.toml` gates) green.
+5. Example, README, CHANGELOG, vendored contract re-sync.
+
+### T4 — Go port — **Sonnet 5**
+
+Repo: `axiam-go-sdk` (module `github.com/ilpanich/axiam-go-sdk`, go 1.25,
+flat root package + `middleware/`, `internal/jwks/`).
+
+1. New root-package file `oidc.go` (+ `oidc_types.go`): `OidcDiscover`,
+   `OidcBegin`, `OidcExchange`, `OidcRefresh`, `LoginClientCredentials`,
+   `Introspect`, `Revoke`, `SsoStart`, `SsoComplete` on the existing `*Client`.
+   PKCE via `crypto/rand` + `crypto/sha256`; ID-token checks via
+   `internal/jwks/verifier.go`.
+2. `OidcStateStore` interface + in-memory impl (mutex + TTL) in the root
+   package; `middleware.OidcLoginHandler`/`middleware.OidcCallbackHandler`
+   `http.Handler` helpers in `middleware/` following `nethttp.go` conventions.
+3. Secrets: match the SDK's existing sensitive-string handling (§7 row for Go).
+4. Table-driven tests next to `oidc.go` using the same `httptest` patterns as
+   `client_test.go`; same coverage list as T1; run with `-race`.
+5. Example in `examples/`, README, CHANGELOG, vendored contract re-sync.
+   `go vet ./...`, `go test -race ./...` green.
+
+### T5 — Java port — **Sonnet 5**
+
+Repo: `axiam-java-sdk` (`io.github.ilpanich:axiam-sdk`, Java 21, Maven,
+Spring optional/provided).
+
+1. New package `io.axiam.sdk.oidc`: `OidcOperations` implemented by
+   `AxiamClient` (`oidcDiscover`, `oidcBegin`, `oidcExchange`, `oidcRefresh`,
+   `loginClientCredentials`, `introspect`, `revoke`, `ssoStart`, `ssoComplete`),
+   records for the §2 types, `SecureRandom` + `MessageDigest` for PKCE,
+   ID-token checks via the client's existing JWKS path.
+2. Spring glue in `io.axiam.sdk.spring`: an `AxiamOidcLoginController`-style
+   registrar (or a pair of `HandlerFunction`s) auto-configured only when the
+   consumer opts in via properties — same conditional-on-class pattern as
+   `AxiamAutoConfiguration`.
+3. Tests with the repo's existing HTTP-mock approach (WireMock/MockWebServer —
+   use what's already a test dependency; add nothing new unless absent); same
+   coverage list as T1. `mvn -q verify` green.
+4. Example under `examples/`, README, CHANGELOG, vendored contract re-sync, BOM
+   untouched (no new runtime deps).
+
+### T6 — Kotlin port — **Sonnet 5**
+
+Repo: `axiam-kotlin-sdk` (JVM-only, Kotlin 2.1, Ktor 2.x `compileOnly`).
+
+1. New `src/main/kotlin/io/axiam/sdk/oidc/` mirroring T5's shape with suspend
+   functions on `AxiamClient` (camelCase names per contract); PKCE via
+   `java.security.SecureRandom`/`MessageDigest`; ID-token checks via
+   `internal/JwksVerifier.kt`.
+2. Ktor glue in `ktor/`: `Route.axiamOidcLogin(client, store, opts)` extension
+   installing the login-redirect and callback routes — kept `compileOnly`-safe
+   exactly like `AxiamAuthentication.kt` (core must compile without Ktor).
+3. Tests with ktor-server-test-host + the repo's existing HTTP-mock style; same
+   coverage list as T1. `./gradlew check` green.
+4. Example, README, CHANGELOG, vendored contract re-sync.
+
+### T7 — C# port — **Sonnet 5**
+
+Repo: `axiam-csharp-sdk` (`Axiam.Sdk` + `Axiam.Sdk.AspNetCore`, net8.0).
+
+1. In `Axiam.Sdk`: `Auth/Oidc/` folder — `OidcDiscoverAsync`, `OidcBegin`
+   (sync, no I/O beyond cached discovery), `OidcExchangeAsync`,
+   `OidcRefreshAsync`, `LoginClientCredentialsAsync`, `IntrospectAsync`,
+   `RevokeAsync`, `SsoStartAsync`, `SsoCompleteAsync` (PascalCase +
+   `Async` suffix per §1/SDK-Q08); `RandomNumberGenerator` + `SHA256` for PKCE;
+   ID-token checks via `Auth/Jwk.cs` machinery.
+2. In `Axiam.Sdk.AspNetCore`: minimal-API extension
+   `MapAxiamOidcLogin(this IEndpointRouteBuilder, ...)` wiring the
+   redirect + callback endpoints into the existing middleware/session pipeline;
+   `IOidcStateStore` + `MemoryOidcStateStore` registered via DI.
+3. Tests in the existing `tests/` projects (same mock style as current
+   HTTP tests); same coverage list as T1. `dotnet test` green.
+4. Example under `examples/`, README/docfx page, CHANGELOG, vendored contract
+   re-sync.
+
+### T8 — PHP port — **Sonnet 5**
+
+Repo: `axiam-php-sdk` (`axiam/axiam-sdk`, PHP ≥8.1, Laravel provider +
+Symfony bundle, PHPStan).
+
+1. New `src/Oidc/` (e.g. `OidcClient.php`, `AuthorizationRequest.php`,
+   `OidcTokenSet.php`, `OidcStateStoreInterface.php`, `MemoryOidcStateStore.php`)
+   with camelCase methods surfaced on `AxiamClient`: `oidcDiscover`, `oidcBegin`,
+   `oidcExchange`, `oidcRefresh`, `loginClientCredentials`, `introspect`,
+   `revoke`, `ssoStart`, `ssoComplete`. PKCE via `random_bytes` + `hash('sha256')`
+   with base64url; ID-token checks via `src/Auth/JwksVerifier.php`.
+2. Framework glue: Laravel — two invokable controllers + route macro in the
+   existing provider; Symfony — controller pair registered by the bundle,
+   both optional and off by default.
+3. Secrets use the repo's existing sensitive-value class (§7 row for PHP).
+4. PHPUnit tests with the repo's existing HTTP-mock approach; same coverage
+   list as T1. `composer test` + PHPStan at the configured level green.
+5. Example, README, CHANGELOG, vendored contract re-sync.
+
+### T9 — Cross-SDK conformance review — **Opus 5**
+
+After T1–T8 land:
+
+1. Diff every SDK's §12 surface against the contract: names, argument order,
+   error mapping, Sensitive coverage, single-flight `oidc_refresh`, S256-only,
+   stateless-state rule, cookie-jar on `sso_complete`. Produce a
+   pass/fail matrix per SDK per rule (same format as prior conformance docs in
+   `claude_dev/`).
+2. Verify the RFC 7636 Appendix B vector test exists in all eight repos.
+3. Update each repo's Conformance Statement section in the vendored contract,
+   and the master `sdks/CONTRACT.md` conformance table here.
+4. File follow-up issues for any drift instead of hot-fixing inside the review
+   task (keeps the review adversarial and cheap to re-run).
+
+## 5. What is explicitly out of scope
+
+- Server-side changes — the provider endpoints already exist and are contract-
+  stable; any server bug found becomes an issue, not a scope expansion.
+- Implicit/hybrid flows and non-S256 PKCE — rejected by design.
+- Device-authorization grant (RFC 8628) — server doesn't expose it yet.
+- REST `/oauth2/userinfo` in the SDK vocabulary — stays excluded (existing
+  contract closing note); ID-token claims + gRPC `get_user_info` cover it.
+- Browser/SPA-side helpers — these SDKs are backend SDKs; the frontend flow is
+  the consuming app's redirect + AXIAM's hosted login.
+
+## 6. Acceptance criteria (applies to every SDK task)
+
+1. All §12 operations implemented with contract-mandated names and semantics.
+2. Full test coverage of the §3 ID-token checklist (one failing test per rule).
+3. RFC 7636 Appendix B PKCE vector test present and passing.
+4. No new runtime dependency unless the language stdlib lacks CSPRNG/SHA-256
+   (none of the eight needs one).
+5. Secrets `Sensitive`-wrapped; no token material in logs, exceptions, or
+   `Debug`/`toString`.
+6. Example + README + CHANGELOG + vendored CONTRACT re-sync committed.
+7. Repo's full check pipeline green; signed commit per project rules.
+
+## 7. Suggested execution schedule
+
+| Wave | Tasks | Parallelism |
+|---|---|---|
+| 1 | T0 | solo (blocks everything) |
+| 2 | T1 | solo (reference) |
+| 3 | T2–T8 | 7 agents in parallel, one repo each |
+| 4 | T9 | solo |
+
+Cost note: only 3 of 10 tasks run on Opus 5; the seven parallel ports — the bulk
+of the token spend — run on Sonnet 5 against a locked spec and a working
+reference implementation, which is where Sonnet is reliably as good and several
+times cheaper.
+
+## 8. Deferred SDKs (Swift, C, C++)
+
+These are device/IoT-oriented SDKs (Swift ships NIOSSL specifically for
+client-cert mTLS; C/C++ target embedded consumers). The browser-redirect OIDC
+RP flow has no natural home there, and their auth story (mTLS, password,
+service credentials) is already covered. Defer §12 with the same
+carve-out pattern the contract already uses for their gRPC deferral. If
+server-side Swift (Vapor) demand materializes, a T-Swift port can be cloned
+from T6's shape; `login_client_credentials` alone may be worth adding to C/C++
+for machine-to-machine use — file as a separate follow-up decision.

--- a/crates/axiam-api-grpc/src/config.rs
+++ b/crates/axiam-api-grpc/src/config.rs
@@ -70,7 +70,47 @@ impl Default for GrpcConfig {
     }
 }
 
+/// `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` — presence pins
+/// [`GrpcConfig::grpc_authz_per_sec`] against a posture preset.
+pub const ENV_GRPC_AUTHZ_PER_SEC: &str = "AXIAM__GRPC__GRPC_AUTHZ_PER_SEC";
+
 impl GrpcConfig {
+    /// G7: applies the deployment rate-limit posture preset's gRPC authz
+    /// ceiling, reading the process environment.
+    ///
+    /// The preset values live in ONE place —
+    /// `axiam_api_rest::config::rate_limit::RateLimitProfile::preset()` — and
+    /// are handed here by the composition root (`axiam-server::main`) so the
+    /// whole `AXIAM__RATE_LIMIT__PROFILE` family (REST + gRPC) moves
+    /// coherently from a single operator-facing env var. This crate
+    /// deliberately does not own a second copy of the numbers.
+    ///
+    /// Returns `true` when the preset was applied, `false` when the operator
+    /// pinned [`ENV_GRPC_AUTHZ_PER_SEC`] explicitly (explicit env always wins).
+    ///
+    /// **Keying caveat:** the gRPC limiter is per-IP only — there is no
+    /// client identity at the layer that keys it (see
+    /// [`GrpcRateLimitKeyMode`]). Behind a shared NAT/ingress IP this is a
+    /// *fleet-wide* ceiling, not a per-client one; that is exactly why the
+    /// M2M presets raise it.
+    pub fn apply_rate_limit_preset_from_env(&mut self, per_sec: u32) -> bool {
+        self.apply_rate_limit_preset(per_sec, |name| std::env::var_os(name).is_some())
+    }
+
+    /// [`GrpcConfig::apply_rate_limit_preset_from_env`] with the environment
+    /// lookup injected, for tests.
+    pub fn apply_rate_limit_preset<F>(&mut self, per_sec: u32, is_set: F) -> bool
+    where
+        F: Fn(&str) -> bool,
+    {
+        if is_set(ENV_GRPC_AUTHZ_PER_SEC) {
+            false
+        } else {
+            self.grpc_authz_per_sec = per_sec;
+            true
+        }
+    }
+
     pub fn bind_address(&self) -> SocketAddr {
         let addr = format!("{}:{}", self.host, self.port);
         addr.parse()
@@ -103,6 +143,54 @@ mod tests {
     fn default_key_mode_is_ip() {
         assert_eq!(GrpcConfig::default().key, GrpcRateLimitKeyMode::Ip);
         assert_eq!(GrpcRateLimitKeyMode::default(), GrpcRateLimitKeyMode::Ip);
+    }
+
+    /// G7 single-source-of-truth guard: the gRPC shipped default written
+    /// down in `docs/deployment/rate-limit-sizing.md` must equal
+    /// [`GrpcConfig::default`]. (The `gateway`/`mesh` columns of the same
+    /// row are checked against the preset table on the REST side, which
+    /// owns the numbers — see
+    /// `axiam_api_rest::config::rate_limit::tests::documented_presets_match_applied_profiles`.)
+    #[test]
+    fn documented_grpc_default_matches_shipped_config() {
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("docs/deployment/rate-limit-sizing.md");
+        let md = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()));
+        let row = md
+            .lines()
+            .map(str::trim)
+            .find(|l| l.starts_with(&format!("| `{ENV_GRPC_AUTHZ_PER_SEC}`")))
+            .unwrap_or_else(|| panic!("{} must document {ENV_GRPC_AUTHZ_PER_SEC}", path.display()));
+        let documented: u32 = row
+            .trim_matches('|')
+            .split('|')
+            .nth(1)
+            .expect("posture row has an `internet` column")
+            .trim()
+            .parse()
+            .expect("`internet` column is a plain integer");
+        assert_eq!(
+            documented,
+            GrpcConfig::default().grpc_authz_per_sec,
+            "docs/deployment/rate-limit-sizing.md disagrees with GrpcConfig::default()"
+        );
+    }
+
+    /// G7: the preset only lands when the operator has NOT pinned
+    /// `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` — explicit env always wins.
+    #[test]
+    fn rate_limit_preset_applies_only_when_env_unset() {
+        let mut cfg = GrpcConfig::default();
+        assert_eq!(cfg.grpc_authz_per_sec, 100);
+        assert!(cfg.apply_rate_limit_preset(1_000, |_| false));
+        assert_eq!(cfg.grpc_authz_per_sec, 1_000);
+
+        let mut pinned = GrpcConfig::default();
+        assert!(!pinned.apply_rate_limit_preset(1_000, |n| n == ENV_GRPC_AUTHZ_PER_SEC));
+        assert_eq!(pinned.grpc_authz_per_sec, 100);
     }
 
     #[test]

--- a/crates/axiam-api-rest/src/config/mod.rs
+++ b/crates/axiam-api-rest/src/config/mod.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 pub mod rate_limit;
 
-pub use rate_limit::RateLimitConfig;
+pub use rate_limit::{RateLimitConfig, RateLimitPosture, RateLimitProfile};
 
 /// Configuration for the Actix-Web REST API server.
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/axiam-api-rest/src/config/rate_limit.rs
+++ b/crates/axiam-api-rest/src/config/rate_limit.rs
@@ -51,6 +51,196 @@ pub enum RateLimitKeyMode {
     IpClientId,
 }
 
+impl RateLimitKeyMode {
+    /// Stable, log-safe name — identical to the `AXIAM__RATE_LIMIT__KEY`
+    /// value that selects this mode.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ip => "ip",
+            Self::ClientId => "client_id",
+            Self::IpClientId => "ip_client_id",
+        }
+    }
+}
+
+/// Deployment rate-limit **posture preset** (G7).
+///
+/// Environment variable: `AXIAM__RATE_LIMIT__PROFILE` = `internet` |
+/// `gateway` | `mesh` (default `internet`).
+///
+/// **Why a preset instead of new defaults.** Benchmark run 3 measured that
+/// the shipped defaults (`token 20/min`, `introspect 10/min`,
+/// `revoke 10/min`, `authz_check 300/min`, all keyed per-IP) flatten a
+/// 50-VU single-source-IP load to ~0–14 req/s at ~100% `429`, while the
+/// same 2-core server sustains ~1 800 token issuances/s and ~740–2 300
+/// authz checks/s. Those defaults are *correct* for a small
+/// internet-facing deployment and *wrong* for an M2M/NAT'd fleet where
+/// many OAuth2 clients share one egress IP. Rather than silently weaken
+/// the internet-facing abuse posture for everyone, the M2M sizing is an
+/// **opt-in preset**: one env var moves the whole machine-traffic family
+/// coherently (key mode + token/introspect/revoke/authz + the gRPC authz
+/// ceiling), and the shipped defaults are byte-for-byte unchanged.
+///
+/// **Human endpoints are never touched by any preset.** `login_per_min`,
+/// `register_per_min`, `password_reset_per_min` and `mfa_per_min` stay at
+/// their strict per-IP defaults in every profile — they gate
+/// password/OTP guessing and account-enumeration, which are human-scale
+/// attacks whose economics do not change because the deployment is a
+/// service mesh. Raise them deliberately, one env var at a time.
+///
+/// **Security caveat an operator MUST read before selecting a preset**
+/// (also in `docs/deployment/rate-limit-sizing.md`): both non-default
+/// presets set the key mode to `client_id`, and the `client_id` is parsed
+/// from the *unauthenticated* request body (`client_secret_post`,
+/// RFC 6749 §2.3.1) before any credential is verified. An attacker can
+/// therefore rotate `client_id` values to mint fresh buckets. Under those
+/// modes the token/introspect/revoke limits are a **fairness / noisy-
+/// neighbour control between cooperating clients**, not an anti-abuse
+/// control against a determined attacker; the anti-abuse job moves to the
+/// edge (WAF / API gateway / mTLS). This is a property of the D8 key
+/// modes themselves, not of the presets — the presets just make it the
+/// active posture, which is exactly why they are opt-in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RateLimitProfile {
+    /// Shipped default: small internet-facing deployment, strict per-IP
+    /// limits on every endpoint. No field is preset — the defaults in
+    /// [`RateLimitConfig::default`] apply verbatim.
+    #[default]
+    Internet,
+    /// M2M fleet reaching an internet-facing AXIAM through a shared
+    /// NAT/egress gateway (the topology run 3 showed the defaults break).
+    /// Per-client buckets and machine-scale ceilings on the machine
+    /// endpoints; human endpoints unchanged.
+    Gateway,
+    /// AXIAM reachable only on a private network / service mesh (no
+    /// internet exposure on the machine endpoints). Ceilings sized as
+    /// runaway-loop guards rather than abuse controls; human endpoints
+    /// still unchanged, because "private network" is not "no humans".
+    Mesh,
+}
+
+/// The machine-traffic limits a non-default [`RateLimitProfile`] presets.
+///
+/// Human endpoints are deliberately absent from this struct — a preset
+/// cannot express them, so it cannot weaken them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MachineLimitPreset {
+    /// Bucket-key mode for `/oauth2/token`, `/oauth2/revoke`,
+    /// `/oauth2/introspect` (the only endpoints that honor it).
+    pub key: RateLimitKeyMode,
+    /// `/oauth2/token` per minute per bucket.
+    pub token_per_min: u32,
+    /// `/oauth2/introspect` per minute per bucket.
+    pub introspect_per_min: u32,
+    /// `/oauth2/revoke` per minute per bucket.
+    pub revoke_per_min: u32,
+    /// REST authz-check endpoints per minute per IP.
+    pub authz_check_per_min: u32,
+    /// gRPC `AuthorizationService` per second per IP — applied to
+    /// `axiam_api_grpc::GrpcConfig::grpc_authz_per_sec` by the composition
+    /// root (`axiam-server::main`). Kept here so the whole family has one
+    /// source of truth.
+    pub grpc_authz_per_sec: u32,
+}
+
+/// `AXIAM__RATE_LIMIT__KEY` — presence pins [`RateLimitConfig::key`].
+pub const ENV_KEY: &str = "AXIAM__RATE_LIMIT__KEY";
+/// `AXIAM__RATE_LIMIT__TOKEN_PER_MIN`.
+pub const ENV_TOKEN_PER_MIN: &str = "AXIAM__RATE_LIMIT__TOKEN_PER_MIN";
+/// `AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN`.
+pub const ENV_INTROSPECT_PER_MIN: &str = "AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN";
+/// `AXIAM__RATE_LIMIT__REVOKE_PER_MIN`.
+pub const ENV_REVOKE_PER_MIN: &str = "AXIAM__RATE_LIMIT__REVOKE_PER_MIN";
+/// `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN`.
+pub const ENV_AUTHZ_CHECK_PER_MIN: &str = "AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN";
+
+impl RateLimitProfile {
+    /// Stable, log-safe name — identical to the
+    /// `AXIAM__RATE_LIMIT__PROFILE` value that selects this profile.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Internet => "internet",
+            Self::Gateway => "gateway",
+            Self::Mesh => "mesh",
+        }
+    }
+
+    /// The machine-traffic limits this profile presets, or `None` for
+    /// [`RateLimitProfile::Internet`] (which presets nothing at all).
+    ///
+    /// Every number below is anchored to the run-3 measured envelope on
+    /// 2-core server / 2-core DB containers (`benchmarks/PUBLIC_BENCH_ANALYSIS.md`
+    /// §6, laptop-class and explicitly temporary): token issuance
+    /// ~1 800/s (~108 000/min), introspection ~2 200/s (~132 000/min),
+    /// authz checks ~740/s cache-off and ~2 300/s cache-on
+    /// (~44 400 / ~138 000 per minute), gRPC single authz check ~603/s.
+    /// The presets are *per bucket*, so they are deliberately a small
+    /// fraction of the whole-server ceiling.
+    pub const fn preset(self) -> Option<MachineLimitPreset> {
+        match self {
+            Self::Internet => None,
+            // 600/min = 10/s per client ≈ 0.55% of the measured 1 800/s
+            // server ceiling: ~180 distinct clients running flat out are
+            // needed to saturate, so one compromised credential cannot
+            // become the DoS engine. Introspect is 10× token per the
+            // public §6 rule (resource servers introspect per request).
+            // Authz 6 000/min = 100/s per client, the low end of §6's
+            // 6 000–60 000 band.
+            Self::Gateway => Some(MachineLimitPreset {
+                key: RateLimitKeyMode::ClientId,
+                token_per_min: 600,
+                introspect_per_min: 6_000,
+                revoke_per_min: 600,
+                authz_check_per_min: 6_000,
+                grpc_authz_per_sec: 1_000,
+            }),
+            // Private-network sizing: 6 000/min token = 100/s per client
+            // (~5.6% of the measured ceiling) and 60 000/min authz =
+            // 1 000/s per client, ABOVE the measured 740/s cache-off
+            // ceiling — i.e. on this hardware the authz limit stops a
+            // runaway retry loop, not an attacker. Documented as such.
+            Self::Mesh => Some(MachineLimitPreset {
+                key: RateLimitKeyMode::ClientId,
+                token_per_min: 6_000,
+                introspect_per_min: 60_000,
+                revoke_per_min: 6_000,
+                authz_check_per_min: 60_000,
+                grpc_authz_per_sec: 5_000,
+            }),
+        }
+    }
+}
+
+/// What the composition root actually resolved — the input to the startup
+/// posture log line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RateLimitPosture {
+    /// The selected profile.
+    pub profile: RateLimitProfile,
+    /// `true` when a non-default preset was applied to at least the fields
+    /// the operator did not pin explicitly.
+    pub preset_applied: bool,
+    /// Env vars the operator set explicitly, which therefore beat the
+    /// preset. Names only — never values (some are not secret, but the
+    /// log line stays uniformly value-free for this list).
+    pub operator_overrides: Vec<&'static str>,
+    /// gRPC authz ceiling the preset wants, for the composition root to
+    /// hand to `axiam_api_grpc::GrpcConfig`. `None` under `internet`.
+    pub grpc_authz_per_sec_preset: Option<u32>,
+}
+
+impl RateLimitPosture {
+    /// Comma-joined override list for the startup log (`"none"` when empty).
+    pub fn overrides_display(&self) -> String {
+        if self.operator_overrides.is_empty() {
+            "none".to_owned()
+        } else {
+            self.operator_overrides.join(",")
+        }
+    }
+}
+
 /// Rate limit configuration.
 /// Environment variables: AXIAM__RATE_LIMIT__LOGIN_PER_MIN, etc.
 #[derive(Debug, Clone, Deserialize)]
@@ -83,6 +273,13 @@ pub struct RateLimitConfig {
     /// `/oauth2/introspect` honor this; `/auth/login` and every other
     /// endpoint always stay per-IP).
     pub key: RateLimitKeyMode,
+    /// Deployment posture preset (G7, default:
+    /// [`RateLimitProfile::Internet`] — presets nothing, so the shipped
+    /// defaults above apply verbatim). Configure via
+    /// `AXIAM__RATE_LIMIT__PROFILE`. Applied by
+    /// [`RateLimitConfig::apply_profile_from_env`] at startup; see
+    /// [`RateLimitProfile`] for the values and the security caveat.
+    pub profile: RateLimitProfile,
 }
 
 impl Default for RateLimitConfig {
@@ -97,11 +294,95 @@ impl Default for RateLimitConfig {
             revoke_per_min: 10,
             authz_check_per_min: 300,
             key: RateLimitKeyMode::Ip,
+            profile: RateLimitProfile::Internet,
         }
     }
 }
 
 impl RateLimitConfig {
+    /// Applies [`RateLimitConfig::profile`]'s preset to every machine-traffic
+    /// limit the operator did **not** pin with an explicit
+    /// `AXIAM__RATE_LIMIT__*` env var, reading the process environment.
+    ///
+    /// Call once at startup, before [`RateLimitConfig::validate`] and before
+    /// the config is cloned into the App factory.
+    ///
+    /// **Precedence:** explicit env var > profile preset > shipped default.
+    /// **Known limitation:** "explicit" means *an env var is present*. A
+    /// value coming from `config/default.toml` (the optional, non-shipped
+    /// file source in `axiam-server::load_config`) is indistinguishable from
+    /// "unset" here and will be overwritten by a non-default profile. Set the
+    /// env var to pin it. This is documented in
+    /// `docs/deployment/rate-limit-sizing.md`.
+    pub fn apply_profile_from_env(&mut self) -> RateLimitPosture {
+        self.apply_profile(|name| std::env::var_os(name).is_some())
+    }
+
+    /// [`RateLimitConfig::apply_profile_from_env`] with the environment
+    /// lookup injected — `is_set(name)` answers "did the operator pin this
+    /// env var?". Pure and unit-testable; the env-reading wrapper is the
+    /// only impure part.
+    pub fn apply_profile<F>(&mut self, is_set: F) -> RateLimitPosture
+    where
+        F: Fn(&str) -> bool,
+    {
+        let Some(preset) = self.profile.preset() else {
+            // `internet`: nothing is preset — this is a no-op by
+            // construction, so the shipped posture cannot drift.
+            return RateLimitPosture {
+                profile: self.profile,
+                preset_applied: false,
+                operator_overrides: Vec::new(),
+                grpc_authz_per_sec_preset: None,
+            };
+        };
+
+        let mut overrides: Vec<&'static str> = Vec::new();
+        if is_set(ENV_KEY) {
+            overrides.push(ENV_KEY);
+        } else {
+            self.key = preset.key;
+        }
+        for (env, field, value) in [
+            (
+                ENV_TOKEN_PER_MIN,
+                &mut self.token_per_min,
+                preset.token_per_min,
+            ),
+            (
+                ENV_INTROSPECT_PER_MIN,
+                &mut self.introspect_per_min,
+                preset.introspect_per_min,
+            ),
+            (
+                ENV_REVOKE_PER_MIN,
+                &mut self.revoke_per_min,
+                preset.revoke_per_min,
+            ),
+            (
+                ENV_AUTHZ_CHECK_PER_MIN,
+                &mut self.authz_check_per_min,
+                preset.authz_check_per_min,
+            ),
+        ] {
+            if is_set(env) {
+                overrides.push(env);
+            } else {
+                *field = value;
+            }
+        }
+
+        // NOTE: login/register/password_reset/mfa are intentionally absent.
+        // No preset may touch a human endpoint — see `RateLimitProfile`.
+
+        RateLimitPosture {
+            profile: self.profile,
+            preset_applied: true,
+            operator_overrides: overrides,
+            grpc_authz_per_sec_preset: Some(preset.grpc_authz_per_sec),
+        }
+    }
+
     /// Validates all rate limits are >= 1 (governor panics on zero).
     pub fn validate(&self) {
         assert!(self.login_per_min >= 1, "login_per_min must be >= 1");
@@ -127,6 +408,354 @@ impl RateLimitConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// `docs/deployment/rate-limit-sizing.md` — the operator-facing sizing
+    /// page. Its posture table is the ONLY place the shipped values are
+    /// written down for humans, and these tests are what keep it honest.
+    const POSTURE_DOC: &str = "docs/deployment/rate-limit-sizing.md";
+    /// The published benchmark analysis carries the same "shipped default"
+    /// column in its §6 recommended-settings table. Checked opportunistically
+    /// (the file is owned by the benchmark harness, not this crate).
+    const PUBLIC_BENCH_DOC: &str = "benchmarks/PUBLIC_BENCH_ANALYSIS.md";
+
+    const TABLE_BEGIN: &str = "<!-- rate-limit-posture-table:begin -->";
+    const TABLE_END: &str = "<!-- rate-limit-posture-table:end -->";
+
+    /// `crates/axiam-api-rest` → repository root.
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+    }
+
+    fn cells(line: &str) -> Vec<String> {
+        line.trim()
+            .trim_matches('|')
+            .split('|')
+            .map(|c| c.trim().trim_matches('`').trim().to_owned())
+            .collect()
+    }
+
+    /// Parses the marker-delimited posture table into
+    /// `env var -> [internet, gateway, mesh]`.
+    fn posture_table() -> HashMap<String, Vec<String>> {
+        let path = repo_root().join(POSTURE_DOC);
+        let md = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()));
+        let body = md
+            .split(TABLE_BEGIN)
+            .nth(1)
+            .unwrap_or_else(|| panic!("{POSTURE_DOC} must contain {TABLE_BEGIN}"))
+            .split(TABLE_END)
+            .next()
+            .unwrap_or_else(|| panic!("{POSTURE_DOC} must contain {TABLE_END}"));
+
+        let mut table = HashMap::new();
+        for line in body.lines() {
+            let line = line.trim();
+            if !line.starts_with("| `AXIAM__") {
+                continue;
+            }
+            let cells = cells(line);
+            assert_eq!(
+                cells.len(),
+                4,
+                "{POSTURE_DOC}: posture row must have env + 3 profile columns: {line}"
+            );
+            table.insert(cells[0].clone(), cells[1..].to_vec());
+        }
+        assert!(
+            !table.is_empty(),
+            "{POSTURE_DOC}: posture table parsed to zero rows — did the format change?"
+        );
+        table
+    }
+
+    /// Column index: 0 = `internet`, 1 = `gateway`, 2 = `mesh`.
+    fn documented(table: &HashMap<String, Vec<String>>, env: &str, column: usize) -> String {
+        table
+            .get(env)
+            .unwrap_or_else(|| panic!("{POSTURE_DOC} must document {env}"))[column]
+            .clone()
+    }
+
+    fn documented_u32(table: &HashMap<String, Vec<String>>, env: &str, column: usize) -> u32 {
+        let raw = documented(table, env, column);
+        raw.parse()
+            .unwrap_or_else(|e| panic!("{POSTURE_DOC}: {env} column {column} ({raw:?}): {e}"))
+    }
+
+    /// **Single source of truth guard (G7).** Every shipped default written
+    /// down in `docs/deployment/rate-limit-sizing.md` must equal
+    /// `RateLimitConfig::default()`. Change one, this test makes you change
+    /// the other.
+    #[test]
+    fn documented_defaults_match_shipped_config() {
+        let table = posture_table();
+        let d = RateLimitConfig::default();
+
+        assert_eq!(documented(&table, ENV_KEY, 0), d.key.as_str());
+        for (env, actual) in [
+            ("AXIAM__RATE_LIMIT__LOGIN_PER_MIN", d.login_per_min),
+            ("AXIAM__RATE_LIMIT__REGISTER_PER_MIN", d.register_per_min),
+            (
+                "AXIAM__RATE_LIMIT__PASSWORD_RESET_PER_MIN",
+                d.password_reset_per_min,
+            ),
+            ("AXIAM__RATE_LIMIT__MFA_PER_MIN", d.mfa_per_min),
+            (ENV_TOKEN_PER_MIN, d.token_per_min),
+            (ENV_INTROSPECT_PER_MIN, d.introspect_per_min),
+            (ENV_REVOKE_PER_MIN, d.revoke_per_min),
+            (ENV_AUTHZ_CHECK_PER_MIN, d.authz_check_per_min),
+        ] {
+            assert_eq!(
+                documented_u32(&table, env, 0),
+                actual,
+                "{POSTURE_DOC} documents a different shipped default for {env}"
+            );
+        }
+    }
+
+    /// The documented `gateway`/`mesh` columns must equal what
+    /// [`RateLimitConfig::apply_profile`] actually produces — including the
+    /// gRPC ceiling handed to `axiam-api-grpc` by the composition root.
+    #[test]
+    fn documented_presets_match_applied_profiles() {
+        let table = posture_table();
+        let shipped = RateLimitConfig::default();
+
+        for (column, profile) in [(1, RateLimitProfile::Gateway), (2, RateLimitProfile::Mesh)] {
+            let mut cfg = RateLimitConfig {
+                profile,
+                ..RateLimitConfig::default()
+            };
+            // Nothing pinned by the operator: the preset applies in full.
+            let posture = cfg.apply_profile(|_| false);
+            assert!(posture.preset_applied, "{profile:?}");
+            assert!(posture.operator_overrides.is_empty(), "{profile:?}");
+
+            assert_eq!(
+                documented(&table, ENV_KEY, column),
+                cfg.key.as_str(),
+                "{profile:?} key mode"
+            );
+            for (env, actual) in [
+                (ENV_TOKEN_PER_MIN, cfg.token_per_min),
+                (ENV_INTROSPECT_PER_MIN, cfg.introspect_per_min),
+                (ENV_REVOKE_PER_MIN, cfg.revoke_per_min),
+                (ENV_AUTHZ_CHECK_PER_MIN, cfg.authz_check_per_min),
+            ] {
+                assert_eq!(
+                    documented_u32(&table, env, column),
+                    actual,
+                    "{POSTURE_DOC} documents a different {profile:?} value for {env}"
+                );
+            }
+            assert_eq!(
+                documented_u32(&table, "AXIAM__GRPC__GRPC_AUTHZ_PER_SEC", column),
+                posture
+                    .grpc_authz_per_sec_preset
+                    .expect("non-default profile presets a gRPC ceiling"),
+                "{profile:?} gRPC ceiling"
+            );
+
+            // Human endpoints: identical to shipped, in the doc AND in code.
+            assert_eq!(cfg.login_per_min, shipped.login_per_min);
+            assert_eq!(cfg.register_per_min, shipped.register_per_min);
+            assert_eq!(cfg.password_reset_per_min, shipped.password_reset_per_min);
+            assert_eq!(cfg.mfa_per_min, shipped.mfa_per_min);
+            for env in [
+                "AXIAM__RATE_LIMIT__LOGIN_PER_MIN",
+                "AXIAM__RATE_LIMIT__REGISTER_PER_MIN",
+                "AXIAM__RATE_LIMIT__PASSWORD_RESET_PER_MIN",
+                "AXIAM__RATE_LIMIT__MFA_PER_MIN",
+            ] {
+                assert_eq!(
+                    documented_u32(&table, env, column),
+                    documented_u32(&table, env, 0),
+                    "{POSTURE_DOC}: {profile:?} must not change the human endpoint {env}"
+                );
+            }
+        }
+    }
+
+    /// The published benchmark analysis (§6 "Recommended settings by
+    /// deployment") repeats the shipped defaults in its own table; run 3's
+    /// publishing guidance requires those to stay in sync with code. The file
+    /// belongs to the benchmark harness, so a missing file is tolerated — a
+    /// *wrong* value is not.
+    #[test]
+    fn public_benchmark_doc_shipped_defaults_match_code() {
+        let path = repo_root().join(PUBLIC_BENCH_DOC);
+        let Ok(md) = std::fs::read_to_string(&path) else {
+            eprintln!("{PUBLIC_BENCH_DOC} not present — skipping cross-doc drift check");
+            return;
+        };
+        let d = RateLimitConfig::default();
+        let expected: HashMap<&str, String> = HashMap::from([
+            (ENV_KEY, d.key.as_str().to_owned()),
+            (ENV_TOKEN_PER_MIN, d.token_per_min.to_string()),
+            (ENV_INTROSPECT_PER_MIN, d.introspect_per_min.to_string()),
+            (ENV_AUTHZ_CHECK_PER_MIN, d.authz_check_per_min.to_string()),
+            (
+                "AXIAM__RATE_LIMIT__LOGIN_PER_MIN",
+                d.login_per_min.to_string(),
+            ),
+        ]);
+
+        let mut checked = 0usize;
+        for line in md.lines() {
+            let line = line.trim();
+            if !line.starts_with("| `AXIAM__RATE_LIMIT__") {
+                continue;
+            }
+            let cells = cells(line);
+            let Some(want) = expected.get(cells[0].as_str()) else {
+                continue;
+            };
+            // The §6 "Shipped default" column is prose-decorated
+            // (e.g. "10 (per IP)"); compare on the leading token only.
+            let got = cells
+                .get(1)
+                .map(|c| {
+                    c.split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim_matches('`')
+                        .to_owned()
+                })
+                .unwrap_or_default();
+            assert_eq!(
+                &got, want,
+                "{PUBLIC_BENCH_DOC} §6 shipped default for {} disagrees with \
+                 RateLimitConfig::default()",
+                cells[0]
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= expected.len(),
+            "{PUBLIC_BENCH_DOC}: only matched {checked} of {} rate-limit rows — \
+             §6 table format changed?",
+            expected.len()
+        );
+    }
+
+    /// G7: the default profile presets NOTHING. This is what guarantees the
+    /// shipped internet-facing posture cannot drift as presets evolve.
+    #[test]
+    fn internet_profile_is_a_no_op() {
+        let mut cfg = RateLimitConfig::default();
+        let before = cfg.clone();
+        let posture = cfg.apply_profile(|_| panic!("internet must not consult the environment"));
+
+        assert_eq!(posture.profile, RateLimitProfile::Internet);
+        assert!(!posture.preset_applied);
+        assert!(posture.operator_overrides.is_empty());
+        assert_eq!(posture.grpc_authz_per_sec_preset, None);
+        assert_eq!(posture.overrides_display(), "none");
+
+        assert_eq!(cfg.key, before.key);
+        assert_eq!(cfg.token_per_min, before.token_per_min);
+        assert_eq!(cfg.introspect_per_min, before.introspect_per_min);
+        assert_eq!(cfg.revoke_per_min, before.revoke_per_min);
+        assert_eq!(cfg.authz_check_per_min, before.authz_check_per_min);
+    }
+
+    /// Precedence: an explicitly-set env var beats the preset, and is named
+    /// in the posture (so the startup log tells the operator why a value
+    /// isn't what the profile advertises).
+    #[test]
+    fn explicit_env_vars_win_over_the_preset() {
+        let mut cfg = RateLimitConfig {
+            profile: RateLimitProfile::Gateway,
+            token_per_min: 2_000,
+            key: RateLimitKeyMode::IpClientId,
+            ..RateLimitConfig::default()
+        };
+        let posture = cfg.apply_profile(|name| name == ENV_TOKEN_PER_MIN || name == ENV_KEY);
+
+        // Pinned by the operator — untouched.
+        assert_eq!(cfg.token_per_min, 2_000);
+        assert_eq!(cfg.key, RateLimitKeyMode::IpClientId);
+        // Not pinned — preset applies.
+        assert_eq!(cfg.introspect_per_min, 6_000);
+        assert_eq!(cfg.revoke_per_min, 600);
+        assert_eq!(cfg.authz_check_per_min, 6_000);
+
+        assert!(posture.preset_applied);
+        assert_eq!(posture.operator_overrides, vec![ENV_KEY, ENV_TOKEN_PER_MIN]);
+        assert_eq!(
+            posture.overrides_display(),
+            format!("{ENV_KEY},{ENV_TOKEN_PER_MIN}")
+        );
+    }
+
+    /// Non-negotiable invariant: **no profile may raise a human endpoint.**
+    /// If someone adds `login_per_min` to a preset, this fails.
+    #[test]
+    fn no_profile_touches_human_endpoints() {
+        let shipped = RateLimitConfig::default();
+        for profile in [
+            RateLimitProfile::Internet,
+            RateLimitProfile::Gateway,
+            RateLimitProfile::Mesh,
+        ] {
+            let mut cfg = RateLimitConfig {
+                profile,
+                ..RateLimitConfig::default()
+            };
+            cfg.apply_profile(|_| false);
+            assert_eq!(cfg.login_per_min, shipped.login_per_min, "{profile:?}");
+            assert_eq!(
+                cfg.register_per_min, shipped.register_per_min,
+                "{profile:?}"
+            );
+            assert_eq!(
+                cfg.password_reset_per_min, shipped.password_reset_per_min,
+                "{profile:?}"
+            );
+            assert_eq!(cfg.mfa_per_min, shipped.mfa_per_min, "{profile:?}");
+        }
+    }
+
+    /// Presets must stay well inside the measured envelope: a per-bucket
+    /// limit is a fraction of the whole-server ceiling, never a multiple of
+    /// it. (Measured run 3, 2 cores: ~1 800 issuances/s = 108 000/min.)
+    #[test]
+    fn presets_stay_below_the_measured_server_ceiling() {
+        const MEASURED_TOKEN_PER_MIN_CEILING: u32 = 108_000;
+        for profile in [RateLimitProfile::Gateway, RateLimitProfile::Mesh] {
+            let preset = profile.preset().expect("non-default profile has a preset");
+            assert!(
+                preset.token_per_min < MEASURED_TOKEN_PER_MIN_CEILING / 10,
+                "{profile:?}: a single bucket must not be able to claim >10% of the \
+                 measured server ceiling"
+            );
+        }
+    }
+
+    #[test]
+    fn profile_deserializes_from_documented_env_values() {
+        for (raw, expected) in [
+            ("\"internet\"", RateLimitProfile::Internet),
+            ("\"gateway\"", RateLimitProfile::Gateway),
+            ("\"mesh\"", RateLimitProfile::Mesh),
+        ] {
+            assert_eq!(
+                serde_json::from_str::<RateLimitProfile>(raw).unwrap(),
+                expected
+            );
+        }
+        assert_eq!(RateLimitProfile::default(), RateLimitProfile::Internet);
+        assert_eq!(
+            RateLimitConfig::default().profile,
+            RateLimitProfile::Internet
+        );
+        assert!(serde_json::from_str::<RateLimitProfile>("\"m2m\"").is_err());
+    }
 
     /// D8 acceptance: default behavior (`ip`) is unchanged — a
     /// freshly-defaulted config must key exactly the way it did before this

--- a/crates/axiam-api-rest/src/handlers/bootstrap.rs
+++ b/crates/axiam-api-rest/src/handlers/bootstrap.rs
@@ -26,6 +26,7 @@
 use actix_web::{HttpResponse, web};
 use axiam_auth::password;
 use axiam_core::error::AxiamError;
+use axiam_core::id::new_id;
 use axiam_core::models::organization::CreateOrganization;
 use axiam_core::models::tenant::CreateTenant;
 use axiam_core::repository::{OrganizationRepository, TenantRepository};
@@ -361,11 +362,11 @@ pub async fn bootstrap<C: Connection + Clone>(
     //
     // SurrealDB v3 quirk: BEGIN TRANSACTION occupies result slot 0;
     // the first statement result is at .take(1). (See MEMORY.md)
-    let user_id = Uuid::new_v4();
+    let user_id = new_id();
     let user_id_str = user_id.to_string();
     let role_id_str = seed_result.super_admin_role_id.to_string();
     let tenant_id_str = tenant_id.to_string();
-    let ph_id_str = Uuid::new_v4().to_string();
+    let ph_id_str = new_id().to_string();
 
     // Apply the server-configured password pepper (REQ-14 AC-1) — the same
     // pepper the user repository uses at login-time verification. Previously

--- a/crates/axiam-api-rest/src/lib.rs
+++ b/crates/axiam-api-rest/src/lib.rs
@@ -16,7 +16,7 @@ pub mod webhook;
 pub mod webhook_consumer;
 
 pub use authz::{AuthzChecker, AuthzData, RequirePermission};
-pub use config::{RateLimitConfig, ServerConfig};
+pub use config::{RateLimitConfig, RateLimitPosture, RateLimitProfile, ServerConfig};
 pub use error::AxiamApiError;
 pub use extractors::auth::{AuthenticatedUser, SessionValidator};
 pub use extractors::cert_auth::{CertificateAuthenticated, VerifiedClientCert};

--- a/crates/axiam-api-rest/src/webhook.rs
+++ b/crates/axiam-api-rest/src/webhook.rs
@@ -34,6 +34,7 @@
 //! to update for this format change.
 
 use axiam_auth::crypto::{aes256gcm_decrypt, aes256gcm_encrypt};
+use axiam_core::id::new_id;
 use axiam_core::repository::WebhookRepository;
 use axiam_federation::ssrf::{self, SsrfError};
 use chrono::Utc;
@@ -182,7 +183,7 @@ impl<W: WebhookRepository + Clone + 'static> WebhookDeliveryService<W> {
         for webhook in webhooks {
             let msg = axiam_amqp::WebhookMessage {
                 webhook_id: webhook.id,
-                delivery_id: Uuid::new_v4(),
+                delivery_id: new_id(),
                 tenant_id,
                 event_type: event_type.clone(),
                 payload: payload.clone(),

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -165,6 +165,8 @@ pub fn issue_client_credentials_token(
         iss: config.effective_issuer().to_owned(),
         iat: now,
         exp: now + config.access_token_lifetime_secs as i64,
+        // Not `new_id()`: a jti is a uniqueness marker inside an already-signed
+        // JWT, not a record id, so key locality is irrelevant here.
         jti: Uuid::new_v4().to_string(),
         aud: Some(AUD_M2M.to_string()),
         scope,

--- a/crates/axiam-core/src/id.rs
+++ b/crates/axiam-core/src/id.rs
@@ -1,0 +1,150 @@
+//! Identifier generation for persisted entities.
+//!
+//! # Why v7 and not v4
+//!
+//! Every repository in `axiam-db` writes its rows as
+//! `CREATE type::record('<table>', $id)`, where `$id` is the hyphenated string
+//! form of a [`Uuid`]. SurrealDB stores records in an ordered key-value engine
+//! (`surrealkv:` in dev/prod compose, `file:`/RocksDB in the k8s StatefulSet),
+//! so the record id *is* the primary key and its ordering determines physical
+//! layout.
+//!
+//! With v4 the key is uniformly random, so consecutive inserts scatter across
+//! the whole keyspace: every insert dirties a different page, the working set
+//! for a write burst is the entire index rather than its tail, and LSM
+//! compaction rewrites overlapping ranges repeatedly. UUIDv7 (RFC 9562) puts a
+//! 48-bit big-endian Unix-millisecond timestamp in the high bits, so ids
+//! generated close in time sort close together and inserts append to the tail
+//! of the keyspace instead of scattering.
+//!
+//! Two properties this depends on are verified by the tests below rather than
+//! assumed:
+//!
+//! 1. **The string form sorts like the byte form.** We store ids as
+//!    hyphenated strings, so the ordering benefit would be lost if the textual
+//!    encoding permuted it. Lowercase hex is order-preserving here, and the
+//!    hyphens sit at fixed offsets, so it holds — but it is asserted, because
+//!    the whole rationale collapses without it.
+//! 2. **Ids are monotonic within a single millisecond.** `uuid`'s
+//!    [`Uuid::now_v7`] carries a per-millisecond counter (RFC 9562 §6.2
+//!    "monotonic random"), so a burst of inserts inside one millisecond is
+//!    still ordered rather than randomly permuted inside that millisecond's
+//!    bucket.
+//!
+//! # When NOT to use this
+//!
+//! [`new_id`] must not be used for anything whose security depends on being
+//! unguessable — session tokens, download/cancel tokens, reset tokens,
+//! passwords, or any other bearer capability.
+//!
+//! v4 spends 122 bits on randomness. v7 spends 48 on the timestamp and, because
+//! of the monotonic counter, ids minted in the *same* millisecond share a long
+//! common prefix and differ only in the low counter bits. Two adjacent same-ms
+//! ids can therefore share ~90 of their 128 bits, which is ample for collision
+//! resistance but nowhere near enough for secrecy.
+//!
+//! That distinction is the rule this module encodes: **v7 for identifiers, CSPRNG
+//! for secrets.** Identifiers in AXIAM are not capabilities — every repository
+//! read is tenant-scoped and every route is checked by the authz engine, so
+//! knowing another entity's id grants nothing. Secrets are generated separately
+//! (see `generate_cancel_token` in the GDPR handlers, which uses a 256-bit
+//! `rand` draw for exactly this reason).
+//!
+//! # Disclosure trade-off
+//!
+//! A v7 id discloses its own creation time to anyone who can see it. For AXIAM
+//! entities this reveals nothing new: `created_at` is already part of the
+//! public representation of every entity that carries one, and JWTs already
+//! carry `iat` alongside the `jti`/`sub` claims.
+
+use uuid::Uuid;
+
+/// Generate the identifier for a newly created, persisted entity.
+///
+/// Use this for anything that becomes a SurrealDB record id or a foreign key.
+/// See the module docs for why this is v7 and for the cases that must keep
+/// using a CSPRNG instead.
+#[inline]
+#[must_use]
+pub fn new_id() -> Uuid {
+    Uuid::now_v7()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn is_version_7() {
+        let id = new_id();
+        assert_eq!(id.get_version_num(), 7, "new_id must mint UUIDv7");
+        assert_eq!(id.get_variant(), uuid::Variant::RFC4122);
+    }
+
+    /// The ordering guarantee must survive the hyphenated-string encoding,
+    /// because that is the form actually handed to `type::record(...)`.
+    #[test]
+    fn string_form_sorts_in_generation_order() {
+        let ids: Vec<Uuid> = (0..10_000).map(|_| new_id()).collect();
+
+        let generated: Vec<String> = ids.iter().map(Uuid::to_string).collect();
+        let mut sorted = generated.clone();
+        sorted.sort();
+
+        assert_eq!(
+            sorted, generated,
+            "hyphenated string ordering must match generation order, otherwise \
+             storing ids as strings discards the v7 locality benefit"
+        );
+    }
+
+    /// A burst inside one millisecond must stay ordered, not shuffle within
+    /// that millisecond's bucket.
+    #[test]
+    fn monotonic_within_a_single_millisecond() {
+        let ids: Vec<Uuid> = (0..5_000).map(|_| new_id()).collect();
+
+        // Confirm the burst really did share milliseconds, so this test is
+        // exercising the counter rather than trivially passing on distinct
+        // timestamps.
+        let distinct_ms: HashSet<&[u8]> = ids.iter().map(|u| &u.as_bytes()[0..6]).collect();
+        assert!(
+            distinct_ms.len() < ids.len(),
+            "expected several ids per millisecond in a tight burst"
+        );
+
+        for pair in ids.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "v7 ids must increase monotonically: {} !< {}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn ids_are_unique() {
+        let ids: HashSet<Uuid> = (0..50_000).map(|_| new_id()).collect();
+        assert_eq!(ids.len(), 50_000);
+    }
+
+    /// The embedded timestamp must track wall-clock time, since ordering
+    /// across processes and restarts relies on it.
+    #[test]
+    fn embeds_current_unix_millis() {
+        let before = chrono::Utc::now().timestamp_millis();
+        let id = new_id();
+        let after = chrono::Utc::now().timestamp_millis();
+
+        let b = id.as_bytes();
+        let ms = i64::from(u32::from_be_bytes([b[0], b[1], b[2], b[3]])) << 16
+            | i64::from(u16::from_be_bytes([b[4], b[5]]));
+
+        assert!(
+            (before..=after).contains(&ms),
+            "embedded timestamp {ms} outside [{before}, {after}]"
+        );
+    }
+}

--- a/crates/axiam-core/src/lib.rs
+++ b/crates/axiam-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! AXIAM Core — Domain types, repository traits, and error definitions.
 
 pub mod error;
+pub mod id;
 pub mod models;
 pub mod repository;

--- a/crates/axiam-db/src/repository/account_deletion.rs
+++ b/crates/axiam-db/src/repository/account_deletion.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`AccountDeletionRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{AccountDeletion, AccountDeletionStatus, CreateAccountDeletion};
 use axiam_core::repository::AccountDeletionRepository;
 use chrono::{DateTime, Utc};
@@ -178,7 +179,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
         scheduled_purge_at: DateTime<Utc>,
         cancel_token_hash: String,
     ) -> AxiamResult<AccountDeletion> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let created_at = Utc::now();
 
         let query = "BEGIN TRANSACTION; \
@@ -233,7 +234,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
 
 impl<C: Connection> AccountDeletionRepository for SurrealAccountDeletionRepository<C> {
     async fn create(&self, input: CreateAccountDeletion) -> AxiamResult<AccountDeletion> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/amqp_nonce_replay.rs
+++ b/crates/axiam-db/src/repository/amqp_nonce_replay.rs
@@ -6,6 +6,7 @@
 //! reject replayed messages (NEW-4). Mirrors [`super::saml_replay`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::repository::AmqpNonceRepository;
 use chrono::{DateTime, Utc};
 use surrealdb::{Connection, Surreal};
@@ -47,7 +48,7 @@ impl<C: Connection> AmqpNonceRepository for SurrealAmqpNonceRepository<C> {
         nonce: Uuid,
         expires_at: DateTime<Utc>,
     ) -> AxiamResult<()> {
-        let row_id = Uuid::new_v4().to_string();
+        let row_id = new_id().to_string();
 
         let result = self
             .db

--- a/crates/axiam-db/src/repository/audit.rs
+++ b/crates/axiam-db/src/repository/audit.rs
@@ -4,6 +4,7 @@
 //! `FOR update NONE` and `FOR delete NONE`.
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::audit::{ActorType, AuditLogEntry, AuditOutcome, CreateAuditLogEntry};
 use axiam_core::repository::{AuditLogFilter, AuditLogRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -229,7 +230,7 @@ impl<C: Connection> SurrealAuditLogRepository<C> {
 
 impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
     async fn append(&self, input: CreateAuditLogEntry) -> AxiamResult<AuditLogEntry> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let metadata = input

--- a/crates/axiam-db/src/repository/ca_certificate.rs
+++ b/crates/axiam-db/src/repository/ca_certificate.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`CaCertificateRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::certificate::{
     CaCertificate, CertificateStatus, KeyAlgorithm, StoreCaCertificate,
 };
@@ -149,7 +150,7 @@ impl<C: Connection> SurrealCaCertificateRepository<C> {
 
 impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C> {
     async fn create(&self, input: StoreCaCertificate) -> AxiamResult<CaCertificate> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/certificate.rs
+++ b/crates/axiam-db/src/repository/certificate.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`CertificateRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::certificate::{
     Certificate, CertificateStatus, CertificateType, KeyAlgorithm, StoreCertificate,
 };
@@ -185,7 +186,7 @@ impl<C: Connection> SurrealCertificateRepository<C> {
 
 impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
     async fn create(&self, input: StoreCertificate) -> AxiamResult<Certificate> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/consent.rs
+++ b/crates/axiam-db/src/repository/consent.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ConsentRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{Consent, CreateConsent};
 use axiam_core::repository::ConsentRepository;
 use chrono::{DateTime, Utc};
@@ -82,7 +83,7 @@ impl<C: Connection> SurrealConsentRepository<C> {
 
 impl<C: Connection> ConsentRepository for SurrealConsentRepository<C> {
     async fn create(&self, input: CreateConsent) -> AxiamResult<Consent> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/email_config.rs
+++ b/crates/axiam-db/src/repository/email_config.rs
@@ -791,6 +791,8 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
         let override_cfg = self.get_tenant_override(tenant_id).await?;
         let effective = match override_cfg {
             None => org_cfg,
+            // Not `new_id()`: the merged view is computed, never persisted, so
+            // this id names no record and gains nothing from being sortable.
             Some(ov) => axiam_core::models::email::effective_email_config(
                 &org_cfg,
                 &ov,

--- a/crates/axiam-db/src/repository/email_verification_token.rs
+++ b/crates/axiam-db/src/repository/email_verification_token.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`EmailVerificationTokenRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::email_verification::{
     CreateEmailVerificationToken, EmailVerificationToken,
 };
@@ -98,7 +99,7 @@ impl<C: Connection> EmailVerificationTokenRepository
         &self,
         input: CreateEmailVerificationToken,
     ) -> AxiamResult<EmailVerificationToken> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/erasure_proof.rs
+++ b/crates/axiam-db/src/repository/erasure_proof.rs
@@ -4,6 +4,7 @@
 //! erasure occurred. They contain no PII — only a pseudonym and timestamp.
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{CreateErasureProof, ErasureProof};
 use axiam_core::repository::ErasureProofRepository;
 use chrono::{DateTime, Utc};
@@ -49,7 +50,7 @@ impl<C: Connection> SurrealErasureProofRepository<C> {
 
 impl<C: Connection> ErasureProofRepository for SurrealErasureProofRepository<C> {
     async fn create(&self, input: CreateErasureProof) -> AxiamResult<ErasureProof> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/export_job.rs
+++ b/crates/axiam-db/src/repository/export_job.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ExportJobRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{CreateExportJob, ExportJob, ExportJobStatus};
 use axiam_core::repository::ExportJobRepository;
 use chrono::{DateTime, Utc};
@@ -126,7 +127,7 @@ impl<C: Connection> SurrealExportJobRepository<C> {
 
 impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
     async fn create(&self, input: CreateExportJob) -> AxiamResult<ExportJob> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/federation_config.rs
+++ b/crates/axiam-db/src/repository/federation_config.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`FederationConfigRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::federation::{
     CreateFederationConfig, FederationConfig, FederationProtocol, UpdateFederationConfig,
 };
@@ -202,7 +203,7 @@ impl<C: Connection> SurrealFederationConfigRepository<C> {
 
 impl<C: Connection> FederationConfigRepository for SurrealFederationConfigRepository<C> {
     async fn create(&self, input: CreateFederationConfig) -> AxiamResult<FederationConfig> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let protocol = protocol_to_string(&input.protocol);
         let attribute_map = input.attribute_map.unwrap_or_else(|| serde_json::json!({}));
 

--- a/crates/axiam-db/src/repository/federation_link.rs
+++ b/crates/axiam-db/src/repository/federation_link.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`FederationLinkRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::federation::{CreateFederationLink, FederationLink};
 use axiam_core::repository::FederationLinkRepository;
 use chrono::{DateTime, Utc};
@@ -97,7 +98,7 @@ impl<C: Connection> SurrealFederationLinkRepository<C> {
 
 impl<C: Connection> FederationLinkRepository for SurrealFederationLinkRepository<C> {
     async fn create(&self, input: CreateFederationLink) -> AxiamResult<FederationLink> {
-        let id = Uuid::new_v4();
+        let id = new_id();
 
         let result = self
             .db

--- a/crates/axiam-db/src/repository/federation_login_state.rs
+++ b/crates/axiam-db/src/repository/federation_login_state.rs
@@ -6,6 +6,7 @@
 //! caller check and can be swept by `cleanup_expired`.
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::repository::{FederationLoginState, FederationLoginStateRepository};
 use chrono::{DateTime, Utc};
 use surrealdb::{Connection, Surreal};
@@ -50,7 +51,7 @@ impl<C: Connection> SurrealFederationLoginStateRepository<C> {
 
 impl<C: Connection> FederationLoginStateRepository for SurrealFederationLoginStateRepository<C> {
     async fn insert(&self, row: &FederationLoginState) -> AxiamResult<()> {
-        let row_id = Uuid::new_v4().to_string();
+        let row_id = new_id().to_string();
 
         let result = self
             .db

--- a/crates/axiam-db/src/repository/group.rs
+++ b/crates/axiam-db/src/repository/group.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`GroupRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
 use axiam_core::models::user::{User, UserStatus};
 use axiam_core::repository::{GroupRepository, PaginatedResult, Pagination};
@@ -129,7 +130,7 @@ impl<C: Connection> SurrealGroupRepository<C> {
 
 impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
     async fn create(&self, input: CreateGroup) -> AxiamResult<Group> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/notification_rule.rs
+++ b/crates/axiam-db/src/repository/notification_rule.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`NotificationRuleRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::notification_rule::{
     CreateNotificationRule, NotificationEventType, NotificationRule, UpdateNotificationRule,
 };
@@ -114,7 +115,7 @@ impl<C: Connection> SurrealNotificationRuleRepository<C> {
 
 impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleRepository<C> {
     async fn create(&self, input: CreateNotificationRule) -> AxiamResult<NotificationRule> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let events_str: Vec<String> = input.events.iter().map(|e| e.to_db_string()).collect();
 
         let result = self

--- a/crates/axiam-db/src/repository/oauth2_auth_code.rs
+++ b/crates/axiam-db/src/repository/oauth2_auth_code.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`AuthorizationCodeRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{AuthorizationCode, CreateAuthorizationCode};
 use axiam_core::repository::AuthorizationCodeRepository;
 use chrono::{DateTime, Utc};
@@ -84,7 +85,7 @@ impl<C: Connection> SurrealAuthorizationCodeRepository<C> {
 
 impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepository<C> {
     async fn create(&self, input: CreateAuthorizationCode) -> AxiamResult<AuthorizationCode> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/oauth2_client.rs
+++ b/crates/axiam-db/src/repository/oauth2_client.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`OAuth2ClientRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{CreateOAuth2Client, OAuth2Client, UpdateOAuth2Client};
 use axiam_core::repository::{OAuth2ClientRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -88,7 +89,7 @@ impl<C: Connection> SurrealOAuth2ClientRepository<C> {
 
 impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> {
     async fn create(&self, input: CreateOAuth2Client) -> AxiamResult<(OAuth2Client, String)> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/oauth2_refresh_token.rs
+++ b/crates/axiam-db/src/repository/oauth2_refresh_token.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`RefreshTokenRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{CreateRefreshToken, RefreshToken};
 use axiam_core::repository::RefreshTokenRepository;
 use chrono::{DateTime, Utc};
@@ -87,7 +88,7 @@ impl<C: Connection> SurrealRefreshTokenRepository<C> {
 
 impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> {
     async fn create(&self, input: CreateRefreshToken) -> AxiamResult<RefreshToken> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let user_id_str = input.user_id.map(|u| u.to_string());

--- a/crates/axiam-db/src/repository/organization.rs
+++ b/crates/axiam-db/src/repository/organization.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`OrganizationRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::organization::{CreateOrganization, Organization, UpdateOrganization};
 use axiam_core::repository::{OrganizationRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -61,7 +62,7 @@ impl<C: Connection> SurrealOrganizationRepository<C> {
 
 impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> {
     async fn create(&self, input: CreateOrganization) -> AxiamResult<Organization> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let metadata = input

--- a/crates/axiam-db/src/repository/password_history.rs
+++ b/crates/axiam-db/src/repository/password_history.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PasswordHistoryRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::password_history::{CreatePasswordHistoryEntry, PasswordHistoryEntry};
 use axiam_core::repository::PasswordHistoryRepository;
 use chrono::{DateTime, Utc};
@@ -74,7 +75,7 @@ impl<C: Connection> SurrealPasswordHistoryRepository<C> {
 
 impl<C: Connection> PasswordHistoryRepository for SurrealPasswordHistoryRepository<C> {
     async fn create(&self, input: CreatePasswordHistoryEntry) -> AxiamResult<PasswordHistoryEntry> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/password_reset_token.rs
+++ b/crates/axiam-db/src/repository/password_reset_token.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PasswordResetTokenRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::password_reset::{CreatePasswordResetToken, PasswordResetToken};
 use axiam_core::repository::PasswordResetTokenRepository;
 use chrono::{DateTime, Utc};
@@ -91,7 +92,7 @@ impl<C: Connection> SurrealPasswordResetTokenRepository<C> {
 
 impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRepository<C> {
     async fn create(&self, input: CreatePasswordResetToken) -> AxiamResult<PasswordResetToken> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/permission.rs
+++ b/crates/axiam-db/src/repository/permission.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PermissionRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::permission::{
     CreatePermission, Permission, PermissionGrant, UpdatePermission,
 };
@@ -138,7 +139,7 @@ impl<C: Connection> SurrealPermissionRepository<C> {
 
 impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
     async fn create(&self, input: CreatePermission) -> AxiamResult<Permission> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/pgp_key.rs
+++ b/crates/axiam-db/src/repository/pgp_key.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`PgpKeyRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::pgp_key::{
     PgpKey, PgpKeyAlgorithm, PgpKeyPurpose, PgpKeyStatus, StorePgpKey,
 };
@@ -157,7 +158,7 @@ impl<C: Connection> SurrealPgpKeyRepository<C> {
 
 impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
     async fn create(&self, input: StorePgpKey) -> AxiamResult<PgpKey> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let result = self
             .db
             .query(

--- a/crates/axiam-db/src/repository/resource.rs
+++ b/crates/axiam-db/src/repository/resource.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ResourceRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::resource::{CreateResource, Resource, UpdateResource};
 use axiam_core::repository::{PaginatedResult, Pagination, ResourceRepository};
 use chrono::{DateTime, Utc};
@@ -95,7 +96,7 @@ impl<C: Connection> SurrealResourceRepository<C> {
 
 impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
     async fn create(&self, input: CreateResource) -> AxiamResult<Resource> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
         let parent_id_str = input.parent_id.map(|p| p.to_string());

--- a/crates/axiam-db/src/repository/role.rs
+++ b/crates/axiam-db/src/repository/role.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`RoleRepository`].
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::role::{CreateRole, Role, RoleAssignment, UpdateRole};
 use axiam_core::repository::{PaginatedResult, Pagination, RoleRepository};
 use chrono::{DateTime, Utc};
@@ -120,7 +121,7 @@ impl<C: Connection> SurrealRoleRepository<C> {
 
 impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
     async fn create(&self, input: CreateRole) -> AxiamResult<Role> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/saml_replay.rs
+++ b/crates/axiam-db/src/repository/saml_replay.rs
@@ -6,6 +6,7 @@
 //! replayed assertions (D-09).
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::repository::AssertionReplayRepository;
 use chrono::{DateTime, Utc};
 use surrealdb::{Connection, Surreal};
@@ -46,7 +47,7 @@ impl<C: Connection> AssertionReplayRepository for SurrealAssertionReplayReposito
         assertion_id: &str,
         expires_at: DateTime<Utc>,
     ) -> AxiamResult<()> {
-        let row_id = Uuid::new_v4().to_string();
+        let row_id = new_id().to_string();
         let assertion_id_owned = assertion_id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/scope.rs
+++ b/crates/axiam-db/src/repository/scope.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ScopeRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::scope::{CreateScope, Scope, UpdateScope};
 use axiam_core::repository::ScopeRepository;
 use chrono::{DateTime, Utc};
@@ -66,7 +67,7 @@ impl<C: Connection> SurrealScopeRepository<C> {
 
 impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
     async fn create(&self, input: CreateScope) -> AxiamResult<Scope> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
         let resource_id_str = input.resource_id.to_string();

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`ServiceAccountRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::service_account::{
     CreateServiceAccount, ServiceAccount, UpdateServiceAccount,
 };
@@ -116,7 +117,7 @@ impl<C: Connection> SurrealServiceAccountRepository<C> {
 
 impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository<C> {
     async fn create(&self, input: CreateServiceAccount) -> AxiamResult<(ServiceAccount, String)> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 

--- a/crates/axiam-db/src/repository/session.rs
+++ b/crates/axiam-db/src/repository/session.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`SessionRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::session::{CreateSession, Session};
 use axiam_core::repository::SessionRepository;
 use chrono::{DateTime, Utc};
@@ -96,7 +97,7 @@ impl<C: Connection> SurrealSessionRepository<C> {
 
 impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
     async fn create(&self, input: CreateSession) -> AxiamResult<Session> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/tenant.rs
+++ b/crates/axiam-db/src/repository/tenant.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`TenantRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::tenant::{CreateTenant, Tenant, TenantStatus, UpdateTenant};
 use axiam_core::repository::{PaginatedResult, Pagination, TenantRepository};
 use chrono::{DateTime, Utc};
@@ -103,7 +104,7 @@ impl<C: Connection> SurrealTenantRepository<C> {
 
 impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
     async fn create(&self, input: CreateTenant) -> AxiamResult<Tenant> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let org_id_str = input.organization_id.to_string();
         let metadata = input

--- a/crates/axiam-db/src/repository/user.rs
+++ b/crates/axiam-db/src/repository/user.rs
@@ -6,6 +6,7 @@
 
 use axiam_auth::password;
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::user::{CreateUser, UpdateUser, User, UserStatus};
 use axiam_core::repository::{PaginatedResult, Pagination, UserRepository};
 use chrono::{DateTime, Utc};
@@ -244,7 +245,7 @@ impl<C: Connection> SurrealUserRepository<C> {
 
 impl<C: Connection> UserRepository for SurrealUserRepository<C> {
     async fn create(&self, input: CreateUser) -> AxiamResult<User> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
         let tenant_id_str = input.tenant_id.to_string();
 
@@ -719,9 +720,9 @@ impl<C: Connection> SurrealUserRepository<C> {
         ip_address: Option<String>,
         user_agent: Option<String>,
     ) -> AxiamResult<User> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
-        let consent_id = Uuid::new_v4().to_string();
+        let consent_id = new_id().to_string();
         let tenant_id_str = input.tenant_id.to_string();
         // SECHRD-12/T-24-93 (RESEARCH Pitfall 5): admin-created users go
         // through this write path, so their initial password must be seeded
@@ -731,7 +732,7 @@ impl<C: Connection> SurrealUserRepository<C> {
         // work against for these users. Federated-user creation paths
         // (oidc.rs/saml.rs) have no local password and are intentionally
         // left untouched.
-        let ph_id_str = Uuid::new_v4().to_string();
+        let ph_id_str = new_id().to_string();
 
         let password_hash = password::hash_password(&input.password, self.pepper.as_deref())
             .map_err(|e| classify_write_error(e, "user"))?;

--- a/crates/axiam-db/src/repository/webauthn_credential.rs
+++ b/crates/axiam-db/src/repository/webauthn_credential.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`WebauthnCredentialRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::webauthn_credential::{
     CreateWebauthnCredential, WebauthnCredential, WebauthnCredentialType,
 };
@@ -105,7 +106,7 @@ impl<C: Connection> SurrealWebauthnCredentialRepository<C> {
 
 impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRepository<C> {
     async fn create(&self, input: CreateWebauthnCredential) -> AxiamResult<WebauthnCredential> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let id_str = id.to_string();
 
         let result = self

--- a/crates/axiam-db/src/repository/webhook.rs
+++ b/crates/axiam-db/src/repository/webhook.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`WebhookRepository`].
 
 use axiam_core::error::AxiamResult;
+use axiam_core::id::new_id;
 use axiam_core::models::webhook::{CreateWebhook, RetryPolicy, UpdateWebhook, Webhook};
 use axiam_core::repository::{PaginatedResult, Pagination, WebhookRepository};
 use chrono::{DateTime, Utc};
@@ -108,7 +109,7 @@ impl<C: Connection> SurrealWebhookRepository<C> {
 
 impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
     async fn create(&self, input: CreateWebhook) -> AxiamResult<Webhook> {
-        let id = Uuid::new_v4();
+        let id = new_id();
         let retry = input.retry_policy.unwrap_or_default();
         let result = self
             .db

--- a/crates/axiam-federation/src/oidc.rs
+++ b/crates/axiam-federation/src/oidc.rs
@@ -557,6 +557,9 @@ where
             .clone()
             .unwrap_or_else(|| format!("{}.{}@federated.local", claims.sub, config_id));
 
+        // Deliberately v4, not `new_id()`: a non-usable password must still be
+        // unguessable, and v7 trades randomness for a sortable timestamp.
+        // See `axiam_core::id` — v7 is for identifiers, never for secrets.
         let random_password = Uuid::new_v4().to_string();
 
         let create_user = CreateUser {

--- a/crates/axiam-federation/src/saml.rs
+++ b/crates/axiam-federation/src/saml.rs
@@ -264,6 +264,9 @@ where
 
         let idp = self.fetch_idp_metadata(metadata_url).await?;
 
+        // Deliberately v4, not `new_id()`: the AuthnRequest ID is echoed back
+        // in `InResponseTo` and gates replay detection, so it must not be
+        // predictable from the request's timing.
         let authn_request_id = format!("_{}", Uuid::new_v4());
         let authn_request = AuthnRequest {
             id: authn_request_id.clone(),
@@ -711,6 +714,11 @@ where
 
         // Federated users get a random non-usable password since they
         // authenticate through the external IdP.
+        //
+        // Deliberately v4, not `new_id()`: this value must be unguessable, and
+        // a v7 id spends 48 bits on a timestamp that an attacker can bound from
+        // the user's creation time. See `axiam_core::id` — v7 is for
+        // identifiers, never for secrets.
         let random_password = Uuid::new_v4().to_string();
 
         let create_user = CreateUser {

--- a/crates/axiam-pki/src/pgp.rs
+++ b/crates/axiam-pki/src/pgp.rs
@@ -1,6 +1,7 @@
 //! OpenPGP key management — generation, audit signing, and encryption.
 
 use axiam_core::error::{AxiamError, AxiamResult};
+use axiam_core::id::new_id;
 use axiam_core::models::audit::AuditLogEntry;
 use axiam_core::models::pgp_key::{
     CreatePgpKey, EncryptedExport, GeneratedPgpKey, PgpKey, PgpKeyAlgorithm, PgpKeyPurpose,
@@ -187,7 +188,7 @@ impl<R: PgpKeyRepository> PgpService<R> {
         .map_err(|e| AxiamError::Internal(format!("spawn_blocking join error: {e}")))??;
 
         Ok(SignedAuditBatch {
-            batch_id: Uuid::new_v4(),
+            batch_id: new_id(),
             tenant_id,
             signing_key_id: signing_key.id,
             entry_ids: entry_ids_clone,

--- a/crates/axiam-server/src/cleanup.rs
+++ b/crates/axiam-server/src/cleanup.rs
@@ -575,6 +575,10 @@ impl<C: Connection + Send + Sync + 'static> CleanupTask<C> {
             .map_err(|e| AxiamError::Internal(format!("export encrypt failed: {e}")))?;
 
         // (d) Generate single-use 24h download token (D-13).
+        //
+        // Deliberately v4, not `new_id()`: this token is the sole bearer
+        // credential for the export download, so it must stay maximally random.
+        // See `axiam_core::id` — v7 is for identifiers, never for secrets.
         let raw_download_token = Uuid::new_v4().to_string();
         let token_hash = {
             use sha2::{Digest, Sha256};

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -665,7 +665,44 @@ async fn main() -> std::io::Result<()> {
         http_client.clone(),
     );
 
+    // G7: resolve the deployment rate-limit posture BEFORE validation and
+    // before `config.rate_limit` / `config.grpc` are cloned into the App
+    // factory and the gRPC task. `AXIAM__RATE_LIMIT__PROFILE` (default
+    // `internet`) presets the machine-traffic family — key mode, token,
+    // introspect, revoke, REST authz and the gRPC authz ceiling — as one
+    // coherent unit; any `AXIAM__RATE_LIMIT__*` / `AXIAM__GRPC__*` env var the
+    // operator set explicitly still wins. Human endpoints (login, register,
+    // password reset, MFA) are never preset — see `RateLimitProfile`.
+    let mut rate_limit_posture = config.rate_limit.apply_profile_from_env();
+    if let Some(per_sec) = rate_limit_posture.grpc_authz_per_sec_preset
+        && !config.grpc.apply_rate_limit_preset_from_env(per_sec)
+    {
+        rate_limit_posture
+            .operator_overrides
+            .push(axiam_api_grpc::config::ENV_GRPC_AUTHZ_PER_SEC);
+    }
+
     config.rate_limit.validate();
+
+    // G7: one non-secret line stating the posture this process is actually
+    // enforcing, so an operator can see what they shipped (all values are
+    // configuration, never credentials).
+    tracing::info!(
+        profile = config.rate_limit.profile.as_str(),
+        preset_applied = rate_limit_posture.preset_applied,
+        key_mode = config.rate_limit.key.as_str(),
+        login_per_min = config.rate_limit.login_per_min,
+        register_per_min = config.rate_limit.register_per_min,
+        password_reset_per_min = config.rate_limit.password_reset_per_min,
+        mfa_per_min = config.rate_limit.mfa_per_min,
+        token_per_min = config.rate_limit.token_per_min,
+        introspect_per_min = config.rate_limit.introspect_per_min,
+        revoke_per_min = config.rate_limit.revoke_per_min,
+        authz_check_per_min = config.rate_limit.authz_check_per_min,
+        grpc_authz_per_sec = config.grpc.grpc_authz_per_sec,
+        operator_overrides = %rate_limit_posture.overrides_display(),
+        "Rate-limit posture active"
+    );
 
     let bind_addr = config.server.bind_address();
     let server_config = config.server.clone();
@@ -1105,32 +1142,36 @@ async fn main() -> std::io::Result<()> {
         }
     });
 
+    // G8/B2: optional HTTP/2 window tuning for the TLS bind. Unset keys are
+    // never forwarded to actix, so the default build is bit-identical to
+    // before. See `axiam_server::tls::Http2Tuning`.
+    let h2_tuning = axiam_server::tls::Http2Tuning::load()?;
+    let mut http_server = http_server;
+    if let Some(size) = h2_tuning.initial_stream_window_size {
+        http_server = http_server.h2_initial_window_size(size);
+    }
+    if let Some(size) = h2_tuning.initial_connection_window_size {
+        http_server = http_server.h2_initial_connection_window_size(size);
+    }
+
     // Bind plaintext (proxy-terminated TLS, the default) or, when
     // `server.tls.enabled`, bind with rustls restricted to TLS 1.3 (F-04 /
     // ASVS V9.1.2). `build_rustls_server_config` fails fast on any cert/key
     // misconfiguration, so a misconfigured TLS server never starts insecurely.
     let http_server = if tls_config.enabled {
+        // Also fails fast on `http2=false`, which the actix rustls bind cannot
+        // honour (it re-prepends h2 to ALPN) — see `axiam_server::tls`.
         let rustls_config = axiam_server::tls::build_rustls_server_config(&tls_config)?;
         tracing::info!(
             bind = %bind_addr,
-            http2_offered = tls_config.http2,
+            alpn = "h2,http/1.1",
             resumption = "tls1.3-tickets",
             early_data = false,
+            h2_stream_window = h2_tuning.effective_stream_window(),
+            h2_connection_window = h2_tuning.effective_connection_window(),
+            h2_tuning_default = h2_tuning.is_default(),
             "Direct TLS enabled — negotiating TLS 1.3 only"
         );
-        // B2 honesty: the http2=false knob narrows the rustls config's ALPN to
-        // http/1.1, but actix-web's rustls HttpService re-adds h2 to ALPN, so
-        // h2 still wins negotiation on this bind. Warn so an operator expecting
-        // a true http/1.1-only listener is not misled.
-        if !tls_config.http2 {
-            tracing::warn!(
-                "server.tls.http2=false requested: the rustls config advertises http/1.1 only, \
-                 but the actix-web rustls HttpServer bind unconditionally re-adds h2 to ALPN, so \
-                 h2 remains offered and preferred. For a genuine http/1.1-only TLS listener (e.g. \
-                 the p2 h2-isolation benchmark cell) front the server with the tls13-h1 nginx edge. \
-                 See docs/security-profiles.md."
-            );
-        }
         http_server.bind_rustls_0_23(&bind_addr, rustls_config)?
     } else {
         http_server.bind(&bind_addr)?

--- a/crates/axiam-server/src/tls.rs
+++ b/crates/axiam-server/src/tls.rs
@@ -29,25 +29,214 @@ use rustls::{RootCertStore, ServerConfig};
 /// value is plenty for a benchmark/service workload and caps memory.
 const RESUMPTION_CACHE_SIZE: usize = 512;
 
-/// The ALPN protocol list the rustls listener is *built with*, given the
-/// `http2` knob.
+/// The ALPN protocol list the rustls listener is built with.
 ///
-/// **Important caveat (B2):** for the REST listener this list is only fully
-/// authoritative when the rustls `ServerConfig` is used directly. actix-web's
-/// `HttpServer::bind_rustls_0_23` path funnels through
-/// `actix_http::HttpService::rustls_0_23_with_config`, which unconditionally
-/// **prepends** `["h2", "http/1.1"]` to whatever `alpn_protocols` we set. So
-/// with the current actix bind, `http2 = false` narrows the config's list to
-/// `http/1.1` but h2 is re-added and still wins negotiation. A *true*
-/// http/1.1-only TLS listener therefore requires either fronting with the
-/// `tls13-h1` nginx edge (see the benchmarks) or an H1-only actix service.
-/// This helper is unit-tested and records operator intent; it is authoritative
-/// for any non-actix consumer of the config.
-fn alpn_protocols(http2: bool) -> Vec<Vec<u8>> {
-    if http2 {
-        vec![b"h2".to_vec(), b"http/1.1".to_vec()]
-    } else {
-        vec![b"http/1.1".to_vec()]
+/// This is exactly what the actix-web rustls bind ends up advertising, and it
+/// is **not** configurable — see [`reject_unsupported_http2_knob`] for the
+/// source-level proof.
+fn alpn_protocols() -> Vec<Vec<u8>> {
+    vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+}
+
+/// Reject `server.tls.http2 = false`, which the native listener **cannot**
+/// honour.
+///
+/// # Why this is a hard error rather than a warning (G8)
+///
+/// The knob used to narrow the rustls `ServerConfig`'s ALPN list to
+/// `http/1.1`, log a warning, and then serve h2 anyway. That is the worst of
+/// both worlds: an operator (or a benchmark cell) can *believe* the listener is
+/// HTTP/1.1-only while every client still negotiates h2. Startup now fails, in
+/// the same fail-fast style as every other misconfiguration in this module.
+///
+/// The knob is unimplementable on this bind, verified against the exact
+/// versions in `Cargo.lock` (actix-web 4.14.0 / actix-http 3.13.1 /
+/// rustls 0.23.42):
+///
+/// * `actix_web::HttpServer::bind_rustls_0_23` (actix-web-4.14.0
+///   `src/server.rs:587`) delegates to `listen_rustls_0_23_inner`
+///   (`src/server.rs:1006`), which finishes with
+///   `.rustls_0_23_with_config(config, acceptor_config)`.
+/// * `actix_http::HttpService::rustls_0_23_with_config` (actix-http-3.13.1
+///   `src/service.rs:735`) then does, unconditionally:
+///
+///   ```text
+///   let mut protos = vec![b"h2".to_vec(), b"http/1.1".to_vec()];   // :747
+///   protos.extend_from_slice(&config.alpn_protocols);              // :748
+///   config.alpn_protocols = protos;                                // :749
+///   ```
+///
+///   so `h2` always lands at index 0 of the effective list. Every actix TLS
+///   bind documents this ("ALPN protocols "h2" and "http/1.1" are added to any
+///   configured ones") and every one of them shares the prepend.
+/// * rustls picks the ALPN protocol by **server** preference order —
+///   `our_protocols.iter().find(|ours| their_protocols.contains(ours))` in
+///   rustls-0.23.42 `src/server/hs.rs:99-108` — so index 0 wins for any client
+///   offering h2. Appending to the list can never outrank the prepended `h2`.
+/// * The h2 support cannot be compiled out either: actix-web's `rustls-0_23`
+///   feature *implies* `http2` (actix-web-4.14.0 `Cargo.toml`,
+///   `rustls-0_23 = ["__tls", "http2", ...]`), and the ALPN prepend lives in a
+///   module gated only on `rustls-0_23`, not on `http2`.
+///
+/// A genuinely `http/1.1`-only TLS 1.3 listener is therefore available only by:
+/// 1. fronting the plaintext bind with the `tls13-h1` nginx edge
+///    (`benchmarks/targets/axiam/tls/tls13-h1.conf`) — what the G8 conviction
+///    cell uses; or
+/// 2. abandoning `actix_web::HttpServer` for this bind and driving
+///    `actix_http::H1Service::rustls_0_23` (actix-http-3.13.1
+///    `src/h1/service.rs:371`) directly on an `actix_server::Server` — that
+///    constructor is the one rustls service factory in the tree that does
+///    **not** touch `alpn_protocols`. See
+///    `claude_dev/b2-tls-h2-investigation.md` for why that rewrite is not
+///    justified today.
+fn reject_unsupported_http2_knob(tls: &TlsConfig) -> io::Result<()> {
+    if tls.http2 {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "server.tls.http2=false is not supported by the native TLS listener: \
+         actix-web's rustls bind unconditionally prepends \"h2\" to the ALPN \
+         list (actix-http HttpService::rustls_0_23_with_config), and rustls \
+         selects by server preference, so h2 would still be negotiated. \
+         Refusing to start rather than silently serving the opposite of what \
+         was configured. For an http/1.1-only TLS 1.3 endpoint, leave \
+         server.tls disabled and terminate TLS at an edge that does not enable \
+         HTTP/2 (see benchmarks/targets/axiam/tls/tls13-h1.conf and \
+         docs/security-profiles.md).",
+    ))
+}
+
+/// Maximum legal HTTP/2 flow-control window, `2^31 - 1` (RFC 9113 §6.5.2;
+/// `h2::frame::settings::MAX_INITIAL_WINDOW_SIZE` in h2 0.4.15).
+const MAX_H2_WINDOW_SIZE: u32 = (1 << 31) - 1;
+
+/// actix-http 3.13.1's default initial **stream** window (`src/config.rs:19`,
+/// `DEFAULT_H2_STREAM_WINDOW_SIZE`). Recorded so operators can see what an
+/// unset knob means; never written into the builder.
+pub const ACTIX_DEFAULT_H2_STREAM_WINDOW: u32 = 1024 * 1024;
+
+/// actix-http 3.13.1's default initial **connection** window
+/// (`src/config.rs:14`, `DEFAULT_H2_CONN_WINDOW_SIZE`).
+pub const ACTIX_DEFAULT_H2_CONNECTION_WINDOW: u32 = 2 * 1024 * 1024;
+
+/// HTTP/2 tuning surface for the native TLS listener (G8/B2).
+///
+/// h2 is only ever negotiated on the rustls bind (the plaintext bind is served
+/// as HTTP/1.1 — `HttpServer::bind` never calls `listen_auto_h2c`), so these
+/// keys live next to the TLS ones and are a no-op when `server.tls.enabled` is
+/// false.
+///
+/// **Every field defaults to `None`, and `None` means "do not call the actix
+/// setter at all"** — an unset config reproduces today's behaviour byte for
+/// byte, because `actix_web::HttpServer` itself stores these as `Option`s and
+/// only forwards them to `HttpService` when `Some`
+/// (actix-web-4.14.0 `src/server.rs:1041-1048`).
+///
+/// | Env var | Type | Unset ⇒ actix default |
+/// |---|---|---|
+/// | `AXIAM__SERVER__H2__INITIAL_STREAM_WINDOW_SIZE` | `u32` bytes | 1 MiB |
+/// | `AXIAM__SERVER__H2__INITIAL_CONNECTION_WINDOW_SIZE` | `u32` bytes | 2 MiB |
+///
+/// # What is deliberately *not* exposed
+///
+/// * **`max_concurrent_streams`** — actix-http 3.13.1 never sets it. Its h2
+///   handshake builder (`src/h2/mod.rs:60-71`) calls only
+///   `initial_window_size` and `initial_connection_window_size`; the underlying
+///   `h2::server::Builder::max_concurrent_streams` (h2-0.4.15
+///   `src/server.rs:858`) exists but is unreachable, and neither
+///   `actix_http::HttpServiceBuilder` nor `actix_web::HttpServer` re-exports
+///   it. Because actix never sends `SETTINGS_MAX_CONCURRENT_STREAMS`
+///   (`h2::frame::Settings` derives `Default`, i.e. `None`), the server
+///   advertises *no* stream limit — so a stream cap is provably **not** the
+///   cause of the B2 concurrency ceiling, and inventing a knob for it here
+///   would be a lie.
+/// * **keep-alive** — `HttpServer::keep_alive` exists but is shared by h1 and
+///   h2 and does not bear on a multiplexed-connection ceiling: the single h2
+///   connection stays open for the whole run either way. Changing it would
+///   alter p0 and p2 alike, so it is not a B2 lever.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Http2Tuning {
+    /// `SETTINGS_INITIAL_WINDOW_SIZE` advertised per stream, in bytes.
+    pub initial_stream_window_size: Option<u32>,
+    /// Connection-level receive window, in bytes.
+    pub initial_connection_window_size: Option<u32>,
+}
+
+impl Http2Tuning {
+    /// Load the `server.h2` subtree using the same sources and idiom as the
+    /// main `AppConfig` loader (`config/default.toml` + `AXIAM__*` env with a
+    /// `__` separator).
+    ///
+    /// An absent subtree yields [`Self::default`] (all `None`).
+    pub fn load() -> io::Result<Self> {
+        let sources = config::Config::builder()
+            .add_source(config::File::with_name("config/default").required(false))
+            .add_source(config::Environment::with_prefix("AXIAM").separator("__"))
+            .build()
+            .map_err(|e| io::Error::other(format!("failed to load configuration: {e}")))?;
+
+        let tuning = match sources.get::<Self>("server.h2") {
+            Ok(t) => t,
+            // Nothing configured at all — keep actix's defaults.
+            Err(config::ConfigError::NotFound(_)) => Self::default(),
+            Err(e) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("invalid server.h2 configuration: {e}"),
+                ));
+            }
+        };
+        tuning.validate()?;
+        Ok(tuning)
+    }
+
+    /// Reject window sizes HTTP/2 cannot express, so a typo fails at startup
+    /// rather than at the first h2 handshake (`h2::server::Builder` asserts
+    /// `size <= MAX_WINDOW_SIZE` and would panic inside a worker).
+    fn validate(&self) -> io::Result<()> {
+        for (name, value) in [
+            (
+                "initial_stream_window_size",
+                self.initial_stream_window_size,
+            ),
+            (
+                "initial_connection_window_size",
+                self.initial_connection_window_size,
+            ),
+        ] {
+            let Some(v) = value else { continue };
+            if v == 0 || v > MAX_H2_WINDOW_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "server.h2.{name} must be between 1 and {MAX_H2_WINDOW_SIZE} \
+                         bytes (RFC 9113 §6.5.2); got {v}"
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// True when nothing is configured, i.e. actix's defaults are untouched.
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// The window actix will actually use per stream (configured or default) —
+    /// for the startup log line only.
+    pub fn effective_stream_window(&self) -> u32 {
+        self.initial_stream_window_size
+            .unwrap_or(ACTIX_DEFAULT_H2_STREAM_WINDOW)
+    }
+
+    /// The window actix will actually use per connection (configured or
+    /// default) — for the startup log line only.
+    pub fn effective_connection_window(&self) -> u32 {
+        self.initial_connection_window_size
+            .unwrap_or(ACTIX_DEFAULT_H2_CONNECTION_WINDOW)
     }
 }
 
@@ -132,8 +321,13 @@ fn build_client_cert_verifier(
 ///
 /// Fails fast (returning an `io::Error` that aborts startup) when TLS is enabled
 /// but misconfigured: a missing `cert_path`/`key_path`, an unreadable or
-/// malformed PEM file, an empty cert chain, or a cert/key mismatch.
+/// malformed PEM file, an empty cert chain, a cert/key mismatch, or an
+/// unsatisfiable `http2 = false` request (see [`reject_unsupported_http2_knob`]).
 pub fn build_rustls_server_config(tls: &TlsConfig) -> io::Result<ServerConfig> {
+    // Checked before any file IO: an unsatisfiable ALPN request is a config
+    // error regardless of whether the cert/key happen to be readable.
+    reject_unsupported_http2_knob(tls)?;
+
     let cert_path = tls.cert_path.as_ref().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -218,9 +412,9 @@ pub fn build_rustls_server_config(tls: &TlsConfig) -> io::Result<ServerConfig> {
         )
     })?;
 
-    // ALPN (B2): advertise h2+http/1.1 by default, or http/1.1-only when the
-    // operator disables h2. See `alpn_protocols` for the actix-bind caveat.
-    config.alpn_protocols = alpn_protocols(tls.http2);
+    // ALPN (B2/G8): h2 + http/1.1. This is not configurable — `http2 = false`
+    // was rejected above because actix re-prepends h2 regardless.
+    config.alpn_protocols = alpn_protocols();
 
     // TLS 1.3 session resumption (B2). Without a ticketer + session store a
     // rustls server does a *full* handshake on every connection; k6 opens many
@@ -256,18 +450,125 @@ mod tests {
         assert!(tls.key_path.is_none());
     }
 
+    /// The advertised list is fixed: `h2` then `http/1.1`, matching exactly
+    /// what actix-http prepends, so the rustls config and the effective
+    /// listener agree.
     #[test]
-    fn alpn_list_reflects_http2_knob() {
-        assert_eq!(
-            alpn_protocols(true),
-            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
-        );
-        assert_eq!(alpn_protocols(false), vec![b"http/1.1".to_vec()]);
+    fn alpn_list_is_h2_then_http11() {
+        assert_eq!(alpn_protocols(), vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
     }
 
     #[test]
     fn default_offers_http2() {
         assert!(TlsConfig::default().http2);
+        reject_unsupported_http2_knob(&TlsConfig::default())
+            .expect("the default (http2=true) must be accepted");
+    }
+
+    /// G8: `http2=false` is unsatisfiable on the actix rustls bind, so it must
+    /// abort startup instead of quietly serving h2.
+    #[test]
+    fn http2_false_is_rejected_at_startup() {
+        let tls = TlsConfig {
+            enabled: true,
+            http2: false,
+            ..TlsConfig::default()
+        };
+        let err = reject_unsupported_http2_knob(&tls)
+            .expect_err("http2=false must be rejected, not silently ignored");
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+        assert!(err.to_string().contains("not supported"), "got: {err}");
+    }
+
+    /// The rejection must fire before any cert/key IO, so the operator sees the
+    /// real problem even on an otherwise-valid TLS config.
+    #[test]
+    fn http2_false_rejected_even_with_valid_cert_and_key() {
+        let pki = gen_test_pki();
+        let tls = TlsConfig {
+            enabled: true,
+            http2: false,
+            cert_path: Some(write_tmp("h2knob-cert", &pki.server_cert_pem)),
+            key_path: Some(write_tmp("h2knob-key", &pki.server_key_pem)),
+            ..TlsConfig::default()
+        };
+        let err = build_rustls_server_config(&tls)
+            .expect_err("http2=false must abort the build even with a good keypair");
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    // ---------------------------------------------------------------------
+    // G8 — HTTP/2 tuning surface
+    // ---------------------------------------------------------------------
+
+    /// Unset means "never call the actix setter", i.e. today's behaviour.
+    #[test]
+    fn h2_tuning_defaults_to_untouched_actix_behaviour() {
+        let t = Http2Tuning::default();
+        assert!(t.is_default());
+        assert_eq!(t.initial_stream_window_size, None);
+        assert_eq!(t.initial_connection_window_size, None);
+        assert_eq!(t.effective_stream_window(), ACTIX_DEFAULT_H2_STREAM_WINDOW);
+        assert_eq!(
+            t.effective_connection_window(),
+            ACTIX_DEFAULT_H2_CONNECTION_WINDOW
+        );
+        t.validate().expect("the default must validate");
+    }
+
+    /// The recorded actix defaults must match actix-http 3.13.1's constants
+    /// (`DEFAULT_H2_STREAM_WINDOW_SIZE` = 1 MiB,
+    /// `DEFAULT_H2_CONN_WINDOW_SIZE` = 2 MiB).
+    #[test]
+    fn recorded_actix_h2_defaults_match_upstream() {
+        assert_eq!(ACTIX_DEFAULT_H2_STREAM_WINDOW, 1_048_576);
+        assert_eq!(ACTIX_DEFAULT_H2_CONNECTION_WINDOW, 2_097_152);
+    }
+
+    #[test]
+    fn h2_tuning_accepts_the_legal_window_range() {
+        for v in [1u32, 65_535, 1 << 20, MAX_H2_WINDOW_SIZE] {
+            let t = Http2Tuning {
+                initial_stream_window_size: Some(v),
+                initial_connection_window_size: Some(v),
+            };
+            t.validate()
+                .unwrap_or_else(|e| panic!("{v} must be legal: {e}"));
+            assert!(!t.is_default());
+            assert_eq!(t.effective_stream_window(), v);
+            assert_eq!(t.effective_connection_window(), v);
+        }
+    }
+
+    #[test]
+    fn h2_tuning_rejects_zero_and_oversized_windows() {
+        for bad in [0u32, MAX_H2_WINDOW_SIZE + 1] {
+            let stream = Http2Tuning {
+                initial_stream_window_size: Some(bad),
+                initial_connection_window_size: None,
+            };
+            let err = stream
+                .validate()
+                .expect_err("illegal stream window must fail fast");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+            assert!(
+                err.to_string().contains("initial_stream_window_size"),
+                "got: {err}"
+            );
+
+            let conn = Http2Tuning {
+                initial_stream_window_size: None,
+                initial_connection_window_size: Some(bad),
+            };
+            let err = conn
+                .validate()
+                .expect_err("illegal connection window must fail fast");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+            assert!(
+                err.to_string().contains("initial_connection_window_size"),
+                "got: {err}"
+            );
+        }
     }
 
     #[test]
@@ -492,8 +793,8 @@ mod tests {
         };
         let config = build_rustls_server_config(&tls)
             .expect("server config with client_auth off must build");
-        // Sanity: default ALPN (http2 defaults to true) is wired through.
-        assert_eq!(config.alpn_protocols, alpn_protocols(true));
+        // Sanity: the fixed h2 + http/1.1 ALPN list is wired through.
+        assert_eq!(config.alpn_protocols, alpn_protocols());
     }
 
     /// A CA bundle file whose content isn't valid PEM at all (garbage bytes

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,10 @@ gRPC (Protocol Buffers), and AMQP (AsyncAPI).
 - [`deployment/README.md`](./deployment/README.md) — Docker Compose and
   Kubernetes deployment guide: required environment variables, secrets, and
   NetworkPolicies
+- [`deployment/rate-limit-sizing.md`](./deployment/rate-limit-sizing.md) —
+  sizing your rate limits: the measured hardware envelope, the
+  `internet`/`gateway`/`mesh` posture presets, and the security caveats of
+  per-client keying
 
 ## Admin & PKI guides
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -197,6 +197,14 @@ layers derive their bucket key the same way.
 | `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN` | Max authz-check requests per minute per key (default `300`). |
 | `AXIAM__RATE_LIMIT__TRUSTED_HOPS` | Number of trusted reverse-proxy hops to skip from the right of `X-Forwarded-For` when deriving the client IP (default `0` — set to `1` behind a single ingress/nginx). |
 | `AXIAM__RATE_LIMIT__KEY` | Bucket-key derivation mode: `ip` (default) \| `client_id` \| `ip_client_id`. See below. |
+| `AXIAM__RATE_LIMIT__PROFILE` | Deployment posture preset: `internet` (default — the shipped values above, unchanged) \| `gateway` \| `mesh`. Sets the machine-traffic family (key mode, token/introspect/revoke/authz, and the gRPC authz ceiling) coherently in one variable; never changes the human endpoints. See [Sizing your rate limits](rate-limit-sizing.md). |
+
+> **Which numbers should you actually run?** See
+> **[Sizing your rate limits](rate-limit-sizing.md)** — the measured hardware
+> envelope, the `gateway`/`mesh` presets, how to size by hand, and the
+> security caveats that come with per-client keying. The shipped defaults are
+> tuned for a small internet-facing deployment and are known to be too strict
+> for a NAT'd M2M fleet.
 
 ### `AXIAM__RATE_LIMIT__KEY` — NAT'd-fleet key configurability (D8)
 

--- a/docs/deployment/rate-limit-sizing.md
+++ b/docs/deployment/rate-limit-sizing.md
@@ -1,0 +1,246 @@
+# Sizing your rate limits
+
+AXIAM ships with rate limits **on by default**. That is deliberate — most
+IAM servers ship with none — but it means the shipped numbers are a
+*posture choice*, and the right posture depends on who is calling you.
+
+This page tells you which posture you are in, what the measured hardware
+envelope is, and how to move the limits without quietly turning the
+anti-abuse controls off.
+
+- Mechanism, layering and the `AXIAM__RATE_LIMIT__KEY` semantics:
+  [Deployment Guide § Rate limiting](README.md#rate-limiting).
+- Source of truth for the shipped values:
+  [`crates/axiam-api-rest/src/config/rate_limit.rs`](../../crates/axiam-api-rest/src/config/rate_limit.rs).
+  The table below is checked against that file by a unit test
+  (`cargo test -p axiam-api-rest --lib rate_limit`), so it cannot silently
+  drift from the code.
+
+---
+
+## 1. The one-line summary
+
+| You are… | Use | Why |
+|---|---|---|
+| A small internet-facing deployment; humans log in from many IPs | the shipped defaults (`internet`) | The defaults are sized to stop single-source credential-stuffing and token-probing floods. |
+| An M2M / microservice / IoT fleet reaching AXIAM through a shared NAT or egress gateway | `AXIAM__RATE_LIMIT__PROFILE=gateway` | Many distinct OAuth2 clients share one source IP; per-IP buckets collide and the fleet throttles itself. |
+| Reachable only on a private network / service mesh | `AXIAM__RATE_LIMIT__PROFILE=mesh` | Ceilings become runaway-loop guards; abuse control lives at the network edge. |
+
+Presets are **opt-in**. Setting no profile keeps the shipped defaults
+byte-for-byte. **No profile ever changes the human endpoints**
+(`login`, `register`, `password_reset`, `mfa`) — those stay strict and
+per-IP in every posture. Raise them only deliberately, one env var at a
+time, and read §5 first.
+
+---
+
+## 2. The evidence (why this page exists)
+
+From benchmark run 3 (2026-07-25/26, `1.0.0-alpha19`,
+[`benchmarks/PUBLIC_BENCH_ANALYSIS.md`](../../benchmarks/PUBLIC_BENCH_ANALYSIS.md)
+§4/§6):
+
+- With the **shipped defaults**, a 50-VU load generator on a **single
+  source IP** was flattened to ~0–14 req/s on every limited endpoint at
+  ~100% `429` (client-credentials 0.9/s, introspection 0.4/s). Unlimited
+  paths in the same pass were untouched — JWKS served 27 700/s. The limits
+  work exactly as designed.
+- The **same 2-core server** sustains ~1 800 token issuances/s and
+  ~740–2 300 authz checks/s when unthrottled.
+
+Both facts are true at once. A single IP producing 10 token requests per
+second is an attacker on a small public deployment and a perfectly normal
+Tuesday for a NAT'd device fleet. The defaults cannot serve both, so AXIAM
+keeps the strict posture as the default and makes the machine-scale
+posture an explicit, logged choice.
+
+### Measured envelope (what the hardware did)
+
+Reproduced from the public analysis §6. **These are laptop-class
+measurements** (Docker containers pinned to 2 cores / 1 GiB each, on a
+developer machine) and are **explicitly temporary** — they exist to give
+you a starting order of magnitude, not an SLA. Re-measure on your own
+hardware before committing to a number.
+
+| Envelope (server / DB) | Token issuance | Introspection | Authz checks (cache off / on) | Userinfo | Logins (Argon2id, OWASP params) |
+|---|---|---|---|---|---|
+| 2 cores / 2 cores | ~1 800/s | ~2 200/s | ~740 / ~2 300/s | ~5 000/s | ~69/s |
+| 2 cores / 4 cores | ~1 800/s | ~2 200/s | ~1 000 / higher | ~7 500/s (server-bound) | ~69/s |
+
+Two shape facts that matter more than the absolute numbers:
+
+1. **Authz checks and userinfo scale with database CPU**; token issuance
+   does not (it is server-CPU bound until ~1 800/s per 2 cores).
+2. **Logins are Argon2id-bound** at ~69/s per 2 cores. Login limits are a
+   password-guessing control, but they are also the one place where a
+   flood costs you real CPU — another reason not to raise them casually.
+
+---
+
+## 3. The postures
+
+`AXIAM__RATE_LIMIT__PROFILE` = `internet` (default) | `gateway` | `mesh`.
+It sets the whole machine-traffic family — key mode, token, introspect,
+revoke, REST authz, and the gRPC authz ceiling — coherently, so you cannot
+half-apply it.
+
+**Precedence: an explicit env var always beats the preset, which always
+beats the shipped default.** If you set `AXIAM__RATE_LIMIT__TOKEN_PER_MIN`
+yourself, the profile leaves it alone (and the startup log names it in
+`operator_overrides`).
+
+<!-- rate-limit-posture-table:begin -->
+| Env var | `internet` (shipped default) | `gateway` | `mesh` |
+|---|---|---|---|
+| `AXIAM__RATE_LIMIT__KEY` | `ip` | `client_id` | `client_id` |
+| `AXIAM__RATE_LIMIT__LOGIN_PER_MIN` | 10 | 10 | 10 |
+| `AXIAM__RATE_LIMIT__REGISTER_PER_MIN` | 5 | 5 | 5 |
+| `AXIAM__RATE_LIMIT__PASSWORD_RESET_PER_MIN` | 3 | 3 | 3 |
+| `AXIAM__RATE_LIMIT__MFA_PER_MIN` | 5 | 5 | 5 |
+| `AXIAM__RATE_LIMIT__TOKEN_PER_MIN` | 20 | 600 | 6000 |
+| `AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN` | 10 | 6000 | 60000 |
+| `AXIAM__RATE_LIMIT__REVOKE_PER_MIN` | 10 | 600 | 6000 |
+| `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN` | 300 | 6000 | 60000 |
+| `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` | 100 | 1000 | 5000 |
+<!-- rate-limit-posture-table:end -->
+
+Per-minute values are **per bucket**, and the bucket is whatever
+`AXIAM__RATE_LIMIT__KEY` selects — per IP under `internet`, per OAuth2
+`client_id` under both presets (on `/oauth2/token`, `/oauth2/revoke`,
+`/oauth2/introspect` only; everything else is always per-IP).
+
+### Where the preset numbers come from
+
+Anchored to the measured envelope above, deliberately as a **small
+fraction of the whole-server ceiling** so that one bucket can never be the
+whole machine:
+
+| Preset value | Derivation |
+|---|---|
+| `gateway` token 600/min | 10/s per client ≈ 0.55% of the measured ~1 800/s server ceiling — ~180 clients running flat out to saturate, so one compromised credential is not a DoS engine. |
+| `gateway` introspect 6 000/min | 10× the token limit; resource servers introspect once per protected request (the public §6 rule of thumb). |
+| `gateway` revoke 600/min | Paired with issuance — revocation is per-token, so it tracks the token rate. |
+| `gateway` authz 6 000/min | 100/s per client, the **low** end of the 6 000–60 000 band in public §6; the server measured ~740/s cache-off in total. |
+| `mesh` token 6 000/min | 100/s per client ≈ 5.6% of the measured ceiling. |
+| `mesh` authz 60 000/min | 1 000/s per client — **above** the measured 740/s cache-off whole-server ceiling. On this hardware it stops a runaway retry loop, not an attacker. Sized honestly, not aspirationally. |
+| gRPC 1 000 / 5 000 per sec | The gRPC authz path measured ~603/s per 2 cores. These are coarse ceilings; see the keying caveat in §5. |
+
+### Turning it on
+
+```bash
+# docker-compose / k8s env
+AXIAM__RATE_LIMIT__PROFILE=gateway
+# …and if one client legitimately needs more than the preset:
+AXIAM__RATE_LIMIT__TOKEN_PER_MIN=2000     # wins over the preset
+```
+
+Behind a NAT/ingress also set `AXIAM__RATE_LIMIT__TRUSTED_HOPS` to the
+number of trusted proxy hops, otherwise every bucket keys on the proxy's
+IP (see [Deployment Guide § Rate limiting](README.md#rate-limiting)).
+
+---
+
+## 4. Sizing by hand
+
+If no preset fits, size from your own traffic rather than from ours:
+
+1. **Measure your per-client peak** over a 1-minute window in production
+   (or staging under load), per endpoint class.
+2. **Multiply by 2** for burst headroom — the limiter is a fixed 60 s
+   window, so a client that bunches its requests at a window boundary can
+   legitimately look 2× peak.
+3. **Sanity-check against the envelope**: the sum of your per-bucket
+   limits × expected concurrent buckets should not exceed what your
+   hardware measured (§2). A limit above the machine's capacity is not a
+   limit, it is documentation.
+4. **Introspection**: 10–20× your token limit if resource servers
+   introspect per request. Consider caching introspection results at the
+   resource server instead.
+5. **Authz checks**: enable `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true`
+   before raising the authz limit — the measured 3× on checks buys more
+   headroom than a bigger number does, and it cuts DB load 40–75%.
+6. **Never size the human endpoints from throughput.** 10 logins/min/IP is
+   not a capacity number; it is the number of password guesses you are
+   willing to let one source make per minute.
+
+---
+
+## 5. Security caveats — read before selecting a preset
+
+**1. `client_id` keying is not an anti-abuse control.** The `client_id` is
+read from the *unauthenticated* form body (`client_secret_post`,
+RFC 6749 §2.3.1) **before** any credential is verified. An attacker can
+rotate `client_id` values and mint a fresh bucket per value. Under
+`client_id` / `ip_client_id`, the token/introspect/revoke limits are a
+**fairness control between cooperating clients**, not a defence against a
+determined attacker — that job moves to your edge (WAF, API gateway,
+mTLS, or IP allow-listing). This is a property of the key modes
+themselves, not of the presets; the presets simply make it the active
+posture, which is why they are opt-in and logged.
+
+**2. A rotating `client_id` also grows the bucket keyspace.** Distinct
+keys accumulate in the in-memory governor and in the shared
+`rate_limit_bucket` table. Neither is unbounded in practice (windows
+expire and the cleanup task sweeps), but a sustained rotation flood is a
+resource-consumption vector, and each rejected request still costs one
+client lookup. Front an internet-exposed `client_id`-mode deployment with
+something that rate-limits by IP before AXIAM sees the request.
+
+**3. The gRPC authz limiter is per-IP only.** There is no client identity
+at the layer that keys it (the `tower` layer runs before tonic resolves
+per-RPC claims), so `AXIAM__GRPC__KEY` is reserved and currently a no-op.
+Behind a shared ingress IP, `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` is a
+**fleet-wide** ceiling, not a per-client one.
+
+**4. Requests with no parseable `client_id` fall back to the IP key.**
+That fallback is fail-safe (it never disables limiting), but note the
+consequence under a preset: an anonymous or malformed flood is then
+metered against the *preset's* larger per-IP number, not the strict
+default. Point 2's advice applies.
+
+**5. Presets cannot detect values set in `config/default.toml`.**
+"Explicitly set" means *an `AXIAM__…` environment variable is present*. A
+value coming from the optional TOML file source looks unset to the preset
+and will be overwritten. Pin it with an env var.
+
+**6. Human endpoints are excluded by construction.** No profile can raise
+`login`, `register`, `password_reset` or `mfa` — the preset struct has no
+field for them. If users arrive through a shared NAT and 10/min/IP is too
+tight, raise `AXIAM__RATE_LIMIT__LOGIN_PER_MIN` explicitly, knowing you
+are widening a password-guessing budget (and remembering that logins cost
+~1/69th of a 2-core server each).
+
+---
+
+## 6. Confirming what you shipped
+
+At boot the server emits exactly one line describing the **active**
+posture — key mode, every per-minute value, the gRPC per-second ceiling,
+whether a preset was applied, and which env vars overrode it:
+
+```json
+{"level":"INFO","fields":{"message":"Rate-limit posture active",
+ "profile":"gateway","preset_applied":true,"key_mode":"client_id",
+ "login_per_min":10,"register_per_min":5,"password_reset_per_min":3,
+ "mfa_per_min":5,"token_per_min":2000,"introspect_per_min":6000,
+ "revoke_per_min":600,"authz_check_per_min":6000,
+ "grpc_authz_per_sec":1000,
+ "operator_overrides":"AXIAM__RATE_LIMIT__TOKEN_PER_MIN"}}
+```
+
+Grep for `Rate-limit posture active` in your startup logs. If
+`operator_overrides` is `none` and `preset_applied` is `false`, you are
+running the shipped internet-facing defaults.
+
+---
+
+## 7. Related
+
+- [Deployment Guide § Rate limiting](README.md#rate-limiting) — mechanism,
+  layers, `AXIAM__RATE_LIMIT__KEY` and `TRUSTED_HOPS` semantics.
+- [`benchmarks/PUBLIC_BENCH_ANALYSIS.md`](../../benchmarks/PUBLIC_BENCH_ANALYSIS.md)
+  §6 — the recommended-settings table these numbers derive from, plus every
+  other tuning knob.
+- [`claude_dev/rate-limit-posture-decision.md`](../../claude_dev/rate-limit-posture-decision.md)
+  — why the defaults were **not** moved, and the abuse-vector analysis
+  behind the preset values.

--- a/docs/security-profiles.md
+++ b/docs/security-profiles.md
@@ -61,23 +61,89 @@ verified peer certificate is present on the connection (i.e. TLS was terminated
 upstream) — so with native mTLS enabled a spoofed header can never assert an
 identity.
 
-### ALPN / HTTP-version (`AXIAM__SERVER__TLS__HTTP2`, default `true`)
+### ALPN / HTTP version — the listener is always `h2` + `http/1.1`
 
-The rustls config is built advertising `h2` + `http/1.1` by default. Setting
-`AXIAM__SERVER__TLS__HTTP2=false` narrows the config's ALPN list to
-`http/1.1` only.
+The native TLS listener advertises `h2` then `http/1.1`, and **this is not
+configurable**.
 
-**Caveat — actix-web re-adds h2.** The REST listener is served through
-actix-web's `HttpServer::bind_rustls_0_23`, whose service factory
-(`actix_http::HttpService::rustls_0_23_with_config`) unconditionally
-**prepends** `["h2", "http/1.1"]` to whatever ALPN we configure. As a result,
-on the actix bind the `http2=false` knob is an *intent signal* — h2 is re-added
-and still wins negotiation. A genuinely `http/1.1`-only TLS 1.3 listener is
-obtained by fronting with the `tls13-h1` nginx edge
-(`benchmarks/targets/axiam/tls/tls13-h1.conf`). The rustls-level list is still
-authoritative for any non-actix consumer of the config and is unit-tested. See
-`benchmarks/PRIVATE_BENCH_ANALYSIS.md` §4.3 for why this matters (the p2 TLS
-throughput asymmetry is primarily an h2-vs-h1.1 effect).
+`AXIAM__SERVER__TLS__HTTP2=false` used to narrow the rustls config's ALPN list,
+log a warning, and then serve h2 anyway. **It now aborts startup** with an
+`Unsupported` error. A setting that silently does the opposite of what it says
+is worse than no setting — especially in a benchmark, where it can manufacture a
+fake "HTTP/1.1 cell".
+
+Why it cannot work (verified against actix-web 4.14.0 / actix-http 3.13.1 /
+rustls 0.23.42, the versions in `Cargo.lock`):
+
+- `HttpServer::bind_rustls_0_23` (actix-web `src/server.rs:587`) routes through
+  `actix_http::HttpService::rustls_0_23_with_config` (actix-http
+  `src/service.rs:735`), which unconditionally **prepends** `["h2",
+  "http/1.1"]` to whatever ALPN list we configure (`src/service.rs:747-749`) —
+  our list is appended, so `h2` is always first.
+- rustls selects ALPN by **server preference order**
+  (rustls `src/server/hs.rs:99-108`), so the prepended `h2` wins for every
+  client that offers it. Appending can never outrank it.
+- h2 cannot be compiled out either: actix-web's `rustls-0_23` feature implies
+  `http2`, and the prepend is gated on `rustls-0_23` alone.
+
+**To serve TLS 1.3 without HTTP/2**, leave `server.tls` disabled and terminate
+TLS at an edge that does not enable HTTP/2 — e.g.
+`benchmarks/targets/axiam/tls/tls13-h1.conf`. There is no in-process option
+short of replacing `HttpServer` with a hand-built `H1Service` listener, which
+AXIAM deliberately does not do.
+
+### HTTP/2 tuning (`AXIAM__SERVER__H2__*`)
+
+Two HTTP/2 flow-control settings are exposed. Both are **unset by default**, and
+unset means the corresponding actix setter is never called — a default
+deployment behaves exactly as it did before these keys existed.
+
+| Env var | Type | Unset ⇒ actix default |
+|---------|------|-----------------------|
+| `AXIAM__SERVER__H2__INITIAL_STREAM_WINDOW_SIZE` | bytes (`u32`) | 1 MiB |
+| `AXIAM__SERVER__H2__INITIAL_CONNECTION_WINDOW_SIZE` | bytes (`u32`) | 2 MiB |
+
+Values outside `1 … 2147483647` (RFC 9113 §6.5.2) are rejected at startup rather
+than panicking inside a worker at the first handshake. These only affect the TLS
+bind — the plaintext bind is HTTP/1.1.
+
+`max_concurrent_streams` is **not** exposed, because actix-http 3.13.1 provides
+no way to set it: its h2 handshake builder configures only the two windows
+(`src/h2/mod.rs:60-71`), and neither `HttpServiceBuilder` nor `HttpServer`
+surfaces the underlying `h2::server::Builder::max_concurrent_streams`. AXIAM
+therefore never sends `SETTINGS_MAX_CONCURRENT_STREAMS`, i.e. it advertises no
+stream limit. Keep-alive is not exposed here either: it is shared by HTTP/1.1
+and HTTP/2 and is not an HTTP/2-specific lever.
+
+### Operational note — one HTTP/2 connection is served by one core
+
+actix pins each accepted TCP connection to a single worker thread
+(actix-server `src/accept.rs:432-438`) and spawns every HTTP/2 stream onto that
+worker's single-threaded runtime (actix-http `src/h2/dispatcher.rs:134-135`;
+`actix_rt::spawn` is `tokio::task::spawn_local`). HTTP/2 multiplexing therefore
+buys header compression and ordering, **not** parallelism: all streams of one
+connection share one core.
+
+Consequences for high-volume callers:
+
+- A single client process holding **one** pooled HTTP/2 connection cannot
+  saturate a multi-core AXIAM instance, no matter how many concurrent requests
+  it multiplexes.
+- Spread high-volume token traffic across **several connections** (client-side
+  pooling, or a stream cap per connection) and across **replicas**. Adding CPUs
+  to one replica only helps when the number of inbound connections is at least
+  the number of workers.
+- AXIAM cannot induce this from the server side: with no advertised
+  `SETTINGS_MAX_CONCURRENT_STREAMS`, a client is never obliged to open a second
+  connection.
+
+This is a property of the actix listener, not of TLS: TLS crypto cost is already
+ruled out by `http_req_tls_handshaking ≈ 0` in the benchmark (session resumption
+works). Whether it materially explains the p2 token-endpoint throughput gap is
+the open question tracked in
+[`claude_dev/b2-tls-h2-investigation.md`](../claude_dev/b2-tls-h2-investigation.md)
+and `benchmarks/PRIVATE_BENCH_ANALYSIS.md` §4.3; the deciding measurement
+(`./run-improvement-tasks.sh g8-tls-h1`) is pending real hardware.
 
 ### Session resumption
 
@@ -119,7 +185,7 @@ override is applied.
 |-----------|------------------------------|---------------|-------|
 | p0        | plaintext HTTP/1.1           | yes           | baseline |
 | p1-tls12  | TLS 1.2                      | **no — N/A-by-policy** | AXIAM is **TLS 1.3-only natively** (per the security standards; ASVS V9.1.2). TLS 1.2 is never offered in-process; a legacy TLS 1.2 endpoint, if ever needed, is an nginx-edge concern outside AXIAM. This profile stays nginx-fronted when run. |
-| p2-tls13  | TLS 1.3 (h2 by default)      | yes (native overlay) | h1-isolation via `tls13-h1.conf` edge |
+| p2-tls13  | TLS 1.3 (always h2 when the client offers it) | yes (native overlay) | h1-isolation is only obtainable via the `tls13-h1.conf` edge — the native listener cannot be made h1-only (see ALPN above) |
 | p3-mtls   | TLS 1.3 + client cert        | **yes (native overlay, D3)** | native mTLS: `docker-compose.native-mtls.yml` sets `CLIENT_AUTH=required` + `CLIENT_CA_PATH=/certs/ca.crt`; no nginx edge. Identity from the verified cert, not a header. |
 
 ### Why p1-tls12 is N/A-by-policy (not "not yet implemented")

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -184,6 +184,16 @@ wins.
 - `AuthzError` MUST carry a `message` field and SHOULD carry the denied `action` and `resource_id` if available from the response body.
 - `NetworkError` MUST carry the underlying OS/transport error as a `cause` (or equivalent chained exception).
 - `OAuthProtocolError`, being an `AuthError` sub-type, MUST satisfy the `AuthError` rule above: its `message` field MUST be present and MUST be `"<error>: <error_description>"`, built from the two `OAuth2ErrorResponse` fields it also exposes individually.
+  - Clarified in contract 1.5: the exactness requirement is on the `message` **field/property**.
+    A language whose error-*rendering* convention prefixes that field (Go `Error()` →
+    `"authentication failed: <message>"`, Rust `Display` via `#[error("authentication failed:
+    {message}")]`) MAY keep the prefix in the rendered string, provided the field itself is
+    exactly `"<error>: <error_description>"`.
+  - Also clarified in contract 1.5: the two individually-exposed field names follow each
+    language's **public-API casing** (`error_description` → `errorDescription` /
+    `ErrorDescription`). Go exports the first as `ErrorCode` rather than `Error`, because a
+    struct field named `Error` would collide with the promoted `Error()` method that satisfies
+    the `error` interface; that rename is conformant.
 - Errors MUST NOT expose raw token strings in their messages, context fields, or stack traces.
 
 ---
@@ -422,10 +432,36 @@ Rules (normative):
 
 All token-carrying fields in all SDKs MUST suppress the token value from any debug, logging, or display output (T-15-09).
 
-**Required behavior:**
-- The raw token string MUST NOT be exposed via any public getter API.
-- Debug/logging representations (`Debug`, `Display` in Rust; `toString`, JSON serialization in JS/TS; `__repr__`, `__str__` in Python; `toString` in Java/Go; `ToString` in C#; `__toString` in PHP) MUST emit a redacted placeholder such as `[SENSITIVE]` or `Sensitive<String>`.
-- SDK internal code THAT NEEDS the raw value accesses it via a crate/module-private method or friend function, not a public API.
+**Required behavior** (restructured in contract 1.5 — see the rationale note below):
+
+1. **Redaction — unconditional MUST.** Debug/logging representations (`Debug`, `Display` in
+   Rust; `toString`, JSON serialization in JS/TS; `__repr__`, `__str__` in Python; `toString`
+   in Java/Go; `ToString` in C#; `__toString` in PHP) MUST emit a redacted placeholder such as
+   `[SENSITIVE]` or `Sensitive<String>`. This covers **every** stringification and
+   structured-serialization sink the language offers, including the ones a naive wrapper
+   misses: Go `%#v`/`fmt.Formatter`/`MarshalJSON`, Node `util.inspect`, Java and C#
+   compiler-generated `record` `toString`, Jackson / `System.Text.Json` /
+   `kotlinx.serialization` writers, and PHP `var_dump`/`print_r`/`var_export`. No other
+   section of this contract relaxes this rule.
+2. **No implicit reachability — MUST.** The raw value MUST NOT be reachable without an
+   explicit, named call: no public field or property, no `Deref`/`AsRef`/implicit conversion
+   operator, no auto-unboxing accessor, and no inherited structural equality that compares the
+   raw value. (A Go named-type conversion — `string(s)` on a `type Sensitive string` — is an
+   *explicit* conversion and is accepted as that language's equivalent of calling the
+   accessor; it is the shape the Go row below prescribes.)
+3. **One explicit accessor — MAY, and RECOMMENDED for §12.** An SDK MAY expose exactly one
+   clearly-named public accessor (`expose`, `reveal`, `get_secret_value`, `Expose`, …)
+   returning the raw value. Where the SDK implements
+   [§12](#§12-oidc--sso-relying-party-helpers) this accessor is RECOMMENDED, because §12 hands
+   `access_token`/`refresh_token`/`id_token` to the **calling application** in the
+   `/oauth2/token` response body rather than to a `Set-Cookie` jar, and the application must be
+   able to read them in order to persist, forward, or later revoke them. An SDK whose accessor
+   stays module-private remains conformant to §7 — but the §12 token set it returns is then
+   unreadable by its own callers, so it SHOULD widen the accessor. Widening a module-private
+   accessor to public is a non-breaking, additive change.
+4. **Point-of-use discipline — MUST.** SDK internal code that needs the raw value calls that
+   accessor (or a module-private equivalent) explicitly, at the point of use, and MUST NOT pass
+   the returned value to any log/trace/serialize sink.
 
 Per-language implementation guidance:
 | Language   | Mechanism                                                         |
@@ -441,6 +477,25 @@ Per-language implementation guidance:
 | Swift      | `struct Sensitive<T>: CustomStringConvertible` whose `description` returns `"[SENSITIVE]"`; not `Encodable` in a way that emits the value |
 | C          | Opaque `axiam_sensitive_t` handle; there is no public accessor returning the raw string, and it is never written to logs/`printf` output |
 | C++        | `class Sensitive<T>` with `operator<<`/`to_string` returning `"[SENSITIVE]"`; raw value only via a private/friend accessor |
+
+The **C** and **C++** rows keep their "no public accessor" wording deliberately: both SDKs defer
+§12 in its entirety ([§12.6](#§126-deferred-sdks-swift-c-c)), so no token material is ever handed
+to their callers outside the §4 cookie jar and rule 3 above has nothing to enable there. Should a
+later §12 port land in either, rule 3 applies to it unchanged.
+
+**Why §7 reads this way (contract 1.5, non-breaking clarification).** Contract 1.4's §7 said
+flatly that "the raw token string MUST NOT be exposed via any public getter API". That was written
+when every token lived only in the §1/§4 `httpOnly` cookie jar, where no caller ever needed one.
+§12 changed the premise: it returns tokens *to* the caller. Read literally, §7 and §12 were
+mutually unsatisfiable, and the eight implementing SDKs resolved it three different ways —
+accessor already public (TypeScript `expose()`, Python `SecretStr.get_secret_value()`, PHP
+`reveal()`, Go's named-type conversion), accessor widened for §12 (Rust `Sensitive::expose()`
+`pub(crate)` → `pub`; C# a new public `Sensitive<T>.Expose()`), or accessor left module-private
+(Java package-private `expose()`, Kotlin `internal expose()`). The rules above separate the
+non-negotiable half — redaction, rule 1 — from the half §12 legitimately needs — an explicit
+accessor, rule 3 — so that all three resolutions are conformant. The point of the wrapper was
+never to make reading a token impossible; it is to make *leaking* one require a deliberate,
+greppable call.
 
 **The token MUST NOT appear in:**
 - Log files (structured or unstructured)
@@ -536,8 +591,29 @@ All SDKs that manage token state (access + refresh tokens) MUST implement a sing
 2. **Result sharing.** After the single in-flight refresh resolves (success or failure), all waiting requesters receive the outcome simultaneously:
    - On success: all waiting requests are retried with the new tokens.
    - On failure: all waiting requests fail with `AuthError`.
+
+   **Observable requirement (clarified in contract 1.5; not a new obligation).** A burst of N
+   concurrent refresh-triggering callers MUST produce exactly **one** refresh wire call, and all
+   N callers MUST receive *that one call's* outcome. Merely serializing the N callers behind a
+   mutex so that each then issues its **own** refresh call is **not** conformant: AXIAM refresh
+   tokens are opaque, server-stored, and **single-use with rotation**, so callers 2..N would
+   replay an already-consumed token and fail with `invalid_grant`. "Exactly one in-flight"
+   (rule 1) and "result sharing" (rule 2) are two halves of one requirement, not alternatives.
 3. **No retry on refresh failure.** A 401 response to the refresh call itself is `AuthError` — the user must re-authenticate. The SDK MUST NOT attempt to refresh again (no retry loop).
 4. **Thread/concurrency safety.** The guard MUST be safe across concurrent goroutines (Go), async tasks (Rust/TS/Python), threads (Java/C#/PHP-Swoole).
+5. **Mechanism is free; a dedicated guard instance is permitted** (added in contract 1.5).
+   Rules 1–4 constrain observable behaviour only. The per-language table below is guidance, not
+   a mandate: an own coalescer holding a shared future/promise/`Deferred`/`Task`, a channel
+   broadcast, a condition variable publishing a shared result, and a semaphore guarding a cached
+   task are all conformant, provided rule 2's observable requirement holds. An operation that
+   needs its own guard because the shared guard's API is specialized to a different token
+   namespace — e.g. the §1 cookie-session access-token freshness comparison, which is
+   meaningless for an OAuth2 `refresh_token` grant — MAY use a **dedicated instance of an
+   equally strong mechanism**; it MUST NOT substitute a weaker one. Where an implementation
+   composes an operation-specific coalescer *with* the shared guard, a **bounded** (never
+   unbounded) wait to acquire the shared guard is permitted, and exhausting that bound MUST
+   raise `AuthError` rather than return a stale token set; the specific bound is an
+   implementation detail and is deliberately **not** part of this contract.
 
 Per-language implementation guidance:
 | Language   | Mechanism                                                         |
@@ -554,7 +630,13 @@ Per-language implementation guidance:
 | C          | `pthread_mutex_t` guarding an in-flight flag + condition variable; waiters block until the single refresh completes |
 | C++        | `std::mutex` + `std::shared_future<TokenPair>` held under the lock   |
 
-**Test requirement:** Each SDK MUST include a test that fires N (≥5) concurrent requests against an expired token and asserts exactly 1 refresh call is made. (See Phase 18 success criterion #2 for Go reference.)
+**Test requirement:** Each SDK MUST include a test that fires N (≥5) concurrent requests against
+an expired token and asserts exactly 1 refresh call is made. (See Phase 18 success criterion #2
+for Go reference.) Clarified in contract 1.5: the test MUST also assert that **all N callers
+received that one call's outcome** (rule 2), and the requirement applies **per refresh
+operation** — an SDK that ships both the §1 `refresh` and the
+[§12](#§12-oidc--sso-relying-party-helpers) `oidc_refresh` needs the test for each, because they
+run on different token namespaces and (per rule 5) may use different guard instances.
 
 ---
 
@@ -722,6 +804,26 @@ verifier, at the `jwks_uri` the discovery document advertises.
    require `?tenant_id=<uuid>` because the client is authenticating *itself* there. The §5
    `X-Tenant-ID` header is still emitted on these requests (§5 rule 2 is unconditional) — the
    header and the query parameter are **not** substitutes for one another.
+
+   **The header and the query parameter may legitimately disagree in form** (documented in
+   contract 1.5). §5 rule 2 emits `X-Tenant-ID` carrying whichever identifier the client was
+   constructed with, which may be a **slug**, while these three endpoints require a **UUID**
+   in `?tenant_id=`. A slug-configured client therefore sends a slug header alongside a UUID
+   query parameter on the same request. This is correct and accepted: the `/oauth2/*` handlers
+   are public paths that read the tenant **only** from the query parameter
+   (`crates/axiam-api-rest/src/handlers/oauth2.rs`, `web::Query<TenantQuery>`) and never
+   inspect `X-Tenant-ID`, so the header is inert there. It is still emitted because §5 rule 2
+   admits no exceptions and because request logging/tracing relies on it.
+
+   **Consequence — a slug-only client cannot call five of the nine operations.** A client
+   constructed with `tenant_slug` and with no prior login to resolve the UUID from cannot call
+   `oidc_exchange`, `oidc_refresh`, `login_client_credentials`, `introspect`, or `revoke`: per
+   [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 4 the SDK MUST raise
+   its taxonomy error client-side rather than send a slug in `tenant_id`. Applications needing
+   those five operations SHOULD construct the client in UUID form, or pass `tenant_id`
+   explicitly per call. `oidc_discover`, `oidc_begin`, `sso_start`, and `sso_complete` are
+   unaffected — the first two touch no tenant-scoped endpoint, and the federation pair carries
+   slug forms in its JSON body (§5.1).
 3. **Client authentication is `client_secret_post`.** `client_id`/`client_secret` travel in the
    form body. The server documents no HTTP Basic (`client_secret_basic`) alternative, so SDKs
    MUST NOT send an `Authorization: Basic` header to `/oauth2/*`.
@@ -729,8 +831,19 @@ verifier, at the `jwks_uri` the discovery document advertises.
    and `RevokeRequest` both mark `token`, `client_id`, and `client_secret` as required
    (non-nullable); `token_type_hint` is optional. A public client cannot call them.
 5. **`revoke` returns no body.** Per RFC 7009 the server answers `200` for unknown, expired,
-   or already-revoked tokens. `revoke` therefore returns void/`Unit`/`nil` and MUST treat any
-   `200` as success. Only `401` (client authentication failed) is an error.
+   or already-revoked tokens. `revoke` therefore returns void/`Unit`/`nil` and MUST treat a
+   `200` as success — including for a token it has never issued (idempotence is the point of
+   RFC 7009), and every implementing SDK MUST carry a test for that idempotent case.
+
+   **Corrected in contract 1.5.** Contract 1.4 added "Only `401` (client authentication failed)
+   is an error", which contradicted the §2 `5xx → NetworkError` row and would have turned a
+   server failure into a silent success. The rule is: a `200` MUST be success; treating **any
+   other `2xx`** as success is permitted and RECOMMENDED (six of the eight implementing SDKs
+   accept any 2xx, which is what their HTTP clients report natively); a `5xx` MUST **not** be
+   treated as success and remains a `NetworkError` per §2; a `401` carrying an
+   `OAuth2ErrorResponse` body is an `OAuthProtocolError` per
+   [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3. `revoke`
+   returning void does not make a server error a success.
 6. **`sso_complete` delivers the session as `Set-Cookie`.** `SsoLoginSuccessResponse` carries
    `user_id`, `session_id`, `expires_in`, and `redirect_uri` and **no token material**; the
    §4 cookie-jar requirement therefore applies verbatim, and an SDK without a persistent
@@ -764,9 +877,29 @@ further claims the server sends in a language-idiomatic open map — the ID toke
 set is not enumerated by `openapi.json` (the field is typed as an opaque string there), so SDKs
 MUST NOT reject unknown claims.
 
+**`AuthorizationRequest` carries no `redirect_uri` — the caller owns it** (documented in
+contract 1.5). The four fields above are the complete shape, and all eight implementing SDKs
+match it exactly. `oidc_exchange` must nevertheless replay the `redirect_uri` **byte-identically**
+(RFC 6749 §4.1.3), so the caller MUST remember it alongside `state`, `nonce`, and `code_verifier`
+between `oidc_begin` and `oidc_exchange` — this is a real footgun and is called out here
+deliberately. Where an SDK offers the optional `OidcStateStore`
+([§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 1), the store **entry**
+does carry a `redirect_uri` field and is where every SDK's framework glue parks it. Adding
+`redirect_uri` to `AuthorizationRequest` itself is a candidate for a future revision; it is
+explicitly *not* part of contract 1.5, because doing so now would change a type all eight SDKs
+have already shipped.
+
 **`oidc_begin` inputs and construction (normative).** `oidc_begin` performs **no network I/O**
-— it takes an already-fetched `OidcConfiguration` (from `oidc_discover`), `client_id`,
-`redirect_uri`, and the requested scope, and returns `AuthorizationRequest`:
+— it takes an already-fetched `OidcConfiguration` (from `oidc_discover`), the `redirect_uri`, and
+the requested scope, and returns `AuthorizationRequest`. **`client_id` is not a per-call
+argument** (corrected in contract 1.5 — contract 1.4 listed it here in error): it comes from
+client configuration, because [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+rule 4 must compare the ID token's `aud` against the *same* value and two sources could disagree.
+All eight implementing SDKs read it from client configuration. When no `client_id` is configured
+an SDK MUST fail fast with **no wire call** — either its §2 taxonomy error or its language's
+programming-error type is acceptable, since a missing client configuration is a deployment
+mistake, not an authentication outcome. Given that, the returned `AuthorizationRequest` is built
+as follows:
 
 1. `state` and `nonce` are independently generated from a cryptographically secure RNG, at
    least 16 bytes (128 bits) each — 32 bytes RECOMMENDED — encoded base64url **without**
@@ -798,8 +931,14 @@ MUST omit (rather than send empty/null) any optional field the caller did not su
 **`oidc_refresh` vs `refresh`.** `oidc_refresh` operates on an `OidcTokenSet` obtained from
 the OAuth2 token endpoint. It is a **distinct operation** from the §1 `refresh`, which drives
 the cookie/opaque-token session path at `POST /api/v1/auth/refresh` (§5.1). The two MUST NOT
-be merged, aliased, or made to fall back to one another. `oidc_refresh` MUST run under the §9
-single-flight refresh guard.
+be merged, aliased, or made to fall back to one another. `oidc_refresh` MUST be governed by a
+§9-conformant single-flight guard — including §9 rule 2's observable requirement (one wire call
+per burst, that one outcome shared with every concurrent caller) and §9's test requirement in its
+own right. Clarified in contract 1.5: §9 rule 5 permits a **dedicated guard instance** for the
+OAuth2 token namespace rather than literally reusing the §1 cookie-session guard object, and five
+of the eight implementing SDKs deliberately do exactly that because the §1 guard's API is
+specialized to comparing the cookie access token's freshness — a comparison with no meaning for a
+`refresh_token` grant. The mechanism is free; the observable behaviour is not.
 
 **`login_client_credentials` as a credential source.** After a successful
 `login_client_credentials` an SDK MAY adopt the returned `access_token` as the client's bearer
@@ -851,6 +990,16 @@ above; **C** snake_case with the mandatory `axiam_` prefix — `axiam_oidc_disco
 `axiam_sso_complete`. No login/auth/authz method names beyond this map and the §1 map are
 permitted in any SDK.
 
+**Which object hosts the nine methods** (added in contract 1.5 — §12 was previously silent). They
+SHOULD live directly on the SDK's existing client type, and do in seven of the eight implementing
+SDKs. An SDK MAY instead place them on a separate, additionally-exported host object where a
+**packaging constraint** requires it: the TypeScript SDK uses a Node-only `OidcClient` because its
+CI forbids `node:crypto` and `jose` from reaching the browser bundle, and §12 has no browser
+persona to serve (a browser relying party performs the redirect; it holds no `client_secret` and
+never calls `/oauth2/token`). The method **names** in the map above are fixed either way — only the
+host is free. An SDK that uses a separate host MUST say so in its README's §12 section, and MUST
+NOT split the nine across two hosts.
+
 ### §12.3 Cross-cutting rules (normative, identical in all SDKs)
 
 1. **Stateless by default.** `oidc_begin` and `oidc_exchange` MUST NOT store `state`, `nonce`,
@@ -861,7 +1010,14 @@ permitted in any SDK.
    where offered it MUST have a 10-minute TTL and a **single-use** `consume(state)` operation
    that returns the stored tuple and atomically deletes it (mirroring the server's
    `federation_login_state` semantics). The store MUST be opt-in: the core operations MUST
-   remain usable without one.
+   remain usable without one. Clarified in contract 1.5: a store **entry** carries `state`,
+   `nonce`, `code_verifier` (wrapped per rule 2), and `redirect_uri` — the last because
+   `oidc_exchange` must replay it byte-identically and `AuthorizationRequest` does not carry it
+   — plus, optionally, a caller-supplied `return_to`. The 10-minute TTL is a **maximum**: a
+   constructor-configurable TTL MUST be clamped down to it so no caller can exceed the
+   contract, while a shorter TTL (for tests, or a tighter deployment) is honoured. Expiry
+   sweeping MUST be **lazy** — performed on write and/or on a size query — and MUST NOT use a
+   background timer, thread, or task: a library must not keep its host process alive.
 2. **Sensitive wrapping (§7).** `access_token`, `refresh_token`, `id_token`, `client_secret`,
    and `code_verifier` MUST each be held behind the SDK's `Sensitive<T>` equivalent (§7). They
    MUST NOT appear in `Debug`/`toString`/`__repr__`/`ToString`/`String()` output, log records,
@@ -880,6 +1036,24 @@ permitted in any SDK.
    `token_expired`, or `nonce_mismatch` — matching the [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
    rule that failed. Per §2's construction rules, no error raised by this section may embed a
    token, client secret, or code verifier in its message or context fields.
+
+   **The seven reason codes are a closed vocabulary** (clarified in contract 1.5). No SDK may
+   add an eighth, so several distinct failures deliberately share one code, and the following
+   mappings are normative rather than incidental:
+   - `token_expired` is the code for **every** §12.4 rule-5 time failure — a past `exp`, an
+     **absent** `exp`, an absent or future `iat`, and a future `nbf` all report `token_expired`.
+     (There is no `token_not_yet_valid`, `iat_in_future`, or `missing_exp` code, and contract 1.4
+     enumerated three time conditions against a single code without saying so.)
+   - `unknown_kid` covers "the JOSE header carries no `kid` at all" as well as "no key matches
+     the `kid`", and a JWKS transport failure during the rule-2 re-fetch MAY surface as
+     `unknown_kid` rather than `invalid_signature`.
+   - `invalid_alg` covers a JOSE header that cannot be parsed or decoded at all, since the
+     algorithm cannot then be established.
+   - `invalid_signature` is the catch-all for any other verification failure, so no SDK needs to
+     invent a code for an unclassified case.
+
+   A future contract revision MAY widen the vocabulary; until then a caller needing finer
+   granularity reads the error message, not the code.
 4. **Tenant context (§5).** `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
    `introspect`, and `revoke` all require a `tenant_id` **UUID** for the query parameter. An SDK
    MUST accept it as an explicit argument, and MAY default to the client-level `tenant_id` when
@@ -901,9 +1075,25 @@ permitted in any SDK.
    unchanged, and §6.1 client identities apply if configured. The discovery cache MUST be keyed
    on the normalized **scheme + host + port** of the base URL used to fetch the document
    (lowercased scheme and host, default port made explicit), so a document fetched from one
-   origin can never be served for another — cross-issuer cache poisoning. The cache MUST NOT be
-   keyed on, or shared across, tenants, and MUST NOT be process-global unless the key includes
-   the origin as specified. TTL MUST be at least 5 minutes, MAY be configurable, and concurrent
+   origin can never be served for another — cross-issuer cache poisoning.
+
+   **Rewritten in contract 1.5** — contract 1.4 said the cache "MUST NOT be keyed on, or shared
+   across, tenants", which is self-contradictory (not keying on the tenant *is* sharing across
+   tenants). The rule is:
+   - The cache MUST NOT be keyed on the tenant, and sharing one document across tenants of the
+     same origin is **correct and intended**: the discovery document is a per-origin protocol
+     artifact and carries no tenant-specific content. (JWKS likewise: it is a single global key
+     set, so per-tenant JWKS caches MUST NOT be built.)
+   - The cache MUST NOT serve a document fetched from one origin to a request against another.
+     A **per-client-instance** cache satisfies this by construction where the client is bound to
+     a single base URL for its lifetime, and four of the eight implementing SDKs rely on exactly
+     that invariant rather than on an explicit key; the other four key on the normalized origin
+     explicitly. Both are conformant.
+   - A **process-global** cache, or any cache shared between clients that may target different
+     origins, MUST key on the normalized origin exactly as specified above.
+
+   TTL MUST be at least 5 minutes, MAY be configurable (a smaller configured value MUST be
+   raised to the 5-minute floor), and concurrent
    callers MUST share a single in-flight fetch (single-flight, using the same mechanism §9
    prescribes for that language). The document's own `issuer` value is the authoritative issuer
    for [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange) rule 3; because
@@ -928,13 +1118,31 @@ requirement:
    `JwksDocument`) selected by the header's `kid`. On an unknown `kid` the SDK performs **one**
    JWKS re-fetch and then fails — the same rule the §10 middleware already implements. A token
    with no `kid`, or whose `kid` is still unknown after the single re-fetch, MUST be rejected.
+
+   **"One re-fetch" is normative per cooldown window, not per token** (corrected in contract
+   1.5). Taken literally against a *warm* JWKS cache, "one re-fetch then fail" is
+   unimplementable without defeating the fetch rate-limiting that makes an unknown-`kid` path
+   safe in the first place: an attacker who can present arbitrary `kid` values would otherwise
+   drive one JWKS fetch per forged token. Every real implementation — the §10 middleware, and
+   the libraries the SDKs build on (`jose`'s `createRemoteJWKSet`, Nimbus `RemoteJWKSet`, and the
+   hand-rolled equivalents) — therefore enforces a **cooldown window** (30–60 s is typical):
+   the first unknown `kid` triggers exactly one re-fetch and opens the window; a further unknown
+   `kid` inside that window re-consults the cached set with **no** network call and fails
+   immediately. The observable requirements are that an unknown `kid` MUST NOT cause unbounded
+   JWKS fetching, MUST NOT be accepted, and MUST cause at most one re-fetch per window. An SDK
+   MUST NOT weaken this into "never re-fetch" (key rotation would break) or "always re-fetch"
+   (a fetch-amplification vector).
 3. **Issuer.** The `iss` claim MUST equal the discovery document's `issuer` by exact string
    comparison — no normalization, no trailing-slash tolerance, no substring or prefix matching.
 4. **Audience.** The `aud` claim MUST contain the RP's own `client_id`. When `aud` holds more
    than one audience, an `azp` claim MUST be present and MUST equal that `client_id`.
 5. **Time.** `exp` MUST be in the future and `iat` MUST NOT be in the future; `nbf` MUST be
    honored when present. Permitted clock skew is at most 60 seconds in either direction and
-   MUST NOT be configurable above that bound.
+   MUST NOT be configurable above that bound (a larger configured value MUST be clamped down,
+   not rejected). Clarified in contract 1.5: `exp` and `iat` are both treated as **required** —
+   an ID token missing either is rejected — and every failure of this rule reports the single
+   reason code `token_expired`, per the closed-vocabulary note in
+   [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3.
 6. **Nonce.** The `nonce` claim MUST be present and MUST equal, by constant-time comparison,
    the nonce the caller received from `oidc_begin` and passed into `oidc_exchange`. This is
    mandatory for `oidc_exchange` — the helper always requests the `openid` scope, so the server
@@ -1015,6 +1223,28 @@ Phase acceptance criteria in each SDK plan include: "CONTRACT.md §1–§10 conf
 verified." (and §1–§11 where the §11 helpers are shipped, §1–§12 where the §12 helpers are
 shipped).
 
+**Conformance state as of contract 1.5** (2026-07). Eight SDKs implement §12 and state §1–§12;
+three defer it and are unchanged:
+
+| SDK | Statement | Notes |
+|-----|-----------|-------|
+| Rust | §1–§12 | §12 host: existing `AxiamClient` |
+| TypeScript | §1–§12 | §12 host: Node-only `OidcClient` (§12.2 packaging carve-out) |
+| Python | §1–§12 | nine identical names on `AxiamClient` and `AsyncAxiamClient` |
+| Java | §1–§12 | plus the permitted `*Async` companion twins (no `oidcBeginAsync`) |
+| Kotlin | §1–§7, §9–§12 | §8 AMQP deferred (pre-existing, documented carve-out); `suspend` functions, no `*Async` twins |
+| C# | §1–§12 | `*Async` throughout except the deliberate synchronous `OidcBegin` |
+| PHP | §1–§12 | — |
+| Go | §1–§12 | — |
+| Swift | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+| C | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+| C++ | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+
+`login_client_credentials` credential adoption is a §12.1 **MAY**: TypeScript, PHP, and Go
+implement it as an opt-in flag; Rust, Python, Java, and Kotlin skip it; C# exposes the flag and
+throws `NotSupportedException` when it is set. All five positions are conformant — divergence on a
+MAY is not a defect.
+
 ### C# `Grpc.Tools` Exception
 
 C# is the one documented deviation from the `buf` codegen pipeline. The C# SDK uses `Grpc.Tools` MSBuild integration (via a `<Protobuf Include=... GrpcServices="Client" />` entry in the `.csproj`, pointed at the `proto/` copy vendored in its repo) to generate gRPC client stubs at build time, rather than a `buf generate` plugin entry. This is intentional (D-01 in `15-CONTEXT.md`) and does not affect behavioral conformance with §1–§10. All other SDKs (Rust, TypeScript, Go, Python, Java, PHP) run `buf generate` as their codegen step.
@@ -1023,6 +1253,60 @@ C# is the one documented deviation from the `buf` codegen pipeline. The C# SDK u
 
 No SDK currently ships a dedicated `CHANGELOG.md`; breaking changes to this contract are
 recorded here until one exists.
+
+- **2026-07 (§12 cross-SDK conformance review, contract 1.5)** — **non-breaking / clarifying.**
+  No new obligations, no signature changes, no vocabulary changes. Contract 1.4's §12 was
+  implemented independently in eight SDKs; the cross-SDK review
+  (`claude_dev/sdk-oidc-sso-conformance-review.md`) found ten places where the contract text was
+  self-contradictory, unimplementable as literally worded, or silent on a point the eight ports
+  had to resolve for themselves. This revision makes the contract describe the behaviour the eight
+  already share:
+  - **§7 restructured** into four numbered rules that separate the unconditional redaction MUST
+    (rule 1) from the explicit-accessor MAY (rule 3). §7's flat "the raw token string MUST NOT be
+    exposed via any public getter API" and §12's requirement to hand tokens to the caller were
+    mutually unsatisfiable; six of the eight SDKs have a publicly reachable accessor and two do
+    not, and all eight are now conformant. Redaction is unchanged and non-negotiable. The C/C++
+    "no public accessor" rows are unchanged (both defer §12).
+  - **§9 gains rule 5** (mechanism is free; a dedicated guard instance for a second token
+    namespace is permitted; a bounded wait for a shared guard is permitted and its bound is not
+    contract-worthy), and rule 2 now states the observable requirement — one wire call per burst,
+    that one outcome shared with all N callers — explicitly, because serialize-without-sharing
+    fails against single-use rotating refresh tokens. The §9 test requirement is clarified to
+    apply per refresh operation, so `oidc_refresh` needs its own burst test.
+  - **§12.1 note 2** documents that a slug `X-Tenant-ID` header legitimately accompanies a UUID
+    `?tenant_id=` query parameter (the `/oauth2/*` handlers read only the query parameter), and
+    that a slug-only client with no resolved UUID cannot call five of the nine operations.
+  - **§12.1 note 5** corrected: a `200` MUST be success, any other `2xx` MAY be, a `5xx` MUST NOT
+    be — removing the contradiction with the §2 `5xx → NetworkError` row.
+  - **§12.1** now states that `client_id` is **not** a per-call `oidc_begin` argument (it comes
+    from client configuration, as all eight SDKs implement it), and documents that
+    `AuthorizationRequest` deliberately carries no `redirect_uri` and that the caller must carry
+    it between `oidc_begin` and `oidc_exchange`.
+  - **§12.1** `oidc_refresh` paragraph: "MUST run under the §9 guard" → "MUST be governed by a
+    §9-conformant single-flight guard", pointing at the new §9 rule 5.
+  - **§12.2** gains one normative paragraph permitting either host object for the nine methods,
+    with the browser-bundle rationale; the method names remain fixed.
+  - **§12.3 rule 1** now enumerates the state-store entry fields (including `redirect_uri`),
+    states that the 10-minute TTL is a clamped maximum, and requires lazy sweeping with no
+    background timer/thread.
+  - **§12.3 rule 3** declares the seven ID-token reason codes a **closed** vocabulary and pins
+    the many-to-one mappings that follow from it — notably that every rule-5 time failure
+    (past `exp`, absent `exp`, absent or future `iat`, future `nbf`) reports `token_expired`.
+  - **§12.3 rule 6** rewritten: contract 1.4's "MUST NOT be keyed on, or shared across, tenants"
+    was self-contradictory. Sharing one discovery document across tenants of an origin is correct;
+    a per-client-instance cache satisfies the origin requirement by construction; a process-global
+    or cross-client cache MUST key on the normalized origin.
+  - **§12.4 rule 2** corrected: "one JWKS re-fetch then fail" is normative **per cooldown
+    window**, not per token — the literal reading is unimplementable on a warm cache without
+    creating a fetch-amplification vector.
+  - **§12.4 rule 5** states that `exp` and `iat` are both required and that skew above 60 s is
+    clamped, not rejected.
+  - **§2** construction rules clarify that the `"<error>: <error_description>"` requirement binds
+    the `message` *field* (a language may still prefix its rendered form) and that the two
+    exposed field names follow per-language casing, with Go's `ErrorCode` rename accepted.
+  - **Conformance Statement** gains a per-SDK table for the eight §12 implementers (including
+    Kotlin's pre-existing §8 carve-out) and records that `login_client_credentials` credential
+    adoption is a MAY on which divergence is legal.
 
 - **2026-07 (§12 OIDC / SSO relying-party helpers, contract 1.4)** — **non-breaking / additive.**
   Added §12 "OIDC / SSO Relying-Party Helpers" (SHOULD-level for v1.0): nine new canonical
@@ -1085,6 +1369,6 @@ recorded here until one exists.
 
 ---
 
-*Contract version: 1.4 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07*
+*Contract version: 1.5 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -61,7 +61,9 @@ canonical operations with the same `(action, resource[, scope])` argument order.
 `refresh`, `logout`, `check_access`, `can`, `batch_check`); **C** uses snake_case with an
 `axiam_` prefix on every symbol (`axiam_login`, `axiam_verify_mfa`, `axiam_refresh`,
 `axiam_logout`, `axiam_check_access`, `axiam_can`, `axiam_batch_check`). No new
-login/auth/authz method names beyond this map are permitted in these SDKs either. The
+login/auth/authz method names beyond this map and the
+[§12](#§12-oidc--sso-relying-party-helpers) OIDC/SSO relying-party map are permitted in these
+SDKs either. The
 gRPC-only `get_user_info` operation is **deferred** in all four of these SDKs for as long
 as they ship no gRPC transport (they already defer gRPC in v1 — see §1.1); when a gRPC
 transport is added, the method name is `getUserInfo` (Kotlin/Swift), `get_user_info` (C++),
@@ -77,7 +79,7 @@ to match its own `checkAccess(action, resource)` and every other SDK's `can`/`Ca
 - `can` is an alias for `check_access` targeting browser/UI scenarios; it calls `POST /api/v1/authz/check` via REST (avoids N round-trips when combined with `batch_check` for page-level permission gating).
 - `batch_check` calls `POST /api/v1/authz/check/batch` and returns results in the same order as input.
 - `get_user_info` calls `axiam.v1.UserInfoService/GetUserInfo` over gRPC (§1.1). It is the only operation in this map without a REST equivalent in the SDK vocabulary.
-- No SDK is permitted to expose additional login/auth/authz method names that diverge from this map.
+- No SDK is permitted to expose additional login/auth/authz method names that diverge from this map or from the [§12](#§12-oidc--sso-relying-party-helpers) OIDC/SSO relying-party map, which extends the same locked vocabulary.
 
 ### §1.1 gRPC-only operations
 
@@ -142,17 +144,28 @@ All SDKs MUST expose exactly three error types. Additional sub-types are permitt
 | `AuthzError`  | Authorization failure: caller lacks permission for the requested operation |
 | `NetworkError`| Transport-level failure: connection refused, timeout, TLS error, DNS failure |
 
+Sub-types added by later sections of this contract:
+
+| Error type          | Meaning                                                        |
+|---------------------|----------------------------------------------------------------|
+| `OAuthProtocolError`| RFC 6749 protocol error returned by an `/oauth2/*` endpoint as an `OAuth2ErrorResponse` body (`invalid_grant`, `invalid_client`, `invalid_request`, `unsupported_grant_type`, …). A language-idiomatic **sub-type of `AuthError`** (it does not replace it), added for [§12](#§12-oidc--sso-relying-party-helpers). Carries `error` and `error_description` as publicly accessible fields |
+
 ### HTTP Status → Error Type Mapping
 
 | HTTP Status | Error Type    | Notes                                         |
 |-------------|---------------|-----------------------------------------------|
 | 400         | `NetworkError`| Malformed request (SDK programming error)     |
+| 400 from `/oauth2/*` with an `OAuth2ErrorResponse` body | `OAuthProtocolError` | RFC 6749 protocol error (e.g. `invalid_grant` from `POST /oauth2/token`). MUST NOT collapse into the generic `400` → `NetworkError` row above ([§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3) |
 | 401         | `AuthError`   | Unauthenticated; triggers refresh if tokens present |
+| 401 from `/oauth2/*` with an `OAuth2ErrorResponse` body | `OAuthProtocolError` | Client authentication failed at `POST /oauth2/introspect` / `POST /oauth2/revoke`. MUST NOT trigger the §9 single-flight refresh guard |
 | 403         | `AuthzError`  | Authenticated but not authorized              |
 | 408, 429    | `NetworkError`| Timeout / rate-limited                        |
 | 409         | `AuthzError`  | Conflict (resource-level access denied)       |
 | 5xx         | `NetworkError`| Server error; SDK should NOT retry auth       |
 | Connection error / DNS / TLS | `NetworkError` | Transport-layer failures   |
+
+Where two rows match the same response, the more specific (endpoint- and body-qualified) row
+wins.
 
 ### gRPC Status → Error Type Mapping
 
@@ -170,6 +183,7 @@ All SDKs MUST expose exactly three error types. Additional sub-types are permitt
 - `AuthError` MUST carry a `message` field describing the failure.
 - `AuthzError` MUST carry a `message` field and SHOULD carry the denied `action` and `resource_id` if available from the response body.
 - `NetworkError` MUST carry the underlying OS/transport error as a `cause` (or equivalent chained exception).
+- `OAuthProtocolError`, being an `AuthError` sub-type, MUST satisfy the `AuthError` rule above: its `message` field MUST be present and MUST be `"<error>: <error_description>"`, built from the two `OAuth2ErrorResponse` fields it also exposes individually.
 - Errors MUST NOT expose raw token strings in their messages, context fields, or stack traces.
 
 ---
@@ -657,6 +671,326 @@ macro over an `axiam_require_access(...)` guard function. All compose strictly o
 
 ---
 
+## §12 OIDC / SSO Relying-Party Helpers
+
+**Requirement level: SHOULD (v1.0).** This section adds the *relying-party* (RP) half of the
+OIDC/OAuth2 story: the operations a backend application needs in order to offer "Login with
+AXIAM" (authorization-code + PKCE against AXIAM's own OIDC provider), to authenticate itself
+as a service account (`client_credentials`), to introspect/revoke tokens, and to drive the
+server's upstream-IdP federation endpoints. It is **additive to §1**: the nine operations
+below are part of the same locked method vocabulary and are subject to the same
+"no diverging names" rule. An SDK that ships §1–§11 without these helpers remains conformant;
+an SDK that ships them states conformance to §1–§12. Three SDKs defer the whole section —
+see [§12.6](#§126-deferred-sdks-swift-c-c).
+
+These helpers MUST be built on the SDK's existing machinery — the §4 cookie jar, the §6/§6.1
+TLS configuration, the §7 `Sensitive<T>` wrapper, the §9 single-flight refresh guard, and the
+JWKS verifier the §10 middleware already uses. No SDK may fork, duplicate, or re-implement
+any of them for §12.
+
+### §12.1 Canonical operation set and endpoint map
+
+Nine canonical operations. Every column below is verified against `openapi.json`; deviating
+from a schema name, HTTP method, content type, or parameter location is a contract violation.
+
+| Canonical operation | Wire call | Request (content type / schema) | Success response |
+|---------------------|-----------|---------------------------------|------------------|
+| `oidc_discover` | `GET /.well-known/openid-configuration` | no body, no query parameters | `200` `OidcDiscoveryDocument` |
+| `oidc_begin` | **none — pure local computation, no network I/O** | n/a | `AuthorizationRequest` (SDK type) |
+| `oidc_exchange` | `POST /oauth2/token?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `TokenRequest` | `200` `TokenResponse` |
+| `oidc_refresh` | `POST /oauth2/token?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `TokenRequest` | `200` `TokenResponse` |
+| `login_client_credentials` | `POST /oauth2/token?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `TokenRequest` | `200` `TokenResponse` |
+| `introspect` | `POST /oauth2/introspect?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `IntrospectRequest` | `200` `IntrospectionResponse` |
+| `revoke` | `POST /oauth2/revoke?tenant_id=<uuid>` | `application/x-www-form-urlencoded` / `RevokeRequest` | `200`, **empty body** |
+| `sso_start` | `POST /api/v1/auth/federation/oidc/start` | `application/json` / `OidcStartRequest` | `200` `OidcStartResponse` |
+| `sso_complete` | `POST /api/v1/auth/federation/oidc/callback` | `application/json` / `OidcPublicCallbackRequest` | `200` `SsoLoginSuccessResponse` + `Set-Cookie` |
+
+Error responses: `400` from `POST /oauth2/token` and `401` from `POST /oauth2/introspect` /
+`POST /oauth2/revoke` carry an `OAuth2ErrorResponse` body and map to `OAuthProtocolError`
+(§2, [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 3).
+`GET /oauth2/jwks` (schema `JwksDocument`) is used by [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+rule 2 but is **not** a vocabulary operation — it is reached through the SDK's existing JWKS
+verifier, at the `jwks_uri` the discovery document advertises.
+
+**Non-obvious wire details (all normative):**
+
+1. **The token endpoint is form-encoded, not JSON.** `POST /oauth2/token` accepts
+   `application/x-www-form-urlencoded` per RFC 6749 §4.1.3. An SDK that posts JSON to it is
+   non-conformant.
+2. **`tenant_id` is a required *query* parameter, not a body field.** `TokenRequest`,
+   `IntrospectRequest`, and `RevokeRequest` have no `tenant_id` property; all three endpoints
+   require `?tenant_id=<uuid>` because the client is authenticating *itself* there. The §5
+   `X-Tenant-ID` header is still emitted on these requests (§5 rule 2 is unconditional) — the
+   header and the query parameter are **not** substitutes for one another.
+3. **Client authentication is `client_secret_post`.** `client_id`/`client_secret` travel in the
+   form body. The server documents no HTTP Basic (`client_secret_basic`) alternative, so SDKs
+   MUST NOT send an `Authorization: Basic` header to `/oauth2/*`.
+4. **`introspect` and `revoke` require confidential-client credentials.** `IntrospectRequest`
+   and `RevokeRequest` both mark `token`, `client_id`, and `client_secret` as required
+   (non-nullable); `token_type_hint` is optional. A public client cannot call them.
+5. **`revoke` returns no body.** Per RFC 7009 the server answers `200` for unknown, expired,
+   or already-revoked tokens. `revoke` therefore returns void/`Unit`/`nil` and MUST treat any
+   `200` as success. Only `401` (client authentication failed) is an error.
+6. **`sso_complete` delivers the session as `Set-Cookie`.** `SsoLoginSuccessResponse` carries
+   `user_id`, `session_id`, `expires_in`, and `redirect_uri` and **no token material**; the
+   §4 cookie-jar requirement therefore applies verbatim, and an SDK without a persistent
+   cookie store silently loses the session.
+7. **The federation `nonce` never leaves the server.** `OidcStartResponse` returns
+   `authorize_url`, `state`, and `expires_in_secs` only (10-min TTL, single-use `state`,
+   D-22). SDKs MUST round-trip `state` unmodified into `sso_complete` and MUST NOT synthesize,
+   expect, or validate a nonce on the federation path. [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+   does **not** apply to `sso_start`/`sso_complete` — no ID token is returned to the SDK there.
+8. **CSRF.** `/oauth2/*` is unauthenticated, so no `axiam_csrf` cookie exists yet on a first
+   call; §3 step 3 already governs this — omit the `X-CSRF-Token` header rather than inventing
+   a value.
+
+**SDK-side types.** These are the type names every SDK exposes (per-language casing applies to
+type names as it does to methods); the wire schema each one deserializes is named in
+parentheses. Where an SDK type name differs from the OpenAPI schema name, the SDK name below is
+authoritative for the public surface:
+
+| SDK type | Wire schema | Fields |
+|----------|-------------|--------|
+| `OidcConfiguration` | `OidcDiscoveryDocument` | `issuer`, `authorization_endpoint`, `token_endpoint`, `userinfo_endpoint`, `jwks_uri`, `revocation_endpoint`, `introspection_endpoint`, `response_types_supported`, `subject_types_supported`, `id_token_signing_alg_values_supported`, `scopes_supported`, `token_endpoint_auth_methods_supported`, `claims_supported`, `grant_types_supported` — all required |
+| `AuthorizationRequest` | *(local, no wire form)* | `url`, `state`, `nonce`, `code_verifier` |
+| `OidcTokenSet` | `TokenResponse` | `access_token`, `token_type`, `expires_in` (required); `scope?`, `refresh_token?`, `id_token?`, `id_claims?` (optional) |
+| `IntrospectionResult` | `IntrospectionResponse` | `active` (required); `sub?`, `client_id?`, `scope?`, `token_type?`, `exp?`, `iat?` |
+| `OidcStateStore` / `MemoryOidcStateStore` | *(local, optional — rule 1)* | see [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks) rule 1 |
+
+`id_claims` is the decoded, **already-validated** ID-token claim set (see
+[§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)). It MUST expose at
+minimum `iss`, `sub`, `aud`, `exp`, `iat`, and `nonce` when present, and MUST preserve any
+further claims the server sends in a language-idiomatic open map — the ID token's full claim
+set is not enumerated by `openapi.json` (the field is typed as an opaque string there), so SDKs
+MUST NOT reject unknown claims.
+
+**`oidc_begin` inputs and construction (normative).** `oidc_begin` performs **no network I/O**
+— it takes an already-fetched `OidcConfiguration` (from `oidc_discover`), `client_id`,
+`redirect_uri`, and the requested scope, and returns `AuthorizationRequest`:
+
+1. `state` and `nonce` are independently generated from a cryptographically secure RNG, at
+   least 16 bytes (128 bits) each — 32 bytes RECOMMENDED — encoded base64url **without**
+   padding (RFC 4648 §5; no `=` characters).
+2. `code_verifier` is a fresh high-entropy string of 43–128 characters drawn only from the
+   RFC 7636 §4.1 unreserved set `[A-Za-z0-9-._~]`. The RECOMMENDED construction is 32 CSPRNG
+   bytes encoded base64url without padding (43 characters).
+3. `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))`, without padding, and
+   `code_challenge_method` is the literal string `S256`. Every SDK MUST include the RFC 7636
+   Appendix B test vector as a unit test.
+4. The requested scope MUST contain `openid`; the helper adds it when the caller omits it.
+5. `url` is `authorization_endpoint` (taken from the discovery document, never hardcoded) with
+   exactly these RFC 3986-percent-encoded query parameters: `response_type=code`, `client_id`,
+   `redirect_uri`, `scope` (space-separated), `state`, `nonce`, `code_challenge`,
+   `code_challenge_method=S256`. An SDK MAY accept additional caller-supplied query parameters
+   but MUST NOT add any of its own beyond these eight.
+
+**Grant-specific `TokenRequest` field sets (normative).**
+
+| Operation | `grant_type` | Additional form fields |
+|-----------|--------------|------------------------|
+| `oidc_exchange` | `authorization_code` | `code`, `code_verifier`, `redirect_uri`, `client_id`, `client_secret` (confidential clients only) |
+| `oidc_refresh` | `refresh_token` | `refresh_token`, `client_id`, `client_secret` (confidential clients only), `scope` (optional) |
+| `login_client_credentials` | `client_credentials` | `client_id`, `client_secret`, `scope` (optional) |
+
+An SDK MUST NOT send form fields outside the set listed for the grant it is performing, and
+MUST omit (rather than send empty/null) any optional field the caller did not supply.
+
+**`oidc_refresh` vs `refresh`.** `oidc_refresh` operates on an `OidcTokenSet` obtained from
+the OAuth2 token endpoint. It is a **distinct operation** from the §1 `refresh`, which drives
+the cookie/opaque-token session path at `POST /api/v1/auth/refresh` (§5.1). The two MUST NOT
+be merged, aliased, or made to fall back to one another. `oidc_refresh` MUST run under the §9
+single-flight refresh guard.
+
+**`login_client_credentials` as a credential source.** After a successful
+`login_client_credentials` an SDK MAY adopt the returned `access_token` as the client's bearer
+credential exactly as it does for a `login()` result. It requests no `openid` scope and the
+response carries no `id_token`.
+
+### §12.2 Per-language naming map
+
+Casing follows the §1 rules unchanged. Twelve languages are covered: the seven columns below
+(TypeScript and JavaScript share one column, as in §1) plus Kotlin, Swift, C, and C++ in the
+"Additional languages" paragraph that follows.
+
+| Canonical operation | Rust (snake_case) | TypeScript/JS (camelCase) | Python (snake_case) | Java (camelCase) | C# (PascalCase) | PHP (camelCase) | Go (PascalCase) |
+|---------------------|-------------------|---------------------------|---------------------|------------------|-----------------|-----------------|-----------------|
+| `oidc_discover` | `oidc_discover` | `oidcDiscover` | `oidc_discover` | `oidcDiscover` | `OidcDiscoverAsync` | `oidcDiscover` | `OidcDiscover` |
+| `oidc_begin` | `oidc_begin` | `oidcBegin` | `oidc_begin` | `oidcBegin` | `OidcBegin` | `oidcBegin` | `OidcBegin` |
+| `oidc_exchange` | `oidc_exchange` | `oidcExchange` | `oidc_exchange` | `oidcExchange` | `OidcExchangeAsync` | `oidcExchange` | `OidcExchange` |
+| `oidc_refresh` | `oidc_refresh` | `oidcRefresh` | `oidc_refresh` | `oidcRefresh` | `OidcRefreshAsync` | `oidcRefresh` | `OidcRefresh` |
+| `login_client_credentials` | `login_client_credentials` | `loginClientCredentials` | `login_client_credentials` | `loginClientCredentials` | `LoginClientCredentialsAsync` | `loginClientCredentials` | `LoginClientCredentials` |
+| `introspect` | `introspect` | `introspect` | `introspect` | `introspect` | `IntrospectAsync` | `introspect` | `Introspect` |
+| `revoke` | `revoke` | `revoke` | `revoke` | `revoke` | `RevokeAsync` | `revoke` | `Revoke` |
+| `sso_start` | `sso_start` | `ssoStart` | `sso_start` | `ssoStart` | `SsoStartAsync` | `ssoStart` | `SsoStart` |
+| `sso_complete` | `sso_complete` | `ssoComplete` | `sso_complete` | `ssoComplete` | `SsoCompleteAsync` | `ssoComplete` | `SsoComplete` |
+
+**C# `Async` suffix (§1 "Async method naming", SDK-Q08).** C# is `*Async`-only (TAP) for every
+operation that performs I/O, exactly as it is for `GetUserInfoAsync` in the §1 map. `OidcBegin`
+is the **single deliberate exception in this section**: it performs no network I/O (see
+[§12.1](#§121-canonical-operation-set-and-endpoint-map)), so it is a synchronous
+`OidcBegin` with **no** `Async` suffix. No `OidcBeginAsync` may be added.
+
+**Java.** The canonical camelCase names above are the synchronous surface. Per the §1
+"Async method naming" table Java MAY additionally expose `*Async` companion methods on the same
+client object (`oidcExchangeAsync`, `oidcRefreshAsync`, …); these are the accepted per-language
+exception to the "no additional diverging names" rule and nothing else.
+
+**Python.** The canonical snake_case names above appear on `AxiamClient` (sync) and, as
+`async def` twins under the *same* names, on `AsyncAxiamClient`. `async_*`-prefixed names remain
+prohibited (SDK-Q08).
+
+**Additional languages (Kotlin, Swift, C, C++).** **Kotlin** implements §12 and uses camelCase
+`suspend` functions identical to the TypeScript column (`oidcDiscover`, `oidcBegin`,
+`oidcExchange`, `oidcRefresh`, `loginClientCredentials`, `introspect`, `revoke`, `ssoStart`,
+`ssoComplete`); no `*Async` twins. **Swift**, **C**, and **C++** defer the whole section
+([§12.6](#§126-deferred-sdks-swift-c-c)), but the names are reserved now so a later port cannot
+diverge: **Swift** camelCase and **C++** snake_case exactly as the TypeScript and Rust columns
+above; **C** snake_case with the mandatory `axiam_` prefix — `axiam_oidc_discover`,
+`axiam_oidc_begin`, `axiam_oidc_exchange`, `axiam_oidc_refresh`,
+`axiam_login_client_credentials`, `axiam_introspect`, `axiam_revoke`, `axiam_sso_start`,
+`axiam_sso_complete`. No login/auth/authz method names beyond this map and the §1 map are
+permitted in any SDK.
+
+### §12.3 Cross-cutting rules (normative, identical in all SDKs)
+
+1. **Stateless by default.** `oidc_begin` and `oidc_exchange` MUST NOT store `state`, `nonce`,
+   or `code_verifier` inside the SDK, in process-global state, or in any implicit cache. The
+   caller owns that storage (typically its own HTTP session) and passes the `nonce` and
+   `code_verifier` back into `oidc_exchange` explicitly. Framework integrations MAY offer an
+   optional `OidcStateStore` interface with a `MemoryOidcStateStore` reference implementation;
+   where offered it MUST have a 10-minute TTL and a **single-use** `consume(state)` operation
+   that returns the stored tuple and atomically deletes it (mirroring the server's
+   `federation_login_state` semantics). The store MUST be opt-in: the core operations MUST
+   remain usable without one.
+2. **Sensitive wrapping (§7).** `access_token`, `refresh_token`, `id_token`, `client_secret`,
+   and `code_verifier` MUST each be held behind the SDK's `Sensitive<T>` equivalent (§7). They
+   MUST NOT appear in `Debug`/`toString`/`__repr__`/`ToString`/`String()` output, log records,
+   error messages, exception payloads, stack traces, or serialized diagnostics, and MUST NOT be
+   reachable through a public getter. `state` and `nonce` are **not** secrets and are exposed
+   as plain strings. See [§12.5](#§125-sensitivet-applicability) for the per-language wrapper.
+3. **Error taxonomy (§2).** An `OAuth2ErrorResponse` body MUST surface as `OAuthProtocolError`
+   — a language-idiomatic sub-type of `AuthError` — carrying `error` and `error_description` as
+   publicly accessible fields, with `message` set to `"<error>: <error_description>"`. A `400`
+   from `POST /oauth2/token` MUST NOT surface as the generic `NetworkError` the §2 `400` row
+   otherwise prescribes, and a `401` from `POST /oauth2/introspect` or `POST /oauth2/revoke`
+   MUST NOT enter the §9 single-flight refresh guard (client-credential failure is not a
+   session expiry, and retrying cannot help). ID-token validation failures MUST raise
+   `AuthError` (or an `AuthError` sub-type) carrying a stable machine-readable reason code —
+   `invalid_alg`, `unknown_kid`, `invalid_signature`, `invalid_issuer`, `invalid_audience`,
+   `token_expired`, or `nonce_mismatch` — matching the [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange)
+   rule that failed. Per §2's construction rules, no error raised by this section may embed a
+   token, client secret, or code verifier in its message or context fields.
+4. **Tenant context (§5).** `oidc_exchange`, `oidc_refresh`, `login_client_credentials`,
+   `introspect`, and `revoke` all require a `tenant_id` **UUID** for the query parameter. An SDK
+   MUST accept it as an explicit argument, and MAY default to the client-level `tenant_id` when
+   the client was constructed in UUID form (§5). When no UUID is available — e.g. a client
+   constructed with `tenant_slug` only and no prior login to resolve it from — the SDK MUST
+   raise its taxonomy error **client-side, without a wire call** (same discipline as §1.1
+   rule 3); it MUST NOT send a slug in the `tenant_id` query parameter. `sso_start` carries
+   org/tenant context in the `OidcStartRequest` body and follows the §5.1 rules: one tenant form
+   (`tenant_id` or `tenant_slug`) **and** one org form (`org_id` or `org_slug`), alongside the
+   required `federation_config_id` and `redirect_uri`. `sso_complete` needs neither, because the
+   server recovers the full context from the single-use `state` row.
+5. **REST `/oauth2/userinfo` stays out of the vocabulary.** §12 adds no userinfo operation. A
+   relying party's claims come from the validated ID token (`OidcTokenSet.id_claims`); identity
+   lookups against a live session use the gRPC `get_user_info` operation (§1.1). SDKs MUST NOT
+   call `GET /oauth2/userinfo`, and MUST NOT substitute it for either — §1.1 rule 6 already
+   places that endpoint outside the SDK method vocabulary.
+6. **TLS and discovery-cache keying (§6).** Every §12 call goes through the SDK's §6-configured
+   transport with strict verification on; §6's absolute prohibition on TLS-bypass surfaces is
+   unchanged, and §6.1 client identities apply if configured. The discovery cache MUST be keyed
+   on the normalized **scheme + host + port** of the base URL used to fetch the document
+   (lowercased scheme and host, default port made explicit), so a document fetched from one
+   origin can never be served for another — cross-issuer cache poisoning. The cache MUST NOT be
+   keyed on, or shared across, tenants, and MUST NOT be process-global unless the key includes
+   the origin as specified. TTL MUST be at least 5 minutes, MAY be configurable, and concurrent
+   callers MUST share a single in-flight fetch (single-flight, using the same mechanism §9
+   prescribes for that language). The document's own `issuer` value is the authoritative issuer
+   for [§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange) rule 3; because
+   the server derives it from `AuthConfig::oauth2_issuer_url` (falling back to
+   `AuthConfig::jwt_issuer`) it may legitimately differ from the base URL behind a proxy, so an
+   SDK MUST NOT reject a discovery document on an issuer/base-URL mismatch. Likewise SDKs MUST
+   read `jwks_uri` from the document rather than hardcoding `/oauth2/jwks`.
+
+### §12.4 ID-token validation checklist (normative for `oidc_exchange`)
+
+Validation reuses each SDK's existing JWKS verifier (the one the §10 middleware uses — extend
+it, never fork it) and follows OIDC Core §3.1.3.7. All seven requirements below MUST be
+enforced before `oidc_exchange` returns, and every SDK MUST carry one failing test per
+requirement:
+
+1. **Algorithm.** The JOSE header `alg` MUST be exactly `EdDSA`. The value `none` MUST be
+   rejected outright, as MUST every other algorithm — including any algorithm the discovery
+   document's `id_token_signing_alg_values_supported` might additionally advertise. The `alg`
+   MUST be read from the header and checked *before* any signature work; an SDK MUST NOT let
+   the token select its own verification algorithm.
+2. **Signature.** Verify the Ed25519 signature against the key from `jwks_uri` (schema
+   `JwksDocument`) selected by the header's `kid`. On an unknown `kid` the SDK performs **one**
+   JWKS re-fetch and then fails — the same rule the §10 middleware already implements. A token
+   with no `kid`, or whose `kid` is still unknown after the single re-fetch, MUST be rejected.
+3. **Issuer.** The `iss` claim MUST equal the discovery document's `issuer` by exact string
+   comparison — no normalization, no trailing-slash tolerance, no substring or prefix matching.
+4. **Audience.** The `aud` claim MUST contain the RP's own `client_id`. When `aud` holds more
+   than one audience, an `azp` claim MUST be present and MUST equal that `client_id`.
+5. **Time.** `exp` MUST be in the future and `iat` MUST NOT be in the future; `nbf` MUST be
+   honored when present. Permitted clock skew is at most 60 seconds in either direction and
+   MUST NOT be configurable above that bound.
+6. **Nonce.** The `nonce` claim MUST be present and MUST equal, by constant-time comparison,
+   the nonce the caller received from `oidc_begin` and passed into `oidc_exchange`. This is
+   mandatory for `oidc_exchange` — the helper always requests the `openid` scope, so the server
+   always issues a `nonce`. For `oidc_refresh` and `login_client_credentials`, rules 1–5 and 7
+   apply to any `id_token` present and rule 6 is skipped (OIDC Core §12.2 does not require a
+   `nonce` in a refresh-issued ID token).
+7. **All-or-nothing failure.** On failure of *any* rule above, the SDK MUST raise `AuthError`
+   with the matching reason code from [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks)
+   rule 3 and MUST **discard the entire token set** — the `access_token` and `refresh_token`
+   from the same response MUST NOT be returned to the caller, adopted as the client's
+   credential, or written to any store. There is no partial success, and no "validation
+   disabled" or "skip ID-token checks" option may exist on any public API.
+
+[§12.4](#§124-id-token-validation-checklist-normative-for-oidc_exchange) does not apply to
+`sso_start`/`sso_complete`: the federation flow returns the session as `Set-Cookie` and no ID
+token reaches the SDK ([§12.1](#§121-canonical-operation-set-and-endpoint-map) note 7).
+
+### §12.5 `Sensitive<T>` applicability
+
+The five fields named in [§12.3](#§123-cross-cutting-rules-normative-identical-in-all-sdks)
+rule 2 — `access_token`, `refresh_token`, `id_token`, `client_secret`, `code_verifier` — use
+the **same concrete wrapper this contract already specifies per language in §7**; §12 defines
+no new mechanism. Concretely: Rust newtype `Sensitive<T>` with custom `Debug`/`Display`;
+TypeScript class with a private `#value` and `toString()` returning `"[SENSITIVE]"`; Python
+`__repr__`/`__str__` returning `"Sensitive(<redacted>)"`; final Java class with a redacting
+`toString()`; C# struct with a `ToString()` override; PHP `__toString()`; Go string type with a
+redacting `String()`; Kotlin `value class Sensitive<T>` (never a `data class`, whose generated
+`toString` would leak); Swift `struct Sensitive<T>: CustomStringConvertible`; C opaque
+`axiam_sensitive_t`; C++ `class Sensitive<T>` with a redacting `operator<<`/`to_string`. See
+the §7 table for the authoritative per-language row. Two additions specific to §12:
+`code_verifier` is secret **for its whole lifetime**, including while it sits in an
+`AuthorizationRequest` returned to the caller and in any `OidcStateStore` entry; and JSON or
+other structured serialization of `OidcTokenSet`, `AuthorizationRequest`, or an
+`OidcStateStore` entry MUST NOT emit the wrapped values.
+
+### §12.6 Deferred SDKs (Swift, C, C++)
+
+`axiam-swift-sdk`, `axiam-c-sdk`, and `axiam-cplusplus-sdk` **defer §12 in its entirety**, with
+the same carve-out discipline §1/§1.1 already applies to their `get_user_info`/gRPC deferral.
+These are device- and IoT-oriented SDKs: the Swift SDK ships NIOSSL specifically for client-cert
+mTLS, and the C/C++ SDKs target embedded consumers. The browser-redirect relying-party flow has
+no natural home in any of them, and their authentication story — §6.1 mTLS, password login,
+service credentials — is already complete without it.
+
+Accordingly, each of these three SDKs MUST document §12 as a deferred follow-up in its scope
+section (same wording pattern as its existing "gRPC transport deferred" carve-out), MUST NOT
+partially implement the vocabulary, and MUST NOT substitute a hand-rolled OAuth2 flow for it.
+Their conformance statement stays at "§1–§10" (or "§1–§11" where the §11 helpers ship) and MUST
+NOT claim §12. If a later port lands, it MUST use the reserved names already fixed in
+[§12.2](#§122-per-language-naming-map) and MUST satisfy §12.1–§12.5 unchanged. Two follow-up
+decisions are recorded as open rather than resolved here: a server-side-Swift (Vapor) port
+cloned from the Kotlin shape, and adding `login_client_credentials` alone to C/C++ for
+machine-to-machine use.
+
+---
+
 ## Closing Notes
 
 ### Conformance Statement
@@ -670,8 +1004,16 @@ statement to:
 
 > "This SDK conforms to CONTRACT.md §1–§11."
 
+An SDK that additionally ships the §12 OIDC/SSO relying-party helpers updates its statement to:
+
+> "This SDK conforms to CONTRACT.md §1–§12."
+
+The three SDKs that defer §12 ([§12.6](#§126-deferred-sdks-swift-c-c)) keep their existing
+statement and MUST NOT claim §12.
+
 Phase acceptance criteria in each SDK plan include: "CONTRACT.md §1–§10 conformance
-verified." (and §1–§11 where the §11 helpers are shipped).
+verified." (and §1–§11 where the §11 helpers are shipped, §1–§12 where the §12 helpers are
+shipped).
 
 ### C# `Grpc.Tools` Exception
 
@@ -681,6 +1023,22 @@ C# is the one documented deviation from the `buf` codegen pipeline. The C# SDK u
 
 No SDK currently ships a dedicated `CHANGELOG.md`; breaking changes to this contract are
 recorded here until one exists.
+
+- **2026-07 (§12 OIDC / SSO relying-party helpers, contract 1.4)** — **non-breaking / additive.**
+  Added §12 "OIDC / SSO Relying-Party Helpers" (SHOULD-level for v1.0): nine new canonical
+  operations — `oidc_discover`, `oidc_begin`, `oidc_exchange`, `oidc_refresh`,
+  `login_client_credentials`, `introspect`, `revoke`, `sso_start`, `sso_complete` — with a
+  twelve-language naming map (§12.2), six cross-cutting rules (§12.3), the normative ID-token
+  validation checklist (§12.4, `EdDSA`-only, S256-only PKCE, all-or-nothing discard), and a
+  `Sensitive<T>` applicability note (§12.5). They target the already-shipping server surface
+  (`/.well-known/openid-configuration`, `/oauth2/token|introspect|revoke|jwks`,
+  `/api/v1/auth/federation/oidc/start|callback`) — no server or `openapi.json` change. The §2
+  taxonomy gains one sub-type, `OAuthProtocolError` (an `AuthError` sub-type carrying `error` +
+  `error_description`), plus two endpoint-qualified rows in the HTTP-status mapping; the three
+  existing top-level error types are unchanged. No existing signature changes. The eight
+  backend-capable SDKs (Rust, TypeScript, Python, Java, Kotlin, C#, PHP, Go) add the operations
+  and state "§1–§12"; the device-oriented SDKs (Swift, C, C++) document §12 as a deferred
+  follow-up and keep their existing statement (§12.6).
 
 - **2026-07 (§1.1 gRPC userinfo, contract 1.3)** — **non-breaking / additive.** Added a new
   canonical operation `get_user_info` (§1 naming map + §1.1 normative semantics), served only
@@ -727,6 +1085,6 @@ recorded here until one exists.
 
 ---
 
-*Contract version: 1.3 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07*
+*Contract version: 1.4 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*

--- a/website/src/docs.ts
+++ b/website/src/docs.ts
@@ -752,10 +752,17 @@ export const DOC_PAGES: DocPage[] = [
         headers: ["Variable", "Default", "Small internet-facing", "M2M / microservices / IoT", "Large multi-tenant"],
         rows: [
           [
+            "AXIAM__RATE_LIMIT__PROFILE",
+            "internet",
+            "internet",
+            "gateway — one variable moves the whole machine-traffic family coherently (key mode + token/introspect/revoke/authz), leaving the human endpoints untouched",
+            "mesh",
+          ],
+          [
             "AXIAM__RATE_LIMIT__KEY",
             "ip",
             "ip",
-            "client_id (or ip_client_id) — per-IP buckets collide behind NAT/gateways",
+            "client_id (or ip_client_id) — per-IP buckets collide behind NAT/gateways — see the security caveat below",
             "ip_client_id",
           ],
           [
@@ -831,8 +838,12 @@ export const DOC_PAGES: DocPage[] = [
         ],
       },
       {
+        type: "warn",
+        text: "Security caveat on `client_id` keying — read before changing the key mode. The `client_id` a request is bucketed by is read from the request body before the client credential is verified (that is what the OAuth2 spec puts there), so an attacker who simply varies the `client_id` string gets a fresh bucket each time and is effectively unlimited on the token, revoke and introspect endpoints. `client_id` keying is a fairness control between well-behaved clients, not an abuse control. `ip` is the only mode whose key an attacker cannot mint at will, which is why it stays the shipped default. Use `client_id`/`ip_client_id` only where something else already authenticates callers at the edge — mTLS, an API gateway, a WAF, or an IP allow-list — which is exactly the topology the M2M column assumes.",
+      },
+      {
         type: "note",
-        text: "Two rules of thumb the data supports: if your traffic is authorization-check-heavy, spend hardware on the database and enable the decision cache before anything else; if it's token-heavy, the limits — not the hardware — are what you'll hit first, so switch the rate-limit key to `client_id` and size TOKEN_PER_MIN from your real per-client peak, keeping the strict per-IP defaults only on the genuinely internet-exposed endpoints (login, register, password-reset, MFA).",
+        text: "Two rules of thumb the data supports: if your traffic is authorization-check-heavy, spend hardware on the database and enable the decision cache before anything else; if it's token-heavy, the limits — not the hardware — are what you'll hit first, so raise TOKEN_PER_MIN from your real per-client peak and — if and only if you have edge authentication per the caveat above — switch the key mode. The genuinely internet-exposed endpoints (login, register, password-reset, MFA) stay strict per-IP in every configuration, including under the gateway and mesh profiles.",
       },
       { type: "h", id: "tls", text: "Direct TLS termination (opt-in)" },
       {


### PR DESCRIPTION
## Summary

This is **step H0** of the Phase H plan: it lands the entire G1–G10 benchmark implementation (previously only on the unmerged branch `claude/g1-timeline-hanging-l0mqd0`) together with the **Phase H follow-up plan** written from the verified 2026-07-28 G-task run results (`results-20260728.tar.xz`). Current `main` (UUIDv7 ids, SDK contract 1.5) is merged in, so the branch merges cleanly.

Supersedes `claude/g1-timeline-hanging-l0mqd0` (same code, no plan) and `claude/benchmark-results-analysis-f1xn2k` (same plan, no code) — both should be closed/deleted without merging after this lands.

## What's in the PR

### G implementation (benchmarks + server, collected-with harness)
- `benchmarks/run-improvement-tasks.sh` — per-task data-collection driver (one subcommand per G task), plus four runner fixes: unwedged telemetry sampler, interrupt-safe stack teardown, g1-dbdirect credential resolution from the running stack, and a working direct-SurrealDB probe with pre-flight validation
- **G2**: post-seed settle gate (`BENCH_SETTLE*`), per-run scenario rotation (`cell_order_index`), `axiam_env` knob dump with secret redaction
- **G4**: refresh-cell fix (cookie `Path` root cause; see `claude_dev/refresh-harness-diagnosis.md`)
- **G5**: `BENCH_AUTHZ_KEYSPACE` cache K-sweep scenario + `claude_dev/decision-cache-decision.md` (decision OPEN behind seven criteria; three cache defects documented)
- **G7**: opt-in rate-limit posture presets (`AXIAM__RATE_LIMIT__PROFILE` = `internet`|`gateway`|`mesh`), shipped defaults byte-for-byte unchanged + decision record
- **G8**: ALPN analysis — `AXIAM__SERVER__TLS__HTTP2=false` proven a no-op and turned into a hard startup error (`claude_dev/b2-tls-h2-investigation.md`)
- **G9**: `bench_throttled` counter + shared gRPC result classifier (`claude_dev/grpc-vs-rest-authz-analysis.md`)

### Phase H plan (new)
- `claude_dev/improvement-after-g-benchmark.md` — verdicts of the G run (every number re-verified against the raw k6/meta JSON in the results archive) and tasks **H1–H10** with per-task model assignment. Headlines:
  - **G3 DECIDED**: `coalesced` batch wins 4.98× vs 1.37× → H3 flips the default
  - **G6 PASS**: jemalloc closes 94% of the 309 MiB retention gap → H4 makes it the release default
  - **G4 PASS**: refresh cell is a real rotation (0 fallback, 1.00 req/iter)
  - **G1 narrowed**: ~6 min traffic-cured DB-side clamp; AMQP-backlog hypothesis refuted → H2 endgame
  - **Settle gate proven blind** to the clamp (serial canary passes in ~34 s inside a ~6 min window) → H1 concurrent-canary gate v2
  - **Wrong-directory fault root-caused**: `bench-matrix` unconditionally re-exports `BENCH_RESULTS_DIR` (justfile repeat loop) → H1
- `claude_dev/improvement-after-serious-benchmark.md` — run status header + G6 placeholder filled with the measured D9 numbers

## Test plan

- Docs-only + harness changes on top of the already-CI-green G branch; server-side changes (G7 presets, G8 hard error) carry their unit tests from the original branch commits
- Benchmark acceptance criteria are laptop-measured per the plan (this environment has no k6/Docker stacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEy1xiV1vxiFqL7rXfEYfp