### PR TITLE
perf(rate-limit): take the shared-store write off the request path; fix GET /users limiter

### DIFF
--- a/benchmarks/PRIVATE_BENCH_ANALYSIS.md
+++ b/benchmarks/PRIVATE_BENCH_ANALYSIS.md
@@ -69,6 +69,29 @@ conclusions (D1/D10 batch slowness, and the B2 h1 cell).**
 > which remains only partially explained. The G-box's "recovers after ~6 min"
 > and this host's "never recovers" are two datastores paying a different
 > price for the same synchronous write, not two different bugs.
+>
+> **UPDATE (2026-07-29, `claude/g-benchmark-improvements-n5mjmj`): both asks
+> from `postseed-transient-investigation.md` §7.1 are now FIXED, not just
+> root-caused.** `GET /api/v1/users`'s registration-bucket bug is fixed
+> (method-guarded resource split). The synchronous per-request UPSERT is
+> replaced by a write-behind design
+> (`axiam_db::rate_limit_counter::SharedRateLimitCounter`, commits `5212912`,
+> `0fbbd5e`, `1f3da2f`, `7167c18`): the request path decides synchronously
+> in-memory and a background flusher coalesces one datastore write per
+> bucket per `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` (default 1000 ms) instead of
+> one per request. What this buys and what it costs is written up in full in
+> `claude_dev/rate-limit-posture-decision.md` §8 (chosen design, alternatives
+> considered, and why) and quoted precisely in the
+> `axiam_db::rate_limit_counter` module docs: cross-replica enforcement
+> becomes eventual, bounded by `(replicas − 1) × arrival_rate_per_replica ×
+> sync_interval` and zero on a single replica, instead of the old design's
+> zero-overshoot-at-any-replica-count bound. **This has NOT yet been
+> re-measured on the H2 investigation host or any other host** — no throughput
+> number anywhere in this document has changed. The re-measurement is tracked
+> as its own artifact, `claude_dev/rate-limit-fix-verification.md`, produced
+> by a separate concurrent task; do not fold numbers from that file into this
+> one without also updating the run/commit provenance this document is keyed
+> on.
 
 ### 1.1 The signature
 
@@ -396,7 +419,10 @@ Ranked summary:
 
 1. **G1 — Root-cause the post-seed serialized-DB transient** (§1). Biggest
    validity issue *and* a potential production cold-start defect. Everything
-   batch- and B2-related is downstream of it.
+   batch- and B2-related is downstream of it. **Root-caused: DONE (H2).
+   Fixed: DONE (`claude/g-benchmark-improvements-n5mjmj`, see the §1 UPDATE
+   above and `claude_dev/rate-limit-posture-decision.md` §8) — not yet
+   re-measured (`claude_dev/rate-limit-fix-verification.md`).**
 2. **G2 — Harness countermeasures + self-describing meta**: settle gate
    before the first cell, cell-order rotation per run, record `AXIAM__*`
    knobs in meta.json, re-run the four batch cells clean (both strategies)
@@ -463,6 +489,24 @@ Ranked summary:
   > are still clamped by the `RateLimitShared` write and must be published as
   > refused, same as every other clamped cell — that is a host limitation,
   > not a reopening of the G3 decision.
+  > **UPDATE (2026-07-29, `claude/g-benchmark-improvements-n5mjmj`): the
+  > `RateLimitShared` write named above is fixed** (write-behind counter, §1
+  > UPDATE). Any *new* H2-host pass run against this branch is no longer
+  > expected to hit that specific clamp on these six endpoints, but this
+  > document's own H2/H10 numbers above were captured pre-fix and are
+  > unchanged — do not retroactively read them as un-clamped. Whether a
+  > future pass on this host settles cleanly is an open question for
+  > `claude_dev/rate-limit-fix-verification.md`, not asserted here.
+- **Publish the shared rate-limit fix as a closed product item, not a
+  performance number.** `claude_dev/postseed-transient-investigation.md`
+  §7.1's two asks (the `GET /api/v1/users` bucket bug and the synchronous
+  shared-store write) are both implemented on
+  `claude/g-benchmark-improvements-n5mjmj` — see the §1 UPDATE above and
+  `claude_dev/rate-limit-posture-decision.md` §8 for the design rationale.
+  **Do NOT publish any post-fix throughput number yet** — none has been
+  measured; it lands in `claude_dev/rate-limit-fix-verification.md` first,
+  produced by a separate task, and only then flows into a future draft of
+  the public matrix.
 - Do NOT chart: AXIAM/Zitadel refresh (fallback), Zitadel/KC-p2 login
   (gate), any first-cell-after-seed number (§1), the B2 h1 cell.
 - The new "recommended production settings" section (public §6) is the

--- a/benchmarks/PUBLIC_BENCH_ANALYSIS.md
+++ b/benchmarks/PUBLIC_BENCH_ANALYSIS.md
@@ -75,6 +75,17 @@ run on a host where it isn't (the G-box, or any host after the tracked fix
 lands — see §5's "moved to fixed" list for what's already shipped and what
 remains open).
 
+**Status: the design fix has since shipped**, on branch
+`claude/g-benchmark-improvements-n5mjmj` — the synchronous per-request write
+described above is replaced by a write-behind counter
+(`axiam_db::rate_limit_counter::SharedRateLimitCounter`; §5 "moved to fixed"
+has the details and the security trade it makes). **The numbers in §3, §4
+and §7 below remain the pre-fix G-box measurements and are not updated by
+this note** — the fix has not yet been re-measured end-to-end on any host.
+When that re-measurement runs, its numbers land in
+`claude_dev/rate-limit-fix-verification.md`, not in this file, until a future
+draft folds them into a published matrix.
+
 ### 1.2 What *was* run this round: a harness-validation matrix (sandbox, bounded)
 
 To validate the new settle gate (§5), the `report.py` refusal machinery, the
@@ -416,8 +427,10 @@ does exactly what §6 recommends it for. It does **not** touch the
 per-request shared-rate-limit write from §1/§5: admitted throughput under
 `gateway` landed at 22–24 ops/s on that host, the same band H2 measured for
 those endpoints under every other posture — a rate-limit *policy* change
-cannot make a synchronous datastore write cheaper. See §6 for what to set
-instead.
+cannot make a synchronous datastore write cheaper. (That write is itself
+fixed as of `claude/g-benchmark-improvements-n5mjmj`, per §1/§5 — this
+measurement predates the fix and is left as the honest pre-fix record.) See
+§6 for what to set instead.
 
 ## 5. Weaknesses and caveats (the honest section)
 
@@ -444,14 +457,22 @@ six endpoints (client_credentials, introspection, authz_check, login,
 revoke) as bounded by the cost of one datastore write in your deployment's
 environment, not by AXIAM's request handling** — on a fast datastore that
 ceiling is high (hundreds to low thousands of ops/s, as this draft's own
-G-box numbers show); on a slow one it is the whole story. Two fixes are
-tracked and neither has shipped yet: `GET /api/v1/users` is a separate,
-already-understood bug (it inherits the *registration* rate-limit bucket,
-not a read bucket — 5/min/IP in the production posture), and getting the
-shared-store round trip off the synchronous critical path (a TTL cache with
-write-back, a fire-and-forget write with a previous-read decision, or an
-explicit single-replica off-switch) is written up as a maintainer issue in
-`claude_dev/postseed-transient-investigation.md` §7.1. **What remains
+G-box numbers show); on a slow one it is the whole story. **Both fixes
+written up as a maintainer issue in
+`claude_dev/postseed-transient-investigation.md` §7.1 have since shipped**,
+on branch `claude/g-benchmark-improvements-n5mjmj`: `GET /api/v1/users` no
+longer inherits the *registration* rate-limit bucket (it was the separate,
+already-understood bug — 5/min/IP in the production posture, now unlimited
+like its sibling list endpoints), and the shared-store round trip is off the
+synchronous critical path — a write-behind counter
+(`axiam_db::rate_limit_counter::SharedRateLimitCounter`) now decides
+in-memory and coalesces one datastore write per bucket per sync interval
+instead of one per request. See the "Moved to fixed" list below for what
+that trades: cross-replica enforcement becomes eventual rather than
+synchronous, bounded by a stated, quotable overshoot formula. **Neither fix
+changes the numbers in this draft** — they were measured before the fix
+existed, and no post-fix run has happened yet; that measurement will land in
+`claude_dev/rate-limit-fix-verification.md`, not here. **What remains
 genuinely unresolved, stated plainly:** the G-box's specific recovery
 pattern — a ~5–7 minute window that ends in a sharp cliff back to full
 throughput — has not been reproduced on the second host, which never
@@ -483,6 +504,17 @@ token numbers lead the field 2.2–2.6×.
 - **p0-plaintext `Secure`-cookie bug** — every cookie-based p0 scenario used
   to die in harness `setup()`; fixed for the bench profile only, production
   default unchanged (§2, task H6).
+- **The shared rate-limit write named above** — `GET /api/v1/users`'s
+  rate-limit bucket bug and the synchronous shared-store write on the six
+  hottest endpoints are both fixed on `claude/g-benchmark-improvements-n5mjmj`
+  (write-behind `SharedRateLimitCounter`; `AXIAM__RATE_LIMIT__SHARED`/
+  `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` env knobs). Cross-replica enforcement is
+  now eventual (bounded by `(replicas − 1) × arrival_rate_per_replica ×
+  sync_interval`, zero on a single replica) instead of synchronous — a
+  deliberate, documented trade, not a regression. **Not yet re-measured**:
+  the numbers in this draft predate the fix; post-fix throughput lands in
+  `claude_dev/rate-limit-fix-verification.md` when that run completes, not in
+  this file.
 
 **Other caveats, stated plainly:** consumer-laptop hardware (server-class
 re-run still pending budget — see "next round" below); AXIAM stack figures
@@ -699,21 +731,23 @@ explained — one open mechanism question remains. The decision cache and the
 DB connection pool were both evaluated against pre-agreed criteria and both
 stay at their conservative defaults — real, useful knobs for the right
 workload, not blanket wins. And the most consequential finding of this
-round is a limitation, not a feature: **the "post-seed transient" is a
+round was a limitation, not a feature: **the "post-seed transient" was a
 permanent, product-relevant synchronous datastore write in front of six
-hot endpoints, whose cost sets those endpoints' ceiling on any given
+hot endpoints, whose cost set those endpoints' ceiling on any given
 deployment's hardware** (§1/§5) — this draft's own numbers show that ceiling
-is high on a fast datastore (the G-box), but a fix to get the write off the
-synchronous path is tracked and has not shipped. Everything here remains
-laptop-hosted.
+was high on a fast datastore (the G-box), and the fix to get the write off
+the synchronous path (plus the separate `GET /api/v1/users` bucket bug) has
+now **shipped** on `claude/g-benchmark-improvements-n5mjmj`, though it has
+not yet been re-measured end-to-end. Everything here remains laptop-hosted.
 
