### PR TITLE
fix(db): hold a live pool reference in repositories, not a boot-time clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stale DB handles after a reconnect: every repository was built at boot from a one-time
+  `pool.handle_for_repo()` **clone** of the pooled SurrealDB connection, so when the pool's
+  reconnect loop evicted a poisoned connection (observed ~7 minutes into a sustained load
+  run) every repository stayed pinned to the dead one and returned 401 permanently until
+  the process restarted — while `/ready`, which probes through the pool slot, still
+  reported healthy. Repositories now hold a live `DbHandle` over the pool slot and resolve
+  the current connection per query, so a swap is picked up on the very next query. The REST
+  `AppState.db` (bootstrap handler, tenant seeder) and the gRPC layer's handle held the same
+  boot-time clone and were fixed the same way
 - `meta.json` could be written as invalid JSON when a host fact spanned two lines — a
   `docker version` against an unreachable daemon prints an empty line and *then* fails, so
   the `|| echo unknown` fallback produced a literal newline mid-string and took `report.py`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ name = "axiam-db"
 version = "1.0.0-alpha21"
 dependencies = [
  "aes-gcm 0.11.0",
+ "arc-swap",
  "argon2",
  "axiam-auth",
  "axiam-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ futures-lite = "2"
 
 # Database
 surrealdb = "3"
+# Lock-free atomic swap of the pooled SurrealDB connection: the DB pool slot is
+# read on every query and written only by a reconnect, so readers must never
+# take a lock or queue behind the (essentially never) writer.
+arc-swap = "1"
 
 # Authentication & Crypto
 # jsonwebtoken 11 removed implicit per-optional-dependency Cargo features

--- a/claude_dev/db-pool-design.md
+++ b/claude_dev/db-pool-design.md
@@ -552,3 +552,85 @@ long enough, at high enough throughput, for `pool_size`'s effect (if any)
 to be distinguishable from noise. Absent both, re-running the same
 comparison on this hardware would just reproduce the same unconfirmable
 result.
+
+---
+
+## 11. Post-F2 correction — the construction-time clone was a stale-handle bug
+
+**Status: fixed.** F2 shipped §6 Option B as written: `handle_for_repo()`
+returned an owned `Surreal<C>` **clone** and each repository held it for the
+process lifetime. That is where the design was wrong, and the defect is worth
+recording because the reasoning that produced it looks sound in isolation.
+
+### 11.1 What went wrong
+
+§6 justified the clone with *"at `pool_size = 1` it hands out the single pooled
+handle exactly as `client_cloned()` did — byte-for-byte identical routing."*
+True, and irrelevant: identical *routing* is not identical *lifetime*. The pool
+also introduced a per-handle reconnect loop (§5, D-12/PERF-04) whose whole job is
+to **replace** the connection in the pool slot. §6 and §5 were designed against
+each other and never reconciled:
+
+- the reconnect loop swaps the slot;
+- repositories held a clone taken from the slot at boot;
+- so a swap updated what the *pool* pointed at and left every repository pinned
+  to the **evicted** connection.
+
+Those clones share the evicted `Arc<inner>` — the dead router task and the
+`reqwest` client with the now-rejected cached token — so from the swap onward
+every repository query 401s **permanently**, until the process restarts.
+
+Two things made it hard to see:
+
+1. **Readiness reported healthy throughout.** `DbPool::health_check` (§8 item 4)
+   probes *through the pool slot*, so it observes the fresh connection. The
+   probe and the request path were reading different connections — exactly the
+   split the clone created.
+2. **The eviction test asserted the wrong subject.** §8 item 4 proved that
+   *the slot* observes only the new handle after a swap. It never asserted that
+   a handle **already handed out** does — which was the failing property.
+
+Observed in the wild ~7 minutes into a sustained load run during the rate-limit
+verification: a benchmark cell starts clean, then produces a wall of 401s with
+the server otherwise healthy, cleared instantly by `docker restart`. The matrix
+tolerated it only because it restarts the process per cell, so a single cell was
+the exposure window; a long single-cell soak was not protected at all.
+
+### 11.2 The fix
+
+`handle_for_repo()` now returns a **live** `DbHandle<C>` — the pool slot itself
+(`Arc<ArcSwap<Surreal<C>>>`), not a connection cloned out of it. Repositories
+resolve the current connection per operation via `self.db.current().query(..)`,
+so a reconnect-loop swap is observed by the very next query.
+
+- **Slot type: `ArcSwap`, not `RwLock`.** The slot is read on every DB call and
+  written essentially never. `ArcSwap::load_full` is a lock-free atomic read, so
+  the hot path takes no lock and cannot queue behind a writer — and it stays
+  **synchronous**, so resolving the handle adds no `.await` point to any query
+  path. `DbManager` and `DbPool` store the same slot type, so one swap mechanism
+  serves the manager, the pool, and every bound repository.
+- **Churn.** Repository *bodies* still hold one handle field and are otherwise
+  untouched; the change is `self.db.query(..)` → `self.db.current().query(..)`
+  at the ~245 query sites, plus 15 places where a query builder outlives its
+  statement and the resolved handle goes into a named local. Constructors take
+  `impl Into<DbHandle<C>>`, so every `kv-mem` unit test that passes a
+  `Surreal<Db>` compiles unchanged.
+- **Same reach for direct-query holders.** `AppState.db` (REST — the bootstrap
+  handler and the tenant seeder) and the gRPC layer's handle had the identical
+  defect for the identical reason, and hold a `DbHandle` now too.
+
+### 11.3 What §8's test plan should have said
+
+Item 4 ("per-handle poisoned-handle eviction") asserts a property of the pool
+slot. The property that actually protects production is one level out, and is
+now tested as `pool::tests::repository_bound_at_boot_follows_a_later_handle_swap`:
+
+> Build a repository from the pool **once**, as composition does at boot. Swap
+> the pooled connection underneath it. The already-built repository must serve
+> its next query from the new connection.
+
+That test fails against the original construction-time clone (verified by
+reverting `handle_for_repo` to the clone: the post-swap write panics), which is
+what item 4 could never have caught. The general lesson: when a component's
+lifetime is longer than the resource it holds, test the **holder** after the
+resource changes, not the resource.

--- a/claude_dev/rate-limit-fix-verification.md
+++ b/claude_dev/rate-limit-fix-verification.md
@@ -207,6 +207,13 @@ a follow-up issue on its own. It did not affect the correctness of any
 number in §3/§4/§6 above (each was captured on a fresh boot before the
 condition recurred).
 
+> **Update — fixed.** `pool.handle_for_repo()` now returns a live `DbHandle`
+> (the pool slot itself) instead of a one-time clone, so every repository
+> resolves the current connection per query and follows a reconnect-loop swap.
+> `AppState.db` and the gRPC handle held the same boot-time clone and were
+> fixed the same way. See `db-pool-design.md` §11; regression test:
+> `pool::tests::repository_bound_at_boot_follows_a_later_handle_swap`.
+
 ## 8. Verdict
 
 **The clamp is gone on this host, for five of the six previously-wrapped

--- a/claude_dev/run-4-benchmark-instructions.md
+++ b/claude_dev/run-4-benchmark-instructions.md
@@ -259,35 +259,50 @@ pre-fix) and these narrative points:
 
 ---
 
-## §7 Known hazard — read this before a long run
+## §7 Former hazard — the stale-DB-handle bug (FIXED)
 
-**A stale-DB-handle bug can silently kill a long run**, and it is **not fixed**.
+**This section previously said a stale-DB-handle bug could silently kill a long
+run and was not fixed. It is fixed now** — option 3 below was taken. Long
+single-cell soaks no longer need babysitting for this failure mode.
 
-Every repository is built once at boot from a one-time `pool.handle_for_repo()`
-clone rather than a live reference. When the DB pool's proactive-reconnect loop
-swaps in a fresh connection — observed **~7 minutes into a sustained load run**
-— every long-lived handle goes stale and the affected paths **401 permanently
-until the process restarts**. A plain `docker restart` of the server clears it
-instantly.
+**What it was.** Every repository was built once at boot from a one-time
+`pool.handle_for_repo()` **clone** rather than a live reference. When the DB
+pool's reconnect loop swapped in a fresh connection — observed **~7 minutes into
+a sustained load run** — every long-lived handle went stale and the affected
+paths **401'd permanently until the process restarted**. A plain
+`docker restart` of the server cleared it instantly. Readiness did not catch it:
+`health_check` probes through the pool slot, so it saw the *fresh* connection
+and reported healthy while every repository was talking to the dead one.
 
-This was found during the rate-limit verification and is filed as a follow-up
-in the rate-limit PR; it is unrelated to rate limiting itself.
+Found during the rate-limit verification; unrelated to rate limiting itself.
 
-**What it looks like:** a cell that starts fine and then produces a wall of
+**What it looked like:** a cell that started fine and then produced a wall of
 401s / `bench_failed` for the rest of the run, with the server otherwise
 healthy.
 
-**Mitigations, cheapest first:**
+**The fix.** `handle_for_repo()` now returns a live `DbHandle` — the pool slot
+itself — and repositories resolve the current connection per query, so a
+reconnect-loop swap is observed on the very next query instead of pinning them
+to the evicted connection. `AppState.db` (the REST bootstrap handler and tenant
+seeder) and the gRPC layer's handle held the same boot-time clone and were fixed
+the same way. Covered by
+`pool::tests::repository_bound_at_boot_follows_a_later_handle_swap`, which
+fails against the old clone. See `db-pool-design.md` §11 for the full account.
+
+**If you are running an image built before that fix**, the original mitigations
+still apply:
 
 1. **Watch for it.** If a cell's error rate jumps to ~100% mid-run, this is the
    first thing to suspect. Restart the server container and re-run that cell.
 2. **Restart between repeats.** The matrix already does `bench-up` /
    `bench-down` per target/profile per repeat, which resets the process — so a
    *single cell* is the exposure window, not the whole run. That is why the
-   matrix is relatively robust to this and a long single-cell soak is not.
-3. **Fix it first** if you would rather not babysit. It is a contained change
-   (hold a live pool reference in the repositories instead of a boot-time
-   clone), and it would also remove the last reason to distrust a long soak.
+   matrix was relatively robust to this and a long single-cell soak was not.
+
+**Confirm the fix is in the image you are benchmarking** the same way you would
+for any other fix: build from a commit that contains it. A cell that goes to
+~100% 401s mid-run against a post-fix image is *not* this bug — diagnose it
+fresh rather than reaching for the restart.
 
 ---
 