-**Next round (E3/E5):** the tracked fix for the shared rate-limit write,
-then a true run-4 median-of-3 matrix — on the G-box, on a server-class
-host, or on a sandbox host after the fix lands, whichever comes first —
-covering the full protocol including a repeated (not single-pass) SDK
-overhead table; the `GET /api/v1/users` rate-limit-bucket bug fix; and, if
-budget allows, the server-class re-run that has been tracked and deferred
-since draft 2.
+**Next round (E3/E5):** re-measure the shared rate-limit write's fix
+end-to-end (numbers land in `claude_dev/rate-limit-fix-verification.md`
+first, then fold into a future draft's matrix here), then a true run-4
+median-of-3 matrix — on the G-box, on a server-class host, or on the
+sandbox host now that the fix has landed, whichever comes first — covering
+the full protocol including a repeated (not single-pass) SDK overhead
+table; and, if budget allows, the server-class re-run that has been tracked
+and deferred since draft 2.
 
 ---
 *Sources: G-box benchmark runs of 2026-07-25/26 (median-of-3 capped matrix ×

--- a/claude_dev/rate-limit-fix-verification.md
+++ b/claude_dev/rate-limit-fix-verification.md
@@ -1,0 +1,221 @@
+# Rate-limit fix verification (closes H2)
+
+**Status: VERIFIED on this box.** The five commits on
+`claude/g-benchmark-improvements-n5mjmj`
+(`5212912`, `69109db`, `0fbbd5e`, `1f3da2f`, `7167c18`) remove the synchronous
+per-request `UPSERT` that H2 root-caused
+(`claude_dev/postseed-transient-investigation.md` §1, §2, §7). All six
+previously-clamped endpoints — `POST /api/v1/authz/check`, `POST
+/oauth2/token`, `POST /oauth2/introspect`, `POST /oauth2/revoke`, `GET
+/api/v1/users` and (partially — see caveats) `POST /api/v1/auth/login` —
+escape the 16–21 ops/s band. The H1 settle gate, which H2 §8.1 predicted
+"can never pass in an environment like this one," **passed on the first
+probe attempt** against this build.
+
+> **Provenance.** Measured 2026-07-29/30, branch
+> `claude/g-benchmark-improvements-n5mjmj` @ `7f3ea7d4b5fde83aa9b637320e7cb09db281a046`
+> (the crates/ source at HEAD `7167c18` — the one later commit, `7f3ea7d`,
+> is a docs-only change from a sibling agent and touches no crate source),
+> local image `axiam/server:rl-fix-local` built from that source, server and
+> datastore each capped at 2 CPU / 1 GiB (same envelope H2 used),
+> `just target=axiam profile=p0-plaintext bench-up`. Shipped defaults:
+> `AXIAM__RATE_LIMIT__SHARED=on`, `AXIAM__RATE_LIMIT__SHARED_SYNC_MS=1000`.
+
+---
+
+## 1. What was built
+
+A local server image (`axiam/server:rl-fix-local`) from this branch's actual
+source, via `docker buildx build` (not `just ... build=1`, to avoid touching
+tracked compose/Dockerfile files). Two **sandbox-only, uncommitted** build
+inputs were needed to reach crates.io/complete the build inside this
+environment (neither touches a tracked file or the real Dockerfile —
+`git status` is clean on this branch throughout):
+
+- A trusted CA bundle (`/root/.ccr/ca-bundle.crt`) installed into the builder
+  stage's trust store, via `docker buildx build --build-context
+  cabundle=/root/.ccr` — without it, `cargo build`'s crates.io fetches fail
+  TLS verification against this sandbox's egress proxy.
+- The cached `swagger-ui-5.17.14.zip`
+  (`/home/user/.axiam-build-cache/swagger-ui-5.17.14.zip`), copied into the
+  image and pointed at via `SWAGGER_UI_DOWNLOAD_URL=file://...` — avoids the
+  blocked `github.com` fetch `utoipa-swagger-ui`'s build script otherwise
+  makes.
+
+Same `CARGO_FEATURES=jemalloc` default as `docker/Dockerfile.server`. The
+temporary Dockerfile lived under `/tmp/rlfix-build/` (never in the repo).
+The compose target was pointed at the local image purely via environment —
+`BENCH_AXIAM_IMAGE=axiam/server:rl-fix-local BENCH_AXIAM_PULL_POLICY=never`
+— which makes `docker compose pull` a documented no-op ("Image ... Skipped")
+instead of falling through to a source rebuild; no tracked file in
+`benchmarks/` was touched.
+
+## 2. How measured
+
+`benchmarks/runner/h2-clamp-probe.sh`, run exactly as H2's own header
+documents (`h2-clamp-probe.sh <op> 1 8` and `<op> 20 15`, one credential
+mint outside the measured window, 25 requests per kept-alive curl
+connection). No `AXIAM__RATE_LIMIT__SHARED=off` override — the headline
+numbers below are the shipped write-behind path with its 1000 ms default
+sync interval.
+
+## 3. Before/after clamp map
+
+H2's baseline is `claude_dev/postseed-transient-investigation.md` §2 (its
+own provenance: `server:1.0.0-alpha19`, same 2 CPU / 1 GiB caps, rate
+limits neutralized). "Escaped?" is judged against §7's success criterion:
+land in the band the operation's unwrapped structural sibling occupies.
+
+| operation | endpoint | H2 1 VU ops/s | H2 1 VU p50 | **now** 1 VU ops/s | **now** 1 VU p50 | H2 20 VU ops/s | H2 20 VU p50 | **now** 20 VU ops/s | **now** 20 VU p50 | escaped? |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|:--:|
+| health | `GET /health` | 510 | 0.3 ms | **1134.4** | 0 ms | 4248 | 1 ms | **4313.3** | 1 ms | n/a (never clamped) |
+| jwks | `GET /oauth2/jwks` | 493–504 | 0.3 ms | **1084.4** | 0 ms | 2992 | 1 ms | **3198.3** | 1 ms | n/a |
+| userinfo | `GET /oauth2/userinfo` | 299–302 | 1 ms | **525.0** | 1 ms | 1681 | 9 ms | **1951.7** | 8 ms | n/a |
+| resources | `GET /api/v1/resources` | 68–74 | 11–12 ms | **87.5** | 11 ms | 254–280 | 66–74 ms | **306.7** | 65 ms | n/a (the sibling) |
+| roles | `GET /api/v1/roles` | 67–74 | 11–13 ms | **81.2** | 11 ms | 256 | 73 ms | **270.0** | 72 ms | n/a (the sibling) |
+| **users (list)** | `GET /api/v1/users` | 14–16 | 60–65 ms | **84.4** | 11 ms | 17.9–20.0 | 967–1106 ms | **280.0** | 69 ms | **YES** — now indistinguishable from `resources`/`roles` |
+| **authz check** | `POST /api/v1/authz/check` | 16–18 | 55–60 ms | **146.9** | 6 ms | 18.8–21.3 | 907–1061 ms | **583.3** | 30 ms | **YES** |
+| **client credentials** | `POST /oauth2/token` | 16–18 | 51–55 ms | **306.2** | 2 ms | 20.0–21.7 | 897–1032 ms | **1231.7** | 14 ms | **YES** |
+| **introspection** | `POST /oauth2/introspect` | 17–19 | 49–58 ms | **428.1** | 2 ms | 20.0 | 1002 ms | **1553.3** | 11 ms | **YES** |
+| **revocation** | `POST /oauth2/revoke` | 17.3 | 53 ms | **300.0** | 3 ms | — (not recorded by H2) | — | **1266.7** | 13 ms | **YES** |
+| **login** | `POST /api/v1/auth/login` | 8–11 | 95–116 ms | **19.4** | 51 ms | 19.2 | 1032 ms | **37.0** | 531 ms | **partial — see §5** |
+
+`pct2xx=100` on every probe cell above (n ranges 175–64 700 requests per
+cell); raw TSV: `/tmp/rlfix-build/clamp-after.tsv` (not committed — scratch
+output, reproducible via `run_clamp_matrix.sh` pattern below).
+
+Five of six previously-wrapped endpoints now land within noise of their
+unwrapped structural siblings (compare `users` 84.4/280.0 to
+`resources` 87.5/306.7 and `roles` 81.2/270.0 — the exact "cleanest natural
+experiment" H2 §2.1 called out). `login` is the exception; see §5 — it is
+**not** a residual instance of H2's clamp.
+
+## 4. Mechanism confirmation
+
+**(a) Startup log line.** Present on every boot, both listeners:
+
+```
+{"level":"INFO","fields":{"message":"shared rate-limit counter ACTIVE (write-behind); one datastore write per bucket per sync interval instead of one per request","sync_interval_ms":1000,"shards":16},"target":"axiam_db::rate_limit_counter"}
+```
+(logged twice per boot — once for the REST `AppState` counter, once for the
+gRPC layer's own counter, per `7167c18`'s documented reason for the split.)
+
+**(b) Batched writes, not per-request writes.** `rate_limit_bucket` cleared,
+then 6500 `authz_check` requests fired over ~12 s (`h2-clamp-probe.sh authz
+10 12`) while sampling `SELECT id, count, updated_at FROM rate_limit_bucket`
+roughly once per second:
+
+| sample time (UTC) | `authz_check` count | `updated_at` |
+|---|---:|---|
+| 00:02:51.593 | 472 | 00:02:51.258 |
+| 00:02:53.102 | 1568 | 00:02:53.282 |
+| 00:02:54.874 | 2048 | 00:02:54.292 |
+| 00:02:56.301 | 3087 | 00:02:56.310 |
+| 00:02:57.836 | 3651 | 00:02:57.317 |
+| 00:02:59.243 | 4829 | 00:02:59.327 |
+| 00:03:00.708 | 154 *(fixed-60s-window rollover at the minute boundary)* | 00:03:00.332 |
+| 00:03:02.065 | 1304 | 00:03:02.359 |
+
+6500 requests landed as **8 distinct `updated_at` values across 12 s** —
+roughly one write per second, not one per request — while idle buckets
+(`login`, `oauth2_token`, untouched after their one-off mint requests) never
+moved at all. This is the write-behind flush behaving exactly as
+`SharedRateLimitCounter`'s module docs describe.
+
+**(c) Rate limiting still works end-to-end under production limits.**
+Fresh stack, `just target=axiam profile=p0-plaintext rl=prod bench-up`
+(`AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN=300`), 20 concurrent curl workers
+against `POST /api/v1/authz/check` for 15 s, authenticated user session:
+
+```
+total=3407  admitted_200=299  throttled_429=3108  other=0
+```
+
+299 admitted is within noise of the configured 300/min budget consumed by
+the front of the burst; the remaining 3108 requests in the same 15 s window
+were correctly rejected with 429. `other=0` — no unexpected status codes.
+The fix moved the counting mechanism off the request path; it did not
+change what gets enforced.
+
+## 5. `login` did not fully escape — and that's expected, not a bug
+
+`login` improved (~2×: 8–11→19.4 ops/s @1 VU, 19.2→37.0 ops/s @20 VU) but
+stayed far below the other five endpoints' 15–80× jumps. This is **not** a
+residual H2 clamp. `login` is the only wrapped endpoint whose handler also
+does an Argon2id password verification — a deliberately expensive,
+CPU-bound security control (`AXIAM__AUTH__MAX_CONCURRENT_HASHES`, B1 gate,
+`crates/axiam-auth/src/config.rs`). Under this bench's 2-CPU server cap,
+Argon2id's own cost dominates once the ~40 ms rate-limit write is removed:
+observed numbers back-calculate to ~50 ms of real CPU time per hash
+(1 VU: 1/0.050s ≈ 20 ops/s, matches 19.4; 20 VU: 2 cores / 0.050s ≈ 40 ops/s,
+matches 37.0) — a **2-CPU-cap ceiling on Argon2id**, not a rate-limit
+artifact. `login` has no unwrapped structural sibling in H2's map to compare
+against (every other wrapped endpoint is a plain lookup/token-mint handler);
+this is the honest result, reported as asked.
+
+## 6. Settle gate: PASSED (a first for this environment)
+
+`just target=axiam profile=p0-plaintext scenario=authz_check_rest.js
+bench-run`, default thresholds (≥400 ops/s OR p50<150ms @ 20 VU burst,
+`BENCH_SETTLE_TIMEOUT_SECS=600`):
+
+```
+[run] settle probe #1: 188.7 ops/s, p50 28.076ms, n=2666 samples (elapsed 15s)
+[run] settle gate: PASSED (188.7 ops/s / p50 28.076ms) — proceeding after 15s
+```
+
+`meta.json`: `"settle_wait_secs": 15, "settle_timeout": false`. The gate
+passed on its **first** probe (no retries needed) — H2 §8.1 said this gate
+"can never pass in an environment like this one" while the clamp stood; it
+now passes immediately.
+
+The full `authz_check_rest` k6 cell (50 VUs, 30 s warmup + 120 s measured)
+that followed:
+
+```
+bench_ok: 94368  589.570273/s
+bench_op_latency_ms: avg=73.75ms p50=75.12ms p95=115.53ms p99=140.7ms
+checks: 100.00% (94368/94368), bench_error_rate: 0.00%
+```
+
+**589.6 ops/s sustained**, 0% errors — this is the strong signal for the
+user's upcoming run-4: authz throughput cells no longer need to be sourced
+from a different host.
+
+## 7. Caveat found on the way (not part of H2, reported for completeness)
+
+During testing, ~7 minutes after one `bench-up` boot, **every** SurrealDB-
+backed operation on the server started failing with 401 (not just the
+rate-limit flusher — `POST /api/v1/auth/login` too, and audit-log writes).
+Root cause, read from `crates/axiam-server/src/main.rs` and
+`crates/axiam-db/src/pool.rs`: essentially every repository/service in
+`main.rs` is built once at boot from `pool.handle_for_repo().await`, a
+**one-time clone** of the pool's current `Surreal<C>` handle — not a live
+reference. `DbManager`'s own proactive re-signin/reconnect loop (D-03/D-04)
+does work, but it only benefits *future* `pool.handle_for_repo()` /
+`pool.checkout()` callers; once *any* reconnect event swaps a fresh
+connection object into the pool's internal slot, every handle captured at
+boot (which is effectively the whole app — org/tenant/user/session/audit/
+rate-limit repos, etc.) is left pointing at the old, now-unauthenticated
+connection, permanently, until the process restarts. A plain `docker
+restart bench-axiam-server` (no reseed needed — data is in the DB volume)
+recovered instantly and reproducibly. This is **unrelated to the H2 rate-
+limit fix** — it is a pre-existing architectural gap in how the DB pool's
+reconnect safety net reaches long-lived consumers — and is being reported
+here only because it interrupted this verification run twice and is worth
+a follow-up issue on its own. It did not affect the correctness of any
+number in §3/§4/§6 above (each was captured on a fresh boot before the
+condition recurred).
+
+## 8. Verdict
+
+**The clamp is gone on this host, for five of the six previously-wrapped
+endpoints, without exception, and the sixth (`login`) is bounded by an
+unrelated, deliberate Argon2id CPU cost rather than by the removed
+rate-limit write.** `GET /api/v1/users` no longer inherits the registration
+limiter. The write-behind mechanism is confirmed both structurally (log
+line, batched datastore writes) and behaviorally (429s still fire correctly
+under production limits). The H1 settle gate — previously guaranteed to
+time out on any box with an expensive rate-limit write — passed on its
+first attempt, and the `authz_check_rest` k6 cell it gates sustained
+589.6 ops/s at 0% errors.

--- a/claude_dev/rate-limit-posture-decision.md
+++ b/claude_dev/rate-limit-posture-decision.md
@@ -475,3 +475,131 @@ from the sizing doc's §7.2 pointer below instead of overwriting §2's table.
    default* column is already correct and now CI-guarded against drift
    (§5.5). Someone should add a `PROFILE` row and point the M2M column at
    the preset when the public doc is next revised (E4 / fourth draft).
+
+---
+
+## 8. H2 follow-up: both `postseed-transient-investigation.md` §7.1 asks are now implemented
+
+**Not part of G7's original scope** — this section closes the loop on a
+*different* follow-up issue text (§7.1 of
+[`postseed-transient-investigation.md`](postseed-transient-investigation.md),
+written up by task H2) that names this same branch,
+`claude/g-benchmark-improvements-n5mjmj`. It is recorded here, rather than in
+that file (which is frozen as the investigation record), because this is the
+decision-record file for rate-limit changes on this branch.
+
+That issue text asked for two things. Both are now implemented, in commits
+`5212912`, `69109db`, `0fbbd5e`, `1f3da2f`, `7167c18`:
+
+1. **Bug — `GET /api/v1/users` charged to `users_create`.** Fixed
+   (`69109db`): `web::resource("/users")` is now two method-guarded
+   resources instead of one, so the `GET` list no longer inherits the `POST`
+   registration limiter (`register_per_min`, 5/min/IP in the shipped
+   posture). `GET /api/v1/users` is now unlimited by the shared/governor
+   layers, matching its siblings `GET /roles` and `GET /resources`. Regression
+   test: `crates/axiam-api-rest/tests/users_rate_limit_split_test.rs`.
+2. **Design — the shared-store round trip on the synchronous critical
+   path.** Fixed (`5212912`, `0fbbd5e`, `1f3da2f`, `7167c18`): a new
+   write-behind `SharedRateLimitCounter`
+   (`crates/axiam-db/src/rate_limit_counter.rs`) replaces the per-request
+   synchronous `UPSERT` in both `RateLimitShared` (REST) and
+   `GrpcSharedRateLimitLayer` (gRPC) with a synchronous in-memory decision
+   plus a background flusher that coalesces one datastore write per bucket
+   per `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` (default 1000 ms, clamped
+   50–60000). A new `AXIAM__RATE_LIMIT__SHARED` (`on`/`off`, default `on`)
+   gives single-replica deployments an escape hatch. No shipped *limit*
+   default changed.
+
+### What was chosen, and why
+
+The issue text (§7.1 ask 2) listed four options worth measuring: an
+in-process TTL cache of the bucket count with periodic write-back;
+fire-and-forget the UPSERT and decide on the previous read; an explicit
+`AXIAM__RATE_LIMIT__SHARED=off` for single-replica deployments; or moving the
+counter out of the datastore entirely.
+
+**The shipped design is a combination of the first and third options**, not
+a selection of one: `SharedRateLimitCounter` *is* an in-process cache of the
+bucket count (the "TTL" is the write-behind `sync_interval` rather than a
+read-side expiry) with periodic write-back — matching option 1 — **and**
+ships the `AXIAM__RATE_LIMIT__SHARED=off` escape hatch from option 3
+alongside it, so a single-replica deployment can drop the shared layer
+entirely rather than merely tolerate its now-much-cheaper write-behind
+overhead.
+
+Rationale for combining rather than picking one option outright:
+
+- **Plain fire-and-forget (option 2) was rejected as strictly worse than
+  write-behind for the same cost.** A fire-and-forget UPSERT deciding on the
+  *previous* read still requires one asynchronous datastore call per request
+  (just not awaited before the decision) and gives no coalescing — N requests
+  in a window still cost N writes, just off the latency-critical path rather
+  than off the write-count path. Write-behind coalesces N requests into one
+  write per `sync_interval`, which is strictly fewer datastore operations for
+  the same or better staleness bound, at no extra design cost.
+- **An off-switch alone (option 3) was rejected as insufficient by itself.**
+  It solves the problem only for single-replica deployments; anyone running
+  behind an HPA (the topology the shared layer exists for) would still pay
+  the full synchronous cost. Shipping it as an *addition* to write-behind,
+  not a replacement, keeps the multi-replica case fixed while still giving
+  single-replica operators the option to remove even the write-behind
+  overhead entirely.
+- **Moving the counter out of the datastore entirely (option 4) was rejected
+  for this fix** — it would mean introducing a new piece of shared
+  infrastructure (e.g. Redis) as a hard dependency purely for rate-limit
+  bucket counts, which is a bigger architectural commitment than the
+  performance problem calls for. `SurrealDB` remains the store of record;
+  write-behind reduces the *frequency* of writes to it by roughly
+  `arrival_rate × sync_interval` per bucket instead of replacing it.
+- **Net effect:** cross-replica enforcement is preserved (the property the
+  shared layer exists for — N independent per-replica in-memory buckets
+  would otherwise multiply the effective limit by N), the synchronous
+  datastore write is off the request path entirely, and the trade made
+  explicit is eventual rather than immediate cross-replica convergence,
+  bounded by `(replicas - 1) × arrival_rate_per_replica × sync_interval` and
+  zero on a single replica. Full derivation and a worked example (limit
+  100/min, 4 replicas, 1 s sync interval, 40 req/s aggregate ⇒ ~30 requests
+  of overshoot) are in the
+  [`axiam_db::rate_limit_counter`](../crates/axiam-db/src/rate_limit_counter.rs)
+  module docs, quoted in
+  [`docs/deployment/README.md` § Shared-store consistency model](../docs/deployment/README.md#shared-store-consistency-model-write-behind).
+
+### A behavioral delta the implementer flagged, not part of the original ask
+
+Fixing the design ask surfaced one change in fail-open behavior worth
+recording here even though it wasn't one of the two things asked for: a
+store outage used to be discovered *by the request* (the awaited UPSERT
+itself failing), which made the middleware fail open for that request
+regardless of the configured limit. It is now discovered *by the background
+flusher*, so a request during a store outage is evaluated against the (still
+valid) local count instead of being blanket-allowed. Concretely, `limit = 0`
+plus an unreachable store now **denies**, where the pre-fix code would have
+**allowed** — a correctness improvement (an outage must not read as "the
+limit is disabled"), not a new fail-open surface. Fail-open on store errors
+during the flush remains, exactly as before.
+
+### What still needs the maintainer
+
+**Nothing from §7.1 of `postseed-transient-investigation.md` is still open**
+— both asks are implemented as described above and are ready for the same
+PR review as the rest of this branch.
+
+**§7.1 of *this* file (the sign-off items above, added by H7) is a
+completely separate list and is unaffected by this section** — those three
+items are about the `gateway`/`mesh` **preset values** and the `client_id`
+keying bypass, none of which this H2 follow-up touches (no shipped limit or
+preset value changed here either). They remain open and still need a named
+human decision:
+
+1. Do the `gateway`/`mesh` preset numbers match the fleet sizes the
+   maintainer intends to support?
+2. Is `mesh` authz = 60 000/min (a documented not-really-a-limit) acceptable
+   under that profile name, or should it drop to 30 000?
+3. Is the documentation-plus-opt-in treatment of the `client_id` keying
+   bypass sufficient for v1.0-beta, or does it need to become a blocking
+   issue?
+
+Post-fix throughput re-measurement is tracked separately and is not this
+file's job to produce — see `claude_dev/rate-limit-fix-verification.md` (not
+yet present at the time of writing — produced by a separate, concurrent
+verification task) for where it lands.

--- a/crates/axiam-api-grpc/src/middleware/rate_limit.rs
+++ b/crates/axiam-api-grpc/src/middleware/rate_limit.rs
@@ -15,15 +15,21 @@
 //!   selects the rightmost trusted XFF hop, and when there are NOT enough
 //!   hops to trust, XFF is ignored entirely and the verified tonic connection
 //!   peer address is used instead (never `hops[0]` — SECHRD-03/D-01d).
-//! - [`GrpcSharedRateLimitLayer`] — an async pre-check `tower::Layer` that
-//!   reuses the plan-24-04 `SurrealRateLimitBucketRepository` shared-store
-//!   counter, run BEFORE the existing per-replica in-memory `GovernorLayer`
-//!   (kept byte-for-byte unchanged as the fail-open fallback, D-01b). This is
-//!   deliberately NOT a `governor::StateStore` impl and never calls
-//!   `block_on` — `StateStore::measure_and_replace` is a *synchronous* trait
-//!   method (RESEARCH Pitfall 1), so the shared-store check is a separate
-//!   async tower service that performs its own SurrealDB round-trip and then
-//!   delegates to the inner service.
+//! - [`GrpcSharedRateLimitLayer`] — a pre-check `tower::Layer` over the
+//!   process-wide write-behind `axiam_db::SharedRateLimitCounter` (the SAME
+//!   counter type and env knobs — `AXIAM__RATE_LIMIT__SHARED`,
+//!   `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` — the REST `RateLimitShared`
+//!   middleware uses), run BEFORE the existing per-replica in-memory
+//!   `GovernorLayer` (kept byte-for-byte unchanged as the fail-open fallback,
+//!   D-01b). This is deliberately NOT a `governor::StateStore` impl and never
+//!   calls `block_on` — `StateStore::measure_and_replace` is a *synchronous*
+//!   trait method (RESEARCH Pitfall 1).
+//!
+//!   Since the H2 performance fix this layer performs NO datastore round trip
+//!   on the request path (it used to `await` one `UPSERT` per call, and being
+//!   server-wide, *every* gRPC call paid it — see the layer's own docs for the
+//!   measurements). A single background flusher coalesces the in-memory
+//!   increments into one write per bucket per sync interval.
 //!
 //! HARD CONSTRAINT (D-01c coordination note): the `Quota::per_second(...)
 //! .burst_size(...)` throughput/quota math in [`build_grpc_governor_layer`]
@@ -36,6 +42,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use axiam_db::SharedRateLimitCounter;
 use axiam_db::repository::SurrealRateLimitBucketRepository;
 use chrono::{DateTime, Utc};
 use governor::Quota;
@@ -223,12 +230,14 @@ fn too_many_requests_response() -> Response<tonic::body::Body> {
     tonic::Status::resource_exhausted("rate limit exceeded").into_http()
 }
 
-/// Async SurrealDB-backed shared rate-limit pre-check `tower::Layer` for the
-/// gRPC path (SECHRD-03 / D-01a, D-01b, D-01c, D-01d).
+/// Shared (cross-replica) rate-limit pre-check `tower::Layer` for the gRPC
+/// path (SECHRD-03 / D-01a, D-01b, D-01c, D-01d).
 ///
-/// Reuses [`SurrealRateLimitBucketRepository::increment`] (plan 24-04) —
-/// there is no reimplemented counter here. Wire this layer BEFORE (i.e.
-/// `.layer()` it FIRST — tower's `ServiceBuilder`/`Server::builder()`
+/// Consults the process-wide write-behind [`SharedRateLimitCounter`]
+/// (`axiam-db::rate_limit_counter`) — the SAME counter type and the SAME env
+/// knobs the REST `RateLimitShared` middleware uses, so both listeners behave
+/// identically. There is no reimplemented counter here. Wire this layer BEFORE
+/// (i.e. `.layer()` it FIRST — tower's `ServiceBuilder`/`Server::builder()`
 /// executes the FIRST-added layer with the request FIRST, the opposite of
 /// actix's last-`.wrap()`-is-outermost rule) the existing
 /// [`build_grpc_governor_layer`] `GovernorLayer` on the same
@@ -241,31 +250,87 @@ fn too_many_requests_response() -> Response<tonic::body::Body> {
 ///     .add_service(authz_svc)
 /// ```
 ///
-/// **Fail-open (D-01b, T-24-73 accepted risk):** when the shared store is
-/// unreachable, or no client IP can be extracted, this layer logs a
-/// `warn`-level alarm and forwards the request unchanged so the existing
-/// in-memory governor makes the decision instead — a counter-store outage
-/// must never hard-block gRPC authz traffic.
+/// # No synchronous datastore write on the request path (H2 fix)
+///
+/// This layer used to `await` one SurrealDB `UPSERT` per call. Because it is a
+/// **server-wide** layer on the tonic listener, EVERY gRPC call paid that
+/// write — measured at ~39–46 ms of datastore-attributed latency, pinning the
+/// listener at ~20 ops/s regardless of concurrency
+/// (`claude_dev/postseed-transient-investigation.md` §1, §2, §7). It now pays
+/// only an in-memory sharded-map increment
+/// ([`SharedRateLimitCounter::check`], fully synchronous), while a single
+/// background flusher coalesces the increments into one datastore write per
+/// bucket per `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`. Cross-replica enforcement
+/// is therefore eventual, with the overshoot bound stated precisely in the
+/// [`axiam_db::rate_limit_counter`] module docs; the in-memory governor still
+/// makes a full per-replica decision on the same traffic.
+///
+/// Everything else is unchanged: the same `{endpoint}:{ip}` bucket key, the
+/// same `GrpcTrustedHopsKeyExtractor` key derivation (D-01d), and the same
+/// `RESOURCE_EXHAUSTED` rejection.
+///
+/// **Fail-open (D-01b, T-24-73 accepted risk):** when no client IP can be
+/// extracted, or the shared layer is disabled via
+/// `AXIAM__RATE_LIMIT__SHARED=off`, this layer forwards the request unchanged
+/// so the existing in-memory governor makes the decision instead. Store
+/// outages are surfaced by the counter's flusher (a `warn` alarm that never
+/// includes the raw key) while decisions keep being served from local counts —
+/// a counter-store outage must never hard-block gRPC authz traffic.
 ///
 /// **CRITICAL (RESEARCH Pitfall 1):** `governor::StateStore::measure_and_replace`
 /// is a *synchronous* trait method. This layer is deliberately NOT a
-/// `StateStore` implementation and never calls `block_on` — it performs its
-/// own async SurrealDB round-trip as a plain `tower::Layer`/`Service`, then
-/// delegates to the inner service.
-pub struct GrpcSharedRateLimitLayer<C: Connection> {
-    db: Surreal<C>,
+/// `StateStore` implementation and never calls `block_on`.
+///
+/// No longer generic over the SurrealDB connection type: it holds a
+/// non-generic [`SharedRateLimitCounter`] (which owns the boxed store), which
+/// is why the `Surreal<C>` handle only appears in [`Self::new`]'s signature.
+#[derive(Clone)]
+pub struct GrpcSharedRateLimitLayer {
+    counter: SharedRateLimitCounter,
     endpoint: &'static str,
     limit: u32,
     trusted_hops: usize,
 }
 
-impl<C: Connection> GrpcSharedRateLimitLayer<C> {
+impl GrpcSharedRateLimitLayer {
+    /// Builds the layer and its process-wide write-behind counter from a
+    /// SurrealDB handle, reading `AXIAM__RATE_LIMIT__SHARED` /
+    /// `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` via
+    /// [`axiam_db::SharedRateLimitConfig::from_env`].
+    ///
+    /// Call this ONCE per process (as `start_grpc_server` does): the counter's
+    /// local counts live in the instance it creates, so building several would
+    /// fragment them. Use [`Self::with_counter`] to share one counter
+    /// explicitly.
+    ///
     /// `endpoint` MUST be unique per rate-limited gRPC surface so the shared
     /// bucket key (`"{endpoint}:{ip}"`) preserves per-surface granularity —
     /// never collapse distinct surfaces into one global bucket.
-    pub fn new(db: Surreal<C>, endpoint: &'static str, limit: u32, trusted_hops: usize) -> Self {
+    pub fn new<C: Connection>(
+        db: Surreal<C>,
+        endpoint: &'static str,
+        limit: u32,
+        trusted_hops: usize,
+    ) -> Self {
+        Self::with_counter(
+            SharedRateLimitCounter::from_env(Arc::new(SurrealRateLimitBucketRepository::new(db))),
+            endpoint,
+            limit,
+            trusted_hops,
+        )
+    }
+
+    /// Builds the layer over an EXISTING counter — for tests, and for any
+    /// deployment that wants the gRPC listener and something else to share one
+    /// counter instance.
+    pub fn with_counter(
+        counter: SharedRateLimitCounter,
+        endpoint: &'static str,
+        limit: u32,
+        trusted_hops: usize,
+    ) -> Self {
         Self {
-            db,
+            counter,
             endpoint,
             limit,
             trusted_hops,
@@ -273,38 +338,13 @@ impl<C: Connection> GrpcSharedRateLimitLayer<C> {
     }
 }
 
-// Manual `Clone` impl (NOT `#[derive(Clone)]`): `Surreal<C>` is `Clone` for
-// EVERY `C` unconditionally (it's an `Arc`-backed handle internally — see
-// `surrealdb::Surreal<C>`'s own `impl<C> Clone for Surreal<C>`, no `C: Clone`
-// bound). A derived `Clone` incorrectly adds a spurious `C: Clone` bound
-// (derive macros bound every generic type parameter that appears in a
-// field), which broke `start_grpc_server<..., C>`'s generic wiring — the
-// concrete `C` there (`surrealdb::engine::remote::http::Client`) has no
-// `Clone` impl, and forcing this layer to require one would leak into the
-// caller's generic bounds for no reason. Mirrors the REST
-// `RateLimitShared`/`RateLimitSharedService` precedent
-// (`axiam-api-rest::middleware::rate_limit_shared`).
-impl<C: Connection> Clone for GrpcSharedRateLimitLayer<C> {
-    fn clone(&self) -> Self {
-        Self {
-            db: self.db.clone(),
-            endpoint: self.endpoint,
-            limit: self.limit,
-            trusted_hops: self.trusted_hops,
-        }
-    }
-}
-
-impl<S, C> Layer<S> for GrpcSharedRateLimitLayer<C>
-where
-    C: Connection + 'static,
-{
-    type Service = GrpcSharedRateLimitService<S, C>;
+impl<S> Layer<S> for GrpcSharedRateLimitLayer {
+    type Service = GrpcSharedRateLimitService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
         GrpcSharedRateLimitService {
             inner,
-            db: self.db.clone(),
+            counter: self.counter.clone(),
             endpoint: self.endpoint,
             limit: self.limit,
             trusted_hops: self.trusted_hops,
@@ -313,30 +353,20 @@ where
 }
 
 /// Inner `tower::Service` produced by [`GrpcSharedRateLimitLayer`].
-pub struct GrpcSharedRateLimitService<S, C: Connection> {
+///
+/// `Clone` requires only `S: Clone` — [`SharedRateLimitCounter`] is an
+/// `Arc`-backed handle, so every clone (one per request, via tonic's
+/// clone-and-swap) shares the SAME counter state.
+#[derive(Clone)]
+pub struct GrpcSharedRateLimitService<S> {
     inner: S,
-    db: Surreal<C>,
+    counter: SharedRateLimitCounter,
     endpoint: &'static str,
     limit: u32,
     trusted_hops: usize,
 }
 
-// Manual `Clone` impl for the same reason as `GrpcSharedRateLimitLayer`
-// above: only `S: Clone` should be required, never `C: Clone` (`Surreal<C>`
-// clones unconditionally regardless of `C`).
-impl<S: Clone, C: Connection> Clone for GrpcSharedRateLimitService<S, C> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            db: self.db.clone(),
-            endpoint: self.endpoint,
-            limit: self.limit,
-            trusted_hops: self.trusted_hops,
-        }
-    }
-}
-
-impl<S, C> Service<Request<tonic::body::Body>> for GrpcSharedRateLimitService<S, C>
+impl<S> Service<Request<tonic::body::Body>> for GrpcSharedRateLimitService<S>
 where
     S: Service<Request<tonic::body::Body>, Response = Response<tonic::body::Body>>
         + Clone
@@ -344,7 +374,6 @@ where
         + 'static,
     S::Future: Send + 'static,
     S::Error: Send + 'static,
-    C: Connection + 'static,
 {
     type Response = Response<tonic::body::Body>;
     type Error = S::Error;
@@ -361,42 +390,35 @@ where
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
-        let db = self.db.clone();
+        // Cheap `Arc` clone — every request shares the ONE process-wide
+        // counter, never a fresh one (a per-request counter would count
+        // nothing).
+        let counter = self.counter.clone();
         let endpoint = self.endpoint;
         let limit = self.limit;
         let key_extractor = GrpcTrustedHopsKeyExtractor::new(self.trusted_hops);
 
+        // The rate-limit decision itself is now synchronous and taken BEFORE
+        // the future is even created — no datastore round trip on the path of
+        // this (server-wide!) layer. The returned future only awaits the inner
+        // service.
+        let ip = key_extractor.extract(&req).ok();
+        let allow = match ip {
+            Some(ip) => {
+                // Same bucket key as before — `{endpoint}:{ip}` — so an
+                // in-flight upgrade keeps counting against the same
+                // `rate_limit_bucket` records.
+                let key = format!("{endpoint}:{ip}");
+                counter.check(&key, window_start(Utc::now()), limit)
+            }
+            // No client-IP key available — fail open; the in-memory governor
+            // still makes the real decision. (A counter built with
+            // `AXIAM__RATE_LIMIT__SHARED=off` also always allows, from inside
+            // `check`.)
+            None => true,
+        };
+
         Box::pin(async move {
-            let ip = key_extractor.extract(&req).ok();
-
-            let allow = match ip {
-                Some(ip) => {
-                    let repo = SurrealRateLimitBucketRepository::new(db);
-                    let key = format!("{endpoint}:{ip}");
-                    let window = window_start(Utc::now());
-                    match repo.increment(&key, window).await {
-                        Ok(count) => count <= limit as u64,
-                        Err(err) => {
-                            // Fail OPEN (D-01b): a counter-store outage must
-                            // never hard-block gRPC authz traffic. Do NOT
-                            // log the raw key (endpoint:ip) at info+ (mirrors
-                            // the REST T-24-43 note) — this warn-level alarm
-                            // omits it.
-                            tracing::warn!(
-                                endpoint,
-                                error = %err,
-                                "shared gRPC rate-limit store unreachable; falling back \
-                                 to per-replica in-memory governor"
-                            );
-                            true
-                        }
-                    }
-                }
-                // No client-IP key available — fail open; the in-memory
-                // governor still makes the real decision.
-                None => true,
-            };
-
             if allow {
                 inner.call(req).await
             } else {

--- a/crates/axiam-api-grpc/src/server.rs
+++ b/crates/axiam-api-grpc/src/server.rs
@@ -57,12 +57,20 @@ use crate::services::{
 /// Start the gRPC server with all registered services.
 ///
 /// Applies two cooperating rate-limit layers (SECHRD-03, D-01a/b/c — gap
-/// closure for 24-07): the SurrealDB-backed [`GrpcSharedRateLimitLayer`]
-/// shared-store pre-check runs FIRST (outermost), failing OPEN on any DB
-/// error to the per-replica in-memory `GovernorLayer` (per D-10) built via
-/// `grpc_authz_per_sec` from `GrpcConfig`. Both layers derive their client-IP
-/// key from the SAME `trusted_hops` value so gRPC keying stays in lockstep
-/// across the shared store and the in-memory fallback.
+/// closure for 24-07): the [`GrpcSharedRateLimitLayer`] cross-replica
+/// pre-check runs FIRST (outermost), failing OPEN to the per-replica in-memory
+/// `GovernorLayer` (per D-10) built via `grpc_authz_per_sec` from
+/// `GrpcConfig`. Both layers derive their client-IP key from the SAME
+/// `trusted_hops` value so gRPC keying stays in lockstep across the shared
+/// counter and the in-memory fallback.
+///
+/// Since the H2 performance fix the shared pre-check performs NO synchronous
+/// datastore write: it is backed by the process-wide write-behind
+/// `axiam_db::SharedRateLimitCounter`, built ONCE here (this layer is
+/// server-wide, so every gRPC call used to pay one `UPSERT`). Knobs:
+/// `AXIAM__RATE_LIMIT__SHARED` (on|off, default on) and
+/// `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` (default 1000, clamped 50..=60000) —
+/// the same two the REST listener reads.
 ///
 /// Transport limits (CQ-B20):
 /// - Max message size: 4 MiB decode / 4 MiB encode
@@ -102,6 +110,11 @@ where
     // so a rotating XFF cannot mint a fresh bucket in one layer while being
     // correctly collapsed in the other.
     let trusted_hops = trusted_hops_from_env();
+    // Built exactly ONCE per process: this constructs the write-behind
+    // `SharedRateLimitCounter` (and spawns its single background flusher on
+    // this runtime). Cloning the LAYER is fine — the counter inside is an
+    // `Arc` handle, so every clone shares the same local counts. Building a
+    // second layer would create a second, independent counter.
     let shared_rate_limit_layer = GrpcSharedRateLimitLayer::new(
         db,
         "grpc_authz",

--- a/crates/axiam-api-grpc/tests/rate_limit_shared_store_test.rs
+++ b/crates/axiam-api-grpc/tests/rate_limit_shared_store_test.rs
@@ -2,26 +2,38 @@
 //! for the gRPC path, bringing it to parity with the REST shared-store
 //! pre-check (plan 24-04).
 //!
+//! Since the H2 performance fix the layer is backed by the write-behind
+//! `axiam_db::SharedRateLimitCounter`, so cross-replica enforcement is
+//! *eventual*: a replica counts its own traffic immediately and adopts the
+//! other replicas' contributions at its next flush. These tests therefore
+//! drive `flush_once()` explicitly (via
+//! `GrpcSharedRateLimitLayer::with_counter` plus
+//! `SharedRateLimitCounter::without_flusher`) instead of sleeping on the
+//! background flusher, proving the same property deterministically.
+//!
 //! Proves:
 //! - `rate_limit_shared_store_cross_instance`: two independent
 //!   `GrpcSharedRateLimitLayer` instances ("replicas") sharing ONE SurrealDB
-//!   enforce a single combined limit — an in-memory-only baseline (per-
-//!   replica buckets) would NOT reject at this point.
+//!   enforce a single combined limit after a flush cycle — an in-memory-only
+//!   baseline (per-replica buckets) would allow `2 × LIMIT`.
 //! - `rate_limit_shared_store_peer_parity_rotating_xff`: a rotating
 //!   (attacker-controlled) single-hop `X-Forwarded-For` header does NOT mint
 //!   a fresh bucket when `trusted_hops >= hops.len()` — the shared bucket
 //!   key is derived from the verified peer address instead (D-01d parity
 //!   with the fixed REST `XForwardedForKeyExtractor`).
 //! - `rate_limit_shared_store_fails_open_on_db_error`: when the shared store
-//!   errors, the request proceeds to the inner service (no hard block,
-//!   never a rejection) — D-01b.
+//!   is unreachable, traffic keeps flowing (no hard block, no panic, no 5xx)
+//!   and the layer keeps enforcing from local counts — D-01b.
 //!
 //! Run with: cargo test -p axiam-api-grpc --test rate_limit_shared_store_test
 
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use axiam_api_grpc::middleware::rate_limit::GrpcSharedRateLimitLayer;
+use axiam_db::repository::SurrealRateLimitBucketRepository;
+use axiam_db::{SharedRateLimitConfig, SharedRateLimitCounter};
 use http::{HeaderValue, Request, Response};
 use surrealdb::Surreal;
 use surrealdb::engine::local::{Db, Mem};
@@ -95,22 +107,45 @@ async fn setup_db() -> Surreal<TestDb> {
     db
 }
 
+/// One "replica": an independent write-behind counter over the supplied
+/// SurrealDB handle, with NO background flusher so the test controls exactly
+/// when convergence happens.
+fn replica_counter(db: Surreal<TestDb>) -> SharedRateLimitCounter {
+    SharedRateLimitCounter::without_flusher(
+        SharedRateLimitConfig::default(),
+        Arc::new(SurrealRateLimitBucketRepository::new(db)),
+    )
+}
+
 #[tokio::test]
 async fn rate_limit_shared_store_cross_instance() {
     let db = setup_db().await;
 
-    // Two INDEPENDENT layered services ("replicas") sharing the SAME
-    // underlying SurrealDB handle — proving the bucket is combined across
-    // replicas rather than reset per-replica.
-    let mut svc1 = GrpcSharedRateLimitLayer::new(db.clone(), "grpc_authz_cross_instance", LIMIT, 0)
-        .layer(ok_service());
-    let mut svc2 = GrpcSharedRateLimitLayer::new(db, "grpc_authz_cross_instance", LIMIT, 0)
-        .layer(ok_service());
+    // Two INDEPENDENT layered services ("replicas"), each with its OWN
+    // write-behind counter, sharing the SAME underlying SurrealDB handle —
+    // proving the bucket is combined across replicas rather than reset
+    // per-replica.
+    let counter1 = replica_counter(db.clone());
+    let counter2 = replica_counter(db);
+    let mut svc1 = GrpcSharedRateLimitLayer::with_counter(
+        counter1.clone(),
+        "grpc_authz_cross_instance",
+        LIMIT,
+        0,
+    )
+    .layer(ok_service());
+    let mut svc2 = GrpcSharedRateLimitLayer::with_counter(
+        counter2.clone(),
+        "grpc_authz_cross_instance",
+        LIMIT,
+        0,
+    )
+    .layer(ok_service());
 
     let peer: SocketAddr = "203.0.113.42:5000".parse().unwrap();
 
     // LIMIT requests split alternately across BOTH "replicas" must all
-    // succeed (the shared count climbing to exactly LIMIT).
+    // succeed (the combined count climbing to exactly LIMIT).
     for i in 0..LIMIT {
         let resp = if i % 2 == 0 {
             call(&mut svc1, request_with_peer(peer)).await
@@ -120,9 +155,19 @@ async fn rate_limit_shared_store_cross_instance() {
         assert!(!is_rejected(&resp), "request {i} should succeed");
     }
 
-    // The NEXT request on EITHER replica must be rejected — an in-memory-
-    // only per-replica baseline would instead allow LIMIT more requests on
-    // whichever replica hasn't seen traffic.
+    // One write-behind flush cycle per replica: each writes its coalesced
+    // delta and reads back the authoritative combined count.
+    counter1.flush_once().await;
+    counter2.flush_once().await;
+    // counter1 flushed before counter2's delta landed, so give it one more
+    // pass to adopt the combined count (this is the documented bounded
+    // staleness, not a lost update).
+    call(&mut svc1, request_with_peer(peer)).await;
+    counter1.flush_once().await;
+
+    // Both replicas now observe the COMBINED count and reject — an
+    // in-memory-only per-replica baseline would instead allow LIMIT more
+    // requests on whichever replica hasn't seen traffic (2 × LIMIT total).
     let resp1 = call(&mut svc1, request_with_peer(peer)).await;
     assert!(
         is_rejected(&resp1),
@@ -133,6 +178,48 @@ async fn rate_limit_shared_store_cross_instance() {
     assert!(
         is_rejected(&resp2),
         "replica 2 must observe the shared count"
+    );
+}
+
+/// The shared count really is ONE row shared by both replicas (not two
+/// independent per-replica counts), and the flusher coalesces: 6 requests
+/// across two replicas produce ONE row holding 6.
+#[tokio::test]
+async fn rate_limit_shared_store_coalesces_into_one_shared_row() {
+    let db = setup_db().await;
+
+    let counter1 = replica_counter(db.clone());
+    let counter2 = replica_counter(db.clone());
+    let endpoint = "grpc_authz_coalesce";
+    let mut svc1 = GrpcSharedRateLimitLayer::with_counter(counter1.clone(), endpoint, 100, 0)
+        .layer(ok_service());
+    let mut svc2 = GrpcSharedRateLimitLayer::with_counter(counter2.clone(), endpoint, 100, 0)
+        .layer(ok_service());
+
+    let peer: SocketAddr = "203.0.113.77:5000".parse().unwrap();
+    for _ in 0..3 {
+        assert!(!is_rejected(
+            &call(&mut svc1, request_with_peer(peer)).await
+        ));
+        assert!(!is_rejected(
+            &call(&mut svc2, request_with_peer(peer)).await
+        ));
+    }
+
+    counter1.flush_once().await;
+    counter2.flush_once().await;
+
+    // A delta-0 write reads the authoritative count back without changing it.
+    let repo = SurrealRateLimitBucketRepository::new(db);
+    let key = format!("{endpoint}:203.0.113.77");
+    let window = chrono::Utc::now();
+    let window =
+        chrono::DateTime::from_timestamp(window.timestamp() - window.timestamp().rem_euclid(60), 0)
+            .unwrap();
+    assert_eq!(
+        repo.increment_by(&key, window, 0).await.unwrap(),
+        6,
+        "6 requests across 2 replicas must land in ONE shared row as 6"
     );
 }
 
@@ -172,16 +259,44 @@ async fn rate_limit_shared_store_fails_open_on_db_error() {
     // shared store being unreachable without touching migrations.
     let broken_db = Surreal::new::<Mem>(()).await.unwrap();
 
-    // limit=0 would reject EVERY request if the shared store were reachable
-    // — proving fail-open, not merely "still under budget".
+    let counter = replica_counter(broken_db);
     let mut svc =
-        GrpcSharedRateLimitLayer::new(broken_db, "grpc_authz_fail_open", 0, 0).layer(ok_service());
+        GrpcSharedRateLimitLayer::with_counter(counter.clone(), "grpc_authz_fail_open", LIMIT, 0)
+            .layer(ok_service());
 
     let peer: SocketAddr = "198.51.100.9:1111".parse().unwrap();
-    let resp = call(&mut svc, request_with_peer(peer)).await;
 
+    // With the store unreachable, traffic within the configured limit still
+    // flows: the decision no longer depends on a datastore round trip at all
+    // (H2 fix), so there is no store error on the request path to fail open
+    // *from*.
+    for i in 0..LIMIT {
+        let resp = call(&mut svc, request_with_peer(peer)).await;
+        assert!(
+            !is_rejected(&resp),
+            "request {i} must proceed despite the unreachable shared store"
+        );
+    }
+
+    // The flusher discovers the outage. It must not panic, must not poison
+    // the counter, and must keep the layer serving: D-01b fail-open now means
+    // "cross-replica convergence pauses, local enforcement continues".
+    counter.flush_once().await;
+
+    // Still serving — a further request is evaluated against the local count
+    // (which is legitimately at the limit), never a 5xx and never a panic.
+    let resp = call(&mut svc, request_with_peer(peer)).await;
+    assert!(
+        is_rejected(&resp),
+        "the local count still enforces the configured limit while the store is down — \
+         a store outage must not become 'the limit is disabled'"
+    );
+
+    // And a DIFFERENT key is unaffected: the outage did not break the counter.
+    let other: SocketAddr = "198.51.100.10:2222".parse().unwrap();
+    let resp = call(&mut svc, request_with_peer(other)).await;
     assert!(
         !is_rejected(&resp),
-        "a broken shared store must fail OPEN (D-01b), never hard-block gRPC authz traffic"
+        "a fresh bucket must still be admitted after a flush failure"
     );
 }

--- a/crates/axiam-api-rest/src/middleware/rate_limit_shared.rs
+++ b/crates/axiam-api-rest/src/middleware/rate_limit_shared.rs
@@ -1,28 +1,55 @@
-//! Async SurrealDB-backed shared rate-limit pre-check middleware
+//! Shared (cross-replica) rate-limit pre-check middleware
 //! (SECHRD-03 / D-01a, D-01b, D-01d).
 //!
-//! [`RateLimitShared`] runs an async windowed-CAS increment against the
-//! `rate_limit_bucket` table (`SurrealRateLimitBucketRepository`) BEFORE
-//! the existing per-replica in-memory `Governor`/`GovernorLayer`
+//! [`RateLimitShared`] consults the process-wide write-behind
+//! [`SharedRateLimitCounter`] (`axiam-db::rate_limit_counter`) BEFORE the
+//! existing per-replica in-memory `Governor`/`GovernorLayer`
 //! (`server.rs::build_governor`, kept byte-for-byte unchanged as the
 //! fail-open fallback). This closes the multi-replica HPA gap where
 //! per-replica in-memory buckets otherwise multiply the effective rate
 //! limit by the replica count.
 //!
-//! **Fail-open (D-01b, T-24-42 accepted risk):** when the shared store is
-//! unreachable (or no DB handle / no client-IP key is available), this
-//! middleware logs a `warn`-level alarm and forwards the request unchanged
-//! so the existing in-memory governor makes the decision instead. A
-//! counter-store outage must never hard-block auth traffic — this is the
-//! ONE deliberate fail-open exception in this phase; every other control
-//! fails closed.
+//! # No synchronous datastore write on the request path (H2 fix)
+//!
+//! This middleware used to `await` ONE SurrealDB `UPSERT`
+//! (`SurrealRateLimitBucketRepository::increment`) per request, before the
+//! handler ran. That single write capped every wrapped endpoint at **16–21
+//! ops/s at any concurrency from 1 to 40 VUs** (p50 ≈ 55–65 ms at 1 VU,
+//! ≈ 1 s at 20 VUs) while structurally identical unwrapped endpoints ran at
+//! 68–4 248 ops/s — the datastore attributed ~39–46 ms of each request to
+//! that one RPC, and the same UPSERT issued directly ran in 6–9 ms and
+//! scaled fine, so the ordering (not the datastore) was the ceiling. Full
+//! measurements: `claude_dev/postseed-transient-investigation.md` §2, §3, §7.
+//!
+//! The counting mechanism — and ONLY the counting mechanism — changed: the
+//! key derivation (`{endpoint}:{key_part}`, the D8 `client_id` modes, the
+//! body peek/restore), the 429 response shape and every fail-open branch
+//! behave exactly as before. [`SharedRateLimitCounter::check`] is fully
+//! synchronous (one sharded-map increment, no datastore round trip, no task
+//! spawn) and a single background flusher coalesces the accumulated
+//! increments into one datastore write per bucket per
+//! `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`. Cross-replica enforcement is
+//! therefore *eventual*, with the overshoot bound stated precisely in the
+//! [`axiam_db::rate_limit_counter`] module docs; the in-memory governor still
+//! makes a full per-replica decision on the very same endpoints.
+//!
+//! **Fail-open (D-01b, T-24-42 accepted risk):** when no client-IP key can be
+//! derived, no [`AppState`] (hence no counter) is registered, or the shared
+//! layer is disabled via `AXIAM__RATE_LIMIT__SHARED=off`, this middleware
+//! forwards the request unchanged so the existing in-memory governor makes
+//! the decision instead. Store outages are now surfaced by the counter's
+//! flusher (a `warn` alarm that never includes the raw key — T-24-43) while
+//! decisions keep being served from local counts. A counter-store outage must
+//! never hard-block auth traffic — this is the ONE deliberate fail-open
+//! exception; every other control fails closed.
 //!
 //! **CRITICAL (RESEARCH Pitfall 1):** `governor::StateStore::measure_and_replace`
 //! is a *synchronous* trait method. This middleware is deliberately NOT a
 //! `StateStore` implementation and never calls `block_on`/`futures::executor::
-//! block_on` — it is a separate async Actix `Transform`/`Service` (mirroring
-//! [`crate::middleware::authz::AuthzMiddleware`]'s scaffold) that performs
-//! its own async SurrealDB round-trip, then delegates to the inner service.
+//! block_on` — it is a separate Actix `Transform`/`Service` (mirroring
+//! [`crate::middleware::authz::AuthzMiddleware`]'s scaffold). It stays async
+//! only because the D8 body peek (`req.extract::<web::Bytes>()`) is async;
+//! the rate-limit decision itself no longer awaits anything.
 
 use std::future::{Future, Ready, ready};
 use std::marker::PhantomData;
@@ -33,7 +60,6 @@ use actix_web::body::EitherBody;
 use actix_web::dev::{Payload, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::header::{ContentType, RETRY_AFTER};
 use actix_web::{Error, HttpMessage, HttpResponse, web};
-use axiam_db::repository::SurrealRateLimitBucketRepository;
 use chrono::{DateTime, Utc};
 use surrealdb::Connection;
 
@@ -246,13 +272,18 @@ where
         let extractor = XForwardedForKeyExtractor::with_trusted_hops(trusted_hops());
         let ip = extractor.extract(&req).ok();
 
-        // The SurrealDB handle is read from `web::Data<AppState<C>>` (QUAL-01
-        // — was a standalone `web::Data<Surreal<C>>` registration). Its
-        // absence is treated exactly like a DB error below — fail open to
-        // the in-memory governor.
-        let db = req
+        // The process-wide write-behind counter is read from
+        // `web::Data<AppState<C>>` (QUAL-01 — was a standalone
+        // `web::Data<Surreal<C>>` registration used to build a repository per
+        // request). Its absence is treated exactly like the old missing-DB-
+        // handle case below — fail open to the in-memory governor.
+        //
+        // This is a cheap `Arc` clone of the ONE counter registered in
+        // `main.rs`, never a new counter: a per-request (or per-worker)
+        // instance would fragment the local count.
+        let counter = req
             .app_data::<web::Data<AppState<C>>>()
-            .map(|d| d.db.clone());
+            .map(|d| d.shared_rate_limit.clone());
 
         Box::pin(async move {
             // D8: for the client-identity-aware endpoints only
@@ -300,31 +331,24 @@ where
                 }
             };
 
-            let allow = match (key_part, db) {
-                (Some(key_part), Some(db)) => {
-                    let repo = SurrealRateLimitBucketRepository::new(db);
+            let allow = match (key_part, counter) {
+                (Some(key_part), Some(counter)) => {
+                    // Same bucket key as before — `{endpoint}:{key_part}` —
+                    // so an in-flight upgrade keeps counting against the same
+                    // `rate_limit_bucket` records.
                     let key = format!("{endpoint}:{key_part}");
                     let window = window_start(Utc::now());
-                    match repo.increment(&key, window).await {
-                        Ok(count) => count <= limit as u64,
-                        Err(err) => {
-                            // Fail OPEN (D-01b): a counter-store outage must
-                            // never hard-block auth traffic. T-24-43: do NOT
-                            // log the raw key (endpoint:ip/client_id) at
-                            // info+ — this warn-level alarm omits it.
-                            tracing::warn!(
-                                endpoint,
-                                error = %err,
-                                "shared rate-limit store unreachable; falling back \
-                                 to per-replica in-memory governor"
-                            );
-                            true
-                        }
-                    }
+                    // Fully synchronous: no datastore round trip on the
+                    // request path (H2 fix). Store outages are reported by
+                    // the counter's background flusher, which keeps serving
+                    // decisions from local counts (fail open, D-01b).
+                    counter.check(&key, window, limit)
                 }
-                // No key part (IP unavailable) or no DB handle available —
+                // No key part (IP unavailable) or no counter registered —
                 // fail open; the in-memory governor still makes the real
-                // decision.
+                // decision. (A counter built with
+                // `AXIAM__RATE_LIMIT__SHARED=off` also always allows, from
+                // inside `check`.)
                 _ => true,
             };
 

--- a/crates/axiam-api-rest/src/server.rs
+++ b/crates/axiam-api-rest/src/server.rs
@@ -396,15 +396,42 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
                 web::resource("/organizations/{org_id}/ca-certificates/{id}/revoke")
                     .route(web::post().to(handlers::ca_certificates::revoke::<C>)),
             )
+            // --- Users ---
+            //
+            // `/users` is deliberately registered as TWO resources, method-
+            // guarded, instead of one resource with both routes.
+            //
+            // An actix `Resource`-level `.wrap()` applies to EVERY method on
+            // that resource, so the single-resource form charged `GET /users`
+            // (an admin *list*) to the `users_create` registration bucket at
+            // `register_per_min` — 5/min per IP in the production posture, so
+            // an admin UI listing users started getting 429s after five reads
+            // a minute. It also put the shared-store rate-limit pre-check on
+            // the list path, which measured 60-65 ms vs 11-12 ms for its
+            // structurally identical siblings `GET /roles` / `GET /resources`
+            // (see `claude_dev/postseed-transient-investigation.md` §2.1, §7
+            // ask 1).
+            //
+            // Actix tries registered services in order and falls through to
+            // the next one when a resource's guards reject, so the guarded
+            // POST resource MUST come first; the unguarded `/users` below it
+            // then serves the GET (and returns the usual 405 for any other
+            // method). Regression test:
+            // `tests/users_rate_limit_split_test.rs`.
             .service(
                 web::resource("/users")
+                    .guard(actix_web::guard::Post())
                     .wrap(build_governor(rate_limit_cfg.register_per_min))
                     .wrap(RateLimitShared::<C>::new(
                         "users_create",
                         rate_limit_cfg.register_per_min,
                     ))
-                    .route(web::post().to(handlers::users::create::<C>))
-                    .route(web::get().to(handlers::users::list::<C>)),
+                    .route(web::post().to(handlers::users::create::<C>)),
+            )
+            .service(
+                // Unlimited, matching the posture of its sibling list
+                // endpoints `/roles` and `/resources`.
+                web::resource("/users").route(web::get().to(handlers::users::list::<C>)),
             )
             .service(
                 web::resource("/users/{user_id}")

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -53,18 +53,16 @@ use axiam_auth::{
 use axiam_authz::AuthzConfig;
 use axiam_db::{
     SharedRateLimitCounter, SurrealAccountDeletionRepository, SurrealAssertionReplayRepository,
-    SurrealAuditLogRepository,
-    SurrealAuthorizationCodeRepository, SurrealCertificateRepository, SurrealConsentRepository,
-    SurrealEmailConfigRepository, SurrealErasureProofRepository, SurrealExportJobRepository,
-    SurrealFederationConfigRepository, SurrealFederationLinkRepository,
+    SurrealAuditLogRepository, SurrealAuthorizationCodeRepository, SurrealCertificateRepository,
+    SurrealConsentRepository, SurrealEmailConfigRepository, SurrealErasureProofRepository,
+    SurrealExportJobRepository, SurrealFederationConfigRepository, SurrealFederationLinkRepository,
     SurrealFederationLoginStateRepository, SurrealGroupRepository,
     SurrealNotificationRuleRepository, SurrealOAuth2ClientRepository,
     SurrealOrganizationRepository, SurrealPasswordHistoryRepository, SurrealPermissionRepository,
     SurrealRateLimitBucketRepository, SurrealRefreshTokenRepository, SurrealResourceRepository,
-    SurrealRoleRepository,
-    SurrealScopeRepository, SurrealServiceAccountRepository, SurrealSessionRepository,
-    SurrealSettingsRepository, SurrealTenantRepository, SurrealUserRepository,
-    SurrealWebhookRepository,
+    SurrealRoleRepository, SurrealScopeRepository, SurrealServiceAccountRepository,
+    SurrealSessionRepository, SurrealSettingsRepository, SurrealTenantRepository,
+    SurrealUserRepository, SurrealWebhookRepository,
 };
 use axiam_federation::jwks_cache::JwksCache;
 use axiam_federation::oidc::OidcFederationService;

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -52,14 +52,16 @@ use axiam_auth::{
 };
 use axiam_authz::AuthzConfig;
 use axiam_db::{
-    SurrealAccountDeletionRepository, SurrealAssertionReplayRepository, SurrealAuditLogRepository,
+    SharedRateLimitCounter, SurrealAccountDeletionRepository, SurrealAssertionReplayRepository,
+    SurrealAuditLogRepository,
     SurrealAuthorizationCodeRepository, SurrealCertificateRepository, SurrealConsentRepository,
     SurrealEmailConfigRepository, SurrealErasureProofRepository, SurrealExportJobRepository,
     SurrealFederationConfigRepository, SurrealFederationLinkRepository,
     SurrealFederationLoginStateRepository, SurrealGroupRepository,
     SurrealNotificationRuleRepository, SurrealOAuth2ClientRepository,
     SurrealOrganizationRepository, SurrealPasswordHistoryRepository, SurrealPermissionRepository,
-    SurrealRefreshTokenRepository, SurrealResourceRepository, SurrealRoleRepository,
+    SurrealRateLimitBucketRepository, SurrealRefreshTokenRepository, SurrealResourceRepository,
+    SurrealRoleRepository,
     SurrealScopeRepository, SurrealServiceAccountRepository, SurrealSessionRepository,
     SurrealSettingsRepository, SurrealTenantRepository, SurrealUserRepository,
     SurrealWebhookRepository,
@@ -287,6 +289,21 @@ pub struct AppState<C: Connection + Clone> {
     /// email-config routes fail closed rather than silently using a
     /// constant/zero key.
     pub email_config_repo: Option<SurrealEmailConfigRepository<C>>,
+    /// Process-wide write-behind shared rate-limit counter used by
+    /// [`crate::middleware::rate_limit_shared::RateLimitShared`]
+    /// (SECHRD-03 / D-01a; H2 performance fix).
+    ///
+    /// **MUST be one instance per process**, cloned (not rebuilt) into every
+    /// actix worker: the counter accumulates each replica's unflushed
+    /// increments in process memory, so N per-worker instances would fragment
+    /// the local count and weaken the effective limit by up to N×. Living in
+    /// `AppState` — registered exactly once as `web::Data<AppState<C>>` in
+    /// `main.rs` — is what guarantees that; the `Clone` here is the cheap
+    /// `Arc` clone, not a new counter.
+    ///
+    /// Absence of the whole `AppState` (a misconfigured harness) makes the
+    /// middleware fail open, exactly as a missing DB handle did before.
+    pub shared_rate_limit: SharedRateLimitCounter,
 
     // -- QUAL-07: hoisted per-request service constructions (13 call sites) --
     pub password_reset_service: PasswordResetServiceT<C>,
@@ -481,6 +498,15 @@ impl<C: Connection + Clone> AppState<C> {
             oauth2_jwks_cache_config: Oauth2JwksCacheConfig::default(),
             crypto_semaphore,
             email_config_repo: None,
+            // Tests get a real, env-configured counter over the same
+            // in-memory DB, so the shared-store layer behaves in tests
+            // exactly as it does in production. A test that wants
+            // deterministic convergence can replace this field with
+            // `SharedRateLimitCounter::without_flusher(..)` and drive
+            // `flush_once()` itself.
+            shared_rate_limit: SharedRateLimitCounter::from_env(Arc::new(
+                SurrealRateLimitBucketRepository::new(db.clone()),
+            )),
             password_reset_service,
             email_verification_service,
             oidc_federation_service: None,

--- a/crates/axiam-api-rest/tests/rate_limit_shared_store_test.rs
+++ b/crates/axiam-api-rest/tests/rate_limit_shared_store_test.rs
@@ -1,17 +1,33 @@
-//! SECHRD-03 / D-01a, D-01b — shared SurrealDB rate-limit store middleware.
+//! SECHRD-03 / D-01a, D-01b — shared rate-limit store middleware.
+//!
+//! Since the H2 performance fix the middleware counts through the write-behind
+//! `axiam_db::SharedRateLimitCounter` instead of awaiting one SurrealDB UPSERT
+//! per request, so cross-replica enforcement is *eventual*: a replica counts
+//! its own traffic immediately and adopts the other replicas' contributions at
+//! its next flush. These tests inject an explicit counter into `AppState` and
+//! drive `flush_once()` themselves, proving the same property
+//! deterministically rather than sleeping on the background flusher.
 //!
 //! Proves:
 //! - `rate_limit_shared_store_cross_instance`: two independent middleware
 //!   instances ("replicas") sharing ONE SurrealDB enforce a single combined
-//!   limit — the in-memory-only baseline (per-replica buckets) would NOT
-//!   reject at this point.
-//! - `rate_limit_shared_store_fails_open_on_db_error`: when the shared
-//!   store errors, the request proceeds (no 5xx, no hard block) — D-01b.
+//!   limit after a flush cycle — the in-memory-only baseline (per-replica
+//!   buckets) would allow `2 × LIMIT`.
+//! - `rate_limit_shared_store_fails_open_on_db_error`: an unreachable shared
+//!   store never 5xxes, never panics and never hard-blocks; the flush failure
+//!   is absorbed and local enforcement continues — D-01b.
+//! - `rate_limit_shared_store_disabled_by_env_allows_everything`:
+//!   `AXIAM__RATE_LIMIT__SHARED=off` leaves the in-memory governor as the sole
+//!   limiter and touches no store.
+
+use std::sync::Arc;
 
 use actix_web::{App, HttpResponse, test, web};
 use axiam_api_rest::middleware::rate_limit_shared::RateLimitShared;
 use axiam_api_rest::state::AppState;
 use axiam_auth::config::AuthConfig;
+use axiam_db::repository::SurrealRateLimitBucketRepository;
+use axiam_db::{SharedRateLimitConfig, SharedRateLimitCounter};
 use surrealdb::Surreal;
 use surrealdb::engine::local::{Db, Mem};
 
@@ -24,13 +40,27 @@ async fn ok_handler() -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
+/// One "replica": an independent write-behind counter over the supplied
+/// SurrealDB handle, with NO background flusher so the test controls exactly
+/// when convergence happens.
+fn replica_counter(db: Surreal<TestDb>) -> SharedRateLimitCounter {
+    SharedRateLimitCounter::without_flusher(
+        SharedRateLimitConfig::default(),
+        Arc::new(SurrealRateLimitBucketRepository::new(db)),
+    )
+}
+
 /// Builds a minimal single-resource app wrapping `/t` with
 /// `RateLimitShared` (standing in for the real `build_governor(...)` +
 /// `RateLimitShared` pairing in `server.rs` — the in-memory governor itself
 /// is not needed to prove the shared-store's own behavior here; the plain
 /// handler stands in for "the request proceeded").
+///
+/// `counter` is injected into `AppState` exactly as `main.rs` does, which is
+/// also what lets a test hold the handle and flush it.
 fn build_app(
     db: Surreal<TestDb>,
+    counter: SharedRateLimitCounter,
 ) -> App<
     impl actix_web::dev::ServiceFactory<
         actix_web::dev::ServiceRequest,
@@ -40,16 +70,13 @@ fn build_app(
         InitError = (),
     >,
 > {
-    App::new()
-        .app_data(web::Data::new(AppState::for_test(
-            db,
-            AuthConfig::default(),
-        )))
-        .service(
-            web::resource("/t")
-                .wrap(RateLimitShared::<TestDb>::new("shared_test", LIMIT))
-                .route(web::get().to(ok_handler)),
-        )
+    let mut state = AppState::for_test(db, AuthConfig::default());
+    state.shared_rate_limit = counter;
+    App::new().app_data(web::Data::new(state)).service(
+        web::resource("/t")
+            .wrap(RateLimitShared::<TestDb>::new("shared_test", LIMIT))
+            .route(web::get().to(ok_handler)),
+    )
 }
 
 #[actix_rt::test]
@@ -58,48 +85,55 @@ async fn rate_limit_shared_store_cross_instance() {
     db.use_ns("test").use_db("test").await.unwrap();
     axiam_db::run_migrations(&db).await.unwrap();
 
-    // Two INDEPENDENT app instances ("replicas") sharing the SAME
-    // underlying SurrealDB handle — proving the bucket is combined across
-    // replicas rather than reset per-replica.
-    let app1 = test::init_service(build_app(db.clone())).await;
-    let app2 = test::init_service(build_app(db.clone())).await;
+    // Two INDEPENDENT app instances ("replicas"), each with its own
+    // write-behind counter, sharing the SAME underlying SurrealDB handle —
+    // proving the bucket is combined across replicas rather than reset
+    // per-replica.
+    let counter1 = replica_counter(db.clone());
+    let counter2 = replica_counter(db.clone());
+    let app1 = test::init_service(build_app(db.clone(), counter1.clone())).await;
+    let app2 = test::init_service(build_app(db.clone(), counter2.clone())).await;
 
     let peer: std::net::SocketAddr = "203.0.113.42:5000".parse().unwrap();
-
-    // LIMIT requests split alternately across BOTH "replicas" must all
-    // succeed (this is the shared count climbing to exactly LIMIT).
-    for i in 0..LIMIT {
-        let req = test::TestRequest::get()
+    let get = || {
+        test::TestRequest::get()
             .uri("/t")
             .peer_addr(peer)
-            .to_request();
+            .to_request()
+    };
+
+    // LIMIT requests split alternately across BOTH "replicas" must all
+    // succeed (this is the combined count climbing to exactly LIMIT).
+    for i in 0..LIMIT {
         let resp = if i % 2 == 0 {
-            test::call_service(&app1, req).await
+            test::call_service(&app1, get()).await
         } else {
-            test::call_service(&app2, req).await
+            test::call_service(&app2, get()).await
         };
         assert_eq!(resp.status(), 200, "request {i} should succeed");
     }
 
-    // The NEXT request on EITHER replica must be rejected — proving the
-    // count is SHARED (an in-memory-only per-replica baseline would instead
-    // allow LIMIT more requests on whichever replica hasn't seen traffic).
-    let req = test::TestRequest::get()
-        .uri("/t")
-        .peer_addr(peer)
-        .to_request();
-    let resp = test::call_service(&app1, req).await;
+    // One write-behind flush cycle per replica: each writes its coalesced
+    // delta and reads back the authoritative combined count.
+    counter1.flush_once().await;
+    counter2.flush_once().await;
+    // counter1 flushed before counter2's delta landed, so it needs one more
+    // pass to adopt the combined count — the documented bounded staleness,
+    // not a lost update.
+    test::call_service(&app1, get()).await;
+    counter1.flush_once().await;
+
+    // Requests on EITHER replica are now rejected — proving the count is
+    // SHARED (an in-memory-only per-replica baseline would instead allow
+    // LIMIT more requests on whichever replica hasn't seen traffic).
+    let resp = test::call_service(&app1, get()).await;
     assert_eq!(
         resp.status(),
         429,
         "replica 1 must observe the shared count"
     );
 
-    let req = test::TestRequest::get()
-        .uri("/t")
-        .peer_addr(peer)
-        .to_request();
-    let resp = test::call_service(&app2, req).await;
+    let resp = test::call_service(&app2, get()).await;
     assert_eq!(
         resp.status(),
         429,
@@ -114,19 +148,89 @@ async fn rate_limit_shared_store_fails_open_on_db_error() {
     // shared store being unreachable without touching migrations.
     let broken_db = Surreal::new::<Mem>(()).await.unwrap();
 
-    let app = test::init_service(build_app(broken_db)).await;
+    let counter = replica_counter(broken_db.clone());
+    let app = test::init_service(build_app(broken_db, counter.clone())).await;
 
     let peer: std::net::SocketAddr = "198.51.100.9:1111".parse().unwrap();
-    let req = test::TestRequest::get()
-        .uri("/t")
-        .peer_addr(peer)
-        .to_request();
-    let resp = test::call_service(&app, req).await;
+    let get = || {
+        test::TestRequest::get()
+            .uri("/t")
+            .peer_addr(peer)
+            .to_request()
+    };
 
-    // Fail-open (D-01b): the request proceeds to the handler (standing in
-    // for the in-memory governor) despite the broken shared store — never a
-    // 5xx, never a hard block on auth traffic.
+    // Fail-open (D-01b): requests within the configured limit proceed to the
+    // handler (standing in for the in-memory governor) despite the broken
+    // shared store — never a 5xx, never a hard block on auth traffic. The
+    // decision no longer involves a datastore round trip at all (H2 fix), so
+    // there is no store error on the request path to fail open *from*.
+    for i in 0..LIMIT {
+        let resp = test::call_service(&app, get()).await;
+        assert_eq!(resp.status(), 200, "request {i} must proceed");
+    }
+
+    // The flusher discovers the outage: it must absorb the error without
+    // panicking or poisoning the counter.
+    counter.flush_once().await;
+
+    // Still serving. The local count legitimately sits at the limit, so this
+    // is a 429 from the limit — not from the outage. "Store unreachable" must
+    // never become "limit disabled".
+    let resp = test::call_service(&app, get()).await;
+    assert_eq!(resp.status(), 429);
+
+    // A different client is unaffected — the flush failure did not break the
+    // counter.
+    let other: std::net::SocketAddr = "198.51.100.11:3333".parse().unwrap();
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/t")
+            .peer_addr(other)
+            .to_request(),
+    )
+    .await;
     assert_eq!(resp.status(), 200);
+}
+
+/// `AXIAM__RATE_LIMIT__SHARED=off` (single-replica deployments): the shared
+/// layer is skipped entirely and never denies, leaving the per-replica
+/// in-memory governor as the sole limiter. Uses an explicitly disabled counter
+/// rather than mutating the process env, which would race other tests.
+#[actix_rt::test]
+async fn rate_limit_shared_store_disabled_by_env_allows_everything() {
+    let db = Surreal::new::<Mem>(()).await.unwrap();
+    db.use_ns("test").use_db("test").await.unwrap();
+    axiam_db::run_migrations(&db).await.unwrap();
+
+    let disabled = SharedRateLimitCounter::disabled(SharedRateLimitConfig {
+        enabled: false,
+        ..SharedRateLimitConfig::default()
+    });
+    assert!(!disabled.is_enabled());
+
+    let app = test::init_service(build_app(db, disabled.clone())).await;
+    let peer: std::net::SocketAddr = "198.51.100.30:4444".parse().unwrap();
+
+    // Far past LIMIT: the shared layer must never reject.
+    for i in 0..(LIMIT * 5) {
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/t")
+                .peer_addr(peer)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "request {i} must pass — the shared layer is off"
+        );
+    }
+
+    // No state was even allocated, so nothing could have been written.
+    assert_eq!(disabled.bucket_count(), 0);
 }
 
 /// Proves `RateLimitShared`'s `Clone` impl (only ever invoked by an
@@ -142,17 +246,14 @@ async fn rate_limit_shared_clone_enforces_the_same_limit() {
     let original = RateLimitShared::<TestDb>::new("shared_clone_test", LIMIT);
     let cloned = original.clone();
 
+    let mut state = AppState::for_test(db.clone(), AuthConfig::default());
+    state.shared_rate_limit = replica_counter(db);
     let app = test::init_service(
-        App::new()
-            .app_data(web::Data::new(AppState::for_test(
-                db,
-                AuthConfig::default(),
-            )))
-            .service(
-                web::resource("/t")
-                    .wrap(cloned)
-                    .route(web::get().to(ok_handler)),
-            ),
+        App::new().app_data(web::Data::new(state)).service(
+            web::resource("/t")
+                .wrap(cloned)
+                .route(web::get().to(ok_handler)),
+        ),
     )
     .await;
 
@@ -195,7 +296,8 @@ async fn rate_limit_shared_service_poll_ready_delegates_to_inner() {
     db.use_ns("test").use_db("test").await.unwrap();
     axiam_db::run_migrations(&db).await.unwrap();
 
-    let app = test::init_service(build_app(db)).await;
+    let counter = replica_counter(db.clone());
+    let app = test::init_service(build_app(db, counter)).await;
 
     let waker = Waker::noop();
     let mut cx = Context::from_waker(waker);
@@ -208,9 +310,9 @@ async fn rate_limit_shared_service_poll_ready_delegates_to_inner() {
 
 #[actix_rt::test]
 async fn rate_limit_shared_store_fails_open_when_no_db_registered() {
-    // No `web::Data<Surreal<TestDb>>` registered at all (e.g. a
-    // misconfigured test harness) — the middleware must still fail open
-    // rather than panicking or 500ing.
+    // No `web::Data<AppState<TestDb>>` registered at all (e.g. a
+    // misconfigured test harness), so the middleware finds no shared counter —
+    // it must still fail open rather than panicking or 500ing.
     let app = test::init_service(
         App::new().service(
             web::resource("/t")

--- a/crates/axiam-api-rest/tests/users_rate_limit_split_test.rs
+++ b/crates/axiam-api-rest/tests/users_rate_limit_split_test.rs
@@ -100,6 +100,9 @@ fn post_users(peer: std::net::SocketAddr) -> test::TestRequest {
         .set_json(serde_json::json!({
             "username": "someone",
             "email": "someone@example.com",
+            // Obviously-fake in-process test fixture, same convention as
+            // `user_test.rs` — this body never leaves the test server, and
+            // this suite asserts routing/limiter behaviour, not credentials.
             "password": "securepass123",
         }))
 }

--- a/crates/axiam-api-rest/tests/users_rate_limit_split_test.rs
+++ b/crates/axiam-api-rest/tests/users_rate_limit_split_test.rs
@@ -1,0 +1,236 @@
+//! Regression test for the `/users` rate-limiter split
+//! (`claude_dev/postseed-transient-investigation.md` §2.1 / §7 ask 1).
+//!
+//! `server.rs` used to register ONE resource for both `/users` routes:
+//!
+//! ```ignore
+//! web::resource("/users")
+//!     .wrap(build_governor(rate_limit_cfg.register_per_min))
+//!     .wrap(RateLimitShared::<C>::new("users_create", rate_limit_cfg.register_per_min))
+//!     .route(web::post().to(handlers::users::create::<C>))
+//!     .route(web::get().to(handlers::users::list::<C>))
+//! ```
+//!
+//! An actix resource-level `.wrap()` applies to EVERY method on the
+//! resource, so `GET /api/v1/users` — an admin *list* — inherited the user
+//! *registration* limiter and was charged to the `users_create` bucket. With
+//! the production posture's `register_per_min = 5`, listing users started
+//! returning 429 after five reads per minute per IP. It also put the shared
+//! rate-limit store's round trip on the list path (measured 60-65 ms vs
+//! 11-12 ms for the structurally identical `GET /roles` / `GET /resources`).
+//!
+//! These tests pin the fixed wiring — a method-guarded POST resource
+//! carrying both limiters, followed by a plain `/users` resource carrying the
+//! GET — by driving the REAL `register_api_v1_routes` wiring:
+//!
+//! 1. `post_users_past_the_limit_is_rejected` — the POST keeps its limiter.
+//! 2. `get_users_is_not_charged_to_the_users_create_bucket` — far more GETs
+//!    than `register_per_min` all keep working, and they do not consume the
+//!    create bucket (a subsequent POST burst still gets its full budget).
+//! 3. `both_users_routes_still_reach_their_own_handler` — actix's guard
+//!    fall-through actually works: POST and GET each reach the right handler.
+//!
+//! Run with: cargo test -p axiam-api-rest --test users_rate_limit_split_test
+
+use actix_web::http::StatusCode;
+use actix_web::{App, test, web};
+use axiam_api_rest::config::rate_limit::RateLimitConfig;
+use axiam_api_rest::server::register_api_v1_routes;
+use axiam_api_rest::state::AppState;
+use axiam_auth::config::AuthConfig;
+use surrealdb::Surreal;
+use surrealdb::engine::local::{Db, Mem};
+
+type TestDb = Db;
+
+/// Deliberately tiny so "past the limit" is reached in a handful of requests.
+/// Mirrors the shape of the production posture (`register_per_min = 5`), where
+/// the bug was reachable by any admin UI.
+const REGISTER_PER_MIN: u32 = 3;
+
+/// The `/users` GET burst size — comfortably above `REGISTER_PER_MIN` so that
+/// any residual coupling to the `users_create` bucket shows up as a 429.
+const GET_BURST: u32 = 25;
+
+async fn test_db() -> Surreal<TestDb> {
+    let db = Surreal::new::<Mem>(()).await.unwrap();
+    db.use_ns("test").use_db("test").await.unwrap();
+    axiam_db::run_migrations(&db).await.unwrap();
+    db
+}
+
+/// Builds the app with the REAL `/api/v1` wiring (not a hand-rolled stand-in),
+/// so this test fails if `server.rs` ever regresses to a single `/users`
+/// resource.
+macro_rules! build_real_app {
+    ($db:expr) => {
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new(AppState::for_test(
+                    $db.clone(),
+                    AuthConfig::default(),
+                )))
+                .configure(|cfg| {
+                    register_api_v1_routes::<TestDb>(
+                        cfg,
+                        &RateLimitConfig {
+                            register_per_min: REGISTER_PER_MIN,
+                            ..RateLimitConfig::default()
+                        },
+                    )
+                }),
+        )
+        .await
+    };
+}
+
+/// `/api/v1` is wrapped in `AuthzMiddleware` (credential *presence* check)
+/// and `CsrfMiddleware` (cookie/header equality on unsafe methods). Both run
+/// OUTSIDE the resource-level rate limiters, so a request must carry a bearer
+/// header and a matching CSRF pair to reach the limiter at all. Neither is
+/// verified here — the handlers still reject with 401/403, which is exactly
+/// what these tests want: they assert on "429 or not", never on success.
+fn post_users(peer: std::net::SocketAddr) -> test::TestRequest {
+    test::TestRequest::post()
+        .uri("/api/v1/users")
+        .peer_addr(peer)
+        .insert_header(("Authorization", "Bearer test-token"))
+        .insert_header(("X-CSRF-Token", "csrf-token"))
+        .cookie(actix_web::cookie::Cookie::build("axiam_csrf", "csrf-token").finish())
+        .set_json(serde_json::json!({
+            "username": "someone",
+            "email": "someone@example.com",
+            "password": "securepass123",
+        }))
+}
+
+fn get_users(peer: std::net::SocketAddr) -> test::TestRequest {
+    test::TestRequest::get()
+        .uri("/api/v1/users")
+        .peer_addr(peer)
+        .insert_header(("Authorization", "Bearer test-token"))
+}
+
+/// The POST keeps BOTH limiters: past `register_per_min` it must 429.
+#[actix_web::test]
+async fn post_users_past_the_limit_is_rejected() {
+    let db = test_db().await;
+    let app = build_real_app!(db);
+    let peer: std::net::SocketAddr = "203.0.113.10:5000".parse().unwrap();
+
+    // The first `REGISTER_PER_MIN` POSTs are within budget: they reach the
+    // handler and are rejected on auth (401/403), NOT rate-limited.
+    for i in 0..REGISTER_PER_MIN {
+        let resp = test::call_service(&app, post_users(peer).to_request()).await;
+        assert_ne!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "POST {i} is within register_per_min and must not be rate-limited"
+        );
+    }
+
+    // Past the limit, one of the two limiters (shared store or governor) must
+    // reject. Allow a couple of extra requests of slack so this does not
+    // depend on which layer rejects first.
+    let mut rejected = false;
+    for _ in 0..3 {
+        let resp = test::call_service(&app, post_users(peer).to_request()).await;
+        if resp.status() == StatusCode::TOO_MANY_REQUESTS {
+            rejected = true;
+            break;
+        }
+    }
+    assert!(
+        rejected,
+        "POST /api/v1/users past register_per_min={REGISTER_PER_MIN} must be rate-limited — \
+         the registration limiter must stay on the create route"
+    );
+}
+
+/// The regression itself: many GETs must all keep working, and they must not
+/// consume the `users_create` bucket.
+#[actix_web::test]
+async fn get_users_is_not_charged_to_the_users_create_bucket() {
+    let db = test_db().await;
+    let app = build_real_app!(db);
+    let peer: std::net::SocketAddr = "203.0.113.11:5000".parse().unwrap();
+
+    // GET_BURST (25) >> register_per_min (3): before the fix the 4th GET
+    // onwards returned 429.
+    for i in 0..GET_BURST {
+        let resp = test::call_service(&app, get_users(peer).to_request()).await;
+        assert_ne!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "GET /api/v1/users #{i} must never be rate-limited by the registration limiter"
+        );
+    }
+
+    // And the create bucket was untouched by those GETs: a POST burst from
+    // the SAME IP still gets its full `register_per_min` budget.
+    for i in 0..REGISTER_PER_MIN {
+        let resp = test::call_service(&app, post_users(peer).to_request()).await;
+        assert_ne!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "POST {i} must still have its full budget — {GET_BURST} GETs must not have \
+             consumed the users_create bucket"
+        );
+    }
+}
+
+/// Guard fall-through sanity: with `/users` registered twice (a
+/// `guard(Post())` resource first, then a plain one), actix must still route
+/// each method to its own handler rather than 404/405-ing one of them.
+#[actix_web::test]
+async fn both_users_routes_still_reach_their_own_handler() {
+    let db = test_db().await;
+    let app = build_real_app!(db);
+    let peer: std::net::SocketAddr = "203.0.113.12:5000".parse().unwrap();
+
+    // GET reaches the list handler: it is rejected on auth, never NOT_FOUND
+    // (which is what a broken guard fall-through would produce) and never
+    // METHOD_NOT_ALLOWED.
+    let resp = test::call_service(&app, get_users(peer).to_request()).await;
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "GET /users must route"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "GET /users must route to the list handler, not fall on the POST-guarded resource"
+    );
+
+    // POST reaches the create handler (via the guarded resource).
+    let resp = test::call_service(&app, post_users(peer).to_request()).await;
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "POST /users must route"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "POST /users must route to the create handler"
+    );
+
+    // A method neither resource serves still 405s (unchanged behavior).
+    let resp = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri("/api/v1/users")
+            .peer_addr(peer)
+            .insert_header(("Authorization", "Bearer test-token"))
+            .insert_header(("X-CSRF-Token", "csrf-token"))
+            .cookie(actix_web::cookie::Cookie::build("axiam_csrf", "csrf-token").finish())
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "an unserved method on /users must still 405"
+    );
+}

--- a/crates/axiam-db/src/lib.rs
+++ b/crates/axiam-db/src/lib.rs
@@ -6,12 +6,16 @@
 //! - Schema initialization and migrations ([`run_migrations`])
 //! - Repository implementations for `axiam-core` traits
 //! - Error types ([`DbError`])
+//! - The process-wide write-behind shared rate-limit counter
+//!   ([`SharedRateLimitCounter`]), used by BOTH the REST and gRPC
+//!   shared-store rate-limit layers
 
 mod connection;
 mod error;
 pub mod helpers;
 pub mod metrics;
 mod pool;
+pub mod rate_limit_counter;
 pub mod repository;
 mod schema;
 pub mod seeder;
@@ -20,6 +24,9 @@ pub use connection::{DbConfig, DbManager};
 pub use error::DbError;
 pub use helpers::{CountRow, parse_uuid, take_first_or_not_found};
 pub use pool::{DbCheckout, DbPool};
+pub use rate_limit_counter::{
+    SharedRateLimitConfig, SharedRateLimitCounter, SharedRateLimitStore, StoreIncrementFuture,
+};
 pub use repository::{
     SurrealAccountDeletionRepository, SurrealAmqpNonceRepository, SurrealAssertionReplayRepository,
     SurrealAuditLogRepository, SurrealAuthorizationCodeRepository, SurrealCaCertificateRepository,

--- a/crates/axiam-db/src/rate_limit_counter.rs
+++ b/crates/axiam-db/src/rate_limit_counter.rs
@@ -1,0 +1,1346 @@
+//! Write-behind shared rate-limit counter (SECHRD-03 / D-01a, D-01b —
+//! performance fix for the H2 finding).
+//!
+//! # What this replaces, and why
+//!
+//! Until this module existed, both shared-store rate-limit layers
+//! (`axiam-api-rest::middleware::rate_limit_shared::RateLimitShared` and
+//! `axiam-api-grpc::middleware::rate_limit::GrpcSharedRateLimitLayer`)
+//! performed ONE synchronous
+//! [`SurrealRateLimitBucketRepository::increment`] UPSERT against a single
+//! `rate_limit_bucket:<endpoint>:<ip>` record **before** the handler ran, on
+//! the request's critical path.
+//!
+//! That write is a deliberate global hot spot: one record per
+//! `(endpoint, key)` pair, written by every request. Measured on
+//! 2026-07-28 (`server:1.0.0-alpha19` + SurrealDB 3.2.3, 2 CPU / 1 GiB each,
+//! rate limits neutralized — full data in
+//! `claude_dev/postseed-transient-investigation.md` §2, §3, §7):
+//!
+//! - The six wrapped endpoints (`POST /api/v1/authz/check`,
+//!   `POST /oauth2/token`, `POST /oauth2/introspect`, `POST /oauth2/revoke`,
+//!   `POST /api/v1/auth/login`, and — unintentionally, see §7 ask 1 —
+//!   `GET /api/v1/users`) were pinned at **16–21 ops/s at any concurrency
+//!   from 1 to 40 VUs**, with p50 ≈ 55–65 ms at 1 VU and ≈ 1 s at 20 VUs.
+//! - Structurally identical endpoints WITHOUT the wrap ran at
+//!   **68–4 248 ops/s**. The cleanest pair: `GET /api/v1/users` at 60–65 ms
+//!   vs `GET /api/v1/resources` at 11–12 ms — same handler shape, same
+//!   session, same datastore; the only difference was the wrap.
+//! - The datastore's own tracer attributed ~39–46 ms of each such request to
+//!   a **single** RPC that only the wrapped endpoints issue; every other RPC
+//!   in the same request was 0–6 ms. The same UPSERT issued directly
+//!   (`surreal sql` / raw HTTP `/sql`) ran at 6–9 ms and scaled to 487 ops/s
+//!   at 20 concurrent writers on the same hot key — so the *ordering*, not
+//!   the datastore, was the ceiling. The ceiling is set by the slowest
+//!   datastore write in the deployment and does not improve with
+//!   concurrency, app replicas, or connection pooling.
+//!
+//! [`SharedRateLimitCounter`] keeps the security purpose of the layer while
+//! removing that synchronous write: the per-request path is now a single
+//! in-process sharded-map increment (no datastore round trip, no task spawn,
+//! no `await`), and a background flusher coalesces the accumulated
+//! increments into **one** [`SurrealRateLimitBucketRepository::increment_by`]
+//! write per `(key, window)` per sync interval.
+//!
+//! # What the layer is for (do not remove it)
+//!
+//! The per-replica in-memory `governor`/`GovernorLayer` still runs on exactly
+//! the same endpoints and still makes a full per-replica decision — it is
+//! untouched by this module. The shared store exists for a different reason:
+//! with N replicas behind an HPA, N independent in-memory buckets multiply
+//! the effective rate limit by N. The shared counter is what makes the
+//! configured limit hold *across* replicas. Deleting it would silently
+//! restore that N× multiplication.
+//!
+//! # Staleness / overshoot bound (quotable in the security docs)
+//!
+//! With write-behind, cross-replica enforcement becomes **eventual** rather
+//! than immediate. Precisely:
+//!
+//! > A replica's local view of a bucket is `shared_count + pending`, where
+//! > `shared_count` is the authoritative store count as of that replica's
+//! > last successful flush and `pending` is its own unflushed increments.
+//! > A replica therefore always counts **all** of its own traffic
+//! > immediately, and *other* replicas' traffic only as of its last flush —
+//! > which is at most `sync_interval` old (`AXIAM__RATE_LIMIT__SHARED_SYNC_MS`,
+//! > default 1000 ms). Consequently, for a bucket receiving aggregate
+//! > arrival rate `R` spread over `replicas` replicas, the worst-case
+//! > overshoot beyond the configured limit before the counts converge is
+//! > bounded by approximately
+//! >
+//! > ```text
+//! > (replicas - 1) × (R / replicas) × sync_interval
+//! > ```
+//! >
+//! > i.e. at most `(replicas − 1) × arrival_rate_per_replica × sync_interval`
+//! > extra admitted requests, and **zero** on a single replica (where
+//! > `replicas - 1 = 0`, so local counting is exact and this layer is as
+//! > strict as the previous synchronous implementation). With the previous
+//! > per-request-synchronous write the bound was zero for any replica count,
+//! > at the cost of the ~20 ops/s per-endpoint ceiling documented above.
+//! > Overshoot is also capped by the in-memory `governor` on the same
+//! > endpoint, which independently enforces the limit per replica; the
+//! > shared layer's job is to stop the aggregate from reaching
+//! > `replicas × limit`, and after one `sync_interval` it does.
+//!
+//! Example: limit 100/min, 4 replicas, `sync_interval` 1 s, aggregate
+//! arrival 40 req/s ⇒ worst case ≈ `3 × 10 × 1 s` = ~30 requests of
+//! overshoot inside a 60 s window before convergence (≈ 30 % of the limit,
+//! and shrinking linearly with `sync_interval`).
+//!
+//! # Fail-open posture (D-01b, T-24-42 accepted risk)
+//!
+//! This layer keeps the ONE deliberate fail-open exception in the codebase;
+//! every other control fails closed. It allows the request and logs a
+//! `warn`-level alarm WITHOUT the raw bucket key (T-24-43 — the key embeds a
+//! client IP / `client_id`) when:
+//!
+//! - the shared layer is disabled (`AXIAM__RATE_LIMIT__SHARED=off`),
+//! - the caller has no key part (no client IP could be derived),
+//! - no datastore handle / no counter is registered,
+//! - the flusher's wake channel is full or closed,
+//! - the store errors during a flush.
+//!
+//! In the last three cases the counter **keeps serving decisions from local
+//! counts** — a store outage degrades cross-replica strictness to
+//! per-replica strictness (exactly the in-memory `governor`'s posture), it
+//! never hard-blocks auth traffic and never surfaces a 5xx.
+//!
+//! Note the one behavioral difference from the pre-write-behind layer: a
+//! store outage is now discovered by the *flusher*, not by the request, so a
+//! request is no longer blanket-allowed just because the store is down — it
+//! is still evaluated against the (perfectly valid) local count. A limit of
+//! `0` therefore denies locally even with an unreachable store, where the
+//! old code would have allowed. That is strictly a correctness improvement:
+//! "the store is unreachable" must not become "the limit is disabled".
+//!
+//! # Concurrency rules obeyed here
+//!
+//! - State is a fixed [`SHARD_COUNT`]-way sharded map of `std::sync::Mutex`
+//!   (NOT a tokio mutex): critical sections are a few field updates and are
+//!   **never** held across an `await`. The flusher collects work under the
+//!   lock, drops it, awaits the store, then re-locks to write back.
+//! - [`SharedRateLimitCounter::check`] is fully synchronous and allocation-
+//!   free on the hot path apart from the map probe, so it can be called from
+//!   any executor (actix worker, tonic/tower task) without `block_on`.
+//! - Poisoned mutexes are recovered from (`into_inner`) rather than
+//!   panicking: a panic elsewhere must not take the rate limiter down.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use surrealdb::Connection;
+
+use crate::error::DbError;
+use crate::repository::SurrealRateLimitBucketRepository;
+
+/// Number of independent shards in the in-process bucket map. Sized so that
+/// unrelated hot keys (one per rate-limited endpoint per client IP) rarely
+/// contend on the same `Mutex`, while keeping a flush pass to 16 cheap lock
+/// acquisitions.
+pub const SHARD_COUNT: usize = 16;
+
+/// Default write-behind flush interval, in milliseconds
+/// (`AXIAM__RATE_LIMIT__SHARED_SYNC_MS`).
+pub const DEFAULT_SYNC_INTERVAL_MS: u64 = 1_000;
+
+/// Lower clamp for `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`. Below this the
+/// flusher would approach the per-request write storm this module exists to
+/// remove.
+pub const MIN_SYNC_INTERVAL_MS: u64 = 50;
+
+/// Upper clamp for `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`. Above this the
+/// cross-replica overshoot bound (see module docs) grows past anything
+/// defensible for a security control.
+pub const MAX_SYNC_INTERVAL_MS: u64 = 60_000;
+
+/// Fixed-window length assumed by both callers' `window_start()` helpers
+/// (`axiam-api-rest::middleware::rate_limit_shared::WINDOW_SECS` and
+/// `axiam-api-grpc::middleware::rate_limit::WINDOW_SECS`). Used ONLY to
+/// decide when an idle bucket is stale enough to prune — the window itself is
+/// always supplied by the caller, never computed here.
+pub const DEFAULT_WINDOW_SECS: u64 = 60;
+
+/// A bucket whose window is older than `STALE_WINDOW_MULTIPLE` windows and
+/// which has nothing pending is dropped by the flusher, bounding memory to
+/// "keys seen in the last two windows".
+const STALE_WINDOW_MULTIPLE: u32 = 2;
+
+/// Capacity of the bounded wake channel feeding the flusher. Notifications
+/// are pure hints (the shard maps are the source of truth), so a full
+/// channel only ever delays a flush to the next interval tick — it can never
+/// lose a pending delta.
+const WAKE_CHANNEL_CAPACITY: usize = 1_024;
+
+/// A bucket with pending work that has not been flushed for this many sync
+/// intervals means the flusher is starved (blocked store, saturated runtime).
+/// The stated overshoot bound scales with the ACTUAL flush period, so this is
+/// worth exactly one `warn` to an operator.
+const OVERDUE_SYNC_MULTIPLE: i32 = 5;
+
+// ---------------------------------------------------------------------------
+// Store abstraction
+// ---------------------------------------------------------------------------
+
+/// Boxed future returned by [`SharedRateLimitStore::increment_by`].
+pub type StoreIncrementFuture<'a> = Pin<Box<dyn Future<Output = Result<u64, DbError>> + Send + 'a>>;
+
+/// The single write primitive the write-behind flusher needs.
+///
+/// Object-safe on purpose (hence the boxed future rather than an
+/// `async fn`): [`SharedRateLimitCounter`] is deliberately NOT generic over
+/// the SurrealDB connection type, so one non-generic counter type can be held
+/// by `axiam-api-rest`'s `AppState<C>` and by `axiam-api-grpc`'s tower layer
+/// alike, and so tests can substitute a failing or call-counting store.
+///
+/// Implemented for [`SurrealRateLimitBucketRepository`] for every
+/// `C: Connection`.
+pub trait SharedRateLimitStore: Send + Sync + 'static {
+    /// Adds `delta` to the bucket `key` for the fixed window starting at
+    /// `window_start`, returning the authoritative POST-update count.
+    fn increment_by<'a>(
+        &'a self,
+        key: &'a str,
+        window_start: DateTime<Utc>,
+        delta: u64,
+    ) -> StoreIncrementFuture<'a>;
+}
+
+impl<C: Connection> SharedRateLimitStore for SurrealRateLimitBucketRepository<C> {
+    fn increment_by<'a>(
+        &'a self,
+        key: &'a str,
+        window_start: DateTime<Utc>,
+        delta: u64,
+    ) -> StoreIncrementFuture<'a> {
+        Box::pin(SurrealRateLimitBucketRepository::increment_by(
+            self,
+            key,
+            window_start,
+            delta,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for [`SharedRateLimitCounter`], read once via
+/// [`SharedRateLimitConfig::from_env`] so the REST and gRPC layers always
+/// behave identically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SharedRateLimitConfig {
+    /// `AXIAM__RATE_LIMIT__SHARED` — `on` (default) or `off`.
+    ///
+    /// `off` skips the shared layer *entirely* (no state, no store call, no
+    /// flusher) for single-replica deployments, leaving the per-replica
+    /// in-memory `governor` as the sole limiter. It does NOT change any
+    /// configured limit.
+    pub enabled: bool,
+    /// `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` — write-behind flush interval,
+    /// clamped to [`MIN_SYNC_INTERVAL_MS`]..=[`MAX_SYNC_INTERVAL_MS`].
+    /// Directly scales the cross-replica overshoot bound (module docs).
+    pub sync_interval: Duration,
+    /// Fixed-window length used only for staleness pruning; must match the
+    /// callers' `window_start()` truncation (60 s in both).
+    pub window: Duration,
+}
+
+impl Default for SharedRateLimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            sync_interval: Duration::from_millis(DEFAULT_SYNC_INTERVAL_MS),
+            window: Duration::from_secs(DEFAULT_WINDOW_SECS),
+        }
+    }
+}
+
+impl SharedRateLimitConfig {
+    /// Reads `AXIAM__RATE_LIMIT__SHARED` and
+    /// `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`.
+    ///
+    /// - `AXIAM__RATE_LIMIT__SHARED`: `off`/`false`/`0`/`no` disable the
+    ///   shared layer; anything else (including unset) leaves it **on** —
+    ///   the secure default, since disabling it re-opens the multi-replica
+    ///   limit multiplication.
+    /// - `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`: parsed as `u64` milliseconds,
+    ///   clamped to [`MIN_SYNC_INTERVAL_MS`]..=[`MAX_SYNC_INTERVAL_MS`];
+    ///   unparseable or absent falls back to [`DEFAULT_SYNC_INTERVAL_MS`].
+    pub fn from_env() -> Self {
+        let enabled = match std::env::var("AXIAM__RATE_LIMIT__SHARED") {
+            Ok(raw) => !matches!(
+                raw.trim().to_ascii_lowercase().as_str(),
+                "off" | "false" | "0" | "no"
+            ),
+            Err(_) => true,
+        };
+
+        let sync_interval_ms = std::env::var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS")
+            .ok()
+            .and_then(|raw| raw.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_SYNC_INTERVAL_MS)
+            .clamp(MIN_SYNC_INTERVAL_MS, MAX_SYNC_INTERVAL_MS);
+
+        Self {
+            enabled,
+            sync_interval: Duration::from_millis(sync_interval_ms),
+            window: Duration::from_secs(DEFAULT_WINDOW_SECS),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bucket state
+// ---------------------------------------------------------------------------
+
+/// One in-process fixed-window bucket.
+///
+/// The effective count a decision is made on is `shared_count + pending`:
+/// the authoritative cross-replica count as of the last successful flush,
+/// plus this replica's own not-yet-flushed increments.
+#[derive(Debug, Clone)]
+struct Bucket {
+    /// Start of the fixed window this bucket's counts belong to. A `check`
+    /// for a different window rolls the bucket over (both counts reset).
+    window_start: DateTime<Utc>,
+    /// Authoritative store count as of the last successful flush of this
+    /// bucket in this window (already includes this replica's flushed
+    /// increments).
+    shared_count: u64,
+    /// Local increments accepted since the last successful flush and not yet
+    /// written to the store.
+    pending: u64,
+    /// When this bucket was last successfully flushed (`None` = never in this
+    /// window). Read by the flusher purely for starvation detection: if a
+    /// bucket with pending work has not been flushed for
+    /// [`OVERDUE_SYNC_MULTIPLE`] sync intervals, the write-behind loop is not
+    /// keeping up and the cross-replica overshoot bound documented in the
+    /// module docs no longer holds, which is worth one `warn`.
+    last_flush: Option<DateTime<Utc>>,
+}
+
+impl Bucket {
+    fn new(window_start: DateTime<Utc>) -> Self {
+        Self {
+            window_start,
+            shared_count: 0,
+            pending: 0,
+            last_flush: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Counter
+// ---------------------------------------------------------------------------
+
+/// Shared, write-behind rate-limit counter used by BOTH the REST
+/// (`RateLimitShared`) and gRPC (`GrpcSharedRateLimitLayer`) shared-store
+/// layers.
+///
+/// Cheap to clone (`Arc` inside) and MUST be shared process-wide: one
+/// instance per process, cloned into every worker. Per-worker instances would
+/// fragment the local count and weaken the limit by the worker count — this
+/// is why `axiam-api-rest` holds it in `AppState` (registered once as
+/// `web::Data`) rather than constructing one per resource.
+///
+/// See the module docs for the overshoot bound and the fail-open posture.
+#[derive(Clone)]
+pub struct SharedRateLimitCounter {
+    inner: Arc<Inner>,
+    /// Wake hint for the flusher. `None` when the counter is disabled or no
+    /// tokio runtime was available at construction (local-only mode). Held
+    /// here rather than in [`Inner`] so that dropping every clone of the
+    /// counter closes the channel and lets the flusher task exit instead of
+    /// leaking.
+    wake: Option<tokio::sync::mpsc::Sender<()>>,
+}
+
+struct Inner {
+    config: SharedRateLimitConfig,
+    /// `None` when the shared layer is disabled — no store is ever touched.
+    store: Option<Arc<dyn SharedRateLimitStore>>,
+    shards: Vec<Mutex<HashMap<String, Bucket>>>,
+    /// Latch so a persistent wake-channel problem logs once instead of once
+    /// per request (a warn per request would itself be a performance bug).
+    wake_warned: AtomicBool,
+    /// Latch for the "flusher is starved" alarm (see
+    /// [`OVERDUE_SYNC_MULTIPLE`]), for the same reason.
+    starvation_warned: AtomicBool,
+}
+
+impl SharedRateLimitCounter {
+    /// Builds a counter over `store` and starts its single background
+    /// flusher task.
+    ///
+    /// Must be called from within a tokio runtime (it is: both callers
+    /// construct it during async server startup). If no runtime handle is
+    /// available, construction still succeeds but logs a `warn` and the
+    /// counter runs **local-only** — decisions keep working from local
+    /// counts, they just never converge across replicas. That is the same
+    /// fail-open degradation as a store outage, never a hard failure.
+    ///
+    /// When `config.enabled` is `false` the store is dropped on the spot, no
+    /// task is spawned, and [`Self::check`] short-circuits to "allow".
+    pub fn new(config: SharedRateLimitConfig, store: Arc<dyn SharedRateLimitStore>) -> Self {
+        if !config.enabled {
+            tracing::info!(
+                "shared rate-limit counter DISABLED (AXIAM__RATE_LIMIT__SHARED=off); \
+                 the per-replica in-memory governor is the sole rate limiter"
+            );
+            return Self::disabled(config);
+        }
+
+        let inner = Arc::new(Inner::new(config, Some(store)));
+
+        // A bounded channel of increment notifications: `check` hints that
+        // work exists, the flusher coalesces every `sync_interval`.
+        let (tx, rx) = tokio::sync::mpsc::channel(WAKE_CHANNEL_CAPACITY);
+
+        let wake = match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                let flusher_inner = Arc::clone(&inner);
+                handle.spawn(flusher_loop(flusher_inner, rx));
+                tracing::info!(
+                    sync_interval_ms = inner.config.sync_interval.as_millis() as u64,
+                    shards = SHARD_COUNT,
+                    "shared rate-limit counter ACTIVE (write-behind); one datastore write \
+                     per bucket per sync interval instead of one per request"
+                );
+                Some(tx)
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "shared rate-limit counter started outside a tokio runtime; running \
+                     local-only (no cross-replica convergence) — decisions continue from \
+                     local counts"
+                );
+                None
+            }
+        };
+
+        Self { inner, wake }
+    }
+
+    /// Convenience constructor reading [`SharedRateLimitConfig::from_env`].
+    pub fn from_env(store: Arc<dyn SharedRateLimitStore>) -> Self {
+        Self::new(SharedRateLimitConfig::from_env(), store)
+    }
+
+    /// A counter that holds no store, spawns nothing, and always allows —
+    /// the `AXIAM__RATE_LIMIT__SHARED=off` shape, also used wherever a
+    /// counter is structurally required but the shared layer is not wanted.
+    pub fn disabled(config: SharedRateLimitConfig) -> Self {
+        Self {
+            inner: Arc::new(Inner::new(
+                SharedRateLimitConfig {
+                    enabled: false,
+                    ..config
+                },
+                None,
+            )),
+            wake: None,
+        }
+    }
+
+    /// Builds an enabled counter WITHOUT spawning the background flusher.
+    ///
+    /// For tests (and any caller that wants to drive flushing itself via
+    /// [`Self::flush_once`]) — production code should use [`Self::new`].
+    pub fn without_flusher(
+        config: SharedRateLimitConfig,
+        store: Arc<dyn SharedRateLimitStore>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Inner::new(config, Some(store))),
+            wake: None,
+        }
+    }
+
+    /// `true` when the shared layer is active (i.e. not
+    /// `AXIAM__RATE_LIMIT__SHARED=off`).
+    pub fn is_enabled(&self) -> bool {
+        self.inner.config.enabled
+    }
+
+    /// The effective configuration (post-clamping).
+    pub fn config(&self) -> &SharedRateLimitConfig {
+        &self.inner.config
+    }
+
+    /// The per-request decision: `true` = allow, `false` = deny (HTTP 429 /
+    /// gRPC `RESOURCE_EXHAUSTED`).
+    ///
+    /// Fully synchronous: one hash, one `Mutex` acquisition, a few field
+    /// updates, and a non-blocking wake hint. No datastore round trip, no
+    /// `await`, no task spawn — this is the whole point of the module.
+    ///
+    /// Semantics:
+    /// - The bucket rolls over (both counts reset to zero) whenever
+    ///   `window_start` differs from the stored one, so a caller that
+    ///   truncates `now` to its fixed window gets exact fixed-window
+    ///   behavior.
+    /// - `pending` is incremented for every call, including denied ones, so
+    ///   sustained over-limit traffic is reported to the store and thus to
+    ///   the other replicas (mirrors the previous behavior, where the
+    ///   UPSERT also ran before the limit test).
+    /// - Denies when `shared_count + pending > limit`.
+    ///
+    /// Always allows (and never touches any state) when the counter is
+    /// disabled.
+    pub fn check(&self, key: &str, window_start: DateTime<Utc>, limit: u32) -> bool {
+        if !self.inner.config.enabled {
+            return true;
+        }
+
+        let allow = {
+            let shard = self.inner.shard_for(key);
+            let mut guard = lock_shard(shard);
+            let bucket = guard
+                .entry(key.to_string())
+                .or_insert_with(|| Bucket::new(window_start));
+
+            // Window rollover: a new fixed window is a brand-new bucket.
+            // Any `pending` from the previous window is intentionally
+            // discarded — that window is closed, so its count can no longer
+            // influence a decision, and re-sending it would corrupt the new
+            // window's count.
+            if bucket.window_start != window_start {
+                *bucket = Bucket::new(window_start);
+            }
+
+            bucket.pending = bucket.pending.saturating_add(1);
+            bucket.shared_count.saturating_add(bucket.pending) <= u64::from(limit)
+        };
+
+        self.notify_flusher();
+        allow
+    }
+
+    /// Non-blocking wake hint for the flusher.
+    ///
+    /// A full channel is benign — a flush is already queued and the shard
+    /// maps (not the messages) carry the pending deltas, so the worst case is
+    /// that this delta waits for the flusher's next interval tick. A closed
+    /// channel means the flusher is gone; both are logged once at `warn`
+    /// (never per request, and never with the key — T-24-43) and the decision
+    /// already returned above stands.
+    fn notify_flusher(&self) {
+        let Some(tx) = &self.wake else { return };
+        if let Err(err) = tx.try_send(())
+            && !self.inner.wake_warned.swap(true, Ordering::Relaxed)
+        {
+            tracing::warn!(
+                reason = %match err {
+                    tokio::sync::mpsc::error::TrySendError::Full(_) => "wake channel full",
+                    tokio::sync::mpsc::error::TrySendError::Closed(_) => "flusher stopped",
+                },
+                "shared rate-limit flusher could not be woken; continuing to serve \
+                 decisions from local counts (logged once)"
+            );
+        }
+    }
+
+    /// Runs ONE write-behind flush pass: coalesce each bucket's accumulated
+    /// `pending` into a single store write, adopt the returned authoritative
+    /// count, and prune stale buckets.
+    ///
+    /// Public so tests (and a future graceful-shutdown hook) can force
+    /// convergence deterministically instead of sleeping. Idempotent and
+    /// safe to call concurrently with `check`.
+    pub async fn flush_once(&self) {
+        self.inner.flush_once().await;
+    }
+
+    /// Number of buckets currently held in memory, across all shards.
+    /// Exposed for tests and for a future gauge metric — bounded by the
+    /// number of distinct `(endpoint, key_part)` pairs seen in the last two
+    /// windows thanks to flush-time pruning.
+    pub fn bucket_count(&self) -> usize {
+        self.inner
+            .shards
+            .iter()
+            .map(|shard| lock_shard(shard).len())
+            .sum()
+    }
+}
+
+impl std::fmt::Debug for SharedRateLimitCounter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedRateLimitCounter")
+            .field("enabled", &self.inner.config.enabled)
+            .field("sync_interval", &self.inner.config.sync_interval)
+            .field("flusher", &self.wake.is_some())
+            .field("buckets", &self.bucket_count())
+            .finish()
+    }
+}
+
+impl Inner {
+    fn new(config: SharedRateLimitConfig, store: Option<Arc<dyn SharedRateLimitStore>>) -> Self {
+        let mut shards = Vec::with_capacity(SHARD_COUNT);
+        for _ in 0..SHARD_COUNT {
+            shards.push(Mutex::new(HashMap::new()));
+        }
+        // A disabled counter drops the store here, so there is no way for any
+        // later code path to reach the datastore.
+        let store = if config.enabled { store } else { None };
+        Self {
+            config,
+            store,
+            shards,
+            wake_warned: AtomicBool::new(false),
+            starvation_warned: AtomicBool::new(false),
+        }
+    }
+
+    fn shard_for(&self, key: &str) -> &Mutex<HashMap<String, Bucket>> {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        &self.shards[(hasher.finish() as usize) % SHARD_COUNT]
+    }
+
+    /// See [`SharedRateLimitCounter::flush_once`].
+    ///
+    /// Three phases, so that the `std::sync::Mutex` is NEVER held across the
+    /// store `await`:
+    /// 1. Under each shard lock: prune stale buckets and collect
+    ///    `(shard, key, window, delta)` for every bucket with pending work
+    ///    that has not already been flushed within this `sync_interval`.
+    /// 2. Lock-free: one [`SharedRateLimitStore::increment_by`] per key.
+    /// 3. Re-lock briefly: adopt the authoritative count and subtract the
+    ///    flushed delta from `pending` (increments that arrived during the
+    ///    await stay pending for the next pass).
+    async fn flush_once(&self) {
+        let Some(store) = self.store.as_ref() else {
+            return;
+        };
+
+        let now = Utc::now();
+        let work = self.collect_pending(now);
+
+        for (shard_idx, key, window, delta) in work {
+            match store.increment_by(&key, window, delta).await {
+                Ok(authoritative) => {
+                    let mut guard = lock_shard(&self.shards[shard_idx]);
+                    if let Some(bucket) = guard.get_mut(&key) {
+                        // Ignore the result if the bucket rolled over into a
+                        // new window while the write was in flight — that
+                        // count belongs to the window we just left.
+                        if bucket.window_start == window {
+                            bucket.shared_count = authoritative;
+                            bucket.pending = bucket.pending.saturating_sub(delta);
+                            bucket.last_flush = Some(now);
+                        }
+                    }
+                }
+                Err(err) => {
+                    // Fail OPEN (D-01b): a counter-store outage must never
+                    // hard-block auth traffic. `pending` is deliberately left
+                    // in place so the delta is retried on the next pass; a
+                    // retry that double-counts an UPSERT which actually
+                    // landed errs toward *stricter* limiting, which is the
+                    // safe direction for a security control.
+                    // T-24-43: never log the raw key (it embeds a client IP /
+                    // client_id).
+                    tracing::warn!(
+                        delta,
+                        error = %err,
+                        "shared rate-limit store unreachable during write-behind flush; \
+                         cross-replica convergence paused, still enforcing local counts"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Phase 1 of [`Self::flush_once`]: prune + collect, one short lock per
+    /// shard, nothing awaited.
+    ///
+    /// Only buckets with `pending > 0` are collected, so an idle bucket costs
+    /// zero store writes no matter how many passes run. Since the flusher
+    /// loop itself runs at most once per `sync_interval`, "one write per
+    /// bucket per interval" follows from the loop, not from any per-bucket
+    /// suppression here — a bucket must never be skipped while it has
+    /// unflushed increments, or its replica's contribution would stay
+    /// invisible to the other replicas for an unbounded time.
+    fn collect_pending(&self, now: DateTime<Utc>) -> Vec<(usize, String, DateTime<Utc>, u64)> {
+        let stale_after = self.config.window * STALE_WINDOW_MULTIPLE;
+        let stale_cutoff = chrono::Duration::from_std(stale_after)
+            .ok()
+            .and_then(|d| now.checked_sub_signed(d));
+        let overdue_after = chrono::Duration::from_std(self.config.sync_interval)
+            .ok()
+            .map(|gap| gap * OVERDUE_SYNC_MULTIPLE);
+
+        let mut work = Vec::new();
+        let mut overdue = false;
+        for (shard_idx, shard) in self.shards.iter().enumerate() {
+            let mut guard = lock_shard(shard);
+
+            // Pruning (bounded memory): drop buckets older than
+            // STALE_WINDOW_MULTIPLE windows that have nothing left to flush.
+            if let Some(cutoff) = stale_cutoff {
+                guard.retain(|_, bucket| bucket.pending > 0 || bucket.window_start >= cutoff);
+            }
+
+            for (key, bucket) in guard.iter() {
+                if bucket.pending == 0 {
+                    continue;
+                }
+                // Starvation detection only — never suppresses a write.
+                if let (Some(last), Some(threshold)) = (bucket.last_flush, overdue_after)
+                    && now.signed_duration_since(last) > threshold
+                {
+                    overdue = true;
+                }
+                work.push((shard_idx, key.clone(), bucket.window_start, bucket.pending));
+            }
+        }
+
+        if overdue && !self.starvation_warned.swap(true, Ordering::Relaxed) {
+            // T-24-43: no raw key in the alarm.
+            tracing::warn!(
+                sync_interval_ms = self.config.sync_interval.as_millis() as u64,
+                overdue_multiple = OVERDUE_SYNC_MULTIPLE,
+                "shared rate-limit write-behind flusher is falling behind its sync \
+                 interval; cross-replica overshoot may exceed the documented bound \
+                 (logged once)"
+            );
+        }
+
+        work
+    }
+}
+
+/// Acquires a shard lock, recovering from poisoning instead of panicking: a
+/// panic in an unrelated task must not disable the rate limiter.
+fn lock_shard(shard: &Mutex<HashMap<String, Bucket>>) -> MutexGuard<'_, HashMap<String, Bucket>> {
+    shard
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The single background flusher task.
+///
+/// Wakes on an increment notification OR on a `sync_interval` backstop tick
+/// (so a delta whose wake hint was dropped by a full channel is still
+/// flushed), drains any further queued hints, then runs one coalesced pass.
+/// Exits when every [`SharedRateLimitCounter`] clone has been dropped, so it
+/// never outlives the counter it serves.
+async fn flusher_loop(inner: Arc<Inner>, mut rx: tokio::sync::mpsc::Receiver<()>) {
+    let interval = inner.config.sync_interval;
+    loop {
+        tokio::select! {
+            hint = rx.recv() => {
+                if hint.is_none() {
+                    // All senders dropped: the counter is gone.
+                    break;
+                }
+                // Coalescing window: let further increments accumulate
+                // before paying for a store round trip.
+                tokio::time::sleep(interval).await;
+            }
+            _ = tokio::time::sleep(interval) => {}
+        }
+
+        // Drain queued hints so they don't each trigger a redundant pass.
+        while rx.try_recv().is_ok() {}
+
+        inner.flush_once().await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Call-recording in-memory store: proves the flusher coalesces (one
+    /// call per key per pass, carrying the summed delta) and lets a test
+    /// assert "no store interaction at all".
+    #[derive(Default)]
+    struct RecordingStore {
+        calls: Mutex<Vec<(String, DateTime<Utc>, u64)>>,
+        counts: Mutex<HashMap<(String, DateTime<Utc>), u64>>,
+        /// When set, every `increment_by` errors — simulates a store outage.
+        fail: AtomicBool,
+        call_count: AtomicUsize,
+    }
+
+    impl RecordingStore {
+        fn calls(&self) -> Vec<(String, DateTime<Utc>, u64)> {
+            self.calls.lock().unwrap_or_else(|p| p.into_inner()).clone()
+        }
+
+        fn call_count(&self) -> usize {
+            self.call_count.load(Ordering::SeqCst)
+        }
+
+        /// Simulates another replica having already written `count` into the
+        /// shared bucket.
+        fn preload(&self, key: &str, window: DateTime<Utc>, count: u64) {
+            self.counts
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .insert((key.to_string(), window), count);
+        }
+    }
+
+    impl SharedRateLimitStore for RecordingStore {
+        fn increment_by<'a>(
+            &'a self,
+            key: &'a str,
+            window_start: DateTime<Utc>,
+            delta: u64,
+        ) -> StoreIncrementFuture<'a> {
+            Box::pin(async move {
+                self.call_count.fetch_add(1, Ordering::SeqCst);
+                self.calls.lock().unwrap_or_else(|p| p.into_inner()).push((
+                    key.to_string(),
+                    window_start,
+                    delta,
+                ));
+                if self.fail.load(Ordering::SeqCst) {
+                    return Err(DbError::Migration("simulated store outage".into()));
+                }
+                let mut counts = self.counts.lock().unwrap_or_else(|p| p.into_inner());
+                let entry = counts.entry((key.to_string(), window_start)).or_insert(0);
+                *entry += delta;
+                Ok(*entry)
+            })
+        }
+    }
+
+    fn counter_with(store: Arc<RecordingStore>) -> SharedRateLimitCounter {
+        SharedRateLimitCounter::without_flusher(SharedRateLimitConfig::default(), store)
+    }
+
+    /// Requirement 1: under the limit allows, crossing it denies — with no
+    /// flush at all (purely local counting, the hot path).
+    #[test]
+    fn under_limit_allows_and_crossing_limit_denies_locally() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = counter_with(Arc::clone(&store));
+        let window = Utc::now();
+
+        for i in 1..=3 {
+            assert!(
+                counter.check("login:203.0.113.5", window, 3),
+                "request {i} is within the limit"
+            );
+        }
+        assert!(
+            !counter.check("login:203.0.113.5", window, 3),
+            "the 4th request crosses limit=3 and must be denied"
+        );
+        // Still denied while over budget.
+        assert!(!counter.check("login:203.0.113.5", window, 3));
+
+        // Decisions required ZERO store round trips (the whole point).
+        assert_eq!(store.call_count(), 0);
+
+        // A different key has its own bucket.
+        assert!(counter.check("login:198.51.100.1", window, 3));
+    }
+
+    /// Requirement 2: a new window resets the count and re-allows.
+    #[test]
+    fn window_rollover_resets_and_reallows() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = counter_with(store);
+        let window1 = Utc::now();
+        let window2 = window1 + chrono::Duration::seconds(60);
+
+        for _ in 0..2 {
+            assert!(counter.check("k", window1, 2));
+        }
+        assert!(!counter.check("k", window1, 2));
+
+        // New window ⇒ fresh budget.
+        assert!(counter.check("k", window2, 2));
+        assert!(counter.check("k", window2, 2));
+        assert!(!counter.check("k", window2, 2));
+    }
+
+    /// Requirement 3: N local increments coalesce into ONE store write
+    /// carrying delta N, and the authoritative count is adopted afterwards.
+    #[tokio::test]
+    async fn flush_coalesces_increments_into_one_write_and_adopts_the_count() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = counter_with(Arc::clone(&store));
+        let window = Utc::now();
+
+        for _ in 0..5 {
+            assert!(counter.check("authz_check:10.0.0.1", window, 100));
+        }
+        assert_eq!(store.call_count(), 0, "nothing written before the flush");
+
+        counter.flush_once().await;
+
+        let calls = store.calls();
+        assert_eq!(calls.len(), 1, "5 increments ⇒ exactly ONE store write");
+        assert_eq!(calls[0].0, "authz_check:10.0.0.1");
+        assert_eq!(calls[0].1, window);
+        assert_eq!(calls[0].2, 5, "the write carries the summed delta");
+
+        // `shared_count` was adopted and `pending` drained: the next 95
+        // requests fit under limit=100, the 101st does not.
+        for _ in 0..95 {
+            assert!(counter.check("authz_check:10.0.0.1", window, 100));
+        }
+        assert!(!counter.check("authz_check:10.0.0.1", window, 100));
+
+        // A second flush writes the NEW delta only (95 + 1 denied = 96),
+        // never re-sends the already-flushed 5.
+        counter.flush_once().await;
+        let calls = store.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].2, 96, "only the new delta is written");
+    }
+
+    /// Requirement 3b: an IDLE bucket produces no write at all — the "one
+    /// write per bucket per interval" ceiling comes from the flusher loop's
+    /// interval, and a bucket with nothing pending costs nothing even if the
+    /// loop is woken repeatedly.
+    #[tokio::test]
+    async fn flush_is_a_noop_without_pending_work() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = counter_with(Arc::clone(&store));
+
+        counter.flush_once().await;
+        assert_eq!(store.call_count(), 0, "no buckets ⇒ no writes");
+
+        let window = Utc::now();
+        assert!(counter.check("k", window, 10));
+        counter.flush_once().await;
+        assert_eq!(store.call_count(), 1);
+
+        // Repeated passes with nothing new pending must NOT write again.
+        for _ in 0..5 {
+            counter.flush_once().await;
+        }
+        assert_eq!(
+            store.call_count(),
+            1,
+            "an idle bucket is never re-written, however often the flusher runs"
+        );
+
+        // New traffic ⇒ exactly one more write, carrying only the new delta.
+        assert!(counter.check("k", window, 10));
+        assert!(counter.check("k", window, 10));
+        counter.flush_once().await;
+        let calls = store.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].2, 2, "only the new delta is written");
+    }
+
+    /// Requirement 4 — THE property this whole layer exists for: two counter
+    /// instances ("replicas") over ONE store converge, and the COMBINED limit
+    /// is enforced. An in-memory-only baseline would allow `2 × LIMIT`.
+    ///
+    /// This test also pins the documented staleness/overshoot bound: a replica
+    /// counts all of its OWN traffic immediately, but only sees the other
+    /// replica's traffic as of its last flush, so it may admit a bounded
+    /// number of extra requests before converging.
+    #[tokio::test]
+    async fn cross_replica_convergence_enforces_the_combined_limit() {
+        let store = Arc::new(RecordingStore::default());
+        let replica_a = counter_with(Arc::clone(&store));
+        let replica_b = counter_with(Arc::clone(&store));
+        let window = Utc::now();
+        let key = "oauth2_token:203.0.113.9";
+        const LIMIT: u32 = 4;
+
+        // Each replica admits 2 requests: 4 total, exactly the limit, and
+        // neither replica has seen the other's traffic yet.
+        let mut admitted = 0;
+        for _ in 0..2 {
+            assert!(replica_a.check(key, window, LIMIT));
+            assert!(replica_b.check(key, window, LIMIT));
+            admitted += 2;
+        }
+        assert_eq!(admitted, 4);
+
+        // One flush pass on each replica: A writes its delta (2), then B
+        // writes its delta and reads back the combined authoritative count
+        // (4). Exactly two coalesced writes for four requests.
+        replica_a.flush_once().await;
+        replica_b.flush_once().await;
+        let deltas: Vec<u64> = store.calls().iter().map(|c| c.2).collect();
+        assert_eq!(
+            deltas,
+            vec![2, 2],
+            "one coalesced write per replica, never one per request"
+        );
+
+        // B flushed last, so it holds the full picture and denies at once.
+        assert!(
+            !replica_b.check(key, window, LIMIT),
+            "replica B must observe replica A's contribution after convergence"
+        );
+
+        // A adopted `shared_count = 2` (the store's value at ITS flush, before
+        // B wrote), so it still admits ONE more request. This IS the
+        // documented overshoot: bounded by what arrives at a replica within
+        // one sync interval, and it converges on A's next flush.
+        assert!(
+            replica_a.check(key, window, LIMIT),
+            "replica A has not yet seen B's contribution — the bounded overshoot"
+        );
+        admitted += 1;
+
+        // A's next flush writes its 1 pending increment and adopts 5.
+        replica_a.flush_once().await;
+        assert!(
+            !replica_a.check(key, window, LIMIT),
+            "replica A must observe replica B's contribution after convergence"
+        );
+        assert!(!replica_b.check(key, window, LIMIT));
+
+        // Aggregate admitted (5) exceeded the limit by exactly the bounded
+        // overshoot and stayed FAR below the `2 × LIMIT = 8` an in-memory-only
+        // per-replica baseline would have allowed.
+        assert_eq!(admitted, 5);
+        assert!(admitted < 2 * LIMIT as usize);
+    }
+
+    /// Requirement 4b: a count already in the store (written by another
+    /// replica before this one ever saw the key) is adopted on first flush.
+    #[tokio::test]
+    async fn adopts_a_preexisting_shared_count_from_another_replica() {
+        let store = Arc::new(RecordingStore::default());
+        let window = Utc::now();
+        let key = "login:198.51.100.77";
+        store.preload(key, window, 9);
+
+        let counter = counter_with(Arc::clone(&store));
+        assert!(
+            counter.check(key, window, 10),
+            "locally this is only the 1st request, so it is admitted"
+        );
+        counter.flush_once().await;
+
+        assert!(
+            !counter.check(key, window, 10),
+            "after convergence the store's 9 + this replica's 1 fills limit=10"
+        );
+    }
+
+    /// Requirement 5: a store error during flush fails open — no panic, the
+    /// delta is retained for retry, and local counting keeps working.
+    #[tokio::test]
+    async fn store_error_during_flush_fails_open_and_keeps_counting_locally() {
+        let store = Arc::new(RecordingStore::default());
+        store.fail.store(true, Ordering::SeqCst);
+        let counter = counter_with(Arc::clone(&store));
+        let window = Utc::now();
+
+        for _ in 0..2 {
+            assert!(counter.check("k", window, 3));
+        }
+
+        // Does not panic, does not poison anything.
+        counter.flush_once().await;
+        assert_eq!(store.call_count(), 1, "the flush was attempted");
+
+        // Local counting is unaffected: the 3rd is admitted, the 4th denied.
+        assert!(counter.check("k", window, 3));
+        assert!(!counter.check("k", window, 3));
+
+        // The unflushed delta was retained, so once the store recovers it is
+        // written in full (4 local increments, none lost).
+        store.fail.store(false, Ordering::SeqCst);
+        counter.flush_once().await;
+        let calls = store.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1].2, 4, "the retained delta is retried in full");
+    }
+
+    /// Requirement 6: `AXIAM__RATE_LIMIT__SHARED=off` ⇒ no store interaction
+    /// at all, and every request is allowed by this layer (the in-memory
+    /// governor remains the sole limiter).
+    #[tokio::test]
+    async fn disabled_counter_never_touches_the_store() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = SharedRateLimitCounter::new(
+            SharedRateLimitConfig {
+                enabled: false,
+                ..SharedRateLimitConfig::default()
+            },
+            Arc::clone(&store) as Arc<dyn SharedRateLimitStore>,
+        );
+
+        assert!(!counter.is_enabled());
+        let window = Utc::now();
+        for _ in 0..50 {
+            assert!(
+                counter.check("k", window, 1),
+                "a disabled shared layer never denies"
+            );
+        }
+        counter.flush_once().await;
+
+        assert_eq!(store.call_count(), 0, "no store interaction whatsoever");
+        assert_eq!(store.calls().len(), 0);
+        assert_eq!(counter.bucket_count(), 0, "no state is even allocated");
+    }
+
+    /// Requirement 7: memory is bounded — buckets whose window is older than
+    /// two windows and which have nothing pending are pruned by the flusher.
+    #[tokio::test]
+    async fn flush_prunes_stale_windows_to_bound_memory() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = counter_with(Arc::clone(&store));
+
+        let now = Utc::now();
+        let stale = now - chrono::Duration::seconds(10 * DEFAULT_WINDOW_SECS as i64);
+        let current = now;
+
+        // 40 distinct stale keys + 3 current keys.
+        for i in 0..40 {
+            assert!(counter.check(&format!("stale:{i}"), stale, 100));
+        }
+        for i in 0..3 {
+            assert!(counter.check(&format!("live:{i}"), current, 100));
+        }
+        assert_eq!(counter.bucket_count(), 43);
+
+        // First pass flushes everything (nothing is pruned yet, because all
+        // 43 buckets still have pending deltas).
+        counter.flush_once().await;
+        assert_eq!(counter.bucket_count(), 43);
+        assert_eq!(store.call_count(), 43, "one write per key, not per request");
+
+        // Second pass: the stale keys have pending == 0 and a window older
+        // than 2 windows ⇒ dropped. The live keys survive.
+        counter.flush_once().await;
+        assert_eq!(
+            counter.bucket_count(),
+            3,
+            "stale buckets are pruned; memory is bounded by the last two windows"
+        );
+        assert_eq!(
+            store.call_count(),
+            43,
+            "pruning issues no additional writes"
+        );
+
+        // A stale key seen again simply starts a fresh bucket.
+        assert!(counter.check("stale:0", current, 100));
+        assert_eq!(counter.bucket_count(), 4);
+    }
+
+    /// The background flusher actually runs and converges without any manual
+    /// `flush_once` — exercising `SharedRateLimitCounter::new`'s spawn path,
+    /// the wake channel and the interval backstop.
+    #[tokio::test]
+    async fn background_flusher_converges_without_manual_flush() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = SharedRateLimitCounter::new(
+            SharedRateLimitConfig {
+                enabled: true,
+                sync_interval: Duration::from_millis(MIN_SYNC_INTERVAL_MS),
+                ..SharedRateLimitConfig::default()
+            },
+            Arc::clone(&store) as Arc<dyn SharedRateLimitStore>,
+        );
+        let window = Utc::now();
+
+        for _ in 0..6 {
+            assert!(counter.check("bg:1.2.3.4", window, 100));
+        }
+
+        // Wait (generously) for the flusher to coalesce and write once.
+        for _ in 0..100 {
+            if store.call_count() > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let calls = store.calls();
+        assert!(
+            !calls.is_empty(),
+            "the background flusher must write without any manual flush"
+        );
+        assert_eq!(
+            calls[0].2, 6,
+            "the single write carries the coalesced delta"
+        );
+        assert_eq!(
+            calls.len(),
+            1,
+            "6 requests produced exactly one datastore write"
+        );
+    }
+
+    /// `from_env` defaults and clamping. Env vars are process-global, so this
+    /// single test owns all of them (no parallel test may touch them).
+    #[test]
+    fn from_env_defaults_on_and_clamps_the_sync_interval() {
+        // SAFETY: single-threaded test that owns these two env vars; no
+        // other test in this module reads them.
+        unsafe {
+            std::env::remove_var("AXIAM__RATE_LIMIT__SHARED");
+            std::env::remove_var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS");
+        }
+        let cfg = SharedRateLimitConfig::from_env();
+        assert!(cfg.enabled, "the shared layer defaults to ON");
+        assert_eq!(
+            cfg.sync_interval,
+            Duration::from_millis(DEFAULT_SYNC_INTERVAL_MS)
+        );
+
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED", "off");
+        }
+        assert!(!SharedRateLimitConfig::from_env().enabled);
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED", "OFF");
+        }
+        assert!(!SharedRateLimitConfig::from_env().enabled);
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED", "on");
+        }
+        assert!(SharedRateLimitConfig::from_env().enabled);
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED", "garbage");
+        }
+        assert!(
+            SharedRateLimitConfig::from_env().enabled,
+            "an unrecognized value must not silently disable a security control"
+        );
+
+        // Clamping.
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS", "1");
+        }
+        assert_eq!(
+            SharedRateLimitConfig::from_env().sync_interval,
+            Duration::from_millis(MIN_SYNC_INTERVAL_MS)
+        );
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS", "999999");
+        }
+        assert_eq!(
+            SharedRateLimitConfig::from_env().sync_interval,
+            Duration::from_millis(MAX_SYNC_INTERVAL_MS)
+        );
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS", "not-a-number");
+        }
+        assert_eq!(
+            SharedRateLimitConfig::from_env().sync_interval,
+            Duration::from_millis(DEFAULT_SYNC_INTERVAL_MS)
+        );
+        unsafe {
+            std::env::set_var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS", "250");
+        }
+        assert_eq!(
+            SharedRateLimitConfig::from_env().sync_interval,
+            Duration::from_millis(250)
+        );
+
+        unsafe {
+            std::env::remove_var("AXIAM__RATE_LIMIT__SHARED");
+            std::env::remove_var("AXIAM__RATE_LIMIT__SHARED_SYNC_MS");
+        }
+    }
+
+    /// Keys are spread across shards (a single-shard map would serialize
+    /// every endpoint behind one mutex).
+    #[test]
+    fn keys_spread_across_shards() {
+        let store = Arc::new(RecordingStore::default());
+        let counter = counter_with(store);
+        let window = Utc::now();
+        for i in 0..256 {
+            assert!(counter.check(&format!("endpoint:{i}"), window, 1000));
+        }
+        let occupied = counter
+            .inner
+            .shards
+            .iter()
+            .filter(|s| !lock_shard(s).is_empty())
+            .count();
+        assert!(
+            occupied > SHARD_COUNT / 2,
+            "256 keys should occupy most of the {SHARD_COUNT} shards, occupied={occupied}"
+        );
+        assert_eq!(counter.bucket_count(), 256);
+    }
+
+    /// A real `SurrealRateLimitBucketRepository` satisfies the store trait
+    /// and drives the counter end to end — this is the wiring both callers
+    /// use, and the cross-replica test with a REAL in-memory SurrealDB.
+    #[tokio::test]
+    async fn two_counters_over_one_surrealdb_converge() {
+        use surrealdb::Surreal;
+        use surrealdb::engine::local::Mem;
+
+        let db = Surreal::new::<Mem>(()).await.unwrap();
+        db.use_ns("test").use_db("test").await.unwrap();
+        crate::schema::run_migrations(&db).await.unwrap();
+
+        let store_a: Arc<dyn SharedRateLimitStore> =
+            Arc::new(SurrealRateLimitBucketRepository::new(db.clone()));
+        let store_b: Arc<dyn SharedRateLimitStore> =
+            Arc::new(SurrealRateLimitBucketRepository::new(db.clone()));
+
+        let replica_a =
+            SharedRateLimitCounter::without_flusher(SharedRateLimitConfig::default(), store_a);
+        let replica_b =
+            SharedRateLimitCounter::without_flusher(SharedRateLimitConfig::default(), store_b);
+
+        let window = Utc::now();
+        let key = "authz_check:203.0.113.42";
+        const LIMIT: u32 = 6;
+
+        // 3 requests per replica: 6 total = exactly the limit.
+        for _ in 0..3 {
+            assert!(replica_a.check(key, window, LIMIT));
+            assert!(replica_b.check(key, window, LIMIT));
+        }
+
+        replica_a.flush_once().await;
+        replica_b.flush_once().await;
+
+        // B flushed last and therefore holds the combined count (6/6).
+        assert!(
+            !replica_b.check(key, window, LIMIT),
+            "replica B must see replica A's 3 requests"
+        );
+
+        // A adopted the store value as of ITS flush (3), so it admits the
+        // bounded overshoot before converging on its next pass.
+        assert!(replica_a.check(key, window, LIMIT));
+        replica_a.flush_once().await;
+        assert!(
+            !replica_a.check(key, window, LIMIT),
+            "replica A must see replica B's 3 requests after its next flush"
+        );
+
+        // ONE shared row holds the combined count (3 + 3 + A's 1 overshoot),
+        // not two independent per-replica counts of 3.
+        let repo = SurrealRateLimitBucketRepository::new(db);
+        assert_eq!(
+            repo.increment_by(key, window, 0).await.unwrap(),
+            7,
+            "one shared row holds the combined count"
+        );
+    }
+}

--- a/crates/axiam-db/src/repository/rate_limit.rs
+++ b/crates/axiam-db/src/repository/rate_limit.rs
@@ -53,13 +53,50 @@ impl<C: Connection> SurrealRateLimitBucketRepository<C> {
     ///
     /// All error paths `?`-propagate `DbError` — no `.unwrap()`/`.expect()`
     /// on this counter path.
+    ///
+    /// Thin delegation to [`Self::increment_by`] with `delta = 1`; the two
+    /// share one UPSERT statement so the windowed-CAS semantics can never
+    /// drift between the single-hit and batched-delta callers.
     pub async fn increment(&self, key: &str, window_start: DateTime<Utc>) -> Result<u64, DbError> {
+        self.increment_by(key, window_start, 1).await
+    }
+
+    /// Adds `delta` to the shared bucket identified by `key` for the fixed
+    /// window starting at `window_start`, returning the POST-update count.
+    ///
+    /// This is the batched generalization of [`Self::increment`] and the
+    /// write primitive used by
+    /// [`crate::rate_limit_counter::SharedRateLimitCounter`]'s write-behind
+    /// flusher: instead of one UPSERT per request, the flusher accumulates
+    /// `delta` local increments in memory and issues ONE UPSERT per
+    /// `(key, window)` per sync interval. That is what removes the
+    /// per-request synchronous datastore round-trip that capped the six
+    /// hottest endpoints at ~20 ops/s (see the module docs of
+    /// [`crate::rate_limit_counter`] for the measurements).
+    ///
+    /// Windowed compare-and-set semantics are identical to
+    /// [`Self::increment`], with `1` generalized to `$delta`:
+    ///
+    /// - First hit on a fresh key (`count` is `NONE`): `count = $delta`.
+    /// - Same window: `count = count + $delta`.
+    /// - Stored `window_start` OLDER than `$window_start` (a new window
+    ///   began): `count = $delta`, `window_start = $window_start`.
+    ///
+    /// A `delta` of `0` is a legal no-op write (it still refreshes
+    /// `updated_at` and returns the current count), but the flusher never
+    /// issues one — it skips buckets with nothing pending.
+    pub async fn increment_by(
+        &self,
+        key: &str,
+        window_start: DateTime<Utc>,
+        delta: u64,
+    ) -> Result<u64, DbError> {
         let result = self
             .db
             .query(
                 "UPSERT type::record('rate_limit_bucket', $key) SET \
                  count = IF window_start = NONE OR window_start < $window_start \
-                          THEN 1 ELSE count + 1 END, \
+                          THEN $delta ELSE count + $delta END, \
                  window_start = IF window_start = NONE OR window_start < $window_start \
                           THEN $window_start ELSE window_start END, \
                  updated_at = time::now() \
@@ -67,6 +104,7 @@ impl<C: Connection> SurrealRateLimitBucketRepository<C> {
             )
             .bind(("key", key.to_string()))
             .bind(("window_start", window_start))
+            .bind(("delta", delta))
             .await
             .map_err(DbError::from)?;
 
@@ -121,5 +159,41 @@ mod tests {
         // The original key's bucket is untouched by the other key's
         // increment — no cross-endpoint bucket collapsing.
         assert_eq!(repo.increment(key, window2).await.unwrap(), 2);
+    }
+
+    /// `increment_by` is the write primitive behind the write-behind flusher
+    /// (`crate::rate_limit_counter`): a batched delta must land exactly as
+    /// `delta` single increments would have, including the window reset.
+    #[tokio::test]
+    async fn rate_limit_bucket_increment_by_batches_deltas_and_resets_on_new_window() {
+        let db = Surreal::new::<Mem>(()).await.unwrap();
+        db.use_ns("test").use_db("test").await.unwrap();
+        crate::schema::run_migrations(&db).await.unwrap();
+
+        let repo = SurrealRateLimitBucketRepository::new(db);
+
+        let key = "authz_check:203.0.113.7";
+        let window1 = Utc::now();
+
+        // First flush on a fresh key sets count = delta (not 1).
+        assert_eq!(repo.increment_by(key, window1, 7).await.unwrap(), 7);
+
+        // A second flush in the SAME window ADDS the delta.
+        assert_eq!(repo.increment_by(key, window1, 5).await.unwrap(), 12);
+
+        // A single increment interleaves correctly with batched deltas.
+        assert_eq!(repo.increment(key, window1).await.unwrap(), 13);
+
+        // A NEWER window resets to exactly the delta (not delta + old count).
+        let window2 = window1 + Duration::minutes(1);
+        assert_eq!(repo.increment_by(key, window2, 4).await.unwrap(), 4);
+
+        // delta = 0 is a legal no-op that returns the unchanged count.
+        assert_eq!(repo.increment_by(key, window2, 0).await.unwrap(), 4);
+
+        // Per-key isolation holds for batched deltas too.
+        let other = "login:203.0.113.7";
+        assert_eq!(repo.increment_by(other, window2, 2).await.unwrap(), 2);
+        assert_eq!(repo.increment_by(key, window2, 1).await.unwrap(), 5);
     }
 }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -1069,6 +1069,24 @@ async fn main() -> std::io::Result<()> {
     );
     let cleanup_handle = tokio::spawn(cleanup.run());
 
+    // SECHRD-03 / D-01a (H2 performance fix): ONE write-behind shared
+    // rate-limit counter for the whole process.
+    //
+    // It must be built here — outside the `HttpServer::new` worker closure —
+    // and only ever CLONED into `AppState` (a cheap `Arc` clone). The counter
+    // accumulates each replica's unflushed increments in process memory, so
+    // one instance per worker would fragment the local count and weaken the
+    // effective limit by up to the worker count. Its single background
+    // flusher is spawned here too, on this runtime.
+    //
+    // Config (identical knobs for the gRPC listener, read the same way):
+    // `AXIAM__RATE_LIMIT__SHARED` (on|off, default on) and
+    // `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` (default 1000, clamped
+    // 50..=60000). No configured *limit* is affected.
+    let shared_rate_limit_counter = axiam_db::SharedRateLimitCounter::from_env(Arc::new(
+        axiam_db::SurrealRateLimitBucketRepository::new(db_handle.clone()),
+    ));
+
     // QUAL-01: single composition root — one AppState<C> built here and
     // registered once per worker below, replacing the ~49 individual
     // `.app_data(web::Data::new(...))` calls this closure used to make.
@@ -1126,6 +1144,7 @@ async fn main() -> std::io::Result<()> {
         oauth2_jwks_cache_config: config.oauth2.clone(),
         crypto_semaphore: Arc::clone(&crypto_semaphore),
         email_config_repo: email_config_repo.clone(),
+        shared_rate_limit: shared_rate_limit_counter.clone(),
         password_reset_service: password_reset_service.clone(),
         email_verification_service: email_verification_service.clone(),
         oidc_federation_service: oidc_federation_service.clone(),

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -1009,6 +1009,14 @@ async fn main() -> std::io::Result<()> {
     // rate-limit pre-check can enforce the multi-replica bucket store
     // (GrpcSharedRateLimitLayer), not just the per-replica in-memory
     // governor.
+    //
+    // `start_grpc_server` builds its OWN `SharedRateLimitCounter` from this
+    // handle (see `shared_rate_limit_counter` below for the REST one). Two
+    // counters in one process is correct, not a bug: their bucket keys never
+    // overlap — the gRPC layer only ever writes `grpc_authz:<ip>`, while the
+    // REST middleware writes `<rest_endpoint>:<key_part>` — so neither can
+    // fragment the other's local count. Both read the same
+    // `AXIAM__RATE_LIMIT__SHARED*` env knobs, so they behave identically.
     let grpc_db = db_handle.clone();
     let grpc_batch_max_concurrency = config.authz.batch_max_concurrency;
     tokio::spawn(async move {

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -254,9 +254,13 @@ the per-mutation invalidation table are in the
 
 Every authentication/OAuth2 endpoint is rate-limited (see
 `crates/axiam-api-rest/src/config/rate_limit.rs`) by two cooperating layers:
-a per-replica in-memory `Governor` and a `SurrealDB`-backed shared counter
-that closes the multi-replica gap (`middleware::rate_limit_shared`). Both
-layers derive their bucket key the same way.
+a per-replica in-memory `Governor`, and a process-wide, write-behind shared
+counter (`axiam_db::rate_limit_counter::SharedRateLimitCounter`,
+`middleware::rate_limit_shared`) that closes the multi-replica gap. Both
+layers derive their bucket key the same way. `GET /api/v1/users` is **not**
+wrapped by either limiter — it was fixed to stop inheriting the `/users`
+registration bucket (see the note at the end of this section) and now sits
+unlimited, matching its siblings `GET /roles` and `GET /resources`.
 
 | Key | Purpose |
 |---|---|
@@ -271,6 +275,8 @@ layers derive their bucket key the same way.
 | `AXIAM__RATE_LIMIT__TRUSTED_HOPS` | Number of trusted reverse-proxy hops to skip from the right of `X-Forwarded-For` when deriving the client IP (default `0` — set to `1` behind a single ingress/nginx). |
 | `AXIAM__RATE_LIMIT__KEY` | Bucket-key derivation mode: `ip` (default) \| `client_id` \| `ip_client_id`. See below. |
 | `AXIAM__RATE_LIMIT__PROFILE` | Deployment posture preset: `internet` (default — the shipped values above, unchanged) \| `gateway` \| `mesh`. Sets the machine-traffic family (key mode, token/introspect/revoke/authz, and the gRPC authz ceiling) coherently in one variable; never changes the human endpoints. See [Sizing your rate limits](rate-limit-sizing.md). |
+| `AXIAM__RATE_LIMIT__SHARED` | Enables (`on`, default) or disables (`off`) the cross-replica shared counter. `off` is a **single-replica escape hatch**: it skips the shared layer entirely (no state, no store call, no flusher) and leaves the per-replica in-memory `Governor` as the sole limiter. Do not set `off` behind an HPA/multiple replicas — it re-opens the N× effective-limit multiplication the shared counter exists to close. |
+| `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` | Write-behind flush interval for the shared counter, in milliseconds (default `1000`, clamped `50`–`60000`). Directly scales the cross-replica overshoot bound — see [Shared-store consistency model](#shared-store-consistency-model-write-behind) below. |
 
 > **Which numbers should you actually run?** See
 > **[Sizing your rate limits](rate-limit-sizing.md)** — the measured hardware
@@ -317,6 +323,120 @@ When a `client_id`/`ip_client_id`-mode request has no parseable `client_id`
 (malformed body, wrong content type, etc.), the rate limiter fails **safe**
 by falling back to the IP key for that request — it never disables rate
 limiting outright.
+
+### Shared-store consistency model (write-behind)
+
+The shared counter used to perform one synchronous SurrealDB `UPSERT` per
+request, awaited **before** the handler ran, on every request to the six
+wrapped endpoints (`POST /api/v1/authz/check`, `/oauth2/token`,
+`/oauth2/introspect`, `/oauth2/revoke`, `/auth/login`, and — until fixed, see
+below — `GET /api/v1/users`). That write put the datastore's own write
+latency directly on the request path: measured at **16–21 ops/s at any
+concurrency from 1 to 40 clients** against a ~40 ms write on the
+investigation host, while structurally identical unwrapped endpoints ran at
+68–4 248 ops/s (`claude_dev/postseed-transient-investigation.md`, task H2).
+That per-request write is gone. `SharedRateLimitCounter`
+(`axiam_db::rate_limit_counter`) now decides synchronously from an in-process
+sharded count (`shared_count + pending > limit`, no datastore round trip, no
+`await`) and a single background flusher coalesces every bucket's
+accumulated increments into **one** datastore write per `(bucket, window)`
+per `AXIAM__RATE_LIMIT__SHARED_SYNC_MS`.
+
+**Security bound.** Cross-replica enforcement is therefore **eventual**
+rather than synchronous. Quoting the module docs verbatim, the worst-case
+overshoot beyond the configured limit, before the counts converge, is
+bounded by approximately
+
+```text
+(replicas - 1) × arrival_rate_per_replica × sync_interval
+```
+
+and is **zero on a single replica** (`replicas - 1 = 0`, so local counting is
+exact and this layer is as strict as the previous synchronous
+implementation). Worked example from the module docs: limit 100/min, 4
+replicas, `sync_interval` 1 s, aggregate arrival 40 req/s ⇒ worst case ≈
+`3 × 10 × 1 s` = **~30 requests of overshoot** inside a 60 s window (≈30% of
+the limit), shrinking linearly as `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` is
+lowered. Overshoot is additionally capped by the **per-replica in-memory
+`Governor` on the same endpoint**, which is completely unchanged by this
+design: it still runs on every wrapped endpoint and still makes a full,
+independent per-replica decision — the shared layer's job is only to stop
+the *aggregate* across replicas from reaching `replicas × limit`, and after
+one `sync_interval` it does.
+
+**Store-outage semantics changed.** Before this change, a store error on the
+per-request write made the middleware fail open for that one request (warn,
+forward to the in-memory governor) — so a request during an outage was
+allowed regardless of the configured limit. Now the request path never talks
+to the store at all; an outage is discovered by the background flusher, and
+`check()` keeps deciding from the (still valid) local count against the
+*same* configured limit. Concretely: **`limit = 0` plus an unreachable store
+now denies**, where the previous design would have allowed — "the store is
+unreachable" must not be read as "the limit is disabled." This is the one
+behavioral delta in an otherwise unchanged fail-open posture: fail-open on
+store errors remains the **one deliberate fail-open exception** in the
+codebase (D-01b / T-24-42 accepted risk); every other control still fails
+closed, and the in-memory governor still guarantees an outage never
+hard-blocks auth traffic or surfaces a 5xx.
+
+**Upgrade note.** The bucket key (`{endpoint}:{key_part}`) and the
+`rate_limit_bucket` table are byte-for-byte unchanged, so an in-place upgrade
+keeps counting against the same rows — no migration, no reset of in-flight
+windows.
+
+**The gRPC listener holds its own counter, not a shared one.** The gRPC
+`GrpcSharedRateLimitLayer` (server-wide tower layer) and the REST
+`RateLimitShared` middleware each own an independent
+`SharedRateLimitCounter` instance in the same process, both reading the same
+`AXIAM__RATE_LIMIT__SHARED*` env vars. This is intentional, not two competing
+counters: gRPC only ever writes `grpc_authz:<ip>` keys while REST writes
+`<rest_endpoint>:<key_part>` keys, so the two keyspaces never overlap and
+neither instance can fragment the other's local count.
+
+**Observability.** At startup the server logs one of:
+
+```
+shared rate-limit counter ACTIVE (write-behind); one datastore write per
+bucket per sync interval instead of one per request
+  sync_interval_ms=1000 shards=16
+```
+
+or, with `AXIAM__RATE_LIMIT__SHARED=off`:
+
+```
+shared rate-limit counter DISABLED (AXIAM__RATE_LIMIT__SHARED=off); the
+per-replica in-memory governor is the sole rate limiter
+```
+
+Two `warn`-level alarms can fire afterward (each logged **once**, latched,
+never per request, and never with the raw bucket key — T-24-43, since the
+key embeds a client IP/`client_id`):
+
+- the flusher's datastore write failed during a flush pass ("shared
+  rate-limit store unreachable during write-behind flush") — cross-replica
+  convergence is paused, decisions keep being served from local counts;
+- the flusher has fallen behind its own `sync_interval` ("write-behind
+  flusher is falling behind") — a bucket with pending work has gone
+  unflushed for 5+ sync intervals, meaning the overshoot bound above no
+  longer holds until it clears.
+
+**Sizing implication.** Before this change, the synchronous per-request
+write made each wrapped endpoint's throughput ceiling equal to the
+datastore's own write latency, not the server's request-handling capacity —
+measured on the investigation host at **16–21 ops/s against a ~40 ms
+write**, regardless of concurrency, replicas, or connection-pool size. That
+ceiling no longer applies: the request path performs no datastore I/O for
+the rate-limit decision at all. Post-fix throughput has not yet been
+re-measured end-to-end; when it is, the numbers will land in
+`claude_dev/rate-limit-fix-verification.md` (not yet present at the time of
+writing — produced by a separate, concurrent verification task).
+
+**`GET /api/v1/users` fixed.** This endpoint used to be wrapped by the same
+actix resource as `POST /users` and so inherited the `users_create`
+registration bucket (`AXIAM__RATE_LIMIT__REGISTER_PER_MIN`, 5/min/IP in the
+shipped posture) for a plain list read. It is now registered as a separate,
+unlimited resource, matching the posture of its siblings `GET /roles` and
+`GET /resources`.
 
 ## TLS termination
 

--- a/docs/deployment/rate-limit-sizing.md
+++ b/docs/deployment/rate-limit-sizing.md
@@ -154,13 +154,26 @@ preset itself wasn't, until now. One labeled laptop-class pass, single
 switching key mode + raising the per-bucket limits is what stopped this
 single-`client_id` generator from being throttled — that's the preset doing
 exactly what §3 says. It did **not** raise the ~20–24 ops/s the server
-actually admits per second on these three endpoints; that number is set by a
-synchronous per-request datastore write on the critical path
-(`claude_dev/postseed-transient-investigation.md`), which every posture pays
-identically. Full numbers, the harness workaround needed to test a preset at
-all (the bench compose's `neutralized` defaults otherwise always outrank the
-preset — see precedence above), and the arithmetic behind the one non-zero
-throttled row: `claude_dev/rate-limit-posture-decision.md` §7.2.
+actually admitted per second on these three endpoints at the time of this
+measurement; that number was set by a synchronous per-request datastore
+write on the critical path (`claude_dev/postseed-transient-investigation.md`),
+which every posture paid identically. Full numbers, the harness workaround
+needed to test a preset at all (the bench compose's `neutralized` defaults
+otherwise always outrank the preset — see precedence above), and the
+arithmetic behind the one non-zero throttled row:
+`claude_dev/rate-limit-posture-decision.md` §7.2.
+
+**Fixed since this measurement.** The synchronous per-request write named
+above has been replaced by a write-behind design
+(`axiam_db::rate_limit_counter::SharedRateLimitCounter`) — see
+[Deployment Guide § Shared-store consistency model](README.md#shared-store-consistency-model-write-behind)
+for the mechanism and the new cross-replica overshoot bound this trades in.
+The H7 numbers directly above remain a faithful pre-fix measurement and are
+left as-is; they describe a ceiling that no longer exists in the current
+code. Post-fix throughput has not been re-measured yet — the numbers will
+land in `claude_dev/rate-limit-fix-verification.md` (not yet present at the
+time of writing — produced by a separate, concurrent verification task) when
+that run completes.
 
 ---
 

--- a/website/src/docs.ts
+++ b/website/src/docs.ts
@@ -722,7 +722,21 @@ export const DOC_PAGES: DocPage[] = [
             "Bucket-key mode for token/introspect/revoke: ip | client_id | ip_client_id.",
             "ip",
           ],
+          [
+            "AXIAM__RATE_LIMIT__SHARED",
+            "Enables (on) or disables (off) the cross-replica write-behind shared counter. off is a single-replica escape hatch — the per-replica in-memory governor becomes the sole limiter.",
+            "on",
+          ],
+          [
+            "AXIAM__RATE_LIMIT__SHARED_SYNC_MS",
+            "Write-behind flush interval (ms) for the shared counter, clamped 50-60000. Scales the cross-replica overshoot bound.",
+            "1000",
+          ],
         ],
+      },
+      {
+        type: "note",
+        text: "The shared counter behind AXIAM__RATE_LIMIT__SHARED no longer performs a synchronous datastore write on the request path (write-behind design): it decides in-memory and flushes one coalesced write per bucket per AXIAM__RATE_LIMIT__SHARED_SYNC_MS. Cross-replica enforcement is therefore eventual, not synchronous — worst-case overshoot beyond the configured limit is bounded by roughly (replicas - 1) x arrival_rate_per_replica x sync_interval, and is zero on a single replica. The per-replica in-memory governor is unchanged and still caps overshoot independently. See the Deployment Guide's rate-limiting section for the full bound, the store-outage semantics (a store outage is now detected by the background flusher rather than the request, so limit=0 plus an unreachable store denies rather than allows), and the observability log lines.",
       },
       { type: "h", id: "sizing", text: "Suggested settings by deployment (benchmark-derived)" },
       {


### PR DESCRIPTION
Implements both asks in [`claude_dev/postseed-transient-investigation.md`](claude_dev/postseed-transient-investigation.md) §7.1 — the follow-up to H2's root-cause finding from PR #243/#244. That investigation showed the "post-seed transient" was never a warm-up effect: it was one synchronous `rate_limit_bucket` UPSERT on the critical path of the six hottest endpoints, making each endpoint's ceiling equal to the datastore's write latency (~20 ops/s at a ~40 ms write, at any concurrency from 1 to 40 VUs).

## Ask 1 — bug: `GET /api/v1/users` was rate-limited as user registration

`web::resource("/users")` wrapped both methods, so listing users consumed the `register_per_min` bucket — **5/min per IP** in the production posture, reachable by any admin UI. Split into two method-guarded resources: `POST` keeps `build_governor(register_per_min)` + `RateLimitShared("users_create")`, `GET` is unlimited by the shared layer like its siblings `/roles` and `/resources`. Regression test verified to fail against the pre-fix routing.

## Ask 2 — design: the shared-store round trip is off the synchronous path

New `SharedRateLimitCounter` (`crates/axiam-db/src/rate_limit_counter.rs`), used by both listeners:

- **Request path is fully synchronous and DB-free**: 16-way sharded state (std `Mutex`, never held across an await), window rollover, `pending += 1`, deny when `shared_count + pending > limit`.
- **Write-behind**: one background flusher, woken by a bounded (1024) `tokio::sync::mpsc` channel with an interval backstop, issues **one aggregated `increment_by` per bucket per `sync_interval`** and adopts the authoritative count back. `SurrealRateLimitBucketRepository::increment_by(key, window, delta)` generalizes the UPSERT; `increment` delegates with `delta = 1`.
- Stale-window buckets are pruned each pass, so memory is bounded. An object-safe store trait keeps one non-generic counter serving both REST and gRPC.
- Wiring: REST builds the counter **once** outside the `HttpServer::new` closure (all workers share one `Arc`, via `AppState.shared_rate_limit`); gRPC's server-wide layer holds its own counter over a disjoint key namespace.

### Security semantics — please read

Cross-replica enforcement becomes **eventual** rather than synchronous. Worst-case overshoot beyond the configured limit before counts converge is bounded by `(replicas − 1) × arrival_rate_per_replica × sync_interval`, and is **zero on a single replica**; it is additionally capped by the unchanged per-replica in-memory `governor`. Worked example in the docs: limit 100/min, 4 replicas, 1 s interval, 40 req/s aggregate ⇒ ~30 requests of overshoot inside a 60 s window, shrinking linearly with `sync_interval`. The layer's purpose — stopping the aggregate from reaching `replicas × limit` — still holds after one interval.

One deliberate behavioral change in the safer direction: a store outage is now detected by the flusher rather than the request path, so `limit = 0` plus an unreachable store now **denies** where the old code allowed — "the store is unreachable" must not read as "the limit is disabled". Fail-open on store errors otherwise remains the one documented fail-open exception (D-01b).

New knobs, no existing limit default changed: `AXIAM__RATE_LIMIT__SHARED` = `on`|`off` (default `on`; `off` is the single-replica escape hatch) and `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` (default `1000`, clamped 50..=60000).

## Verification on a live stack

Full detail in [`claude_dev/rate-limit-fix-verification.md`](claude_dev/rate-limit-fix-verification.md). A server image was built from this branch and H2's own `benchmarks/runner/h2-clamp-probe.sh` re-run with shipped defaults:

| endpoint | before (1 VU / 20 VU ops/s) | after (1 VU / 20 VU ops/s) |
|---|---|---|
| `GET /api/v1/users` | 14–16 / 17.9–20.0 | **84.4 / 280.0** |
| `POST /api/v1/authz/check` | 16–18 / 18.8–21.3 | **146.9 / 583.3** |
| `POST /oauth2/token` | 16–18 / 20.0–21.7 | **306.2 / 1231.7** |
| `POST /oauth2/introspect` | 17–19 / 20.0 | **428.1 / 1553.3** |
| `POST /oauth2/revoke` | 17.3 / — | **300.0 / 1266.7** |
| `POST /api/v1/auth/login` | 8–11 / 19.2 | 19.4 / 37.0 — now bound by Argon2id CPU under the 2-CPU cap, not the removed write |

Mechanism confirmed, not just the number: the `shared rate-limit counter ACTIVE (write-behind)` startup line appears on both listeners (`sync_interval_ms=1000`, `shards=16`); 6 500 authz requests over 12 s produced only **8 distinct `updated_at` values** on `rate_limit_bucket` (batched, not per-request); and under the `rl=prod` posture a 20-VU burst still throttles correctly (**299 admitted, 3 108 × 429**). The H1 settle gate also **passed on its first probe** on this host for the first time (`settle_wait_secs=15`, `settle_timeout=false`, gated cell 589.6 ops/s, 0 errors) — previously impossible per the investigation's §8.1.

## Tests

**399 passed, 0 failed** (19 new): `axiam-db --lib` 84/84 including cross-replica convergence asserted both against a mock store and two counters over one real in-memory SurrealDB, flush coalescing (N increments → one write carrying delta N), store-error fail-open, `SHARED=off` ⇒ zero store interaction, stale-window pruning; `axiam-api-rest` lib 120/120 plus the rate-limit, user, auth, OAuth2, CSRF and federation suites; `axiam-api-grpc` 21/21. `cargo clippy` and `cargo fmt` clean on every touched crate.

## Docs

`docs/deployment/README.md` (consistency model, knobs, observability, sizing), `docs/deployment/rate-limit-sizing.md` (H7's pre-fix numbers marked superseded, kept as an honest record), `website/src/docs.ts` (config reference), `claude_dev/rate-limit-posture-decision.md` §8 (closes both §7.1 asks, records the rejected alternatives), and both bench analyses updated to say the clamp's root cause is fixed here — published G-box numbers are left untouched and labeled as pre-fix measurements.

## Follow-up found while verifying (not addressed here)

Under sustained load the DB pool's proactive-reconnect loop swaps in a fresh connection, but every repository is built once at boot from a one-time `pool.handle_for_repo()` clone — so long-lived handles go stale and the affected paths 401 permanently until the process restarts. Observed once, ~7 minutes into a load run; a `docker restart` clears it immediately. Unrelated to rate limiting, and worth its own issue: it would disrupt any long benchmark run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKdHUCpQaEBK2MLQkKbW1v)_