--- a/crates/axiam-api-grpc/src/middleware/rate_limit.rs
+++ b/crates/axiam-api-grpc/src/middleware/rate_limit.rs
@@ -49,7 +49,7 @@ use governor::Quota;
 use governor::clock::QuantaInstant;
 use governor::middleware::NoOpMiddleware;
 use http::{Request, Response};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use tonic::transport::server::{TcpConnectInfo, TlsConnectInfo};
 use tower::{Layer, Service};
 use tower_governor::{
@@ -283,7 +283,7 @@ fn too_many_requests_response() -> Response<tonic::body::Body> {
 ///
 /// No longer generic over the SurrealDB connection type: it holds a
 /// non-generic [`SharedRateLimitCounter`] (which owns the boxed store), which
-/// is why the `Surreal<C>` handle only appears in [`Self::new`]'s signature.
+/// is why the SurrealDB handle only appears in [`Self::new`]'s signature.
 #[derive(Clone)]
 pub struct GrpcSharedRateLimitLayer {
     counter: SharedRateLimitCounter,
@@ -307,7 +307,7 @@ impl GrpcSharedRateLimitLayer {
     /// bucket key (`"{endpoint}:{ip}"`) preserves per-surface granularity —
     /// never collapse distinct surfaces into one global bucket.
     pub fn new<C: Connection>(
-        db: Surreal<C>,
+        db: impl Into<axiam_db::DbHandle<C>>,
         endpoint: &'static str,
         limit: u32,
         trusted_hops: usize,

--- a/crates/axiam-api-grpc/src/server.rs
+++ b/crates/axiam-api-grpc/src/server.rs
@@ -38,7 +38,8 @@ use axiam_core::repository::{
     GroupRepository, PermissionRepository, ResourceRepository, RoleRepository, ScopeRepository,
     UserRepository,
 };
-use surrealdb::{Connection, Surreal};
+use axiam_db::DbHandle;
+use surrealdb::Connection;
 use tonic::transport::{Identity, Server, ServerTlsConfig};
 
 use crate::config::GrpcConfig;
@@ -86,7 +87,7 @@ pub async fn start_grpc_server<R, P, Res, S, G, U, C>(
     user_repo: U,
     auth_config: AuthConfig,
     grpc_config: &GrpcConfig,
-    db: Surreal<C>,
+    db: impl Into<DbHandle<C>>,
     batch_max_concurrency: usize,
 ) -> Result<(), tonic::transport::Error>
 where

--- a/crates/axiam-api-rest/src/handlers/bootstrap.rs
+++ b/crates/axiam-api-rest/src/handlers/bootstrap.rs
@@ -233,7 +233,7 @@ pub async fn bootstrap<C: Connection + Clone>(
                     }));
                 }
             };
-            if !setup_token_is_valid(&state.db, &token_hash).await? {
+            if !setup_token_is_valid(&state.db.current(), &token_hash).await? {
                 return Err(AxiamApiError(AxiamError::AuthorizationDenied {
                     reason: "setup token is invalid, unknown, or already consumed".into(),
                     action: None,
@@ -289,6 +289,7 @@ pub async fn bootstrap<C: Connection + Clone>(
     //    going to be refused anyway.
     let existing_lock: Vec<BootstrapLockRow> = state
         .db
+        .current()
         .query("SELECT locked_at FROM type::record('bootstrap_lock', 'global')")
         .await
         .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?
@@ -334,12 +335,12 @@ pub async fn bootstrap<C: Connection + Clone>(
     let tenant_id = tenant.id;
 
     // 5. Seed permissions (idempotent).
-    seed_permissions(&state.db, tenant_id, PERMISSION_REGISTRY)
+    seed_permissions(&state.db.current(), tenant_id, PERMISSION_REGISTRY)
         .await
         .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?;
 
     // 6. Seed default roles and get their IDs.
-    let seed_result = seed_default_roles(&state.db, tenant_id, PERMISSION_REGISTRY)
+    let seed_result = seed_default_roles(&state.db.current(), tenant_id, PERMISSION_REGISTRY)
         .await
         .map_err(|e| AxiamApiError(AxiamError::Internal(e.to_string())))?;
 
@@ -416,8 +417,10 @@ pub async fn bootstrap<C: Connection + Clone>(
     txn_stmts.push("COMMIT TRANSACTION".to_string());
     let txn_query = txn_stmts.join("; ");
 
-    let mut query = state
-        .db
+    // The builder is re-bound below, so it outlives this statement — hold the
+    // resolved handle in a named local rather than a temporary.
+    let db = state.db.current();
+    let mut query = db
         .query(txn_query)
         .bind(("tenant_id", tenant_id_str))
         .bind(("user_id", user_id_str.clone()))

--- a/crates/axiam-api-rest/src/handlers/tenants.rs
+++ b/crates/axiam-api-rest/src/handlers/tenants.rs
@@ -81,7 +81,7 @@ pub async fn create<C: Connection + Clone>(
     let tenant = state.tenant_repo.create(input).await?;
 
     // Auto-seed permissions for the new tenant so RBAC works immediately.
-    seed_permissions(&state.db, tenant.id, PERMISSION_REGISTRY)
+    seed_permissions(&state.db.current(), tenant.id, PERMISSION_REGISTRY)
         .await
         .map_err(|e| {
             tracing::error!(

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -51,6 +51,7 @@ use axiam_auth::{
     AuthService, EmailVerificationService, MfaMethodService, PasswordResetService, WebauthnService,
 };
 use axiam_authz::AuthzConfig;
+use axiam_db::DbHandle;
 use axiam_db::{
     SharedRateLimitCounter, SurrealAccountDeletionRepository, SurrealAssertionReplayRepository,
     SurrealAuditLogRepository, SurrealAuthorizationCodeRepository, SurrealCertificateRepository,
@@ -74,7 +75,7 @@ use axiam_oauth2::jwks_cache::{
 };
 use axiam_oauth2::token::TokenService;
 use axiam_pki::{CaService, CertService, DeviceAuthService, PgpService};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use tokio::sync::Semaphore;
 
 use crate::extractors::auth::SessionValidator;
@@ -218,7 +219,11 @@ pub type SamlFederationServiceT<C> = SamlFederationService<
 pub struct AppState<C: Connection + Clone> {
     pub authz_config: AuthzConfig,
     pub auth_config: AuthConfig,
-    pub db: Surreal<C>,
+    /// LIVE reference to the pooled SurrealDB connection (NOT a boot-time
+    /// clone): handlers that query directly — `/api/v1/admin/bootstrap`, the
+    /// tenant seeder — must follow a reconnect-loop handle swap just as the
+    /// repositories do, or they permanently 401 after an eviction.
+    pub db: DbHandle<C>,
     pub health_checker: Arc<dyn HealthChecker>,
     pub audit_repo: SurrealAuditLogRepository<C>,
     pub org_repo: SurrealOrganizationRepository<C>,
@@ -359,7 +364,8 @@ impl<C: Connection + Clone> AppState<C> {
     /// let mut state = AppState::for_test(db.clone(), auth_config.clone());
     /// state.email_encryption_key = Some(TEST_KEY);
     /// ```
-    pub fn for_test(db: Surreal<C>, auth_config: AuthConfig) -> Self {
+    pub fn for_test(db: impl Into<DbHandle<C>>, auth_config: AuthConfig) -> Self {
+        let db: DbHandle<C> = db.into();
         // B1: resolve the hash-gate permit count from config (0 = auto → min(cores, 4)).
         let crypto_semaphore =
             Arc::new(Semaphore::new(auth_config.resolved_max_concurrent_hashes()));

--- a/crates/axiam-db/Cargo.toml
+++ b/crates/axiam-db/Cargo.toml
@@ -12,6 +12,7 @@ axiam-core = { workspace = true }
 axiam-auth = { workspace = true }
 argon2 = { workspace = true }
 surrealdb = { workspace = true, features = ["protocol-http"] }
+arc-swap = { workspace = true }
 surrealdb-types = "3"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/axiam-db/src/connection.rs
+++ b/crates/axiam-db/src/connection.rs
@@ -33,13 +33,17 @@
 //! ## Session lifecycle (CQ-B48 closed by the DbPool, F2)
 //!
 //! Repositories no longer hold frozen `client_cloned()` snapshots. They bind a
-//! handle from [`crate::DbPool`], which holds N INDEPENDENT `Surreal<Client>`
-//! handles (not clones), each with its OWN proactive re-signin and reconnect
-//! loop — the same D-04/PERF-04 machinery this module implements, now spawned
-//! once per pooled handle instead of only for the manager's single handle.
+//! LIVE [`crate::DbHandle`] over a slot of [`crate::DbPool`], which holds N
+//! INDEPENDENT `Surreal<Client>` handles (not clones), each with its OWN
+//! proactive re-signin and reconnect loop — the same D-04/PERF-04 machinery
+//! this module implements, now spawned once per pooled handle instead of only
+//! for the manager's single handle.
 //! Every session a request can reach therefore belongs to a pooled handle that
 //! is kept authenticated inside the root-token TTL and rebuilt on
-//! expiry/poison, so the former restart-only ~4-week outage is gone. The
+//! expiry/poison, so the former restart-only ~4-week outage is gone. Binding a
+//! live handle rather than a clone is what makes that rebuild actually reach
+//! the repositories: a clone would keep them on the connection the reconnect
+//! loop just evicted (see `handle.rs`). The
 //! deliberately-un-renewed startup-snapshot `health_probe` that used to alarm
 //! on that gap is removed; readiness is now established by [`crate::DbPool`]
 //! probing its pooled handles (see [`DbManager::connect_handle`], the shared
@@ -48,7 +52,8 @@
 //! ## Reconnect loop, full-jitter backoff, poisoned-handle eviction (PERF-04)
 //!
 //! [`DbManager`]'s own handle is held behind a swappable
-//! `Arc<tokio::sync::RwLock<Surreal<Client>>>` (D-12). A background task
+//! [`crate::DbHandle`] slot — an `Arc<ArcSwap<Surreal<Client>>>` (D-12), read
+//! lock-free on the query hot path. A background task
 //! ([`DbManager::spawn_reconnect_loop`]) polls health through the current
 //! handle and, on [`DbError::Unhealthy`], runs a bounded retry loop using
 //! [`reconnect_backoff_delay`]'s full-jitter exponential backoff (D-10/D-13 —
@@ -69,11 +74,11 @@ use surrealdb::Surreal;
 use surrealdb::engine::remote::http::{Client, Http};
 use surrealdb::opt::auth::Root;
 use surrealdb::types::NotAllowedError;
-use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 use crate::error::DbError;
+use crate::handle::{DbSlot, new_slot};
 use crate::metrics;
 
 /// Cadence at which [`spawn_reconnect_loop`]'s background task polls
@@ -212,13 +217,14 @@ fn re_signin_interval_for(ttl: Duration, fraction: f64) -> Duration {
 /// Manages a connection to SurrealDB over the stateless HTTP engine.
 pub struct DbManager {
     /// SurrealDB client handle (HTTP engine), behind a swappable
-    /// `RwLock` (PERF-04, D-12) so the reconnect loop can atomically replace
+    /// [`DbSlot`] (PERF-04, D-12) so the reconnect loop can atomically replace
     /// a poisoned/broken handle with a freshly-authenticated one — the old
     /// handle is dropped on swap and never recycled or returned to any
     /// caller again. `Arc`-shared (not cloned) with the proactive re-signin
-    /// and reconnect-loop tasks so all sides observe/refresh the SAME
-    /// current handle (see module docs, Pitfall 2).
-    db: Arc<RwLock<Surreal<Client>>>,
+    /// and reconnect-loop tasks — and with every [`crate::DbHandle`] bound to
+    /// it — so all sides observe/refresh the SAME current handle (see module
+    /// docs, Pitfall 2).
+    db: DbSlot<Client>,
     /// Handle to the background proactive re-signin task (D-03/D-04),
     /// owned so it is explicitly droppable/abortable rather than a
     /// fire-and-forget detached task.
@@ -297,8 +303,7 @@ impl DbManager {
     pub(crate) async fn connect_handle(
         config: &DbConfig,
         ttl: Duration,
-    ) -> Result<(Arc<RwLock<Surreal<Client>>>, JoinHandle<()>, JoinHandle<()>), surrealdb::Error>
-    {
+    ) -> Result<(DbSlot<Client>, JoinHandle<()>, JoinHandle<()>), surrealdb::Error> {
         let db = Surreal::new::<Http>(&config.url).await?;
         db.signin(Root {
             username: config.username.clone(),
@@ -309,7 +314,7 @@ impl DbManager {
             .use_db(&config.database)
             .await?;
 
-        let db = Arc::new(RwLock::new(db));
+        let db = new_slot(db);
         let refresh_handle = Self::spawn_proactive_resignin(Arc::clone(&db), config, ttl);
         let reconnect_handle = Self::spawn_reconnect_loop(Arc::clone(&db), config.clone());
         Ok((db, refresh_handle, reconnect_handle))
@@ -372,7 +377,7 @@ impl DbManager {
     /// (the reactive "missed window" safety net, [`DbManager::reconnect`],
     /// is a separate mechanism).
     fn spawn_proactive_resignin(
-        db: Arc<RwLock<Surreal<Client>>>,
+        db: DbSlot<Client>,
         config: &DbConfig,
         ttl: Duration,
     ) -> JoinHandle<()> {
@@ -385,11 +390,11 @@ impl DbManager {
                 tokio::time::sleep(interval).await;
                 // Re-signin only mutates the SAME handle's server-side auth
                 // state via a request (`&self`) — it does not need to swap
-                // the handle itself, so a read lock is sufficient here. The
-                // reconnect loop (spawn_reconnect_loop) is the ONLY task that
-                // ever takes a write lock to replace the handle (D-12).
-                let guard = db.read().await;
-                match guard
+                // the handle itself, so loading the current handle is enough
+                // here. The reconnect loop (spawn_reconnect_loop) is the ONLY
+                // task that ever stores a replacement handle (D-12).
+                let current = db.load_full();
+                match current
                     .signin(Root {
                         username: username.clone(),
                         password: password.clone(),
@@ -441,7 +446,7 @@ impl DbManager {
     /// health through the current handle, and on
     /// `DbError::Unhealthy` runs a bounded, full-jitter exponential-backoff
     /// retry loop calling [`DbManager::reconnect`]. On success, the old
-    /// handle is atomically replaced under the `RwLock` write guard (D-12 —
+    /// handle is atomically stored into the slot (D-12 —
     /// the poisoned handle is dropped right there and never recycled or
     /// returned to any caller again) and health polling resumes at the
     /// normal cadence.
@@ -453,14 +458,14 @@ impl DbManager {
     /// or crash-loops (D-11). A later successful reconnect at that cadence
     /// still swaps the handle and flips health back to `Ok` with no process
     /// restart.
-    fn spawn_reconnect_loop(db: Arc<RwLock<Surreal<Client>>>, config: DbConfig) -> JoinHandle<()> {
+    fn spawn_reconnect_loop(db: DbSlot<Client>, config: DbConfig) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
 
                 let is_unhealthy = {
-                    let guard = db.read().await;
-                    let outcome = guard
+                    let current = db.load_full();
+                    let outcome = current
                         .query("RETURN 1")
                         .await
                         .map_err(Self::classify_query_error)
@@ -489,7 +494,7 @@ impl DbManager {
 
                     match Self::reconnect(&config).await {
                         Ok(fresh) => {
-                            *db.write().await = fresh;
+                            db.store(Arc::new(fresh));
                             info!(attempt, "DbManager reconnect succeeded — handle swapped");
                             reconnected = true;
                             break;
@@ -514,7 +519,7 @@ impl DbManager {
                     tokio::time::sleep(Duration::from_millis(config.reconnect_ceiling_ms)).await;
                     match Self::reconnect(&config).await {
                         Ok(fresh) => {
-                            *db.write().await = fresh;
+                            db.store(Arc::new(fresh));
                             info!(
                                 "DbManager reconnect succeeded after exhaustion — handle \
                                  swapped, resuming normal health polling"
@@ -534,24 +539,27 @@ impl DbManager {
     }
 
     /// Returns an owned clone of the CURRENT SurrealDB client handle, read
-    /// through the swappable `RwLock` (D-12, PERF-04). Async because
-    /// obtaining the current handle requires taking the read lock — a
-    /// successful reconnect-loop swap is observed by the very next call.
+    /// through the swappable slot (D-12, PERF-04) — a successful
+    /// reconnect-loop swap is observed by the very next call. Kept `async`
+    /// for call-site compatibility; the slot read itself is lock-free.
     ///
     /// Callers may further `.clone()` the returned value to obtain an
     /// additional handle sharing this handle's `Arc<inner>` (same router +
     /// `reqwest` client). Production composition no longer uses this to fan out
     /// repositories — that path is now [`crate::DbPool::handle_for_repo`], which
-    /// hands out INDEPENDENT, renewable pooled handles (see the module-doc
-    /// "Session lifecycle" section). This accessor is retained for the
-    /// single-handle [`DbManager`] and its resilience tests.
+    /// hands out INDEPENDENT, renewable pooled handles as LIVE
+    /// [`crate::DbHandle`] references (see the module-doc "Session lifecycle"
+    /// section). This accessor is retained for the single-handle
+    /// [`DbManager`] and its resilience tests. Note the value it returns is a
+    /// SNAPSHOT: it does not follow later swaps, which is why repositories
+    /// bind a [`crate::DbHandle`] instead.
     pub async fn client_cloned(&self) -> Surreal<Client> {
         // F1 instrumentation (zero behavior change): count how many handles are
         // handed out. Under the current single-router architecture every clone
         // shares the SAME dispatcher/`reqwest::Client`, so this counter directly
         // quantifies the single-funnel fan-in the F2 pool will replace.
         metrics::record_handle_checkout();
-        self.db.read().await.clone()
+        (*self.db.load_full()).clone()
     }
 
     /// Verify the database connection is alive and queries succeed.
@@ -566,16 +574,16 @@ impl DbManager {
     /// credentials — D-05) classifies distinctly as [`DbError::Unhealthy`]
     /// rather than a bare query error, so the readiness probe alarms.
     ///
-    /// Reads the CURRENT handle through the swappable `RwLock` (D-12,
+    /// Reads the CURRENT handle through the swappable slot (D-12,
     /// PERF-04) — a successful reconnect-loop swap flips this back to `Ok`
     /// without a process restart.
     pub async fn health_check(&self) -> Result<(), DbError> {
-        let guard = self.db.read().await;
+        let current = self.db.load_full();
         // F1 instrumentation (zero behavior change): the health probe is a real
         // query through the `axiam-db` boundary, so route it through the
         // in-flight gauge + latency wrapper. `instrument_query` is a transparent
         // passthrough — it awaits exactly this future and returns its output.
-        let result = metrics::instrument_query("health_check.manager", guard.query("RETURN 1"))
+        let result = metrics::instrument_query("health_check.manager", current.query("RETURN 1"))
             .await
             .map_err(Self::classify_query_error)?;
         // Surface any statement-level error (HTTP returns 200 even on SQL error).
@@ -678,16 +686,15 @@ mod tests {
         );
     }
 
-    /// D-12 proof: after a `RwLock` write-swap replaces the handle, a reader
+    /// D-12 proof: after a slot store replaces the handle, a reader
     /// observes ONLY the new handle — the old (poisoned) handle is never
     /// recycled or returned again.
     ///
     /// Constructing a real `Surreal<Client>` (HTTP engine) always performs a
     /// live network health-check at connect time (see
     /// `engine::remote::http::native::create_client`), so this test proves
-    /// the swap/eviction MECHANISM — the exact `Arc<RwLock<Surreal<C>>>`
-    /// read/write-guard pattern [`DbManager`] and [`spawn_reconnect_loop`]
-    /// use — against the embedded `kv-mem` engine instead, per
+    /// the swap/eviction MECHANISM — the exact [`DbSlot`] load/store
+    /// pattern [`DbManager`] and [`spawn_reconnect_loop`] use — against the embedded `kv-mem` engine instead, per
     /// 27-RESEARCH.md Open Question 3 ("treat poisoned-connection testing
     /// primarily as a unit-level proof of the swap/eviction, not a real
     /// network-fault simulation"). Two independent in-memory instances stand
@@ -718,23 +725,23 @@ mod tests {
         }
 
         let old_db = new_marked_db("old-poisoned").await;
-        let handle = Arc::new(RwLock::new(old_db));
+        let handle = new_slot(old_db);
 
         // Pre-swap: the current handle is observably the "old" one.
         {
-            let pre_swap = handle.read().await.clone();
+            let pre_swap = handle.load_full();
             let values = read_marker_values(&pre_swap).await;
             assert_eq!(values, vec!["old-poisoned".to_string()]);
         }
 
-        // Simulate a successful reconnect: build a fresh handle and swap it
-        // in under the write guard, exactly as spawn_reconnect_loop does
-        // (`*db.write().await = fresh`) — the old handle is dropped here.
+        // Simulate a successful reconnect: build a fresh handle and store it
+        // into the slot, exactly as spawn_reconnect_loop does
+        // (`db.store(Arc::new(fresh))`) — the old handle is dropped here.
         let new_db = new_marked_db("new-fresh").await;
-        *handle.write().await = new_db;
+        handle.store(Arc::new(new_db));
 
         // Post-swap: every subsequent reader observes ONLY the new handle.
-        let post_swap = handle.read().await.clone();
+        let post_swap = handle.load_full();
         let values = read_marker_values(&post_swap).await;
         assert_eq!(
             values,

--- a/crates/axiam-db/src/handle.rs
+++ b/crates/axiam-db/src/handle.rs
@@ -1,0 +1,198 @@
+//! [`DbHandle`] — a **live** reference to one pooled SurrealDB connection.
+//!
+//! ## The bug this type exists to close
+//!
+//! Before this type, every repository was constructed from a one-time
+//! `pool.handle_for_repo().await` **clone** of the pooled `Surreal<C>` — a
+//! snapshot taken once at boot and then held for the process lifetime. That is
+//! fine right up until the pool's reconnect loop
+//! (`DbManager::spawn_reconnect_loop`, PERF-04/D-12) decides the pooled
+//! connection is poisoned and swaps a brand-new one into the pool slot.
+//!
+//! The swap replaced what the *pool* pointed at, but every repository was still
+//! holding its own clone of the **evicted** connection. Those clones share the
+//! old `Arc<inner>` — the old router task and the old `reqwest` client with the
+//! old (now-rejected) cached auth token — so from that moment on every
+//! repository query 401s, permanently, until the process restarts. Observed
+//! ~7 minutes into a sustained load run during the rate-limit verification: a
+//! cell starts clean and then produces a wall of 401s with the server otherwise
+//! reporting healthy, cleared instantly by `docker restart`.
+//!
+//! Readiness did not catch it either: `DbPool::health_check` probes through the
+//! pool slot, so it observes the *fresh* handle and reports healthy while the
+//! repositories are all talking to the dead one.
+//!
+//! ## The fix
+//!
+//! [`DbHandle`] holds the pool **slot** (`Arc<ArcSwap<Surreal<C>>>`) rather than
+//! a connection cloned out of it, and resolves the current connection at every
+//! call via [`DbHandle::current`]. A reconnect-loop swap is therefore observed
+//! by the very next query on every repository already built from that slot —
+//! no restart, no permanent 401 wall.
+//!
+//! ## Why `ArcSwap` and not `RwLock`
+//!
+//! The slot is read on every single database call and written essentially never
+//! (only by a reconnect). `ArcSwap::load_full` is a lock-free atomic read, so
+//! the hot path takes no lock, cannot be delayed behind a queued writer, and —
+//! importantly for the ~250 repository call sites — stays **synchronous**, so
+//! resolving the current handle adds no `.await` point to any query path.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use surrealdb::engine::remote::http::Client;
+use surrealdb::{Connection, Surreal};
+
+/// The swappable pool slot shared between a pooled handle, its background
+/// refresh/reconnect tasks, and every [`DbHandle`] bound to it.
+///
+/// Writing this slot (a reconnect-loop eviction) is atomically visible to every
+/// holder's next [`DbHandle::current`] call — that visibility *is* the fix.
+pub(crate) type DbSlot<C> = Arc<ArcSwap<Surreal<C>>>;
+
+/// Build a fresh slot around an already-connected handle.
+pub(crate) fn new_slot<C: Connection>(db: Surreal<C>) -> DbSlot<C> {
+    Arc::new(ArcSwap::from_pointee(db))
+}
+
+/// A live reference to one pooled SurrealDB connection.
+///
+/// Repositories hold this instead of an owned `Surreal<C>` so that a
+/// reconnect-loop handle swap is picked up on their next query rather than
+/// leaving them pinned to an evicted connection forever (see the module docs).
+///
+/// Cloning is cheap — clones share the same slot, so they all observe the same
+/// swaps. `Surreal<C>` converts into a `DbHandle<C>` via [`From`], which keeps
+/// tests (and any caller that legitimately owns a standalone connection, such
+/// as an embedded `kv-mem` instance) able to construct repositories exactly as
+/// before; such a handle simply has a slot that nothing ever swaps.
+pub struct DbHandle<C: Connection = Client> {
+    slot: DbSlot<C>,
+}
+
+impl<C: Connection> DbHandle<C> {
+    /// Wrap an existing pool slot. Crate-internal: outside this crate a
+    /// `DbHandle` is obtained from [`crate::DbPool::handle_for_repo`] (live) or
+    /// via `From<Surreal<C>>` (standalone).
+    pub(crate) fn from_slot(slot: DbSlot<C>) -> Self {
+        Self { slot }
+    }
+
+    /// The connection to use for **this** operation.
+    ///
+    /// Resolves the slot on every call, so a reconnect-loop swap is observed
+    /// immediately. The returned `Arc<Surreal<C>>` derefs to the connection, so
+    /// call sites read as `self.db.current().query(..)`.
+    ///
+    /// Lock-free (a single atomic load), so this is safe and cheap to call on
+    /// every query and never blocks behind the reconnect loop.
+    pub fn current(&self) -> Arc<Surreal<C>> {
+        self.slot.load_full()
+    }
+}
+
+impl<C: Connection> Clone for DbHandle<C> {
+    /// Clones share the SAME slot — every clone observes every swap. (Derived
+    /// `Clone` would demand `C: Clone`, which `Connection` does not imply.)
+    fn clone(&self) -> Self {
+        Self {
+            slot: Arc::clone(&self.slot),
+        }
+    }
+}
+
+impl<C: Connection> From<Surreal<C>> for DbHandle<C> {
+    /// Wrap a standalone connection in its own slot. Nothing swaps this slot,
+    /// so the result behaves exactly like holding the connection directly —
+    /// this is the path tests and embedded `kv-mem` callers take.
+    fn from(db: Surreal<C>) -> Self {
+        Self::from_slot(new_slot(db))
+    }
+}
+
+impl<C: Connection> std::fmt::Debug for DbHandle<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbHandle").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use surrealdb::engine::local::{Db, Mem};
+
+    async fn marked(marker: &str) -> Surreal<Db> {
+        let db = Surreal::new::<Mem>(()).await.expect("in-memory connect");
+        db.use_ns("test").use_db("test").await.expect("use ns/db");
+        db.query(format!("CREATE marker SET value = '{marker}'"))
+            .await
+            .and_then(|r| r.check())
+            .expect("seed marker row");
+        db
+    }
+
+    async fn read_marker(db: &Surreal<Db>) -> Vec<String> {
+        let mut result = db
+            .query("SELECT VALUE value FROM marker")
+            .await
+            .and_then(|r| r.check())
+            .expect("read marker rows");
+        result.take(0).expect("deserialize marker values")
+    }
+
+    /// THE regression test for the stale-handle bug: a handle taken *before* a
+    /// slot swap must observe the new connection on its next `current()`, not
+    /// stay pinned to the evicted one.
+    #[tokio::test]
+    async fn current_observes_a_swap_made_after_the_handle_was_taken() {
+        let slot = new_slot(marked("old").await);
+        // Bound once, up-front — exactly how a repository binds at boot.
+        let handle = DbHandle::from_slot(Arc::clone(&slot));
+        assert_eq!(
+            read_marker(&handle.current()).await,
+            vec!["old".to_string()]
+        );
+
+        // The reconnect loop evicts the poisoned connection.
+        slot.store(Arc::new(marked("new").await));
+
+        assert_eq!(
+            read_marker(&handle.current()).await,
+            vec!["new".to_string()],
+            "a handle bound before the swap must follow the slot, not stay \
+             pinned to the evicted connection"
+        );
+    }
+
+    /// Clones share the slot, so a swap reaches every repository built from it
+    /// (repositories are `.clone()`d liberally into per-worker app state).
+    #[tokio::test]
+    async fn clones_share_the_slot_and_all_observe_the_swap() {
+        let slot = new_slot(marked("old").await);
+        let a = DbHandle::from_slot(Arc::clone(&slot));
+        let b = a.clone();
+        let c = b.clone();
+
+        slot.store(Arc::new(marked("new").await));
+
+        for (name, h) in [("a", &a), ("b", &b), ("c", &c)] {
+            assert_eq!(
+                read_marker(&h.current()).await,
+                vec!["new".to_string()],
+                "clone {name} must observe the swap"
+            );
+        }
+    }
+
+    /// `From<Surreal<C>>` yields a working, never-swapped handle — the shape
+    /// tests and embedded callers rely on.
+    #[tokio::test]
+    async fn from_surreal_yields_a_usable_standalone_handle() {
+        let handle: DbHandle<Db> = marked("standalone").await.into();
+        assert_eq!(
+            read_marker(&handle.current()).await,
+            vec!["standalone".to_string()]
+        );
+    }
+}

--- a/crates/axiam-db/src/lib.rs
+++ b/crates/axiam-db/src/lib.rs
@@ -2,7 +2,10 @@
 //! implementations.
 //!
 //! This crate provides:
-//! - Connection management ([`DbManager`], [`DbConfig`])
+//! - Connection management ([`DbManager`], [`DbConfig`], [`DbPool`])
+//! - [`DbHandle`] — the LIVE pooled-connection reference repositories bind to,
+//!   so a reconnect-loop handle swap is observed on the next query rather than
+//!   leaving them pinned to an evicted connection
 //! - Schema initialization and migrations ([`run_migrations`])
 //! - Repository implementations for `axiam-core` traits
 //! - Error types ([`DbError`])
@@ -12,6 +15,7 @@
 
 mod connection;
 mod error;
+mod handle;
 pub mod helpers;
 pub mod metrics;
 mod pool;
@@ -22,6 +26,7 @@ pub mod seeder;
 
 pub use connection::{DbConfig, DbManager};
 pub use error::DbError;
+pub use handle::DbHandle;
 pub use helpers::{CountRow, parse_uuid, take_first_or_not_found};
 pub use pool::{DbCheckout, DbPool};
 pub use rate_limit_counter::{

--- a/crates/axiam-db/src/pool.rs
+++ b/crates/axiam-db/src/pool.rs
@@ -8,6 +8,10 @@
 //!   parallelism, N independent TCP pools, and independently-renewable sessions
 //!   is N separate `Surreal::new::<Http>(..) + signin` connections — exactly
 //!   what [`DbManager::connect_handle`] builds. [`DbPool`] holds N of them.
+//! * Repositories bind a LIVE [`DbHandle`] over a pool slot rather than a
+//!   `Surreal<C>` clone taken at boot, so a reconnect-loop eviction is observed
+//!   by their next query instead of pinning them to the dead connection (see
+//!   [`DbPool::handle_for_repo`] and `handle.rs`).
 //! * Each pooled handle carries its OWN proactive re-signin + reconnect loop
 //!   (the D-04/PERF-04 machinery previously applied only to the manager's
 //!   handle), so **CQ-B48 is closed**: no request can reach an un-renewed
@@ -35,21 +39,26 @@ use std::time::Duration;
 use axiam_core::error::AxiamError;
 use surrealdb::engine::remote::http::Client;
 use surrealdb::{Connection, Surreal};
-use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::connection::{DbConfig, DbManager, ROOT_TOKEN_DURATION};
 use crate::error::DbError;
+#[cfg(test)]
+use crate::handle::new_slot;
+use crate::handle::{DbHandle, DbSlot};
 use crate::metrics;
 
 /// One pooled handle: an independent `Surreal<C>` connection behind the same
-/// swappable `Arc<RwLock<..>>` [`DbManager`] uses (D-12, so its own reconnect
-/// loop can evict a poisoned handle), plus this handle's in-flight count
+/// swappable [`DbSlot`] [`DbManager`] uses (D-12, so its own reconnect loop can
+/// evict a poisoned handle), plus this handle's in-flight count
 /// (least-in-flight checkout input) and its two owned background tasks.
 struct PooledHandle<C: Connection> {
     /// Swappable so the per-handle reconnect loop can atomically evict a
-    /// poisoned handle (D-12) — identical to `DbManager::db`.
-    db: Arc<RwLock<Surreal<C>>>,
+    /// poisoned handle (D-12) — identical to `DbManager::db`. Repositories
+    /// bind a [`DbHandle`] over THIS slot, so an eviction is observed by their
+    /// very next query instead of leaving them on the dead connection.
+    db: DbSlot<C>,
     /// In-flight count for THIS handle — the least-in-flight selection input.
     /// Incremented by [`DbPool::checkout`], decremented when the returned
     /// [`DbCheckout`] guard drops.
@@ -76,8 +85,8 @@ pub struct DbPool<C: Connection = Client> {
     /// How long [`DbPool::checkout`] waits for a permit before returning the
     /// overload error. Only consulted when `semaphore` is `Some`.
     acquire_timeout: Duration,
-    /// Round-robin cursor for [`DbPool::handle_for_repo`] construction-time
-    /// binding (spreads repositories evenly across handles at startup).
+    /// Round-robin cursor for [`DbPool::handle_for_repo`] binding (spreads
+    /// repositories evenly across handles at startup).
     rr: AtomicUsize,
 }
 
@@ -155,22 +164,30 @@ impl<C: Connection> DbPool<C> {
         self.handles.len()
     }
 
-    /// Bind a handle to a repository at CONSTRUCTION time — the minimal-churn
-    /// repo seam (design §6, Option B). Returns an owned `Surreal<C>` bound to
-    /// one pooled handle, chosen round-robin so repositories spread evenly
-    /// across handles at startup. The repository then calls `self.db.query(..)`
-    /// exactly as before — repo bodies are untouched.
+    /// Bind a repository to one pooled handle — the minimal-churn repo seam
+    /// (design §6, Option B). Returns a **live** [`DbHandle`] over the chosen
+    /// pool slot, picked round-robin so repositories spread evenly across
+    /// handles at startup. The repository then calls
+    /// `self.db.current().query(..)`, resolving the slot per operation.
     ///
-    /// This replaces the ~48 `db.client_cloned().await` composition sites. At
-    /// `pool_size = 1` it hands out clones of the single pooled handle exactly
-    /// as `DbManager::client_cloned()` did — byte-for-byte identical routing —
-    /// the only difference being that the handle is now proactively re-signed-in
-    /// (a strict improvement over the frozen snapshot it replaces).
-    pub async fn handle_for_repo(&self) -> Surreal<C> {
+    /// Returning a live reference rather than a `Surreal<C>` **clone** is what
+    /// closes the stale-handle bug: a clone is a snapshot of whatever
+    /// connection occupied the slot at boot, so when this handle's reconnect
+    /// loop evicted a poisoned connection (~7 minutes into a sustained load
+    /// run, in the observed case) every repository stayed pinned to the dead
+    /// one and 401'd permanently until the process restarted — while
+    /// [`health_check`](Self::health_check), which probes through the slot,
+    /// still reported the pool healthy. A [`DbHandle`] follows the slot, so
+    /// the swap is picked up on the next query. See `handle.rs` for the full
+    /// account.
+    ///
+    /// Binding is still round-robin at construction time, so per-repository
+    /// handle spread across the pool is unchanged.
+    pub fn handle_for_repo(&self) -> DbHandle<C> {
         // Preserve the F1 checkout counter semantics (handles handed to repos).
         metrics::record_handle_checkout();
         let idx = self.rr.fetch_add(1, Ordering::Relaxed) % self.handles.len();
-        self.handles[idx].db.read().await.clone()
+        DbHandle::from_slot(Arc::clone(&self.handles[idx].db))
     }
 
     /// Per-operation checkout with least-in-flight handle selection and, when
@@ -194,7 +211,7 @@ impl<C: Connection> DbPool<C> {
         let idx = self.select_least_in_flight();
         let slot = &self.handles[idx];
         slot.in_flight.fetch_add(1, Ordering::Relaxed);
-        let handle = slot.db.read().await.clone();
+        let handle = (*slot.db.load_full()).clone();
 
         Ok(DbCheckout {
             handle,
@@ -226,8 +243,8 @@ impl<C: Connection> DbPool<C> {
     /// alarms rather than treating it as a transient query error.
     pub async fn health_check(&self) -> Result<(), DbError> {
         for slot in &self.handles {
-            let guard = slot.db.read().await;
-            let result = metrics::instrument_query("health_check.pool", guard.query("RETURN 1"))
+            let current = slot.db.load_full();
+            let result = metrics::instrument_query("health_check.pool", current.query("RETURN 1"))
                 .await
                 .map_err(DbManager::classify_query_error)?;
             result.check().map_err(DbManager::classify_query_error)?;
@@ -243,7 +260,7 @@ impl<C: Connection> DbPool<C> {
         let handles = raw
             .into_iter()
             .map(|db| PooledHandle {
-                db: Arc::new(RwLock::new(db)),
+                db: new_slot(db),
                 in_flight: Arc::new(AtomicUsize::new(0)),
                 refresh_handle: None,
                 reconnect_handle: None,
@@ -395,7 +412,7 @@ mod tests {
         );
 
         // handle_for_repo always hands out the single handle.
-        let _h = pool.handle_for_repo().await;
+        let _h = pool.handle_for_repo();
     }
 
     /// Least-in-flight spreads concurrent load evenly across handles and starves
@@ -505,24 +522,24 @@ mod tests {
 
         // Pre-swap: handle 0 is the "old" (poisoned) one.
         {
-            let pre = pool.handles[0].db.read().await.clone();
+            let pre = pool.handles[0].db.load_full();
             assert_eq!(read_marker(&pre).await, vec!["old-0".to_string()]);
         }
 
-        // Evict handle 0 by swapping a fresh handle in under the write guard,
-        // exactly as spawn_reconnect_loop does (`*db.write().await = fresh`).
+        // Evict handle 0 by storing a fresh handle into its slot, exactly as
+        // spawn_reconnect_loop does (`db.store(Arc::new(fresh))`).
         let fresh = new_marked("new-0").await;
-        *pool.handles[0].db.write().await = fresh;
+        pool.handles[0].db.store(Arc::new(fresh));
 
         // Handle 0 now observes ONLY the new handle...
-        let post0 = pool.handles[0].db.read().await.clone();
+        let post0 = pool.handles[0].db.load_full();
         assert_eq!(
             read_marker(&post0).await,
             vec!["new-0".to_string()],
             "the poisoned handle must never be observed after the swap (D-12)"
         );
         // ...and the sibling handle is entirely unaffected by that swap.
-        let post1 = pool.handles[1].db.read().await.clone();
+        let post1 = pool.handles[1].db.load_full();
         assert_eq!(
             read_marker(&post1).await,
             vec!["keep-1".to_string()],
@@ -588,13 +605,13 @@ mod tests {
         let pool = DbPool {
             handles: vec![
                 PooledHandle {
-                    db: Arc::new(RwLock::new(new_mem().await)),
+                    db: new_slot(new_mem().await),
                     in_flight: Arc::new(AtomicUsize::new(0)),
                     refresh_handle: Some(refresh_a),
                     reconnect_handle: Some(reconnect_a),
                 },
                 PooledHandle {
-                    db: Arc::new(RwLock::new(new_mem().await)),
+                    db: new_slot(new_mem().await),
                     in_flight: Arc::new(AtomicUsize::new(0)),
                     refresh_handle: Some(refresh_b),
                     reconnect_handle: Some(reconnect_b),
@@ -615,6 +632,84 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
 
+    /// THE regression test for the stale-handle bug (§7 of the run-4 benchmark
+    /// instructions): a repository built ONCE at boot must follow a
+    /// reconnect-loop handle swap, not stay pinned to the evicted connection.
+    ///
+    /// Before the fix, `handle_for_repo` handed out an owned `Surreal<C>`
+    /// **clone**; when the reconnect loop replaced the pooled connection, every
+    /// repository kept querying the dead one and 401'd permanently until the
+    /// process restarted — while `health_check`, which probes through the pool
+    /// slot, still reported the pool healthy.
+    ///
+    /// Two independent `kv-mem` instances stand in for the evicted and the
+    /// freshly-reconnected connection (same substitution
+    /// `poisoned_handle_evicted_per_handle_others_unaffected` makes, and for the
+    /// same reason: constructing a real `Surreal<Client>` requires a live
+    /// server). Writing through the repository AFTER the swap must land in the
+    /// new instance, and a record written before the swap must no longer be
+    /// visible — which is only true if the repository resolved the slot rather
+    /// than holding a snapshot.
+    #[tokio::test]
+    async fn repository_bound_at_boot_follows_a_later_handle_swap() {
+        use axiam_core::models::organization::CreateOrganization;
+        use axiam_core::repository::OrganizationRepository;
+
+        use crate::repository::SurrealOrganizationRepository;
+        use crate::schema::run_migrations;
+
+        async fn migrated() -> Surreal<Db> {
+            let db = new_mem().await;
+            run_migrations(&db).await.expect("run migrations");
+            db
+        }
+
+        let evicted = migrated().await;
+        let pool = DbPool::from_handles(vec![evicted], 0, Duration::from_millis(20));
+
+        // Bound ONCE, at "boot" — the repository never sees the pool again.
+        let repo = SurrealOrganizationRepository::new(pool.handle_for_repo());
+
+        repo.create(CreateOrganization {
+            name: "Before".into(),
+            slug: "before-swap".into(),
+            metadata: None,
+        })
+        .await
+        .expect("write before the swap");
+        repo.get_by_slug("before-swap")
+            .await
+            .expect("readable before the swap");
+
+        // The reconnect loop evicts the poisoned connection and installs a
+        // fresh one (`db.store(Arc::new(fresh))`, exactly as PERF-04 does).
+        pool.handles[0].db.store(Arc::new(migrated().await));
+
+        // The already-built repository must now be talking to the NEW
+        // connection: a write lands there...
+        repo.create(CreateOrganization {
+            name: "After".into(),
+            slug: "after-swap".into(),
+            metadata: None,
+        })
+        .await
+        .expect(
+            "a repository bound before the swap must keep working afterwards — \
+             this is the permanent-401 failure mode",
+        );
+        repo.get_by_slug("after-swap")
+            .await
+            .expect("post-swap write must be readable through the same repository");
+
+        // ...and the pre-swap record, which lives only in the evicted
+        // connection, is correctly no longer visible.
+        assert!(
+            repo.get_by_slug("before-swap").await.is_err(),
+            "the repository must be reading the NEW connection after the swap, \
+             not the evicted one"
+        );
+    }
+
     /// `handle_for_repo` round-robins across ALL pooled handles (not just the
     /// `pool_size = 1` case covered above) — each successive call advances
     /// the cursor and wraps back to the first handle after a full cycle.
@@ -632,8 +727,8 @@ mod tests {
 
         let mut seen = Vec::new();
         for _ in 0..7 {
-            let handle = pool.handle_for_repo().await;
-            seen.push(read_marker(&handle).await.remove(0));
+            let handle = pool.handle_for_repo();
+            seen.push(read_marker(&handle.current()).await.remove(0));
         }
         assert_eq!(
             seen,

--- a/crates/axiam-db/src/repository/account_deletion.rs
+++ b/crates/axiam-db/src/repository/account_deletion.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{AccountDeletion, AccountDeletionStatus, CreateAccountDeletion};
 use axiam_core::repository::AccountDeletionRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{classify_write_error, parse_uuid};
 
 // ---------------------------------------------------------------------------
@@ -70,7 +71,7 @@ impl AccountDeletionRowWithId {
 // ---------------------------------------------------------------------------
 
 pub struct SurrealAccountDeletionRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealAccountDeletionRepository<C> {
@@ -82,7 +83,8 @@ impl<C: Connection> Clone for SurrealAccountDeletionRepository<C> {
 }
 
 impl<C: Connection> SurrealAccountDeletionRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 
@@ -97,6 +99,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
     ) -> AxiamResult<Option<AccountDeletion>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM account_deletion \
                  WHERE tenant_id = $tenant_id AND user_id = $user_id AND status = 'pending'",
@@ -127,6 +130,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
     ) -> AxiamResult<Option<AccountDeletion>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM account_deletion \
                  WHERE cancel_token_hash = $hash",
@@ -206,6 +210,7 @@ impl<C: Connection> SurrealAccountDeletionRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("user_id", user_id.to_string()))
             .bind(("tenant_id", tenant_id.to_string()))
@@ -237,6 +242,7 @@ impl<C: Connection> AccountDeletionRepository for SurrealAccountDeletionReposito
         let id = new_id();
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('account_deletion', $id) SET \
                  tenant_id = $tenant_id, \
@@ -281,6 +287,7 @@ impl<C: Connection> AccountDeletionRepository for SurrealAccountDeletionReposito
     ) -> AxiamResult<Option<AccountDeletion>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM account_deletion \
                  WHERE tenant_id = $tenant_id AND cancel_token_hash = $hash",
@@ -301,6 +308,7 @@ impl<C: Connection> AccountDeletionRepository for SurrealAccountDeletionReposito
 
     async fn mark_cancelled(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "UPDATE type::record('account_deletion', $id) SET \
                  status = 'cancelled' \
@@ -317,6 +325,7 @@ impl<C: Connection> AccountDeletionRepository for SurrealAccountDeletionReposito
 
     async fn mark_completed(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "UPDATE type::record('account_deletion', $id) SET \
                  status = 'completed' \

--- a/crates/axiam-db/src/repository/amqp_nonce_replay.rs
+++ b/crates/axiam-db/src/repository/amqp_nonce_replay.rs
@@ -9,10 +9,11 @@ use axiam_core::error::{AxiamError, AxiamResult};
 use axiam_core::id::new_id;
 use axiam_core::repository::AmqpNonceRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::CountRow;
 
 // ---------------------------------------------------------------------------
@@ -21,7 +22,7 @@ use crate::helpers::CountRow;
 
 /// SurrealDB implementation of the AMQP nonce replay repository (NEW-4).
 pub struct SurrealAmqpNonceRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 // Manual Clone impl (not derive): avoids the spurious `C: Clone` bound that
@@ -36,7 +37,8 @@ impl<C: Connection> Clone for SurrealAmqpNonceRepository<C> {
 }
 
 impl<C: Connection> SurrealAmqpNonceRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -52,6 +54,7 @@ impl<C: Connection> AmqpNonceRepository for SurrealAmqpNonceRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('amqp_nonce_replay', $row_id) SET \
                  tenant_id = $tenant_id, \
@@ -89,6 +92,7 @@ impl<C: Connection> AmqpNonceRepository for SurrealAmqpNonceRepository<C> {
         // Count expired rows first, then delete.
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM amqp_nonce_replay \
                  WHERE expires_at < time::now() GROUP ALL",
@@ -100,6 +104,7 @@ impl<C: Connection> AmqpNonceRepository for SurrealAmqpNonceRepository<C> {
         let total = count_rows.first().map(|r| r.total).unwrap_or(0);
 
         self.db
+            .current()
             .query("DELETE amqp_nonce_replay WHERE expires_at < time::now()")
             .await
             .map_err(DbError::from)?;

--- a/crates/axiam-db/src/repository/audit.rs
+++ b/crates/axiam-db/src/repository/audit.rs
@@ -9,11 +9,12 @@ use axiam_core::models::audit::{ActorType, AuditLogEntry, AuditOutcome, CreateAu
 use axiam_core::repository::{AuditLogFilter, AuditLogRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
 use serde_json::json;
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -219,11 +220,12 @@ fn apply_filter_binds<'a, C: Connection>(
 /// SurrealDB implementation of the audit log repository.
 #[derive(Clone)]
 pub struct SurrealAuditLogRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealAuditLogRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -241,6 +243,7 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('audit_log', $id) SET \
                  tenant_id = $tenant_id, \
@@ -288,7 +291,8 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
         // Count query.
         let count_sql =
             format!("SELECT count() AS total FROM audit_log WHERE {where_clause} GROUP ALL");
-        let mut count_query = self.db.query(&count_sql);
+        let db = self.db.current();
+        let mut count_query = db.query(&count_sql);
         count_query = count_query.bind(("tenant_id", tenant_id_str.clone()));
         count_query = apply_filter_binds(count_query, &binds);
         let mut count_result = count_query.await.map_err(DbError::from)?;
@@ -301,7 +305,8 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
              ORDER BY timestamp DESC \
              LIMIT $limit START $offset"
         );
-        let mut data_query = self.db.query(&data_sql);
+        let db = self.db.current();
+        let mut data_query = db.query(&data_sql);
         data_query = data_query.bind(("tenant_id", tenant_id_str));
         data_query = apply_filter_binds(data_query, &binds);
         data_query = data_query.bind(("limit", pagination.limit));
@@ -375,6 +380,7 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
         );
         let _ = self
             .db
+            .current()
             .query(&q1_sql)
             .bind(("nil_uuid", nil_uuid.clone()))
             .bind(("pseudonym", pseudonym.to_string()))
@@ -388,6 +394,7 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
         // Query 2: null-out resource_id in entries where someone acted ON this user.
         let _ = self
             .db
+            .current()
             .query(
                 "UPDATE audit_log SET resource_id = $nil_uuid \
                  WHERE tenant_id = $tenant_id AND resource_id = $user_id",
@@ -403,6 +410,7 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
         // Query 3: count entries that now have nil actor_id (as a proxy for rows updated).
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM audit_log \
                  WHERE tenant_id = $tenant_id AND actor_id = $nil_uuid GROUP ALL",
@@ -423,6 +431,7 @@ impl<C: Connection> AuditLogRepository for SurrealAuditLogRepository<C> {
         let id_strings: Vec<String> = ids.iter().map(|id| id.to_string()).collect();
         let r = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM audit_log \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/src/repository/ca_certificate.rs
+++ b/crates/axiam-db/src/repository/ca_certificate.rs
@@ -7,11 +7,12 @@ use axiam_core::models::certificate::{
 };
 use axiam_core::repository::{CaCertificateRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate};
 
 // ---------------------------------------------------------------------------
@@ -139,11 +140,12 @@ impl CaCertificateRowWithId {
 
 #[derive(Clone)]
 pub struct SurrealCaCertificateRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealCaCertificateRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -155,6 +157,7 @@ impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('ca_certificate', $id) SET \
                  organization_id = $org_id, \
@@ -200,6 +203,7 @@ impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C
     async fn get_by_id(&self, organization_id: Uuid, id: Uuid) -> AxiamResult<CaCertificate> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('ca_certificate', $id) \
                  WHERE organization_id = $org_id",
@@ -224,6 +228,7 @@ impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C
     async fn revoke(&self, organization_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('ca_certificate', $id) SET \
                  status = $status \
@@ -262,6 +267,7 @@ impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C
                          WHERE organization_id = $org_id GROUP ALL";
         let count_result = self
             .db
+            .current()
             .query(count_sql)
             .bind(("org_id", org_id_str.clone()))
             .await
@@ -278,6 +284,7 @@ impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C
                         LIMIT $limit START $offset";
         let data_result = self
             .db
+            .current()
             .query(data_sql)
             .bind(("org_id", org_id_str))
             .bind(("limit", pagination.limit))
@@ -300,6 +307,7 @@ impl<C: Connection> CaCertificateRepository for SurrealCaCertificateRepository<C
     async fn get_by_issuer_id(&self, id: Uuid) -> AxiamResult<CaCertificate> {
         let result = self
             .db
+            .current()
             .query("SELECT * FROM type::record('ca_certificate', $id)")
             .bind(("id", id.to_string()))
             .await

--- a/crates/axiam-db/src/repository/certificate.rs
+++ b/crates/axiam-db/src/repository/certificate.rs
@@ -7,11 +7,12 @@ use axiam_core::models::certificate::{
 };
 use axiam_core::repository::{CertificateRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, classify_write_error, paginate, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -175,11 +176,12 @@ impl CertificateRowWithId {
 
 #[derive(Clone)]
 pub struct SurrealCertificateRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealCertificateRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -191,6 +193,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('certificate', $id) SET \
                  tenant_id = $tenant_id, \
@@ -235,6 +238,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
             id, input.issuer_ca_id,
         );
         self.db
+            .current()
             .query(&relate_sql)
             .await
             .map_err(DbError::from)?
@@ -247,6 +251,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
     async fn get_by_id(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<Certificate> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('certificate', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -275,6 +280,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
     ) -> AxiamResult<Certificate> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM certificate \
                  WHERE tenant_id = $tenant_id AND fingerprint = $fingerprint",
@@ -296,6 +302,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
     async fn revoke(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('certificate', $id) SET \
                  status = $status \
@@ -333,6 +340,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
                          WHERE tenant_id = $tenant_id GROUP ALL";
         let count_result = self
             .db
+            .current()
             .query(count_sql)
             .bind(("tenant_id", tenant_id_str.clone()))
             .await
@@ -348,6 +356,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
                         LIMIT $limit START $offset";
         let data_result = self
             .db
+            .current()
             .query(data_sql)
             .bind(("tenant_id", tenant_id_str))
             .bind(("limit", pagination.limit))
@@ -370,6 +379,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
     async fn get_by_fingerprint_global(&self, fingerprint: &str) -> AxiamResult<Certificate> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM certificate \
                  WHERE fingerprint = $fingerprint",
@@ -405,6 +415,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
         );
         let result = self
             .db
+            .current()
             .query(&verify_sql)
             .bind(("tid", tenant_id.to_string()))
             .await
@@ -431,7 +442,7 @@ impl<C: Connection> CertificateRepository for SurrealCertificateRepository<C> {
              WHERE in = certificate:`{}`",
             cert_id,
         );
-        let result = self.db.query(&sql).await.map_err(DbError::from)?;
+        let result = self.db.current().query(&sql).await.map_err(DbError::from)?;
         let mut result = result
             .check()
             .map_err(|e| DbError::Migration(e.to_string()))?;

--- a/crates/axiam-db/src/repository/consent.rs
+++ b/crates/axiam-db/src/repository/consent.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{Consent, CreateConsent};
 use axiam_core::repository::ConsentRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 
 // ---------------------------------------------------------------------------
 // Row structs
@@ -64,7 +65,7 @@ impl ConsentRowWithId {
 // ---------------------------------------------------------------------------
 
 pub struct SurrealConsentRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealConsentRepository<C> {
@@ -76,7 +77,8 @@ impl<C: Connection> Clone for SurrealConsentRepository<C> {
 }
 
 impl<C: Connection> SurrealConsentRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -86,6 +88,7 @@ impl<C: Connection> ConsentRepository for SurrealConsentRepository<C> {
         let id = new_id();
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('consent', $id) SET \
                  tenant_id = $tenant_id, \
@@ -131,6 +134,7 @@ impl<C: Connection> ConsentRepository for SurrealConsentRepository<C> {
     async fn list_by_user(&self, tenant_id: Uuid, user_id: Uuid) -> AxiamResult<Vec<Consent>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM consent \
                  WHERE tenant_id = $tenant_id AND user_id = $user_id \

--- a/crates/axiam-db/src/repository/email_config.rs
+++ b/crates/axiam-db/src/repository/email_config.rs
@@ -19,11 +19,12 @@ use axiam_core::repository::EmailConfigRepository;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -348,7 +349,7 @@ fn encrypt_provider(
 /// `AXIAM__EMAIL_ENCRYPTION_KEY` at startup. Secrets are encrypted on write
 /// and decrypted on read — never stored plaintext (D-17).
 pub struct SurrealEmailConfigRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
     key: [u8; 32],
 }
 
@@ -362,7 +363,8 @@ impl<C: Connection> Clone for SurrealEmailConfigRepository<C> {
 }
 
 impl<C: Connection> SurrealEmailConfigRepository<C> {
-    pub fn new(db: Surreal<C>, key: [u8; 32]) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>, key: [u8; 32]) -> Self {
+        let db = db.into();
         Self { db, key }
     }
 
@@ -395,6 +397,7 @@ impl<C: Connection> SurrealEmailConfigRepository<C> {
     pub async fn backfill_plaintext_secrets(&self) -> AxiamResult<u64> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM email_config \
                  WHERE (provider_kind IN ['smtp'] AND smtp_password_ciphertext = NONE) \
@@ -444,6 +447,7 @@ impl<C: Connection> SurrealEmailConfigRepository<C> {
     ) -> AxiamResult<Option<ExistingSecretColumns>> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT smtp_password_ciphertext, smtp_password_nonce, \
                         api_key_ciphertext, api_key_nonce \
@@ -466,6 +470,7 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
     async fn get_org_config(&self, org_id: Uuid) -> AxiamResult<Option<EmailConfig>> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM email_config \
@@ -542,6 +547,7 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
         .to_string();
         let result = self
             .db
+            .current()
             .query(
                 "UPSERT type::record('email_config', $record_id) SET \
                  scope = 'org', \
@@ -607,6 +613,7 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
 
     async fn delete_org_config(&self, org_id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "DELETE FROM email_config \
                  WHERE scope = 'org' AND scope_id = $scope_id",
@@ -628,6 +635,7 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
         // "no override — inherit everything from org."
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM email_config \
@@ -718,6 +726,7 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
         )
         .to_string();
         self.db
+            .current()
             .query(
                 "UPSERT type::record('email_config', $record_id) SET \
                  scope = 'tenant', \
@@ -766,6 +775,7 @@ impl<C: Connection> EmailConfigRepository for SurrealEmailConfigRepository<C> {
 
     async fn delete_tenant_override(&self, tenant_id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "DELETE FROM email_config \
                  WHERE scope = 'tenant' AND scope_id = $scope_id",

--- a/crates/axiam-db/src/repository/email_template.rs
+++ b/crates/axiam-db/src/repository/email_template.rs
@@ -5,11 +5,12 @@ use axiam_core::models::email_template::{EmailTemplate, SetEmailTemplate, Templa
 use axiam_core::models::settings::SettingsScope;
 use axiam_core::repository::EmailTemplateRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 
 // -----------------------------------------------------------------------
 // Row structs
@@ -75,11 +76,12 @@ impl TemplateRowWithId {
 
 #[derive(Clone)]
 pub struct SurrealEmailTemplateRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealEmailTemplateRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 
@@ -104,6 +106,7 @@ impl<C: Connection> SurrealEmailTemplateRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "UPSERT type::record('email_template', $id) SET \
                  scope = $scope, scope_id = $scope_id, \
@@ -160,6 +163,7 @@ impl<C: Connection> SurrealEmailTemplateRepository<C> {
     ) -> Result<Option<EmailTemplate>, DbError> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM email_template \
@@ -191,6 +195,7 @@ impl<C: Connection> SurrealEmailTemplateRepository<C> {
     ) -> Result<Vec<EmailTemplate>, DbError> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM email_template \
@@ -217,6 +222,7 @@ impl<C: Connection> SurrealEmailTemplateRepository<C> {
         kind: &str,
     ) -> Result<(), DbError> {
         self.db
+            .current()
             .query(
                 "DELETE email_template \
                  WHERE scope = $scope \

--- a/crates/axiam-db/src/repository/email_verification_token.rs
+++ b/crates/axiam-db/src/repository/email_verification_token.rs
@@ -7,11 +7,12 @@ use axiam_core::models::email_verification::{
 };
 use axiam_core::repository::EmailVerificationTokenRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -75,7 +76,7 @@ impl TokenRowWithId {
 
 /// SurrealDB implementation of the email verification token repository.
 pub struct SurrealEmailVerificationTokenRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealEmailVerificationTokenRepository<C> {
@@ -87,7 +88,8 @@ impl<C: Connection> Clone for SurrealEmailVerificationTokenRepository<C> {
 }
 
 impl<C: Connection> SurrealEmailVerificationTokenRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -104,6 +106,7 @@ impl<C: Connection> EmailVerificationTokenRepository
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('email_verification_token', $id) SET \
                  tenant_id = $tenant_id, \
@@ -137,6 +140,7 @@ impl<C: Connection> EmailVerificationTokenRepository
     ) -> AxiamResult<EmailVerificationToken> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM email_verification_token \
@@ -173,6 +177,7 @@ impl<C: Connection> EmailVerificationTokenRepository
         // consume and return the full record with its ID.
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE email_verification_token SET \
                  consumed_at = time::now() \
@@ -226,6 +231,7 @@ impl<C: Connection> EmailVerificationTokenRepository
 
         let result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total \
                  FROM email_verification_token \
@@ -251,6 +257,7 @@ impl<C: Connection> EmailVerificationTokenRepository
     async fn delete_expired(&self) -> AxiamResult<u64> {
         let result = self
             .db
+            .current()
             .query(
                 "DELETE FROM email_verification_token \
                  WHERE expires_at < time::now() \

--- a/crates/axiam-db/src/repository/erasure_proof.rs
+++ b/crates/axiam-db/src/repository/erasure_proof.rs
@@ -8,11 +8,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{CreateErasureProof, ErasureProof};
 use axiam_core::repository::ErasureProofRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 
 // ---------------------------------------------------------------------------
 // Row structs
@@ -31,7 +32,7 @@ struct ErasureProofRow {
 // ---------------------------------------------------------------------------
 
 pub struct SurrealErasureProofRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealErasureProofRepository<C> {
@@ -43,7 +44,8 @@ impl<C: Connection> Clone for SurrealErasureProofRepository<C> {
 }
 
 impl<C: Connection> SurrealErasureProofRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -53,6 +55,7 @@ impl<C: Connection> ErasureProofRepository for SurrealErasureProofRepository<C> 
         let id = new_id();
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('erasure_proof', $id) SET \
                  pseudonym = $pseudonym, \

--- a/crates/axiam-db/src/repository/export_job.rs
+++ b/crates/axiam-db/src/repository/export_job.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::gdpr::{CreateExportJob, ExportJob, ExportJobStatus};
 use axiam_core::repository::ExportJobRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, parse_uuid, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -81,7 +82,7 @@ impl ExportJobRowWithId {
 // ---------------------------------------------------------------------------
 
 pub struct SurrealExportJobRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealExportJobRepository<C> {
@@ -93,7 +94,8 @@ impl<C: Connection> Clone for SurrealExportJobRepository<C> {
 }
 
 impl<C: Connection> SurrealExportJobRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 
@@ -106,6 +108,7 @@ impl<C: Connection> SurrealExportJobRepository<C> {
     pub async fn has_pending_for_user(&self, tenant_id: Uuid, user_id: Uuid) -> AxiamResult<bool> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM export_job \
                  WHERE tenant_id = $tenant_id AND user_id = $user_id \
@@ -130,6 +133,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
         let id = new_id();
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('export_job', $id) SET \
                  tenant_id = $tenant_id, \
@@ -171,6 +175,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
     async fn find_queued(&self) -> AxiamResult<Vec<ExportJob>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM export_job \
                  WHERE status = 'queued' ORDER BY created_at ASC",
@@ -196,6 +201,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
         expires_at: DateTime<Utc>,
     ) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "UPDATE type::record('export_job', $id) SET \
                  status = 'ready', \
@@ -225,6 +231,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
     ) -> AxiamResult<Option<ExportJob>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM export_job \
                  WHERE tenant_id = $tenant_id AND download_token_hash = $hash",
@@ -245,6 +252,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
 
     async fn mark_downloaded(&self, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query("UPDATE type::record('export_job', $id) SET status = 'downloaded'")
             .bind(("id", id.to_string()))
             .await
@@ -260,6 +268,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
         // mark_downloaded + delete sequence.
         let mut result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('export_job', $id) \
                  SET status = 'downloaded' \
@@ -279,6 +288,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
 
         // Delete the row now that it is marked downloaded.
         self.db
+            .current()
             .query("DELETE type::record('export_job', $id)")
             .bind(("id", id.to_string()))
             .await
@@ -291,6 +301,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
 
     async fn mark_failed(&self, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query("UPDATE type::record('export_job', $id) SET status = 'failed'")
             .bind(("id", id.to_string()))
             .await
@@ -302,6 +313,7 @@ impl<C: Connection> ExportJobRepository for SurrealExportJobRepository<C> {
 
     async fn delete(&self, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query("DELETE type::record('export_job', $id)")
             .bind(("id", id.to_string()))
             .await

--- a/crates/axiam-db/src/repository/federation_config.rs
+++ b/crates/axiam-db/src/repository/federation_config.rs
@@ -7,11 +7,12 @@ use axiam_core::models::federation::{
 };
 use axiam_core::repository::{FederationConfigRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -184,7 +185,7 @@ impl FederationConfigRowWithId {
 // ---------------------------------------------------------------------------
 
 pub struct SurrealFederationConfigRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealFederationConfigRepository<C> {
@@ -196,7 +197,8 @@ impl<C: Connection> Clone for SurrealFederationConfigRepository<C> {
 }
 
 impl<C: Connection> SurrealFederationConfigRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -213,6 +215,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('federation_config', $id) SET \
                  tenant_id = $tenant_id, \
@@ -254,6 +257,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
     async fn get_by_id(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<FederationConfig> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM federation_config \
@@ -328,7 +332,8 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
             set_clauses.join(", ")
         );
 
-        let mut query = self.db.query(&sql);
+        let db = self.db.current();
+        let mut query = db.query(&sql);
         query = query
             .bind(("id", id.to_string()))
             .bind(("tenant_id", tenant_id.to_string()));
@@ -349,6 +354,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "DELETE type::record('federation_config', $id) \
                  WHERE tenant_id = $tenant_id RETURN BEFORE",
@@ -381,6 +387,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
 
         let count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM federation_config \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -399,6 +406,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
         // material, so `list()` no longer hydrates those columns per row.
         let data_result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, tenant_id, provider, protocol, \
                  metadata_url, client_id, attribute_map, enabled, allowed_algorithms, \
@@ -431,6 +439,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
         // This is the predicate used by the boot backfill task (D-12).
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM federation_config \
@@ -462,6 +471,7 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
         // Per MEMORY.md: bind() requires owned Strings.
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('federation_config', $config_id) \
                  SET client_secret_nonce = $nonce, \

--- a/crates/axiam-db/src/repository/federation_link.rs
+++ b/crates/axiam-db/src/repository/federation_link.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::federation::{CreateFederationLink, FederationLink};
 use axiam_core::repository::FederationLinkRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{parse_uuid, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -79,7 +80,7 @@ impl FederationLinkRowWithId {
 // ---------------------------------------------------------------------------
 
 pub struct SurrealFederationLinkRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealFederationLinkRepository<C> {
@@ -91,7 +92,8 @@ impl<C: Connection> Clone for SurrealFederationLinkRepository<C> {
 }
 
 impl<C: Connection> SurrealFederationLinkRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -102,6 +104,7 @@ impl<C: Connection> FederationLinkRepository for SurrealFederationLinkRepository
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('federation_link', $id) SET \
                  tenant_id = $tenant_id, \
@@ -140,6 +143,7 @@ impl<C: Connection> FederationLinkRepository for SurrealFederationLinkRepository
     ) -> AxiamResult<FederationLink> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM federation_link \
@@ -175,6 +179,7 @@ impl<C: Connection> FederationLinkRepository for SurrealFederationLinkRepository
     ) -> AxiamResult<Vec<FederationLink>> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM federation_link \
@@ -199,6 +204,7 @@ impl<C: Connection> FederationLinkRepository for SurrealFederationLinkRepository
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "DELETE type::record('federation_link', $id) \
                  WHERE tenant_id = $tenant_id RETURN BEFORE",

--- a/crates/axiam-db/src/repository/federation_login_state.rs
+++ b/crates/axiam-db/src/repository/federation_login_state.rs
@@ -9,11 +9,12 @@ use axiam_core::error::{AxiamError, AxiamResult};
 use axiam_core::id::new_id;
 use axiam_core::repository::{FederationLoginState, FederationLoginStateRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::CountRow;
 
 // ---------------------------------------------------------------------------
@@ -40,11 +41,12 @@ struct FederationLoginStateRow {
 /// SurrealDB implementation of the federation login state repository.
 #[derive(Clone)]
 pub struct SurrealFederationLoginStateRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealFederationLoginStateRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -55,6 +57,7 @@ impl<C: Connection> FederationLoginStateRepository for SurrealFederationLoginSta
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('federation_login_state', $id) SET \
                  state = $state, \
@@ -103,6 +106,7 @@ impl<C: Connection> FederationLoginStateRepository for SurrealFederationLoginSta
         // SELECT and DELETE are no-ops and we return None.
         let mut result = self
             .db
+            .current()
             .query(
                 "BEGIN TRANSACTION; \
                  LET $row = (SELECT state, nonce, tenant_id, federation_config_id, \
@@ -155,6 +159,7 @@ impl<C: Connection> FederationLoginStateRepository for SurrealFederationLoginSta
         // Count expired rows first, then delete.
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM federation_login_state \
                  WHERE expires_at < time::now() GROUP ALL",
@@ -166,6 +171,7 @@ impl<C: Connection> FederationLoginStateRepository for SurrealFederationLoginSta
         let total = count_rows.first().map(|r| r.total).unwrap_or(0);
 
         self.db
+            .current()
             .query("DELETE federation_login_state WHERE expires_at < time::now()")
             .await
             .map_err(DbError::from)?;

--- a/crates/axiam-db/src/repository/group.rs
+++ b/crates/axiam-db/src/repository/group.rs
@@ -6,11 +6,12 @@ use axiam_core::models::group::{CreateGroup, Group, UpdateGroup};
 use axiam_core::models::user::{User, UserStatus};
 use axiam_core::repository::{GroupRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, classify_write_error, paginate, take_first_or_not_found};
 
 /// DB-side row struct for queries where the UUID is already known.
@@ -119,11 +120,12 @@ impl MemberRow {
 /// SurrealDB implementation of the Group repository.
 #[derive(Clone)]
 pub struct SurrealGroupRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealGroupRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -140,6 +142,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('group', $id) SET \
                  tenant_id = $tenant_id, \
@@ -181,6 +184,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('group', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -229,8 +233,8 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -287,6 +291,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
         );
 
         self.db
+            .current()
             .query(query)
             .bind(("id", id_str))
             .bind(("tenant_id", tenant_id_str))
@@ -307,6 +312,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM group \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -318,6 +324,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM group \
                  WHERE tenant_id = $tenant_id \
@@ -348,6 +355,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
         // Verify both user and group belong to the same tenant.
         let mut check = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM user \
                  WHERE id = type::record('user', $user_id) \
@@ -383,7 +391,12 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
         // Create the membership edge.
         let query = format!("RELATE user:`{user_id_str}` -> member_of -> group:`{group_id_str}`;");
 
-        let result = self.db.query(query).await.map_err(DbError::from)?;
+        let result = self
+            .db
+            .current()
+            .query(query)
+            .await
+            .map_err(DbError::from)?;
 
         // QUAL-03/D-09: a RELATE's per-statement failure (e.g. a duplicate
         // membership violating idx_member_of_unique) only surfaces via
@@ -413,6 +426,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
         // with a foreign user+group id pair could sever another tenant's
         // membership. `.check()` surfaces per-statement failures.
         self.db
+            .current()
             .query(
                 "DELETE member_of WHERE \
                  in = type::record('user', $user_id) AND \
@@ -442,6 +456,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
         // Count total members.
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM member_of \
                  WHERE out = type::record('group', $group_id) GROUP ALL",
@@ -454,6 +469,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
         // Fetch member users via the edge.
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM user \
                  WHERE tenant_id = $tenant_id \
@@ -487,6 +503,7 @@ impl<C: Connection> GroupRepository for SurrealGroupRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM group \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/src/repository/notification_rule.rs
+++ b/crates/axiam-db/src/repository/notification_rule.rs
@@ -7,11 +7,12 @@ use axiam_core::models::notification_rule::{
 };
 use axiam_core::repository::{NotificationRuleRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 // -------------------------------------------------------------------
@@ -96,7 +97,7 @@ impl NotificationRuleRowWithId {
 // -------------------------------------------------------------------
 
 pub struct SurrealNotificationRuleRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealNotificationRuleRepository<C> {
@@ -108,7 +109,8 @@ impl<C: Connection> Clone for SurrealNotificationRuleRepository<C> {
 }
 
 impl<C: Connection> SurrealNotificationRuleRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -120,6 +122,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('notification_rule', $id) \
                  SET \
@@ -152,6 +155,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
     async fn get_by_id(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<NotificationRule> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM notification_rule \
@@ -208,7 +212,8 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
             set_clauses.join(", ")
         );
 
-        let mut query = self.db.query(&sql);
+        let db = self.db.current();
+        let mut query = db.query(&sql);
         query = query
             .bind(("id", id.to_string()))
             .bind(("tenant_id", tenant_id.to_string()));
@@ -229,6 +234,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "DELETE type::record('notification_rule', $id) \
                  WHERE tenant_id = $tenant_id RETURN BEFORE",
@@ -261,6 +267,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
 
         let count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total \
                  FROM notification_rule \
@@ -276,6 +283,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
 
         let data_result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM notification_rule \
@@ -308,6 +316,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
     ) -> AxiamResult<Vec<NotificationRule>> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM notification_rule \
@@ -343,6 +352,7 @@ impl<C: Connection> NotificationRuleRepository for SurrealNotificationRuleReposi
         // array shares at least one element with the supplied list.
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM notification_rule \

--- a/crates/axiam-db/src/repository/oauth2_auth_code.rs
+++ b/crates/axiam-db/src/repository/oauth2_auth_code.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{AuthorizationCode, CreateAuthorizationCode};
 use axiam_core::repository::AuthorizationCodeRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -74,11 +75,12 @@ impl AuthCodeRowWithId {
 /// SurrealDB implementation of the AuthorizationCode repository.
 #[derive(Clone)]
 pub struct SurrealAuthorizationCodeRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealAuthorizationCodeRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -90,6 +92,7 @@ impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepo
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('oauth2_auth_code', $id) SET \
                  tenant_id = $tenant_id, \
@@ -159,6 +162,7 @@ impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepo
 
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM oauth2_auth_code \
@@ -207,6 +211,7 @@ impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepo
         // code-burning attacks.
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM \
                  (UPDATE oauth2_auth_code SET used = true \
@@ -241,6 +246,7 @@ impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepo
     async fn delete_expired(&self) -> AxiamResult<u64> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM oauth2_auth_code \
                  WHERE expires_at < time::now() OR used = true GROUP ALL",
@@ -252,6 +258,7 @@ impl<C: Connection> AuthorizationCodeRepository for SurrealAuthorizationCodeRepo
         let count = count_rows.first().map(|r| r.total).unwrap_or(0);
 
         self.db
+            .current()
             .query(
                 "DELETE FROM oauth2_auth_code \
                  WHERE expires_at < time::now() OR used = true",

--- a/crates/axiam-db/src/repository/oauth2_client.rs
+++ b/crates/axiam-db/src/repository/oauth2_client.rs
@@ -6,11 +6,12 @@ use axiam_core::models::oauth2_client::{CreateOAuth2Client, OAuth2Client, Update
 use axiam_core::repository::{OAuth2ClientRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
 use rand::RngExt;
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 /// Generate a random client ID with the `oa_` prefix (32 hex chars).
@@ -78,11 +79,12 @@ impl OAuth2ClientRowWithId {
 /// SurrealDB implementation of the OAuth2Client repository.
 #[derive(Clone)]
 pub struct SurrealOAuth2ClientRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealOAuth2ClientRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -99,6 +101,7 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('oauth2_client', $id) SET \
                  tenant_id = $tenant_id, \
@@ -151,6 +154,7 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('oauth2_client', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -189,6 +193,7 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM oauth2_client \
                  WHERE tenant_id = $tenant_id AND client_id = $client_id",
@@ -238,8 +243,8 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -286,6 +291,7 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
         let id_str = id.to_string();
 
         self.db
+            .current()
             .query(
                 "DELETE type::record('oauth2_client', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -307,6 +313,7 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM oauth2_client \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -318,6 +325,7 @@ impl<C: Connection> OAuth2ClientRepository for SurrealOAuth2ClientRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM oauth2_client \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/src/repository/oauth2_refresh_token.rs
+++ b/crates/axiam-db/src/repository/oauth2_refresh_token.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::oauth2_client::{CreateRefreshToken, RefreshToken};
 use axiam_core::repository::RefreshTokenRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -67,7 +68,7 @@ impl RefreshTokenRowWithId {
 
 /// SurrealDB implementation of the RefreshToken repository.
 pub struct SurrealRefreshTokenRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 // Manual Clone impl (not derive): avoids the spurious `C: Clone` bound that
@@ -81,7 +82,8 @@ impl<C: Connection> Clone for SurrealRefreshTokenRepository<C> {
 }
 
 impl<C: Connection> SurrealRefreshTokenRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -95,6 +97,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('oauth2_refresh_token', $id) SET \
                  tenant_id = $tenant_id, \
@@ -155,6 +158,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT *, meta::id(id) AS record_id \
                  FROM oauth2_refresh_token \
@@ -190,6 +194,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
         // concurrent use.
         let mut result = self
             .db
+            .current()
             .query(
                 "UPDATE oauth2_refresh_token SET revoked = true \
                  WHERE tenant_id = $tenant_id \
@@ -220,6 +225,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
         // RETURN AFTER gives us the updated rows for counting.
         let mut result = self
             .db
+            .current()
             .query(
                 "UPDATE oauth2_refresh_token SET revoked = true \
                  WHERE tenant_id = $tenant_id \
@@ -242,6 +248,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
 
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE oauth2_refresh_token SET revoked = true \
                  WHERE tenant_id = $tenant_id \
@@ -262,6 +269,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
     async fn delete_expired(&self) -> AxiamResult<u64> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM oauth2_refresh_token \
                  WHERE expires_at < time::now() OR revoked = true \
@@ -274,6 +282,7 @@ impl<C: Connection> RefreshTokenRepository for SurrealRefreshTokenRepository<C> 
         let count = count_rows.first().map(|r| r.total).unwrap_or(0);
 
         self.db
+            .current()
             .query(
                 "DELETE FROM oauth2_refresh_token \
                  WHERE expires_at < time::now() OR revoked = true",

--- a/crates/axiam-db/src/repository/organization.rs
+++ b/crates/axiam-db/src/repository/organization.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::organization::{CreateOrganization, Organization, UpdateOrganization};
 use axiam_core::repository::{OrganizationRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 /// DB-side row struct for queries where the UUID is already known.
@@ -51,11 +52,12 @@ impl OrganizationRowWithId {
 /// SurrealDB implementation of the Organization repository.
 #[derive(Clone)]
 pub struct SurrealOrganizationRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealOrganizationRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -71,6 +73,7 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('organization', $id) SET \
                  name = $name, slug = $slug, metadata = $metadata",
@@ -104,6 +107,7 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query("SELECT * FROM type::record('organization', $id)")
             .bind(("id", id_str.clone()))
             .await
@@ -127,6 +131,7 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM organization WHERE slug = $slug",
@@ -161,7 +166,8 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
             sets.join(", ")
         );
 
-        let mut builder = self.db.query(&query).bind(("id", id_str.clone()));
+        let db = self.db.current();
+        let mut builder = db.query(&query).bind(("id", id_str.clone()));
 
         if let Some(name) = input.name {
             builder = builder.bind(("name", name));
@@ -194,6 +200,7 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
     async fn delete(&self, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query("DELETE type::record('organization', $id) RETURN BEFORE")
             .bind(("id", id.to_string()))
             .await
@@ -216,6 +223,7 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
     async fn list(&self, pagination: Pagination) -> AxiamResult<PaginatedResult<Organization>> {
         let mut count_result = self
             .db
+            .current()
             .query("SELECT count() AS total FROM organization GROUP ALL")
             .await
             .map_err(DbError::from)?;
@@ -223,6 +231,7 @@ impl<C: Connection> OrganizationRepository for SurrealOrganizationRepository<C> 
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM organization \

--- a/crates/axiam-db/src/repository/password_history.rs
+++ b/crates/axiam-db/src/repository/password_history.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::password_history::{CreatePasswordHistoryEntry, PasswordHistoryEntry};
 use axiam_core::repository::PasswordHistoryRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 
 // -----------------------------------------------------------------------
 // Row structs
@@ -56,7 +57,7 @@ impl PasswordHistoryRowWithId {
 // -----------------------------------------------------------------------
 
 pub struct SurrealPasswordHistoryRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealPasswordHistoryRepository<C> {
@@ -68,7 +69,8 @@ impl<C: Connection> Clone for SurrealPasswordHistoryRepository<C> {
 }
 
 impl<C: Connection> SurrealPasswordHistoryRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -80,6 +82,7 @@ impl<C: Connection> PasswordHistoryRepository for SurrealPasswordHistoryReposito
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('password_history', $id) SET \
                  tenant_id = $tenant_id, \
@@ -120,6 +123,7 @@ impl<C: Connection> PasswordHistoryRepository for SurrealPasswordHistoryReposito
     ) -> AxiamResult<Vec<PasswordHistoryEntry>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM password_history \
@@ -149,6 +153,7 @@ impl<C: Connection> PasswordHistoryRepository for SurrealPasswordHistoryReposito
         if keep_count == 0 {
             let mut result = self
                 .db
+                .current()
                 .query(
                     "DELETE password_history \
                      WHERE tenant_id = $tenant_id \
@@ -170,6 +175,7 @@ impl<C: Connection> PasswordHistoryRepository for SurrealPasswordHistoryReposito
         // concurrently will have a newer timestamp and be retained.
         let mut result = self
             .db
+            .current()
             .query(
                 "DELETE password_history \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/src/repository/password_reset_token.rs
+++ b/crates/axiam-db/src/repository/password_reset_token.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::password_reset::{CreatePasswordResetToken, PasswordResetToken};
 use axiam_core::repository::PasswordResetTokenRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -73,7 +74,7 @@ impl TokenRowWithId {
 
 /// SurrealDB implementation of the password reset token repository.
 pub struct SurrealPasswordResetTokenRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> Clone for SurrealPasswordResetTokenRepository<C> {
@@ -85,7 +86,8 @@ impl<C: Connection> Clone for SurrealPasswordResetTokenRepository<C> {
 }
 
 impl<C: Connection> SurrealPasswordResetTokenRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -97,6 +99,7 @@ impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRe
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('password_reset_token', $id) SET \
                  tenant_id = $tenant_id, \
@@ -130,6 +133,7 @@ impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRe
     ) -> AxiamResult<PasswordResetToken> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM password_reset_token \
@@ -160,6 +164,7 @@ impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRe
     async fn consume(&self, tenant_id: Uuid, token_hash: &str) -> AxiamResult<PasswordResetToken> {
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE password_reset_token SET \
                  consumed_at = time::now() \
@@ -213,6 +218,7 @@ impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRe
 
         let result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total \
                  FROM password_reset_token \
@@ -238,6 +244,7 @@ impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRe
     async fn delete_expired(&self) -> AxiamResult<u64> {
         let result = self
             .db
+            .current()
             .query(
                 "DELETE FROM password_reset_token \
                  WHERE expires_at < time::now() \
@@ -261,6 +268,7 @@ impl<C: Connection> PasswordResetTokenRepository for SurrealPasswordResetTokenRe
         // rate-limit enforcement.
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE password_reset_token \
                  SET consumed_at = time::now() \

--- a/crates/axiam-db/src/repository/permission.rs
+++ b/crates/axiam-db/src/repository/permission.rs
@@ -8,11 +8,12 @@ use axiam_core::models::permission::{
 use axiam_core::repository::{PaginatedResult, Pagination, PermissionRepository};
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, classify_write_error, paginate, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -128,11 +129,12 @@ impl PermissionGrantRow {
 /// SurrealDB implementation of the Permission repository.
 #[derive(Clone)]
 pub struct SurrealPermissionRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealPermissionRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -145,6 +147,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('permission', $id) SET \
                  tenant_id = $tenant_id, \
@@ -182,6 +185,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('permission', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -231,8 +235,8 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -284,6 +288,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
         );
 
         self.db
+            .current()
             .query(query)
             .bind(("id", id_str))
             .bind(("tenant_id", tenant_id.to_string()))
@@ -304,6 +309,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM permission \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -315,6 +321,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM permission \
                  WHERE tenant_id = $tenant_id \
@@ -359,6 +366,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("tid", tenant_id.to_string()))
             .await
@@ -402,6 +410,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("tid", tenant_id.to_string()))
             .await
@@ -432,6 +441,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM permission \
                  WHERE tenant_id = $tenant_id \
@@ -479,6 +489,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
                  permission:`{perm_id_str}` SET scope_ids = NONE;"
             );
             self.db
+                .current()
                 .query(query)
                 .bind(("tid", tenant_id.to_string()))
                 .await
@@ -498,6 +509,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
                  permission:`{perm_id_str}` SET scope_ids = $scope_ids;"
             );
             self.db
+                .current()
                 .query(query)
                 .bind(("tid", tenant_id.to_string()))
                 .bind(("scope_ids", scope_strs))
@@ -533,6 +545,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT \
                      meta::id(out.id) AS record_id, \
@@ -580,6 +593,7 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
         // query.
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT \
                      meta::id(in) AS role_id, \

--- a/crates/axiam-db/src/repository/pgp_key.rs
+++ b/crates/axiam-db/src/repository/pgp_key.rs
@@ -7,11 +7,12 @@ use axiam_core::models::pgp_key::{
 };
 use axiam_core::repository::{PaginatedResult, Pagination, PgpKeyRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -147,11 +148,12 @@ impl PgpKeyRowWithId {
 
 #[derive(Clone)]
 pub struct SurrealPgpKeyRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealPgpKeyRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -161,6 +163,7 @@ impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
         let id = new_id();
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('pgp_key', $id) SET \
                  tenant_id = $tenant_id, \
@@ -201,6 +204,7 @@ impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
     async fn get_by_id(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<PgpKey> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM pgp_key \
                  WHERE meta::id(id) = $id AND tenant_id = $tenant_id",
@@ -222,6 +226,7 @@ impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
     async fn get_signing_key(&self, tenant_id: Uuid) -> AxiamResult<PgpKey> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM pgp_key \
                  WHERE tenant_id = $tenant_id \
@@ -246,6 +251,7 @@ impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
     async fn revoke(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('pgp_key', $id) SET \
                  status = $status \
@@ -283,6 +289,7 @@ impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
                          WHERE tenant_id = $tenant_id GROUP ALL";
         let count_result = self
             .db
+            .current()
             .query(count_sql)
             .bind(("tenant_id", tenant_id_str.clone()))
             .await
@@ -298,6 +305,7 @@ impl<C: Connection> PgpKeyRepository for SurrealPgpKeyRepository<C> {
                         LIMIT $limit START $offset";
         let data_result = self
             .db
+            .current()
             .query(data_sql)
             .bind(("tenant_id", tenant_id_str))
             .bind(("limit", pagination.limit))

--- a/crates/axiam-db/src/repository/rate_limit.rs
+++ b/crates/axiam-db/src/repository/rate_limit.rs
@@ -12,10 +12,11 @@
 //! global bucket.
 
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 
 /// Row shape returned by the windowed-CAS `UPSERT ... RETURN AFTER` query —
 /// only `count` is needed by the caller.
@@ -27,11 +28,12 @@ struct RateLimitBucketRow {
 /// SurrealDB-backed shared rate-limit bucket counter.
 #[derive(Clone)]
 pub struct SurrealRateLimitBucketRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealRateLimitBucketRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 
@@ -93,6 +95,7 @@ impl<C: Connection> SurrealRateLimitBucketRepository<C> {
     ) -> Result<u64, DbError> {
         let result = self
             .db
+            .current()
             .query(
                 "UPSERT type::record('rate_limit_bucket', $key) SET \
                  count = IF window_start = NONE OR window_start < $window_start \

--- a/crates/axiam-db/src/repository/resource.rs
+++ b/crates/axiam-db/src/repository/resource.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::resource::{CreateResource, Resource, UpdateResource};
 use axiam_core::repository::{PaginatedResult, Pagination, ResourceRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -85,11 +86,12 @@ const MAX_ANCESTOR_DEPTH: usize = 50;
 /// SurrealDB implementation of the Resource repository.
 #[derive(Clone)]
 pub struct SurrealResourceRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealResourceRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -120,6 +122,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str))
@@ -145,6 +148,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('resource', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -251,8 +255,8 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
             .map(|opt| opt.map(|u| u.to_string()))
             .unwrap_or(None);
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -332,6 +336,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(query)
             .bind(("id", id_str.clone()))
             .bind(("resource_id", id_str))
@@ -375,6 +380,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM resource \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -386,6 +392,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM resource \
                  WHERE tenant_id = $tenant_id \
@@ -414,6 +421,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM resource \
                  WHERE tenant_id = $tenant_id AND parent_id = $parent_id",
@@ -463,6 +471,7 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(query)
             .bind(("id", id_str))
             .bind(("tenant_id", tenant_id_str))

--- a/crates/axiam-db/src/repository/role.rs
+++ b/crates/axiam-db/src/repository/role.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::role::{CreateRole, Role, RoleAssignment, UpdateRole};
 use axiam_core::repository::{PaginatedResult, Pagination, RoleRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, classify_write_error, parse_uuid};
 
 #[derive(Debug, SurrealValue)]
@@ -89,11 +90,12 @@ impl RoleAssignmentRow {
 /// SurrealDB implementation of the Role repository.
 #[derive(Clone)]
 pub struct SurrealRoleRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealRoleRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 
@@ -102,6 +104,7 @@ impl<C: Connection> SurrealRoleRepository<C> {
         let tenant_str = tenant_id.to_string();
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM role \
                  WHERE tenant_id = $tenant_id AND name = $name LIMIT 1",
@@ -127,6 +130,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('role', $id) SET \
                  tenant_id = $tenant_id, \
@@ -170,6 +174,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('role', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -221,8 +226,8 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -295,6 +300,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
         );
 
         self.db
+            .current()
             .query(query)
             .bind(("id", id_str))
             .bind(("tenant_id", tenant_id_str))
@@ -315,6 +321,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM role \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -327,6 +334,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM role \
                  WHERE tenant_id = $tenant_id \
@@ -378,6 +386,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("tid", tenant_id.to_string()))
             .bind(("resource_id", resource_id_str))
@@ -442,6 +451,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("tid", tenant_id.to_string()))
             .bind(("resource_id", resource_id_str))
@@ -470,6 +480,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
         // Two queries: direct roles + roles inherited through group membership.
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM role \
                  WHERE tenant_id = $tenant_id \
@@ -519,6 +530,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
         // Each result row contains role fields + the resource_id from the edge.
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(out.id) AS record_id, \
                         out.tenant_id AS tenant_id, \
@@ -586,6 +598,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("tid", tenant_id.to_string()))
             .bind(("resource_id", resource_id_str))
@@ -650,6 +663,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("tid", tenant_id.to_string()))
             .bind(("resource_id", resource_id_str))
@@ -677,6 +691,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM role \
                  WHERE tenant_id = $tenant_id \
@@ -705,6 +720,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
         // naturally excludes group edges (group links never match a user id).
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT VALUE meta::id(id) FROM user \
                  WHERE tenant_id = $tenant_id \
@@ -727,6 +743,7 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
     async fn get_role_group_ids(&self, tenant_id: Uuid, role_id: Uuid) -> AxiamResult<Vec<Uuid>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT VALUE meta::id(id) FROM group \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/src/repository/saml_replay.rs
+++ b/crates/axiam-db/src/repository/saml_replay.rs
@@ -9,10 +9,11 @@ use axiam_core::error::{AxiamError, AxiamResult};
 use axiam_core::id::new_id;
 use axiam_core::repository::AssertionReplayRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::CountRow;
 
 // ---------------------------------------------------------------------------
@@ -21,7 +22,7 @@ use crate::helpers::CountRow;
 
 /// SurrealDB implementation of the SAML assertion replay repository.
 pub struct SurrealAssertionReplayRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 // Manual Clone impl (not derive): avoids the spurious `C: Clone` bound that
@@ -35,7 +36,8 @@ impl<C: Connection> Clone for SurrealAssertionReplayRepository<C> {
 }
 
 impl<C: Connection> SurrealAssertionReplayRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -52,6 +54,7 @@ impl<C: Connection> AssertionReplayRepository for SurrealAssertionReplayReposito
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('saml_assertion_replay', $row_id) SET \
                  tenant_id = $tenant_id, \
@@ -89,6 +92,7 @@ impl<C: Connection> AssertionReplayRepository for SurrealAssertionReplayReposito
         // Count expired rows first, then delete.
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM saml_assertion_replay \
                  WHERE expires_at < time::now() GROUP ALL",
@@ -100,6 +104,7 @@ impl<C: Connection> AssertionReplayRepository for SurrealAssertionReplayReposito
         let total = count_rows.first().map(|r| r.total).unwrap_or(0);
 
         self.db
+            .current()
             .query("DELETE saml_assertion_replay WHERE expires_at < time::now()")
             .await
             .map_err(DbError::from)?;

--- a/crates/axiam-db/src/repository/scope.rs
+++ b/crates/axiam-db/src/repository/scope.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::scope::{CreateScope, Scope, UpdateScope};
 use axiam_core::repository::ScopeRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::take_first_or_not_found;
 
 #[derive(Debug, SurrealValue)]
@@ -56,11 +57,12 @@ impl ScopeRowWithId {
 /// SurrealDB implementation of the Scope repository.
 #[derive(Clone)]
 pub struct SurrealScopeRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealScopeRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -74,6 +76,7 @@ impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('scope', $id) SET \
                  tenant_id = $tenant_id, \
@@ -116,6 +119,7 @@ impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('scope', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -163,8 +167,8 @@ impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -202,6 +206,7 @@ impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
 
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "DELETE type::record('scope', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -224,6 +229,7 @@ impl<C: Connection> ScopeRepository for SurrealScopeRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM scope \
                  WHERE tenant_id = $tenant_id AND resource_id = $resource_id \

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -10,11 +10,12 @@ use axiam_core::repository::{PaginatedResult, Pagination, ServiceAccountReposito
 use chrono::{DateTime, Utc};
 use rand::RngExt;
 use sha2::{Digest, Sha256};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 /// Generate a random client ID with the `sa_` prefix (32 hex chars).
@@ -106,11 +107,12 @@ impl ServiceAccountRowWithId {
 /// SurrealDB implementation of the ServiceAccount repository.
 #[derive(Clone)]
 pub struct SurrealServiceAccountRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealServiceAccountRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -127,6 +129,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('service_account', $id) SET \
                  tenant_id = $tenant_id, \
@@ -175,6 +178,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('service_account', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -212,6 +216,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM service_account \
                  WHERE tenant_id = $tenant_id AND client_id = $client_id",
@@ -258,8 +263,8 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -317,6 +322,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
         );
 
         self.db
+            .current()
             .query(query)
             .bind(("id", id_str))
             .bind(("tenant_id", tenant_id.to_string()))
@@ -337,6 +343,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM service_account \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -348,6 +355,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM service_account \
                  WHERE tenant_id = $tenant_id \
@@ -378,6 +386,7 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('service_account', $id) SET \
                  client_secret_hash = $secret_hash, \

--- a/crates/axiam-db/src/repository/session.rs
+++ b/crates/axiam-db/src/repository/session.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::session::{CreateSession, Session};
 use axiam_core::repository::SessionRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -75,7 +76,7 @@ impl SessionRowWithId {
 
 /// SurrealDB implementation of the Session repository.
 pub struct SurrealSessionRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 // Manual Clone impl (not derive): `#[derive(Clone)]` would add a `C: Clone`
@@ -90,7 +91,8 @@ impl<C: Connection> Clone for SurrealSessionRepository<C> {
 }
 
 impl<C: Connection> SurrealSessionRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -102,6 +104,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('session', $id) SET \
                  tenant_id = $tenant_id, \
@@ -136,6 +139,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('session', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -156,6 +160,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM session \
                  WHERE tenant_id = $tenant_id AND token_hash = $token_hash",
@@ -174,6 +179,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
 
     async fn invalidate(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "DELETE type::record('session', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -193,6 +199,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
         // non-empty BEFORE image — the single-use gate for refresh rotation.
         let mut result = self
             .db
+            .current()
             .query(
                 "DELETE type::record('session', $id) \
                  WHERE tenant_id = $tenant_id RETURN BEFORE",
@@ -208,6 +215,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
 
     async fn invalidate_user_sessions(&self, tenant_id: Uuid, user_id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query("DELETE session WHERE tenant_id = $tenant_id AND user_id = $user_id")
             .bind(("tenant_id", tenant_id.to_string()))
             .bind(("user_id", user_id.to_string()))
@@ -228,6 +236,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
         // the deleted rows so we can count them.
         let mut result = self
             .db
+            .current()
             .query(
                 "DELETE session \
                  WHERE tenant_id = $tenant_id \
@@ -248,6 +257,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
     async fn list_by_user(&self, tenant_id: Uuid, user_id: Uuid) -> AxiamResult<Vec<Session>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM session \
                  WHERE tenant_id = $tenant_id AND user_id = $user_id",
@@ -267,6 +277,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
         // Count expired sessions first, then delete.
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM session \
                  WHERE tenant_id = $tenant_id AND expires_at < time::now() \
@@ -279,6 +290,7 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
         let total = count_rows.first().map(|r| r.total).unwrap_or(0);
 
         self.db
+            .current()
             .query("DELETE session WHERE tenant_id = $tenant_id AND expires_at < time::now()")
             .bind(("tenant_id", tenant_id.to_string()))
             .await

--- a/crates/axiam-db/src/repository/settings.rs
+++ b/crates/axiam-db/src/repository/settings.rs
@@ -1,6 +1,7 @@
 //! SurrealDB implementation of [`SettingsRepository`].
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use axiam_core::error::AxiamResult;
 use axiam_core::models::settings::{
     CertificatePolicy, EmailVerificationPolicy, LockoutPolicy, MfaPolicy, NotificationPolicy,
@@ -10,7 +11,7 @@ use axiam_core::models::settings::{
 };
 use axiam_core::repository::SettingsRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
@@ -193,11 +194,12 @@ WHERE scope = $scope AND scope_id = $scope_id";
 /// SurrealDB implementation of the settings repository.
 #[derive(Clone)]
 pub struct SurrealSettingsRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealSettingsRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 
@@ -299,6 +301,7 @@ impl<C: Connection> SurrealSettingsRepository<C> {
     async fn lookup_org_id(&self, tenant_id: Uuid) -> Result<Uuid, DbError> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT organization_id FROM tenant \
                  WHERE meta::id(id) = $tenant_id",
@@ -325,6 +328,7 @@ impl<C: Connection> SurrealSettingsRepository<C> {
     ) -> Result<Option<SecuritySettings>, DbError> {
         let mut result = self
             .db
+            .current()
             .query(SELECT_WITH_ID)
             .bind(("scope", scope.to_string()))
             .bind(("scope_id", scope_id.to_string()))
@@ -347,6 +351,7 @@ impl<C: Connection> SurrealSettingsRepository<C> {
     ) -> Result<Option<(SecuritySettings, Option<String>)>, DbError> {
         let mut result = self
             .db
+            .current()
             .query(SELECT_WITH_ID)
             .bind(("scope", scope.to_string()))
             .bind(("scope_id", scope_id.to_string()))
@@ -398,7 +403,8 @@ impl<C: Connection> SurrealSettingsRepository<C> {
         );
 
         let bindings = self.bind_settings(settings, overrides_json);
-        let mut builder = self.db.query(&query).bind(("id", id_str.clone()));
+        let db = self.db.current();
+        let mut builder = db.query(&query).bind(("id", id_str.clone()));
         for (name, value) in bindings {
             builder = match value {
                 BindValue::Str(v) => builder.bind((name, v)),
@@ -598,6 +604,7 @@ impl<C: Connection> SettingsRepository for SurrealSettingsRepository<C> {
 
     async fn delete_tenant_override(&self, tenant_id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "DELETE security_settings WHERE scope = 'tenant' \
                  AND scope_id = $scope_id",

--- a/crates/axiam-db/src/repository/tenant.rs
+++ b/crates/axiam-db/src/repository/tenant.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::tenant::{CreateTenant, Tenant, TenantStatus, UpdateTenant};
 use axiam_core::repository::{PaginatedResult, Pagination, TenantRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 fn parse_status(s: &str) -> Result<TenantStatus, DbError> {
@@ -93,11 +94,12 @@ impl TenantRowWithId {
 /// SurrealDB implementation of the Tenant repository.
 #[derive(Clone)]
 pub struct SurrealTenantRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealTenantRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -126,6 +128,7 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(query)
             .bind(("id", id_str.clone()))
             .bind(("org_id", org_id_str))
@@ -151,6 +154,7 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query("SELECT * FROM type::record('tenant', $id)")
             .bind(("id", id_str.clone()))
             .await
@@ -168,6 +172,7 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM tenant \
@@ -208,7 +213,8 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
         let query = format!("UPDATE type::record('tenant', $id) SET {}", sets.join(", "));
 
-        let mut builder = self.db.query(&query).bind(("id", id_str.clone()));
+        let db = self.db.current();
+        let mut builder = db.query(&query).bind(("id", id_str.clone()));
 
         if let Some(name) = input.name {
             builder = builder.bind(("name", name));
@@ -236,6 +242,7 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
     async fn delete(&self, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query("DELETE type::record('tenant', $id)")
             .bind(("id", id.to_string()))
             .await
@@ -253,6 +260,7 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM tenant \
                  WHERE organization_id = $org_id GROUP ALL",
@@ -264,6 +272,7 @@ impl<C: Connection> TenantRepository for SurrealTenantRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM tenant \

--- a/crates/axiam-db/src/repository/user.rs
+++ b/crates/axiam-db/src/repository/user.rs
@@ -10,11 +10,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::user::{CreateUser, UpdateUser, User, UserStatus};
 use axiam_core::repository::{PaginatedResult, Pagination, UserRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, classify_write_error, parse_uuid};
 
 /// DB-side row struct for queries where the UUID is already known.
@@ -216,7 +217,7 @@ impl UserRowWithId {
 
 /// SurrealDB implementation of the User repository.
 pub struct SurrealUserRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
     /// Optional server-side pepper for password hashing.
     pepper: Option<String>,
 }
@@ -231,11 +232,13 @@ impl<C: Connection> Clone for SurrealUserRepository<C> {
 }
 
 impl<C: Connection> SurrealUserRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db, pepper: None }
     }
 
-    pub fn with_pepper(db: Surreal<C>, pepper: String) -> Self {
+    pub fn with_pepper(db: impl Into<DbHandle<C>>, pepper: String) -> Self {
+        let db = db.into();
         Self {
             db,
             pepper: Some(pepper),
@@ -258,6 +261,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('user', $id) SET \
                  tenant_id = $tenant_id, \
@@ -300,6 +304,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('user', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -323,6 +328,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM user \
                  WHERE tenant_id = $tenant_id AND username = $username",
@@ -346,6 +352,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM user \
                  WHERE tenant_id = $tenant_id AND email = $email",
@@ -413,8 +420,8 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
             sets.join(", ")
         );
 
-        let mut builder = self
-            .db
+        let db = self.db.current();
+        let mut builder = db
             .query(&query)
             .bind(("id", id_str.clone()))
             .bind(("tenant_id", tenant_id_str));
@@ -479,6 +486,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let result = self
             .db
+            .current()
             .query(
                 "UPDATE type::record('user', $id) SET \
                  status = 'Inactive', updated_at = time::now() \
@@ -513,6 +521,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
         // caller observes a non-empty row set for a given step.
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id FROM \
                  (UPDATE type::record('user', $id) SET \
@@ -543,6 +552,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let mut count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM user \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -555,6 +565,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
 
         let mut result = self
             .db
+            .current()
             .query(
                 // SEC-043: explicit column projection — mfa_secret and
                 // totp_last_used_step are intentionally excluded so they are
@@ -604,6 +615,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
         let user_id_str = user_id.to_string();
         let tenant_id_str = tenant_id.to_string();
         self.db
+            .current()
             .query(
                 // SurrealDB evaluates each RHS in this SET against the
                 // pre-update document, so `failed_login_attempts` inside the IF
@@ -669,6 +681,7 @@ impl<C: Connection> UserRepository for SurrealUserRepository<C> {
         // tombstone value. Argon2 output is never empty, so login is permanently
         // blocked without needing to make the column nullable.
         self.db
+            .current()
             .query(
                 "UPDATE type::record('user', $id) SET \
                  email = $email_hash, \
@@ -745,6 +758,7 @@ impl<C: Connection> SurrealUserRepository<C> {
         // CREATE password_history=3, COMMIT=4.
         let result = self
             .db
+            .current()
             .query(
                 "BEGIN TRANSACTION; \
                  CREATE type::record('user', $id) SET \
@@ -813,6 +827,7 @@ impl<C: Connection> SurrealUserRepository<C> {
         scheduled_purge_at: DateTime<Utc>,
     ) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "UPDATE type::record('user', $id) SET \
                  deletion_pending = true, \
@@ -838,6 +853,7 @@ impl<C: Connection> SurrealUserRepository<C> {
     /// status back to `Active`.
     pub async fn clear_deletion_pending(&self, tenant_id: Uuid, user_id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "UPDATE type::record('user', $id) SET \
                  deletion_pending = false, \
@@ -861,6 +877,7 @@ impl<C: Connection> SurrealUserRepository<C> {
     pub async fn find_due_for_purge(&self, now: DateTime<Utc>) -> AxiamResult<Vec<User>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM user \
                  WHERE deletion_pending = true \

--- a/crates/axiam-db/src/repository/webauthn_credential.rs
+++ b/crates/axiam-db/src/repository/webauthn_credential.rs
@@ -7,11 +7,12 @@ use axiam_core::models::webauthn_credential::{
 };
 use axiam_core::repository::WebauthnCredentialRepository;
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, take_first_or_not_found};
 
 #[derive(Debug, SurrealValue)]
@@ -94,12 +95,13 @@ impl WebauthnCredentialRowWithId {
 /// SurrealDB implementation of the WebAuthn credential repository.
 #[derive(Clone)]
 pub struct SurrealWebauthnCredentialRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealWebauthnCredentialRepository<C> {
     /// Create a new repository backed by the given SurrealDB client.
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -111,6 +113,7 @@ impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRe
 
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('webauthn_credential', $id) SET \
                  tenant_id = $tenant_id, \
@@ -148,6 +151,7 @@ impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRe
 
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT * FROM type::record('webauthn_credential', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -170,6 +174,7 @@ impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRe
     ) -> AxiamResult<Vec<WebauthnCredential>> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * \
                  FROM webauthn_credential \
@@ -190,6 +195,7 @@ impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRe
 
     async fn update_last_used(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "UPDATE type::record('webauthn_credential', $id) SET \
                  last_used_at = time::now() \
@@ -205,6 +211,7 @@ impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRe
 
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         self.db
+            .current()
             .query(
                 "DELETE type::record('webauthn_credential', $id) \
                  WHERE tenant_id = $tenant_id",
@@ -220,6 +227,7 @@ impl<C: Connection> WebauthnCredentialRepository for SurrealWebauthnCredentialRe
     async fn count_by_user(&self, tenant_id: Uuid, user_id: Uuid) -> AxiamResult<u64> {
         let mut result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM webauthn_credential \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/src/repository/webhook.rs
+++ b/crates/axiam-db/src/repository/webhook.rs
@@ -5,11 +5,12 @@ use axiam_core::id::new_id;
 use axiam_core::models::webhook::{CreateWebhook, RetryPolicy, UpdateWebhook, Webhook};
 use axiam_core::repository::{PaginatedResult, Pagination, WebhookRepository};
 use chrono::{DateTime, Utc};
-use surrealdb::{Connection, Surreal};
+use surrealdb::Connection;
 use surrealdb_types::SurrealValue;
 use uuid::Uuid;
 
 use crate::error::DbError;
+use crate::handle::DbHandle;
 use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 
 // ---------------------------------------------------------------------------
@@ -98,11 +99,12 @@ impl WebhookRowWithId {
 
 #[derive(Clone)]
 pub struct SurrealWebhookRepository<C: Connection> {
-    db: Surreal<C>,
+    db: DbHandle<C>,
 }
 
 impl<C: Connection> SurrealWebhookRepository<C> {
-    pub fn new(db: Surreal<C>) -> Self {
+    pub fn new(db: impl Into<DbHandle<C>>) -> Self {
+        let db = db.into();
         Self { db }
     }
 }
@@ -113,6 +115,7 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
         let retry = input.retry_policy.unwrap_or_default();
         let result = self
             .db
+            .current()
             .query(
                 "CREATE type::record('webhook', $id) SET \
                  tenant_id = $tenant_id, \
@@ -148,6 +151,7 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
     async fn get_by_id(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<Webhook> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM webhook \
                  WHERE meta::id(id) = $id AND tenant_id = $tenant_id",
@@ -214,7 +218,8 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
             set_clauses.join(", ")
         );
 
-        let mut query = self.db.query(&sql);
+        let db = self.db.current();
+        let mut query = db.query(&sql);
         query = query
             .bind(("id", id.to_string()))
             .bind(("tenant_id", tenant_id.to_string()));
@@ -235,6 +240,7 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> AxiamResult<()> {
         let result = self
             .db
+            .current()
             .query(
                 "DELETE type::record('webhook', $id) \
                  WHERE tenant_id = $tenant_id RETURN BEFORE",
@@ -267,6 +273,7 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
 
         let count_result = self
             .db
+            .current()
             .query(
                 "SELECT count() AS total FROM webhook \
                  WHERE tenant_id = $tenant_id GROUP ALL",
@@ -281,6 +288,7 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
 
         let data_result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM webhook \
                  WHERE tenant_id = $tenant_id \
@@ -308,6 +316,7 @@ impl<C: Connection> WebhookRepository for SurrealWebhookRepository<C> {
     async fn get_by_event(&self, tenant_id: Uuid, event_type: &str) -> AxiamResult<Vec<Webhook>> {
         let result = self
             .db
+            .current()
             .query(
                 "SELECT meta::id(id) AS record_id, * FROM webhook \
                  WHERE tenant_id = $tenant_id \

--- a/crates/axiam-db/tests/connection_resilience_test.rs
+++ b/crates/axiam-db/tests/connection_resilience_test.rs
@@ -297,10 +297,11 @@ async fn pooled_handles_survive_token_expiry_without_restart() {
          kept each session alive without a process restart (CQ-B48 closed)",
     );
 
-    // Drive a repo-style bound handle past the TTL too: a handle checked out for
-    // a repository must run a query cleanly, proving the snapshot-401 is gone.
-    let bound = pool.handle_for_repo().await;
+    // Drive a repo-style bound handle past the TTL too: a handle bound for a
+    // repository must run a query cleanly, proving the snapshot-401 is gone.
+    let bound = pool.handle_for_repo();
     bound
+        .current()
         .query("RETURN 1")
         .await
         .and_then(|r| r.check())

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -291,7 +291,7 @@ async fn main() -> std::io::Result<()> {
     );
 
     // Run schema migrations
-    axiam_db::run_migrations(&pool.handle_for_repo().await)
+    axiam_db::run_migrations(&pool.handle_for_repo().current())
         .await
         .expect("Failed to run database migrations");
 
@@ -302,7 +302,7 @@ async fn main() -> std::io::Result<()> {
     // Errors are logged, never fatal — an unminted token just means the
     // env-var gate (AXIAM_BOOTSTRAP_ADMIN_EMAIL) remains the only way in,
     // which is a safe (fail-closed) degraded state, not a startup blocker.
-    match axiam_db::mint_bootstrap_setup_token_if_needed(&pool.handle_for_repo().await).await {
+    match axiam_db::mint_bootstrap_setup_token_if_needed(&pool.handle_for_repo().current()).await {
         Ok(Some(token)) => {
             // D-03b: the ONE deliberate secret-log exception — logged exactly
             // once, at first boot only. Only the sha256 hash is ever
@@ -327,9 +327,8 @@ async fn main() -> std::io::Result<()> {
     // to avoid serving plaintext-secret rows after this deploy.
     {
         let boot_fed_repo =
-            axiam_db::SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
-        let boot_audit_repo =
-            axiam_db::SurrealAuditLogRepository::new(pool.handle_for_repo().await);
+            axiam_db::SurrealFederationConfigRepository::new(pool.handle_for_repo());
+        let boot_audit_repo = axiam_db::SurrealAuditLogRepository::new(pool.handle_for_repo());
         if let Some(fed_key) = config.auth.federation_encryption_key {
             match axiam_federation::secrets::migrate_plaintext_federation_secrets(
                 &boot_fed_repo,
@@ -355,7 +354,7 @@ async fn main() -> std::io::Result<()> {
     {
         if let Some(email_key) = config.email_encryption_key {
             let boot_email_repo =
-                SurrealEmailConfigRepository::new(pool.handle_for_repo().await, email_key);
+                SurrealEmailConfigRepository::new(pool.handle_for_repo(), email_key);
             match boot_email_repo.backfill_plaintext_secrets().await {
                 Ok(n) => tracing::info!(migrated = n, "email config secrets backfill complete"),
                 Err(e) => tracing::warn!(error = %e, "email config secrets backfill failed"),
@@ -371,8 +370,8 @@ async fn main() -> std::io::Result<()> {
     // Seed permissions for all existing tenants (D-07).
     // Uses UPSERT — safe to run on every startup.
     {
-        let seed_org_repo = SurrealOrganizationRepository::new(pool.handle_for_repo().await);
-        let seed_tenant_repo = SurrealTenantRepository::new(pool.handle_for_repo().await);
+        let seed_org_repo = SurrealOrganizationRepository::new(pool.handle_for_repo());
+        let seed_tenant_repo = SurrealTenantRepository::new(pool.handle_for_repo());
         let all_orgs = seed_org_repo
             .list(Pagination {
                 offset: 0,
@@ -394,7 +393,7 @@ async fn main() -> std::io::Result<()> {
                 .expect("Failed to list tenants for permission seeding");
             for tenant in tenants.items {
                 axiam_db::seed_permissions(
-                    &pool.handle_for_repo().await,
+                    &pool.handle_for_repo().current(),
                     tenant.id,
                     axiam_api_rest::permissions::PERMISSION_REGISTRY,
                 )
@@ -404,7 +403,7 @@ async fn main() -> std::io::Result<()> {
                 // registry since this tenant was bootstrapped (bootstrap, which
                 // grants permissions to roles, self-disables after first admin).
                 let backfilled = axiam_db::reconcile_default_role_grants(
-                    &pool.handle_for_repo().await,
+                    &pool.handle_for_repo().current(),
                     tenant.id,
                 )
                 .await
@@ -444,13 +443,15 @@ async fn main() -> std::io::Result<()> {
         .expect("Failed to declare webhook AMQP topology");
     tracing::info!("RabbitMQ connected and queues declared");
 
-    // Raw SurrealDB handle — registered as app_data so handlers that need direct
-    // access (e.g. /api/v1/admin/bootstrap) can request `web::Data<Surreal<C>>`.
-    let db_handle = pool.handle_for_repo().await;
-    let org_repo = SurrealOrganizationRepository::new(pool.handle_for_repo().await);
-    let tenant_repo = SurrealTenantRepository::new(pool.handle_for_repo().await);
+    // LIVE pooled-connection reference — registered in `AppState` so handlers
+    // that need direct access (e.g. /api/v1/admin/bootstrap) resolve the
+    // CURRENT connection per query and therefore follow a reconnect-loop
+    // handle swap, exactly as the repositories do.
+    let db_handle = pool.handle_for_repo();
+    let org_repo = SurrealOrganizationRepository::new(pool.handle_for_repo());
+    let tenant_repo = SurrealTenantRepository::new(pool.handle_for_repo());
     let user_repo = SurrealUserRepository::with_pepper(
-        pool.handle_for_repo().await,
+        pool.handle_for_repo(),
         config
             .auth
             .pepper
@@ -458,25 +459,25 @@ async fn main() -> std::io::Result<()> {
             .map(|p| p.expose_secret().to_string())
             .unwrap_or_default(),
     );
-    let group_repo = SurrealGroupRepository::new(pool.handle_for_repo().await);
-    let role_repo = SurrealRoleRepository::new(pool.handle_for_repo().await);
-    let permission_repo = SurrealPermissionRepository::new(pool.handle_for_repo().await);
-    let resource_repo = SurrealResourceRepository::new(pool.handle_for_repo().await);
-    let scope_repo = SurrealScopeRepository::new(pool.handle_for_repo().await);
-    let service_account_repo = SurrealServiceAccountRepository::new(pool.handle_for_repo().await);
-    let session_repo = SurrealSessionRepository::new(pool.handle_for_repo().await);
+    let group_repo = SurrealGroupRepository::new(pool.handle_for_repo());
+    let role_repo = SurrealRoleRepository::new(pool.handle_for_repo());
+    let permission_repo = SurrealPermissionRepository::new(pool.handle_for_repo());
+    let resource_repo = SurrealResourceRepository::new(pool.handle_for_repo());
+    let scope_repo = SurrealScopeRepository::new(pool.handle_for_repo());
+    let service_account_repo = SurrealServiceAccountRepository::new(pool.handle_for_repo());
+    let session_repo = SurrealSessionRepository::new(pool.handle_for_repo());
     // REQ-7 / D-15: per-request session-validity check so revoked sessions'
     // access tokens are rejected immediately (the AuthenticatedUser extractor
     // consults this on every authenticated request).
     let session_validator: std::sync::Arc<dyn axiam_api_rest::SessionValidator> =
         std::sync::Arc::new(session_repo.clone());
-    let audit_repo = SurrealAuditLogRepository::new(pool.handle_for_repo().await);
-    let ca_cert_repo = SurrealCaCertificateRepository::new(pool.handle_for_repo().await);
+    let audit_repo = SurrealAuditLogRepository::new(pool.handle_for_repo());
+    let ca_cert_repo = SurrealCaCertificateRepository::new(pool.handle_for_repo());
     let federation_link_repo_for_auth =
-        SurrealFederationLinkRepository::new(pool.handle_for_repo().await);
+        SurrealFederationLinkRepository::new(pool.handle_for_repo());
     // A separate refresh-token repo instance for AuthService (used by
     // revoke_all_sessions / revoke_all_sessions_except on password change and reset).
-    let auth_refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
+    let auth_refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo());
     // Single shared bounding semaphore for all CPU-bound crypto operations (CQ-B02 / REQ-14 AC-2).
     // Limits concurrent Argon2 and PKI keygen/sign operations to prevent runtime-thread
     // starvation AND an unauthenticated memory-DoS (each Argon2id arena is ~19 MiB; B1).
@@ -499,13 +500,13 @@ async fn main() -> std::io::Result<()> {
         Arc::clone(&crypto_semaphore),
     );
     // Password history repository — used by the password-change handler.
-    let password_history_repo = SurrealPasswordHistoryRepository::new(pool.handle_for_repo().await);
-    let consent_repo = axiam_db::SurrealConsentRepository::new(pool.handle_for_repo().await);
-    let account_deletion_repo = SurrealAccountDeletionRepository::new(pool.handle_for_repo().await);
-    let export_job_repo = SurrealExportJobRepository::new(pool.handle_for_repo().await);
-    let erasure_proof_repo = SurrealErasureProofRepository::new(pool.handle_for_repo().await);
+    let password_history_repo = SurrealPasswordHistoryRepository::new(pool.handle_for_repo());
+    let consent_repo = axiam_db::SurrealConsentRepository::new(pool.handle_for_repo());
+    let account_deletion_repo = SurrealAccountDeletionRepository::new(pool.handle_for_repo());
+    let export_job_repo = SurrealExportJobRepository::new(pool.handle_for_repo());
+    let erasure_proof_repo = SurrealErasureProofRepository::new(pool.handle_for_repo());
 
-    let webauthn_cred_repo = SurrealWebauthnCredentialRepository::new(pool.handle_for_repo().await);
+    let webauthn_cred_repo = SurrealWebauthnCredentialRepository::new(pool.handle_for_repo());
     let webauthn_service = WebauthnService::new(webauthn_cred_repo.clone(), config.auth.clone())
         .expect("Failed to build WebauthnService");
     let mfa_method_service = MfaMethodService::new(user_repo.clone(), webauthn_cred_repo.clone());
@@ -516,13 +517,13 @@ async fn main() -> std::io::Result<()> {
     let pki_config = PkiConfig {
         encryption_key: load_key_from_env("AXIAM__PKI__ENCRYPTION_KEY"),
     };
-    let cert_repo = SurrealCertificateRepository::new(pool.handle_for_repo().await);
+    let cert_repo = SurrealCertificateRepository::new(pool.handle_for_repo());
     let ca_service = CaService::new(
         ca_cert_repo.clone(),
         pki_config.clone(),
         Arc::clone(&crypto_semaphore),
     );
-    let pgp_repo = SurrealPgpKeyRepository::new(pool.handle_for_repo().await);
+    let pgp_repo = SurrealPgpKeyRepository::new(pool.handle_for_repo());
     let pgp_service = PgpService::new(pgp_repo, pki_config.clone(), Arc::clone(&crypto_semaphore));
     let cert_service = CertService::new(
         ca_cert_repo,
@@ -534,9 +535,9 @@ async fn main() -> std::io::Result<()> {
     // SurrealCaCertificateRepository is cloned; each clone shares the underlying Surreal<C>.
     let device_auth_service = DeviceAuthService::new(
         cert_repo.clone(),
-        SurrealCaCertificateRepository::new(pool.handle_for_repo().await),
+        SurrealCaCertificateRepository::new(pool.handle_for_repo()),
     );
-    let webhook_repo = SurrealWebhookRepository::new(pool.handle_for_repo().await);
+    let webhook_repo = SurrealWebhookRepository::new(pool.handle_for_repo());
     // SEC-031/SEC-059: Webhook secrets stored AES-256-GCM encrypted using the
     // same PKI encryption key. Absent key -> None (SEC-012 fail-closed
     // pattern, mirrors `pki_config.encryption_key` above): the server still
@@ -546,13 +547,12 @@ async fn main() -> std::io::Result<()> {
     let webhook_enc_key: Option<[u8; 32]> = load_key_from_env("AXIAM__PKI__ENCRYPTION_KEY");
     let webhook_delivery =
         axiam_api_rest::webhook::WebhookDeliveryService::new(webhook_repo.clone(), webhook_enc_key);
-    let settings_repo = SurrealSettingsRepository::new(pool.handle_for_repo().await);
+    let settings_repo = SurrealSettingsRepository::new(pool.handle_for_repo());
     // Notification-rule repository — required by the notification_rules handlers'
     // `web::Data<SurrealNotificationRuleRepository>` extractor. Without this
     // registration every /api/v1/notification-rules request 500s with
     // "App data is not configured".
-    let notification_rule_repo =
-        SurrealNotificationRuleRepository::new(pool.handle_for_repo().await);
+    let notification_rule_repo = SurrealNotificationRuleRepository::new(pool.handle_for_repo());
     // Email-config repository (28-04, FUNC-03) — required by the
     // `handlers::email_config::*` handlers' `web::Data<SurrealEmailConfigRepository<C>>`
     // extractor. Only constructed when AXIAM__EMAIL_ENCRYPTION_KEY is present (same
@@ -564,7 +564,7 @@ async fn main() -> std::io::Result<()> {
     let email_config_repo: Option<SurrealEmailConfigRepository<axiam_db::DbClient>> =
         match config.email_encryption_key {
             Some(email_key) => Some(SurrealEmailConfigRepository::new(
-                pool.handle_for_repo().await,
+                pool.handle_for_repo(),
                 email_key,
             )),
             None => {
@@ -574,15 +574,14 @@ async fn main() -> std::io::Result<()> {
                 None
             }
         };
-    let federation_config_repo =
-        SurrealFederationConfigRepository::new(pool.handle_for_repo().await);
-    let federation_link_repo = SurrealFederationLinkRepository::new(pool.handle_for_repo().await);
-    let assertion_replay_repo = SurrealAssertionReplayRepository::new(pool.handle_for_repo().await);
+    let federation_config_repo = SurrealFederationConfigRepository::new(pool.handle_for_repo());
+    let federation_link_repo = SurrealFederationLinkRepository::new(pool.handle_for_repo());
+    let assertion_replay_repo = SurrealAssertionReplayRepository::new(pool.handle_for_repo());
     // NEW-4: durable AMQP nonce store for replay protection, shared by the
     // authz + audit consumers and swept by the periodic cleanup task.
-    let amqp_nonce_repo = SurrealAmqpNonceRepository::new(pool.handle_for_repo().await);
+    let amqp_nonce_repo = SurrealAmqpNonceRepository::new(pool.handle_for_repo());
     let federation_login_state_repo =
-        SurrealFederationLoginStateRepository::new(pool.handle_for_repo().await);
+        SurrealFederationLoginStateRepository::new(pool.handle_for_repo());
     // Process-wide JWKS cache shared by all OIDC federation handlers (D-01/D-02/D-03).
     let jwks_cache = Arc::new(JwksCache::new());
     // B3: process-wide in-process cache for AXIAM's OWN `GET /oauth2/jwks`
@@ -597,13 +596,12 @@ async fn main() -> std::io::Result<()> {
         .timeout(std::time::Duration::from_secs(10))
         .build()
         .expect("failed to build reqwest client");
-    let oauth2_client_repo = SurrealOAuth2ClientRepository::new(pool.handle_for_repo().await);
-    let auth_code_repo = SurrealAuthorizationCodeRepository::new(pool.handle_for_repo().await);
-    let refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
+    let oauth2_client_repo = SurrealOAuth2ClientRepository::new(pool.handle_for_repo());
+    let auth_code_repo = SurrealAuthorizationCodeRepository::new(pool.handle_for_repo());
+    let refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo());
     // Separate instance for password-reset/change handlers that need direct
     // RefreshTokenRepository access via web::Data (TokenService owns the main one).
-    let handler_refresh_token_repo =
-        SurrealRefreshTokenRepository::new(pool.handle_for_repo().await);
+    let handler_refresh_token_repo = SurrealRefreshTokenRepository::new(pool.handle_for_repo());
 
     // OAuth2 authorization code grant services.
     let authorize_service = AuthorizeService::new(
@@ -632,9 +630,9 @@ async fn main() -> std::io::Result<()> {
     // purely to build the two hoisted services below; no handler touches
     // them directly, so they are not their own AppState field.
     let password_reset_token_repo =
-        SurrealPasswordResetTokenRepository::new(pool.handle_for_repo().await);
+        SurrealPasswordResetTokenRepository::new(pool.handle_for_repo());
     let email_verification_token_repo =
-        SurrealEmailVerificationTokenRepository::new(pool.handle_for_repo().await);
+        SurrealEmailVerificationTokenRepository::new(pool.handle_for_repo());
 
     let password_reset_service = PasswordResetService::new(
         user_repo.clone(),


### PR DESCRIPTION
Closes the stale-DB-handle hazard recorded as **not fixed** in [`run-4-benchmark-instructions.md`](claude_dev/run-4-benchmark-instructions.md) §7 and reported as a follow-up in [`rate-limit-fix-verification.md`](claude_dev/rate-limit-fix-verification.md) §7. No tracking issue exists for it — the report lived only in those two docs, both of which are updated here.

§7 offered three options; this PR takes option 3: *"hold a live pool reference in the repositories instead of a boot-time clone."*

> Type parameters are omitted from the type names below — this comment's renderer eats them. Everything stays generic over the connection type exactly as before; see `crates/axiam-db/src/handle.rs` for the real signatures.

## The bug

Every repository was built once at boot from a one-time `pool.handle_for_repo().await` **clone** of the pooled SurrealDB connection. When the pool's reconnect loop evicted a poisoned connection — observed **~7 minutes into a sustained load run** during the rate-limit verification — the swap updated what the *pool* pointed at and left every repository pinned to the **evicted** connection. Those clones share the dead router task and the `reqwest` client carrying the now-rejected cached token, so from that moment every repository query returned **401, permanently**, until the process restarted. A plain `docker restart` cleared it instantly.

Two things kept it hidden:

- **Readiness reported healthy throughout.** `DbPool::health_check` probes *through* the pool slot, so it observed the fresh connection while the entire request path talked to the dead one. The probe and the request path were reading different connections — exactly the split the clone created.
- **The existing D-12 eviction test asserted the wrong subject.** It proved that *the slot* observes only the new handle after a swap. It never asserted that a handle **already handed out** does, which was the failing property.

The benchmark matrix tolerated this only because it restarts the process per cell, so one cell was the exposure window; a long single-cell soak had no protection at all.

## The fix

`handle_for_repo()` now returns a live `DbHandle` — the pool slot itself — instead of a connection cloned out of it:

```rust
// before: a snapshot of whatever occupied the slot at boot
pub async fn handle_for_repo(&self) -> Surreal {
    self.handles[idx].db.read().await.clone()
}

// after: a live reference that follows the slot
pub fn handle_for_repo(&self) -> DbHandle {
    DbHandle::from_slot(Arc::clone(&self.handles[idx].db))
}
```

Repositories resolve the current connection per operation via `self.db.current().query(..)`, so a reconnect-loop swap is observed on the very next query.

- **`ArcSwap`, not a lock.** The slot is an `Arc` of `ArcSwap` over the pooled connection. It is read on every DB call and written essentially never, so the hot path takes a lock-free atomic read: it cannot queue behind the reconnect loop, and it stays **synchronous** — resolving the handle adds no `.await` point to any query path.
- **One swap mechanism.** `DbManager` and `DbPool` now store that same slot type, so the manager, the pool, and every bound repository share it.
- **Same defect fixed at the other holders.** The REST `AppState.db` (bootstrap handler, tenant seeder) and the gRPC layer's handle held the identical boot-time clone for the identical reason, and hold a `DbHandle` now too.
- **No test churn.** Repository and gRPC constructors take `impl Into` of `DbHandle`, so every `kv-mem` test that passes a bare `Surreal` connection compiles unchanged.

Repository *bodies* are otherwise untouched: the change is `self.db.query(..)` → `self.db.current().query(..)` at the 245 query sites, plus 15 places where a query builder outlives its statement and the resolved handle goes into a named local.

## Regression test

`pool::tests::repository_bound_at_boot_follows_a_later_handle_swap` builds a repository from the pool **once** — as composition does at boot — swaps the pooled connection underneath it, and requires the already-built repository to serve its next query from the new connection.

Verified it catches the bug: reverting `handle_for_repo` to the old clone makes the post-swap write panic. That is precisely what the pre-existing slot-level eviction test could never have caught.

## Docs

- `db-pool-design.md` **§11 (new)** — why §6's construction-time clone was wrong (§5's reconnect loop and §6's clone were designed against each other and never reconciled), and what §8's test plan should have asserted.
- `run-4-benchmark-instructions.md` §7 — rewritten from "known hazard, not fixed" to fixed, keeping the old mitigations for anyone benchmarking a pre-fix image.
- `rate-limit-fix-verification.md` §7 — follow-up note closed out.
- `CHANGELOG.md` — entry under Unreleased → Fixed.

## Verification

Local runs used `SWAGGER_UI_DOWNLOAD_URL` pointed at a local placeholder zip (the usual sandbox GitHub-egress workaround; no tracked file or CI config touched).

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check -p axiam-federation -p axiam-api-rest -p axiam-server --no-default-features` — clean (SAML-off path)
- Tests, per crate (the sandbox disk quota cannot hold a whole-workspace test build): `axiam-core`, `axiam-auth`, `axiam-authz`, `axiam-pki`, `axiam-audit`, `axiam-oauth2`, `axiam-federation`, `axiam-amqp`, `axiam-db`, `axiam-api-grpc`, `axiam-api-rest`, `axiam-server` — all pass, zero failures

**CI: all 21 checks green** on `7034e84`, including the full-workspace `Test` job against a live SurrealDB and the E2E suite.

The live-SurrealDB `#[ignore]`d resilience tests were not run locally (no live stack in this sandbox); they are unchanged apart from `handle_for_repo` no longer being `async`.