### PR TITLE
docs(benchmarks): run-4 analysis — post-fix matrix verified, resource usage, prod-limit guidance

### DIFF
--- a/benchmarks/PRIVATE_BENCH_ANALYSIS.md
+++ b/benchmarks/PRIVATE_BENCH_ANALYSIS.md
@@ -1,520 +1,389 @@
 # PRIVATE — Benchmark Post-Mortem & Improvement Plan
 
 > Internal working document. Companion to `PUBLIC_BENCH_ANALYSIS.md`.
-> **Updated 2026-07-26** for **run 3** — the first *serious* run: full
-> median-of-3 capped matrix (AXIAM **1.0.0-alpha19** pulled ghcr image,
-> digest-recorded, vs Keycloak 26.7.0 vs Zitadel v4.15.2; p0-plaintext +
-> p2-tls13; 50 VUs; 2 CPU / 1024 MiB caps) **plus** the full labeled
-> sensitivity set: B2 h1-isolation cell, batch-strategy A/B
-> (`sens-batch-coalesced`), DB-pool A/B (`sens-pool-4`,
-> `sens-pool-4-inflight-64`), native mTLS (`sens-p3-mtls`), prod rate-limit
-> posture (`sens-rl-prod`), all-targets DB-uncapped (`sens-uncapped`),
-> decision-cache ON (`sens-cache-on`), and the F3 expiry soak (cargo test —
-> **PASS**, 10.53 s). Same Dell XPS 15 9570. Run-2 findings that are resolved
-> are compressed; everything still open is carried forward. The executable
+> **Updated 2026-08-02 for run 4** — the first run executed *after* the shared
+> rate-limit write-behind fix, on the post-fix image (build_ref `6875e4b`),
+> G-box (Dell XPS 15 9570, i7-8750H, 12 logical CPUs, ~31 GiB), Docker 29.6.2,
+> k6 v2.1.0. Full median-of-3 capped matrix (AXIAM vs Keycloak vs Zitadel;
+> p0-plaintext + p2-tls13; 50 VUs; 2 CPU per server container, **2048 MiB**
+> per server container — raised from 1024, see §2.3 — DBs at 2 CPU / 1024 MiB),
+> plus sensitivity passes (`sens-db-uncapped`, `sens-cache-on`, `sens-p3-mtls`,
+> `sens-rl-prod`, `sens-batch-concurrent`) and the **first full 11-language SDK
+> pass at three profiles (p0/p2/p3)**. Run-3 findings that are resolved are
+> compressed; everything still open is carried forward. The executable
 > follow-up plan derived from this document is
-> [`claude_dev/improvement-after-serious-benchmark.md`](../claude_dev/improvement-after-serious-benchmark.md).
+> [`claude_dev/improvement-after-run4-benchmark.md`](../claude_dev/improvement-after-run4-benchmark.md).
 
-## 0. Run-3 executive summary
+## 0. Run-4 executive summary
 
-Median-of-3, capped p0, vs run 2 (single-run):
+**The headline: the H2 write-behind rate-limit fix is verified at matrix
+scale.** Run 4 is the re-measurement that `rate-limit-fix-verification.md`
+promised, and it is unambiguous — every endpoint the synchronous
+`rate_limit_bucket` UPSERT used to clamp is now dramatically faster, the
+settle gate cleared in 15–16 s on every session (no timeouts, **zero refused
+cells** — first run ever), and 42/48 matrix cells are valid with every
+invalid cell explained (§2).
 
-| Area | Run 2 | Run 3 (median-of-3) | Verdict |
+Median-of-3, capped, p0, vs run 3 (also median-of-3):
+
+| Scenario | Run 3 | **Run 4** | Δ | Note |
+|---|---|---|---|---|
+| oauth2_client_credentials | 1823 | **2727** (±0.4%) | **+50%** | 7.7× KC, 6.4× Zitadel |
+| token_introspection | 2230 | **4387** (±0.6%) | **+97%** | 2.4× KC, 4.7× Zitadel |
+| authz_check_rest | 737 | **753** (±1.0%) | +2% | DB-pegged, as before |
+| authz_check_grpc | 603 | **887** (±0.3%) | **+47%** | gRPC now BEATS REST +17.8% — G8 inverted (§3.2) |
+| userinfo (REST) | 5008 | 4547 (±0.3%) | −9% | see §2.5 (mem-cap change, run variance) |
+| userinfo_grpc | 3294 | **12665** (±0.4%) | **+284%** | tower-layer write removed from EVERY gRPC call |
+| jwks_fetch | 27784 | 26371 (±1.2%) | −5% | generator-limited, unchanged story |
+| oauth2_password_login | 69 | **69** (±1.8%) | 0% | Argon2id-bound by design — the right result |
+| token_refresh (AXIAM) | fallback-op | **839 real** (±0.4%) | n/a | G4 fix holds at matrix scale, protocol-variant label |
+| authz_batch_rest | invalid | 199 ops/s | — | ⚠ ran `concurrent`, NOT the shipped default (§1) |
+
+Everything that improved is exactly the set of endpoints the H2 fix
+targeted; everything else is flat within noise. The fix costs nothing
+anywhere. **`rate-limit-fix-verification.md` can be closed as CONFIRMED at
+matrix scale.**
+
+Three new discoveries this run, in descending order of importance:
+
+1. **The gRPC production rate limiter over-throttles ×60 — a real product
+   bug found by `sens-rl-prod`** (§1.2). Root-caused to a units mismatch in
+   code, not just observed.
+2. **The bench compose still pins `AXIAM__AUTHZ__BATCH_STRATEGY=concurrent`**,
+   so every run-4 batch cell measured the non-default strategy; the shipped
+   `coalesced` default was never exercised this run (§1.1).
+3. **Decision cache post-fix asymmetry**: with the clamp gone, cache-ON now
+   lifts gRPC checks **13.1×** (887 → 11 598/s) but REST checks only +5%
+   (753 → 791) — the REST authz path has its own non-cache serialization,
+   almost certainly per-request session validation (§3.3).
+
+## 1. ⚠ Run-4 discoveries
+
+### 1.1 Batch cells measured `concurrent`, not the shipped `coalesced` default
+
+`benchmarks/targets/axiam/docker-compose.yml:90` still reads:
+
+```yaml
+AXIAM__AUTHZ__BATCH_STRATEGY: "${AXIAM__AUTHZ__BATCH_STRATEGY:-concurrent}"
+```
+
+That `:-concurrent` fallback predates the H3 decision that made `coalesced`
+the product default, and the runbook
+(`claude_dev/run-4-benchmark-instructions.md` §1) explicitly predicted batch
+"should be ~5× singles, not ~1.4×". It came out at ~1.3× (batch REST 199
+ops/s = 995 checks/s vs 753 singles) — because the harness silently
+overrode the product default back to `concurrent`. Confirmation: the
+`sens-batch-concurrent` pass is **numerically identical to the matrix**
+(198.7 vs 199 REST, 214 vs 175 gRPC — the intended A/B had no B).
+
+Consequences:
+
+- **No run-4 cell measures the shipped batch default.** The G3 settled
+  numbers (`coalesced`: 744 REST ops/s = 3 721 checks/s = 4.98× singles;
+  866–872 gRPC ops/s) remain the only valid coalesced measurements and stay
+  the published verdict for the default.
+- The run-4 matrix batch cells are still *valid measurements of
+  `concurrent`* (0% err, 3/3 runs, DB pegged at 2.0) — publish them only as
+  the labeled non-default strategy.
+- **Fixed in this branch**: the compose fallback is now `coalesced` so run 5
+  measures the real default (and the sensitivity pass becomes a true A/B).
+
+### 1.2 gRPC prod rate limiter admits 1/60th of its configured limit — units-mismatch bug (root-caused)
+
+`sens-rl-prod` (shipped `internet` posture, single-IP 50-VU generator) shows
+the REST limits enforcing **exactly** as configured — and the gRPC limit
+enforcing at 1/60th of configured:
+
+| Scenario | Configured limit | Admitted (bench_ok over the whole session) | Verdict |
 |---|---|---|---|
-| client_credentials | 1788 | **1823** (±0.1%) | ✅ stable; 5.2× KC, 4.3× Zitadel |
-| introspection | 2229 | **2230** (±0.3%) | ✅ stable; KC closed to 1.17× (1908) |
-| jwks | 27059 | **27784** | ✅ stable; generator-limited |
-| userinfo | 5457 | **5008** | ✅ valid 3-way, AXIAM leads 1.3×/5.3× |
-| login (B1) | 67.5, p95 907 | **69, p95 774** | ✅ best-in-field; KC p0 now *valid* (52/s, see §2.4) |
-| token_refresh AXIAM | fallback | **still fallback-op (100%)** | ❌ A8 did NOT take effect for AXIAM (§2.1) |
-| token_refresh KC | fallback | **REAL rotation: 379/s, 0 fallback** | ✅ A8 works for KC |
-| Zitadel gRPC (D11) | 100% errors | **valid, 0% err — 183/s** | ✅ fixed; magnitude prediction was wrong (§2.5) |
-| B2 TLS on CC | −49% | **−50.5%** (1823→903) | ❌ open; h1 conviction cell INVALID (§1) |
-| authz batch | 46/23, "serialized DB" | **matrix cells INVALID — order artifact** (§1) | ⚠ verdict changes completely |
-| authz single REST/gRPC | 745 / 722 | **737 / 603** | ✅ reproduced on pinned image (gRPC −16% vs REST, §3.6) |
-| D3 native mTLS | not run | **parity with p2 across the board, no nginx** | ✅ D3 acceptance PASSED (§3.4) |
-| D7 cache ON | not run | **check REST 2322 (+3.1×), gRPC 1822 (+3.0×)** | ✅ big, ship-decision pending (§3.2) |
-| F2/F3 pool | not run | **pool 4: CC +7%, rest neutral; soak PASS** | ✅ CQ-B48 closed; default stays 1 (§3.3) |
-| A9 provenance | digests unknown | **real digests everywhere, build_ref stamped** | ✅ closed |
-| C1 median-of-3 | not used | **used; spreads ±0.1–2.8%** | ✅ machinery works, noise is small |
+| authz_check_rest | 300/min/IP | 1200 ≈ 300/min | ✅ as configured |
+| oauth2_client_credentials | 20/min/IP | 75 | ✅ as configured (incl. ramp) |
+| token_introspection | 10/min/IP | 27 | ✅ |
+| oauth2_password_login | 10/min/IP | 39 | ✅ |
+| authz_check_grpc | **100/s** (`GRPC_AUTHZ_PER_SEC`) | **400 ≈ 100/min** | ❌ ×60 too strict |
+| authz_batch_grpc | 100/s | 300 ≈ 100/min | ❌ |
+| userinfo_grpc | 100/s (server-wide layer) | 400 ≈ 100/min | ❌ (and see below) |
 
-Note the runbook said alpha17; the run actually used the released
-**1.0.0-alpha19** image (digest `4590…`, build_ref `678f601`) — fine, and now
-provable thanks to A9.
+Root cause, found in code while writing this document
+(`crates/axiam-api-grpc/src/middleware/rate_limit.rs`): the server wires
+**two** cooperating layers —
 
-## 1. ⚠ THE run-3 discovery: a post-seed serialized-DB transient invalidates every "first cell after seed"
+1. `build_grpc_governor_layer(authz_per_sec)` — the in-memory governor,
+   correctly quota'd at `Quota::per_second(authz_per_sec)` (this one was
+   already fixed once, see the module's own comments);
+2. `GrpcSharedRateLimitLayer::new(db, "grpc_authz", grpc_config.grpc_authz_per_sec, …)`
+   — the cross-replica write-behind pre-check, which enforces its `limit`
+   over `WINDOW_SECS = 60` (the REST per-**minute** window) but is handed
+   the per-**second** number verbatim.
 
-**This is the most important finding of the run and rewrites two long-standing
-conclusions (D1/D10 batch slowness, and the B2 h1 cell).**
+So the shared pre-check clamps to `100 per 60 s` before the correctly
+configured governor ever sees the request. The observed ~100 admitted per
+60-s window across all three gRPC scenarios matches exactly. Fix is a
+one-liner conceptually (`limit × 60` at the call site, or a per-second
+window for this layer) plus a regression test asserting admitted ≈
+configured under sustained overload. **Task I1 — this blocks advertising
+any gRPC prod posture.** Note also the pre-existing design smell it
+re-confirms: the layer is server-wide, so `userinfo_grpc` (not an authz
+call) is throttled by the *authz* limit even at correct units (I2).
 
-> **UPDATE (H2, 2026-07-28): this was never post-seed, and "transient" is
-> wrong too.** `claude_dev/postseed-transient-investigation.md` traced the
-> effect to a permanent, product-relevant design property: six endpoints
-> (`POST /api/v1/authz/check`, `POST /oauth2/token`, `POST /oauth2/introspect`,
-> `POST /oauth2/revoke`, `POST /api/v1/auth/login`, and — as a bug —
-> `GET /api/v1/users`) are wrapped with `RateLimitShared`, which performs one
-> synchronous SurrealDB write (the shared rate-limit bucket) before the
-> handler runs. That single round trip — not seeding, not compaction, not
-> data volume — is the "~22 ms serialized unit": it survives idle time,
-> server restarts, datastore restarts, `POOL_SIZE` changes, and even swapping
-> the storage backend to pure in-memory. Structurally identical endpoints
-> without the wrap are unaffected. §1.1–§1.4 below are kept as the *run-3*
-> observation (accurate to what run 3 saw and how the harness was built in
-> response — the settle gate + rotation in §2 of methodology.md are still
-> exactly the right countermeasure), but read "post-seed window" throughout
-> as "the window this particular host's write-cost happened to clear in
-> during run 3", not a seeding effect. On the H2 investigation host the
-> effect never clears at all (16–21 ops/s at any concurrency, indefinitely) —
-> see that document §6 for the reconciliation with run 3's recovery cliff,
-> which remains only partially explained. The G-box's "recovers after ~6 min"
-> and this host's "never recovers" are two datastores paying a different
-> price for the same synchronous write, not two different bugs.
->
-> **UPDATE (2026-07-29, `claude/g-benchmark-improvements-n5mjmj`): both asks
-> from `postseed-transient-investigation.md` §7.1 are now FIXED, not just
-> root-caused.** `GET /api/v1/users`'s registration-bucket bug is fixed
-> (method-guarded resource split). The synchronous per-request UPSERT is
-> replaced by a write-behind design
-> (`axiam_db::rate_limit_counter::SharedRateLimitCounter`, commits `5212912`,
-> `0fbbd5e`, `1f3da2f`, `7167c18`): the request path decides synchronously
-> in-memory and a background flusher coalesces one datastore write per
-> bucket per `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` (default 1000 ms) instead of
-> one per request. What this buys and what it costs is written up in full in
-> `claude_dev/rate-limit-posture-decision.md` §8 (chosen design, alternatives
-> considered, and why) and quoted precisely in the
-> `axiam_db::rate_limit_counter` module docs: cross-replica enforcement
-> becomes eventual, bounded by `(replicas − 1) × arrival_rate_per_replica ×
-> sync_interval` and zero on a single replica, instead of the old design's
-> zero-overshoot-at-any-replica-count bound. **This has NOT yet been
-> re-measured on the H2 investigation host or any other host** — no throughput
-> number anywhere in this document has changed. The re-measurement is tracked
-> as its own artifact, `claude_dev/rate-limit-fix-verification.md`, produced
-> by a separate concurrent task; do not fold numbers from that file into this
-> one without also updating the run/commit provenance this document is keyed
-> on.
+### 1.3 Prod-posture refresh errors (minor)
 
-### 1.1 The signature
+`token_refresh` under prod limits: 111 045 ok / 2 833 failed (2.4%) at
+694/s vs 839 neutralized. Refresh itself is not in the limited set; the
+failures are consistent with the harness's periodic re-login hitting the
+10/min login bucket mid-run and the affected VUs erroring until re-seeded.
+Harness-side follow-up (I13): make the refresh scenario's re-login budget
+fit inside the login limit, or label the cell.
 
-A window of roughly **5–7 minutes after `bench-up` + `bench-seed`** in which
-the AXIAM stack serves requests with:
+## 2. Data-validity notes
 
-- SurrealDB pinned at almost exactly **~1.0–1.3 cores** (never its 2.0 cap),
-- the AXIAM server nearly idle (0.05–0.11 cores),
-- throughput clamped to **~45 req/s** with p50 ≈ `50 VUs × ~22 ms` ≈ 1.05–1.1 s
-  — the classic closed-loop queue on a ~22 ms *serialized* unit of DB work.
+### 2.1 Settle gate & refusals — clean across the board
 
-### 1.2 The evidence (all from this archive)
+Every session's gate cleared on the first probe (15–16 s wait, threshold
+400 ops/s); `settle_timeout` false everywhere; zero refused cells. The H1/H10
+machinery finally had nothing to do — consistent with the H2 fix being real.
 
-1. **Scenario-independence.** In `sens-batch-coalesced` the cells ran in the
-   order check_rest → batch_rest → check_grpc → batch_grpc. The first two
-   cells clamp at **45.4 / 45.2 req/s** — including plain
-   `authz_check_rest`, which the matrix measures at **737 req/s**. The last
-   two cells are healthy (676.6 and — see below — **852.7**).
-2. **Mid-cell recovery caught live.** In `run-1/axiam/p0`, cell 3
-   (`authz_check_grpc`, ~7.4 min after seed) shows SurrealDB at 1.51 cores in
-   the first quarter of the measure window and **2.01 in the last quarter** —
-   the transient *ended during the cell*.
-3. **The B2 h1 cell reproduces it on a different scenario.** The
-   nginx-h1 `oauth2_client_credentials` cell (run first after its own seed)
-   clamps at **44.7 req/s, p50 1105 ms** with nginx at 0.01 cores, server at
-   0.05, SurrealDB at 1.03 — identical signature, nothing to do with TLS.
-4. **The matrix ran scenarios alphabetically**, so `authz_batch_grpc` and
-   `authz_batch_rest` were *always* cells 1–2 after seed — in run 1, run 2
-   (single-run) and all three run-3 repeats. Their suspicious stability
-   (22/41 req/s, ±0.5–0.9%) is the stability of the artifact, not of the
-   batch path.
+### 2.2 Invalid cells — 6/48, all explained, none AXIAM's
 
-### 1.3 What it invalidates
+- KC login p0 **and** p2: only 1/3 valid runs each (single valid runs: 44/s
+  p0, 53/s p2). Still memory-instability at the raised 2048 MiB cap — the H7
+  diagnosis stands: KC needs ~3.5–4 GiB for sustained hashing load (§2.3).
+- Zitadel login p0+p2 (0/3): bcrypt at default cost, p50 ≈ 22 s — known,
+  expected, kept-with-label.
+- Zitadel refresh p0+p2 (0/3): no `offline_access` flow in the harness —
+  known `fallback-op`, excluded from head-to-heads.
 
-- **All matrix batch cells, in every run so far.** The two-run-old
-  "batch is serialized in the DB" narrative (D1 → D10) was measuring the
-  transient. The only *clean* batch cell ever collected is
-  `sens-batch-coalesced`'s cell 4: **authz_batch_grpc (coalesced) =
-  852.7 batches/s = ~4 264 checks/s, p50 49 ms, p95 75 ms** — batch is
-  **6.3× more efficient per check than single checks** once the DB is
-  healthy. There is **no clean cell at all** for: batch REST (either
-  strategy), batch gRPC with the `concurrent` default. D10's A/B is
-  therefore still unfinished — but the prior is now inverted: nothing is
-  wrong with batch; `coalesced` looks excellent.
-- **The B2 h1-isolation cell.** It ran first-after-seed and measured the
-  transient, not HTTP/1.1-over-TLS. ~~**B2 remains open**~~; the native p2 CC
-  halving (1823→903, −50.5%) is confirmed real by the clean matrix cells.
-  **UPDATE (H6, 2026-07-29): B2 is closed as framed — the −50.5% is real but
-  is not a transport cost.** HTTP/2 is acquitted by direct measurement (the
-  "all clients collapse onto one h2 connection" premise never held: 10/50/100
-  concurrent clients open 10/50/100 connections over h2, and both actix
-  workers stay balanced), and h1-vs-h2 over an otherwise identical TLS edge is
-  a wash. TLS 1.3 itself is priced at −13%/−2% on jwks and −8%/−13% on
-  userinfo depending on load. That leaves the CC penalty endpoint-specific,
-  not transport-specific. Full evidence and the one remaining follow-up in
-  `claude_dev/b2-tls-h2-investigation.md`. Note also that the G8 h1 cell's
-  1 059 failed ops had a mundane cause found in H6: **none** of the nginx edge
-  confs declared an `upstream ... keepalive`, so the edge opened and closed a
-  fresh backend TCP connection per proxied request.
-- Probably the low `authz_check_grpc` in `sens-pool-4*` (537 vs 603 —
-  it was cell 3, the recovery window).
+AXIAM: **24/24 valid cells** including, for the first time, refresh
+(protocol-variant-labeled) and both batch cells (labeled `concurrent`, §1.1).
 
-### 1.4 What it might be (to investigate, not assume)
+### 2.3 The 1024→2048 MiB server-cap raise — why, and what it did
 
-Prime suspects, in order: SurrealDB/SurrealKV **post-ingest background work**
-(compaction/index build after the seed's writes) holding a lock that
-serializes foreground queries; the audit/AMQP ingestion backlog from seeding
-draining through serialized DB writes (RabbitMQ shows 0.8–1.0-core spikes in
-some affected cells); something in the server's DB session warm-up. Two facts
-to hold onto: the unit cost is ~22 ms and constant; and recovery is
-spontaneous after ~5–7 min. **If this is SurrealDB compaction, production
-cold-starts and bulk-import windows will exhibit the same behavior — this is
-potentially a product issue, not just a bench artifact.** Top-priority task
-(G1) in the follow-up plan, together with harness countermeasures (settle
-gate + cell-order rotation, G2).
+Run-3's KC login instability was diagnosed (H7) as OOM-driven. For run 4 the
+per-server-container memory cap was raised 1024 → 2048 MiB **for all three
+targets equally** (DBs stay at 1024). Measured effect:
 
-## 2. Harness bugs & data-validity issues
+- Keycloak's container peaked at **1070 MiB** during the run — i.e. above
+  the old 1024 cap; the raise was necessary for KC to survive at all.
+  KC p2 login went from 0/3 to 1/3 valid; p0 stayed 1/3. **2048 is still
+  not enough for sustained-login KC** — run 5 should use 4096 for login
+  cells only (per H7's measured 3.28 GiB peak), labeled.
+- AXIAM's server peaked at **172 MiB** (8.4% of its cap) across the entire
+  run — the jemalloc fix (H4) is confirmed at matrix scale; the old ~490 MiB
+  post-login retention is gone (login cell avg 131 MiB, later cells ~100–110).
+- Zitadel peaked at 216 MiB.
 
-### 2.1 ❌ A8 regression/failure — AXIAM `token_refresh` is STILL fallback-op
+Comparability note: run-4 vs run-3 mem columns are not cap-identical;
+throughput comparisons are unaffected (no target was memory-starved in
+valid run-3 cells except KC login, which was invalid there anyway).
 
-`bench_fallback` fired on **100% of iterations** in every AXIAM refresh cell
-(e.g. run-1 p0: 9 774/9 774; 2 HTTP reqs per iteration — the CC-fallback
-signature), while **Keycloak's cells show zero fallback and real rotation**
-(379/367 req/s p0/p2, one request per iteration). So the A8 code path works
-(KC proves it) but the AXIAM login-first mint is falling back — the
-`axiam_refresh` cookie extraction presumably fails against alpha19 (or login
-succeeded but the refresh grant rejected the cookie-sourced token). The AXIAM
-refresh columns (62/61 req/s) measure the fallback op and are correctly
-excluded from head-to-heads. **Follow-up task G4**; also note the AXIAM
-refresh cells burn the highest server memory of the session (566–606 MiB —
-double-issuance + retention, see §3.5).
+### 2.4 Provenance gap: `build_ref 6875e4b` is not on `main`
 
-### 2.2 ⚠ Sensitivity-pass knobs are not recorded in meta.json
+Every AXIAM cell records `build_ref 6875e4be733e…`, which is **not an
+ancestor of current `origin/main`** (checked 2026-08-02). The run
+presumably used an image built from the merged fix branch before a
+rebase/squash. Nothing suggests the binary differs materially from main's
+content, but A9 provenance discipline says: run 5 must use an image whose
+build_ref is a real main commit (I14).
 
-`sens-pool-4`'s meta.json is indistinguishable from the baseline's — the
-`AXIAM__DB__POOL_SIZE=4` / `BATCH_STRATEGY` / `DECISION_CACHE` exports that
-defined the pass are nowhere in the metadata (only the results-dir name says
-what it was). A5/A9 follow-up (G2): dump the `AXIAM__*` env the compose
-actually received into each cell's meta.json so labeled passes are
-self-describing.
+### 2.5 userinfo REST −9% vs run 3
 
-### 2.3 Invalid cells, all explained
+4547 vs 5008 (both tight medians). Not investigated; plausibly the
+different mem-cap envelope, image differences, thermal variance (this run
+recorded temp_max 96–100 °C on hot cells), or SurrealDB version drift.
+Since the cell is DB-pegged in both runs, park unless run 5 confirms a
+trend (I15). Its gRPC sibling tripled, so nothing product-alarming.
 
-7/48 matrix cells invalid, every one for a known reason: 2× AXIAM batch_grpc
-(p95 > 2 s — and now known-corrupted anyway, §1), 2× Zitadel login + 2×
-Zitadel refresh (bcrypt cost / no offline_access flow — expected,
-kept-with-labels), 1× KC p2 login (§2.4).
+### 2.6 SDK pass — 33/33 records, but the overhead column is empty
 
-### 2.4 ⚠ Keycloak login anomaly: p0 now valid and 2.3× faster than run 2, p2 unchanged-slow
+All 11 SDKs (rust, python, typescript, go, java, csharp, php, c, cpp,
+kotlin, swift) produced ok records at all three profiles — first time ever,
+including first-ever c/cpp/kotlin/swift data. But:
 
-KC p0 login: **52 req/s, p50 919 ms, p95 1070** (2/3 valid runs, ±7.8% — the
-widest spread in the matrix) vs run-2's 22.3/s, p50 2139. But KC **p2** login
-stayed at 23 req/s, p95 2249 (0/3 valid). Same image digest for both
-profiles. No explanation yet — possibly KC hashing-iteration warm-up
-interacting with run order, possibly a real TLS interaction. Don't publish a
-KC-login-got-faster claim; publish p0 as measured (valid) and p2 as
-gate-invalid, and note the asymmetry. Worth one diagnostic run if time
-permits; not AXIAM work.
+- **No wire-baseline was captured** (`wire p95 = —` everywhere), so the E1.3
+  headline metric — p95 overhead vs matched-concurrency wire — could not be
+  computed. The SDK table is real but only intra-SDK comparable (I8).
+- **csharp `refresh` is a no-op measurement**: p50 1.2 µs, "752 361 rps" —
+  the .NET auth helper returns the still-valid cached token without a
+  network call; the bench never forces expiry. Data quirk, not an SDK
+  defect per se — but the harness must force a real refresh (I9).
+- **c and php run at concurrency 1** (single-threaded harnesses; all others
+  16) — their lower latencies AND lower throughputs are load-shape, not SDK
+  quality. Label or fix (I10).
+- **cpp has a bimodal tail**: check p50 3.3 ms / p95 283–336 ms at every
+  profile. Signature of a connection being re-established on a subset of
+  iterations (curl handle churn / no keep-alive on some path). Worth an SDK
+  fix (I11).
+- **python check_access p50 ~30 ms** vs 10–11 ms for go/java/rust/etc. at
+  the same concurrency — asyncio/GIL overhead, worth a look (I12).
+- Client RSS/CPU columns recorded 0.0 — sampler not wired (I8).
 
-#### 2.4.1 H7 diagnostic run (2026-07-29, `claude/g-benchmark-improvements-n5mjmj`) — fairness hygiene only, no KC fixes
+Otherwise the cross-language picture is remarkably consistent: login p50
+228–256 ms across all concurrency-16 SDKs (server Argon2 dominates),
+refresh p50 17.3±0.2 ms across ten SDKs — the server, not the SDKs, sets
+the floor. TLS and mTLS profiles cost the SDKs nothing measurable (matches
+the server-side p2/p3 parity).
 
-One `oauth2_password_login.js` pass each way, per the written procedure in
-`claude_dev/grpc-vs-rest-authz-analysis.md` §2 (single repro run each way,
-per that section's own acceptance bar). `BENCH_MEM` raised from the target's
-compose default (1024m) to **4096m** for this diagnostic only (env override,
-no compose file change) — see why below; `docker stats` sampled every 3 s
-throughout each measured window.
+## 3. What the sensitivity passes taught (run-4 edition)
 
-| profile | result | throughput | p50 | p95 | error | KC CPU (2-core cap) | KC mem peak |
-|---|---|---:|---:|---:|---:|---|---|
-| p0-plaintext | ✅ 100% valid | **27.93 req/s** | 1.63 s | 2.28 s | 0.00% | ~195–200% (saturated) | 3.28 GiB / 4 GiB (82%) |
-| p2-tls13 | ✅ 100% valid | **13.55 req/s** (−51%) | 3.45 s | 4.00 s | 0.00% | ~197–202% (saturated) | 1.48 GiB / 4 GiB (37%) |
+### 3.1 DB-uncapped: the DB is now *the* bottleneck almost everywhere
 
-Both cells are clean 0%-error, 100%-`checks` passes — **not gate-invalid** —
-answering procedure item 3 directly: on this box, with adequate memory
-headroom, p2 is not failing the validity gate at all; it is legitimately
-slower. That reframes the original matrix's "p0 52/s valid vs p2 23/s,
-0/3 valid": **at the target's own compose default of `BENCH_MEM=1024m`, this
-diagnostic reproduced an outright `OOMKilled: true` on `bench-keycloak` twice**
-(once at 1024m, once again at 2560m) before a 4096m cap let the container
-survive a full 50-VU sustained-login window — Keycloak 26 on Quarkus simply
-needs more headroom than the shared 1 GiB per-container default under
-sustained Argon2/PBKDF2-class hashing load. The original run's "0/3 valid"
-for p2 is therefore plausibly **OOM-driven instability**, not a TLS-specific
-gate failure — a harness sizing gap, not a Keycloak or TLS defect. (Not
-re-verified against the original run's exact `BENCH_MEM`; flagged as the
-most likely explanation, not confirmed root cause — the original run's
-containers are gone.)
+With the rate-limit write gone, uncapping the DB (2→4 cores) buys much more
+than it did in run 3:
 
-Procedure item 2 (isolate TLS overhead from KC's own request handling): KC's
-CPU is pegged at the **same** ~195–202% (i.e., the full 2-core cap) in
-**both** profiles, not "idle at p0, pegged at p2" — Argon2/PBKDF2 password
-hashing already saturates the CPU budget at p0 by itself. p2's TLS
-handshake/cipher cost is therefore not new, unused headroom being consumed;
-it is **additional CPU work landing on an already-fully-booked budget**,
-directly cannibalizing hashing throughput — consistent with the −51%
-measured, and a cleaner mechanism than "TLS is expensive in the abstract."
-Procedure item 1 (run-order/warm-up): only one order was run (p0 then p2,
-per the "one diagnostic run each way is sufficient" bar) — not re-tested in
-the opposite order; if the 30% budget affords it, a p2→p0 repeat would
-further separate order effects from the CPU-contention mechanism above, but
-was not required to close this item.
+| cell (p0) | capped → uncapped | Δ | limiter after |
+|---|---|---|---|
+| authz_check_rest | 753 → **1434** | **+90%** | still DB-side latency |
+| authz_check_grpc | 887 → **1678** | **+89%** | 〃 |
+| oauth2_client_credentials | 2727 → **4484** | **+64%** | 〃 |
+| token_introspection | 4387 → **6249** | **+42%** | 〃 |
+| userinfo | 4547 → **7215** | **+59%** | server approaching cap |
+| token_refresh | 839 → **1089** | +30% | 〃 |
+| authz_batch_rest/grpc (`concurrent`) | 199/175 → 379/400 | +91–129% | DB |
+| jwks / login / userinfo_grpc | ±1% | — | generator / Argon2 / server |
 
-**Verdict:** fairness hygiene closed. No AXIAM or Keycloak code was touched.
-Recommendation for any future publication of this pair: size the Keycloak
-container's memory to at least ~3.5–4 GiB before trusting *any* sustained-load
-login cell from it (current target compose default of `BENCH_MEM=1024m` is
-too small and risks silently reporting an OOM-churn number as a TLS
-penalty).
+Run-3's headline ratios were ~+37/+18% on checks; post-fix they are ~+90%.
+The product message: **AXIAM's ceiling now scales with DB CPU on every
+DB-bound path** — good for the "spend hardware on the DB first" guidance,
+and it sharpens the case for SurrealDB tuning / read-scaling work (I5).
 
-### 2.5 ✅ D11 Zitadel gRPC — fixed, but the run-2 magnitude prediction was wrong
+### 3.2 gRPC vs REST inverted (G8 closed in the right direction)
 
-Valid 0%-error cells at last: **183/187 req/s (p0/p2), p50 233 ms**,
-`cc-token-setup` labeled. Run 2 predicted ~1.7–2 k/s from the error-path
-resource profile — real `GetMyUser` calls are ~9× more expensive than the
-auth-rejection path was. Lesson recorded: never extrapolate a valid-cell
-magnitude from an error path. The protocol-efficiency pairing is now
-publishable: Zitadel gRPC is **−80% vs its own REST userinfo** (both
-cc-token-setup), while AXIAM's gRPC userinfo is −34% throughput but **−29%
-cpu·ms/req** vs REST (closed-loop artifact: gRPC p50 14 ms vs REST 4.8 ms,
-but gRPC is cheaper per request and its p95 is 2.3× better).
+Run 3: gRPC checks −18% vs REST (603 vs 737). Run 4: **+17.8%** (887 vs
+753) with p50 38 vs 74 ms. The old deficit was mostly the tower-wide
+rate-limit write (paid by every gRPC call, amortized differently on REST).
+userinfo gRPC vs REST: **+179%** (12 665 vs 4 547) at less CPU — gRPC is
+now unambiguously the low-latency recommendation for service-mesh authz.
+G8 closed.
 
-### 2.6 ✅ Closed this run
+### 3.3 Decision cache post-fix: gRPC 13.1×, REST +5% — new asymmetry
 
-- **A9 provenance:** every container in every cell has a real digest; AXIAM
-  cells carry `build_ref`; the pulled ghcr alpha19 image is what ran
-  (first run on a non-locally-built, digest-pinned binary).
-- **C1 median-of-3:** worked as designed; per-cell throughput spreads
-  ±0.1–2.8% (login/KC cells widest). Single-run deltas ≥ ~5% are now
-  resolvable signal on this laptop.
-- **A7/bench-pack:** shared archive verified secret-free again.
-- **F3 expiry soak:** `pooled_handles_survive_token_expiry_without_restart`
-  **ok** in 10.53 s against a live DB — CQ-B48 stays closed under the pool.
+`sens-cache-on` (K=1-ish bench keyspace, TTL 5 s, `concurrent` batch):
 
-## 3. Sensitivity passes — what each one taught
+- authz_check_grpc 887 → **11 598/s** (13.1×), DB freed.
+- authz_batch_grpc 175 → 8 956 ops/s; batch_rest 199 → 5 240 ops/s
+  (~26 000 checks/s) — cache mostly bypasses the batch-strategy question.
+- **authz_check_rest 753 → 791 (+5%)** despite p50 halving (73.6 → 31.5).
+- token_introspection read −21% in this pass (3 438 vs 4 387) — cache does
+  not touch introspection; treat as run-order/DB variance but re-check (I15).
 
-### 3.1 DB-uncapped (now all three targets — C2 complete)
+The REST asymmetry hypothesis: the REST authz path authenticates via
+**session cookie + CSRF**, which costs a per-request session lookup in
+SurrealDB that the decision cache does not (and should not) cover; the gRPC
+path authenticates via JWT (no DB). With the decision read cached, REST's
+remaining ~1.25 ms/req of serialized DB work is the session read. If
+confirmed, a session-validation cache (or JWT-auth parity for the REST
+check endpoint) is worth ~10× on REST checks for cache users (I4).
+**H5's stays-opt-in decision is unchanged** — the K=1 bench keyspace is
+still a ceiling, not an expectation — but the post-fix ceiling is now 13×,
+so the "measure your own hit rate" guidance got more valuable, and the
+K-sweep should be re-run post-fix before v1.0 (I4).
 
-| cell | capped → uncapped | limiter after uncapping |
-|---|---|---|
-| AXIAM authz_check_rest | 737 → **1013** (+37%) | nothing pegged; round-trip latency (DB 2.83/4) |
-| AXIAM authz_check_grpc | 603 → **712** (+18%) | same |
-| AXIAM userinfo | 5008 → **7457** (+49%) | **AXIAM server pegged (2.05/2)** — its ceiling found |
-| AXIAM CC / introspection / jwks | ±1% | latency-structured / generator |
-| Keycloak (all cells) | ±2% (e.g. CC 351→329) | **KC server pegged in every cell; DB CPU irrelevant to it** |
-| Zitadel jwks | 2071 → **3510** (+70%) | PG at 3.83/4 |
-| Zitadel userinfo | 943 → **1749** (+85%) | PG at 4.01/4 |
-| Zitadel introspection | 910 → **1032** (+13%) | Zitadel server ~pegged |
+### 3.4 Native mTLS (p3): parity again, now post-fix
 
-Keycloak's flat uncapped pass completes the picture: KC is purely
-server-bound, Zitadel purely Postgres-bound, AXIAM DB-bound on authz/userinfo
-and latency-bound on tokens. The public "req/s per *server* core" framing is
-fair to all three.
+CC 1177 (p2: 1180), check_rest 755 (760), check_grpc 894 (892),
+introspection 4313 (4316), userinfo 4421 (4439), userinfo_grpc 12 266
+(12 148), jwks 23 333 (23 716), login 67.3 (67), refresh 828 (834).
+Client-cert verification remains free on top of TLS 1.3 — the IoT headline
+survives the fix. (This pass also validated the two p3 harness fixes on
+main: gRPC-over-TLS dialing and CWD-independent cert paths.)
 
-### 3.2 Decision cache ON (D7) — the single biggest lever measured
+### 3.5 TLS on client_credentials — the plateau narrows the B2 question
 
-`AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true`, TTL 5 s, single-tenant bench
-key space:
+Post-fix: p0 2727 → p2 1180 (**−57%**), while introspection loses 1.6%,
+refresh 0.6%, checks ±1%, jwks −10%, userinfo −2.4%. New and diagnostic:
+the p2 CC cell shows **bottleneck: none** with an eerily flat latency
+distribution — p50 42.6 / p95 43.9 / p99 44.8 ms — i.e. every request pays
+a near-constant ~43 ms, nothing saturates, and throughput is exactly
+50 VUs / 43 ms. That is a *serialization/latency plateau*, not a CPU cost —
+and the rate-limit write can no longer be the suspect (it's gone, and p0 CC
+runs 2 727/s through the same middleware). Something on the CC-under-TLS
+path serializes at ~40 ms. Suspects, in order: per-request client-secret
+Argon2/bcrypt verification interacting with TLS-session-bound connection
+behavior (are p2 connections being torn down and re-handshaked per token?
+`http 2.0` is recorded, but k6's connection reuse per VU under h2 with
+short responses deserves a direct look); a lock around the TLS session
+cache; the token-persist write path batching differently under h2 framing.
+The B2/H6 VU-sweep is finally runnable on this host since nothing else
+clamps: sweep VUs 1→100 at p0 and p2 (I3). A constant-per-request cost will
+scale throughput linearly with VUs; a serialization point will pin it.
 
-- authz_check_rest **737 → 2322 (+215%)**, p50 68→19.6 ms; SurrealDB drops
-  from pegged-2.0 to 1.30 cores.
-- authz_check_grpc **603 → 1822 (+202%)**, p50 62→21 ms; DB 0.54 cores.
-- Every non-authz cell within noise of the matrix (cache is scoped
-  correctly). Batch cells corrupted by §1 (ran first), no conclusion.
+### 3.6 Prod-limit posture (beyond the gRPC bug)
 
-Caveats for the ship-decision (G5): the bench's hit rate is optimistic
-(50 VUs hammering one subject/resource set); the security bound (stale-allow
-≤ TTL even if invalidation is missed) is already documented and
-revocation-tested. Recommendation to take to the plan: **default ON for
-v1.0-beta with TTL 5 s**, prominently documented, off-switch retained.
+REST enforcement is exact (§1.2 table). Unlimited paths are unaffected
+(userinfo 4 572/s, jwks 26 324/s — matrix-identical while the limited
+endpoints 429 at ~28 k attempts/s: the 429 path is cheap, no collateral
+damage). The maintainer's run-3 observation still stands and now has
+sharper numbers behind it: shipped machine-endpoint defaults are 3–5
+orders of magnitude below measured capacity (token 20/min vs ~163 000/min
+measured; authz 300/min vs ~45 000/min). The public doc's §6 now carries
+concrete revised guidance and a proposed-defaults table (see
+`claude_dev/improvement-after-run4-benchmark.md` I6/I7 for the code-side
+proposal).
 
-> **UPDATE (H5, 2026-07-29): decision recorded — stays opt-in (`false`).**
-> `claude_dev/decision-cache-decision.md` walked the clean K-sweep (K=1
-> 3.0–3.15×, K=10 000 +32%, K=100 now measured) against the seven pre-agreed
-> criteria after fixing the three defects the run-3/G5 data had surfaced
-> (unbounded `order` growth, O(shard) `invalidate_subject` under a global
-> mutex, and documenting the process-local revocation bound). The flip is
-> blocked on C1/C2/C4 — see that document for the full criteria table. The
-> recommendation written here (default ON) is superseded.
+## 4. Memory & CPU (run-4, now a first-class publishable story)
 
-### 3.3 DB pool A/B (F2/F3)
+Server-container medians across the p0 matrix (avg during measure window;
+peak = median across runs of per-run peak):
 
-`pool_size=4`: CC **1823 → 1955 (+7.2%)**; `+ max_in_flight=64` changes
-nothing further (the cap never binds at 50 VUs). Everything else within
-noise or transient-affected (§1.3). Introspection −2.5% (noise-level),
-userinfo/login/jwks flat. With the soak green, the honest F3 conclusion:
-**keep `pool_size=1` as the shipped default** (the byte-identical safe
-rollout), document `pool_size=4` as a token-issuance-heavy tuning
-(it buys ~7% there and nothing else at this concurrency), revisit after G1
-removes the transient and an open-loop harness exists (§5.3 of run-2 doc —
-still true).
+| target | server avg RSS | server peak RSS | server avg CPU | cap use (mem) |
+|---|---|---|---|---|
+| **AXIAM** | 97–132 MiB | **≤ 140 MiB** (worst cell: login) | 0.33–1.80 cores | ≤ 7% of 2 GiB |
+| Keycloak | 726–900 MiB | **up to 1 070 MiB** | pegged 2.00 in every valid cell | 52% |
+| Zitadel | 131–165 MiB | 216 MiB | 0.41–2.00 | 11% |
 
-> **UPDATE (H9, 2026-07-29): closed negative — default stays `pool_size=1`.**
-> The pre-agreed ≥5%-on-CC confirm cell turned out to be **unsatisfiable on
-> this host**: H2 found `POST /oauth2/token` permanently clamped to
-> 16–21 ops/s by the `RateLimitShared` write, so there is no settled CC cell
-> to confirm against here. Two independent lines of evidence say the G-box
-> G-run's "+7%" (1955 vs 1823) was noise rather than a `pool_size` effect
-> anyway: `AXIAM__DB__POOL_SIZE` 1→8 changed authz throughput by 0 ops/s at
-> both 1 and 20 VUs (H2 §5.2 — the shared-router mechanism means more pooled
-> handles buy no DB concurrency), and the G-run CC cells were never proven
-> to run outside the settle-gate-blind window in the first place. No code
-> change needed — `pool_size=1` was already the default.
-> `claude_dev/db-pool-design.md` §11 records the full verdict.
+Whole-stack (server+DB+broker) mem: AXIAM 415–590 MiB (SurrealDB 202–356 +
+RabbitMQ ~105–128), Keycloak 814–1129, Zitadel 293–443. Per-request CPU
+(whole stack, p0): CC 1.20 vs KC 5.84 vs Zit 8.20 cpu·ms/req; introspection
+0.78/1.27/4.00; jwks 0.06/0.44/1.42; userinfo 0.73/0.53/2.88 (KC wins that
+one whole-stack; server-only AXIAM 0.25 vs 0.53 — publish both).
+Throughput per stack-GiB (p0): jwks 60 723 vs 5 741 vs 7 330; CC 5 988 vs
+338 vs 1 218; userinfo 8 948 vs 3 999 vs 2 312.
 
-### 3.4 Native mTLS (D3) — acceptance PASSED
+Honesty notes for the public doc: AXIAM's whole-stack RAM sits between
+Zitadel's (smaller) and Keycloak's (larger) because SurrealDB+RabbitMQ ride
+along; the *server* comparison and the per-request/thr-per-GiB measures are
+where AXIAM's efficiency story is unambiguous, so publish per-container
+bars, not just stack totals. Also publish the thermal caveat: laptop hit
+96–100 °C on hot cells; mhz_avg varied 3.16–3.87 GHz across cells.
 
-p3-mtls ran with **no nginx container** (meta: 3 containers, `client_auth:
-x509`, scheme https): CC 903.6 (native p2: 903), check_rest 741 (747),
-introspection 2201 (2225), userinfo 4826 (4822), jwks 24146 (24309),
-login 68.1 (69), userinfo_grpc 3231 (3254). **Client-certificate
-verification costs nothing measurable on top of TLS 1.3** — an excellent
-IoT-story headline, and the proxy-header identity surface is gone from the
-p3 path. (The CC cell still carries the TLS-vs-p0 halving, same as p2 —
-B2 is orthogonal.)
+## 5. Work items (evidence-ranked, post-run-4)
 
-### 3.5 Memory (B1/D9 watch)
+Full specs in
+[`claude_dev/improvement-after-run4-benchmark.md`](../claude_dev/improvement-after-run4-benchmark.md).
 
-Server container RSS across each session: ~75–127 MiB before the login cell;
-**~490 MiB from the login burst onward** (login cell avg 489; every later
-cell ~447–490); refresh cells push to 566–606. Retention confirmed on
-alpha19: ~360 MiB of the burst never returns. The D9 A/B is now fully
-scripted — `benchmarks/run-memory-experiment.sh` builds both images (default
-vs `--features jemalloc`), runs baseline → burst → 10-min watch per variant,
-and emits `results/d9-summary.md` with the ≥30%-gap-closure verdict. Run it
-(G6); until then AXIAM's published mem column for post-login cells stays
-inflated and the doc says so.
+1. **I1 — Fix gRPC shared-limiter ×60 units bug** (§1.2). Product bug,
+   blocks gRPC prod posture. + regression test.
+2. **I2 — Scope gRPC limiter per-method** (server-wide authz limit throttles
+   userinfo/reflection too).
+3. **I3 — CC-under-TLS plateau VU sweep** (§3.5) — last open perf mystery.
+4. **I4 — REST-check session-read serialization** (§3.3) + post-fix cache
+   K-sweep re-run.
+5. **I5 — SurrealDB scaling work** (uncapped +42–90% says DB CPU is the
+   product's ceiling).
+6. **I6/I7 — Rate-limit default revision + sizing docs** (public §6;
+   proposed internet-profile machine-endpoint raises).
+7. **I8–I12 — SDK harness/SDK fixes**: wire baseline, csharp forced
+   refresh, c/php concurrency parity, cpp tail, python asyncio look.
+8. **I13 — refresh-under-prod re-login budget** (§1.3).
+9. **I14 — provenance: build from main** (§2.4).
+10. **I15 — watch items**: userinfo REST −9%, cache-pass introspection −21%.
+11. **Harness (done this branch)**: compose batch default → `coalesced`.
 
-> **UPDATE (H4/G6, 2026-07-28/29): fixed — jemalloc is the release default.**
-> The A/B ran: default malloc retained 376 MiB above baseline (peak 491);
-> jemalloc retained 86 MiB (peak 126) — **94% of the gap closed**, no
-> throughput or latency cost recorded. `crates/axiam-server` ships jemalloc
-> as the release-container default allocator as of H4 (a
-> `--no-default-features` escape hatch stays documented for musl/platform
-> edge cases). The "stays inflated" line above is stale — see
-> `claude_dev/memory-retention-experiment.md` §6 for the full numbers.
+## 6. Publishing guidance for the site (run-4 deliverables)
 
-### 3.6 gRPC-vs-REST authz gap (new, now that both are clean)
-
-Single check: gRPC 603 vs REST 737 (−18%, p0) with *lower* p50 (62 vs 68).
-Not the transient (cells 3–4). Not TLS (identical at p2). Small, real,
-unexplained — parked as a low-priority item (G8); suspect per-call
-UUID-parse/validation or tonic service overhead. The p99 tail from run 1
-(850 ms) remains gone (p99 112–217 ms).
-
-### 3.7 Prod rate-limit posture (C4) — ran; framing matters
-
-With shipped defaults (`token 20/min/IP`, `introspect 10/min/IP`,
-`authz_check 300/min/IP`, `login 10/min/IP`…), a single-IP 50-VU generator
-is — by design — throttled to ~zero on every limited endpoint (CC 0.9/s,
-introspection 0.4/s, ~100% 429s; unlimited paths unaffected: jwks 27.7 k/s,
-userinfo 5 994/s). report.py's posture-mixing guard worked (separate
-subtree, never merged into head-to-heads). Two outputs: (a) the public
-"AXIAM ships default abuse limits; competitors don't" evidence, now
-measured; (b) **the maintainer's observation stands — the defaults are far
-too strict for any M2M/NAT topology**, so the public doc now carries a
-"recommended settings by deployment" section (§6 of the public doc) and G7
-tracks revisiting the shipped defaults + docs.
-
-## 4. Product work items (evidence-ranked, post-run-3)
-
-Full task specs with models and acceptance criteria live in
-[`claude_dev/improvement-after-serious-benchmark.md`](../claude_dev/improvement-after-serious-benchmark.md).
-Ranked summary:
-
-1. **G1 — Root-cause the post-seed serialized-DB transient** (§1). Biggest
-   validity issue *and* a potential production cold-start defect. Everything
-   batch- and B2-related is downstream of it. **Root-caused: DONE (H2).
-   Fixed: DONE (`claude/g-benchmark-improvements-n5mjmj`, see the §1 UPDATE
-   above and `claude_dev/rate-limit-posture-decision.md` §8) — not yet
-   re-measured (`claude_dev/rate-limit-fix-verification.md`).**
-2. **G2 — Harness countermeasures + self-describing meta**: settle gate
-   before the first cell, cell-order rotation per run, record `AXIAM__*`
-   knobs in meta.json, re-run the four batch cells clean (both strategies)
-   and the B2 h1 cell mid-session.
-3. ~~**G3 — B2**: still −50.5% on CC at p2. Clean h1 cell first; then h2
-   stream/flow-control tuning on the actix listener or an accepted,
-   documented position.~~ **DONE (H6) — documented position published, and it
-   is not the position this line anticipated: the transport is exonerated
-   entirely, so there is no listener tuning to do.** What replaces it is one
-   narrow follow-up for the server-class re-run (E3): on a host where
-   `/oauth2/token` is **not** clamped, sweep VUs at p0 and p2 on CC. A cost
-   that scales with VU count is per-request; a throughput that stays pinned
-   regardless of VU count is a serialization point (and `RateLimitShared`'s
-   bucket write is the only one known on that path). See
-   `claude_dev/b2-tls-h2-investigation.md` §6.
-4. **G4 — A8 residual**: AXIAM refresh cookie extraction (harness) — last
-   invalid AXIAM-controlled cell.
-5. **G5 — D7 ship-decision**: default-ON proposal + combined cache+pool
-   cell + realistic-hit-rate caveat work.
-6. **G6 — D9**: run `run-memory-experiment.sh`, decide jemalloc.
-7. **G7 — Rate-limit defaults & tuning guide** (from §3.7 / maintainer note).
-8. **G8 — Small investigations**: gRPC −16% authz gap; KC p0/p2 login
-   asymmetry (diagnostic only); Zitadel offline_access refresh.
-9. **G9 — SDK benches (E1)**: still never run against a live target — the
-   harness exists (7 code-bearing + 4 stubs implemented); wire them into the
-   run-4 protocol so the SDK-overhead table finally exists.
-
-## 5. Security-hardening notes (updated)
-
-1. **B1 stands** (login p95 774 ms, RSS bounded, 0 errors at 50 VUs, OWASP
-   params). D9 retention is the remaining memory item (script ready).
-2. **mTLS native path measured at parity** — the p3 nginx/proxy-header
-   surface is retired for real (§3.4).
-3. **Rate limits**: shipped defaults are effective abuse-stoppers (measured:
-   they flatten a 50-VU single-IP flood) and unsuitable as-is for M2M
-   fleets — hence the public tuning guidance and G7. `key=client_id` mode
-   (D8) is the right default candidate for token endpoints; login stays
-   per-IP.
-4. **Decision cache**: if G5 flips it on by default, the public docs must
-   state the ≤TTL stale-allow bound next to the default, not in a footnote.
-5. **TLS 0-RTT stays off**; resumption verified again at p2/p3.
-
-## 6. Publishing guidance for the site (run-3 deliverables)
-
-- Publish medians + spreads; headline multiples (p0): CC **5.2×/4.3×**,
-  introspection **1.17×/2.45×**, jwks **7.4×/13.4×**, userinfo
-  **1.34×/5.3×**, login: only valid cell at 50 VUs (KC p0 now also valid at
-  52/s — say so; it strengthens rather than weakens the comparison).
-- Publish the mTLS-parity table (§3.4) — it's the IoT differentiator.
-- Publish cache-ON as a labeled sensitivity row with the TTL caveat, never
-  in the default head-to-head.
-- **Do NOT publish any batch number as a verdict** — publish the artifact
-  discovery + the one clean 852-batches/s cell as "measurement corrected,
-  full re-measurement in progress". This *retracts* the draft-1/2 "batch is
-  slow" caveat in the honest direction.
-  > **UPDATE (H3/G3, 2026-07-28): superseded — the re-measurement happened
-  > and the verdict shipped.** On settled cells (G3 run 2–3), `coalesced`
-  > batch REST measured **744 ops/s = 3 721 checks/s = 4.98× singles**;
-  > gRPC coalesced **866–872 ops/s ≈ 4 330 checks/s**, p95 74 ms. `coalesced`
-  > is now the shipped default (`crates/axiam-authz/src/config.rs`,
-  > `concurrent` stays selectable). Publish the G3 table as the batch
-  > verdict, not as "in progress" — see `claude_dev/authz-batch-investigation.md`
-  > for the closing data. On *this* investigation host (H2/H10) batch cells
-  > are still clamped by the `RateLimitShared` write and must be published as
-  > refused, same as every other clamped cell — that is a host limitation,
-  > not a reopening of the G3 decision.
-  > **UPDATE (2026-07-29, `claude/g-benchmark-improvements-n5mjmj`): the
-  > `RateLimitShared` write named above is fixed** (write-behind counter, §1
-  > UPDATE). Any *new* H2-host pass run against this branch is no longer
-  > expected to hit that specific clamp on these six endpoints, but this
-  > document's own H2/H10 numbers above were captured pre-fix and are
-  > unchanged — do not retroactively read them as un-clamped. Whether a
-  > future pass on this host settles cleanly is an open question for
-  > `claude_dev/rate-limit-fix-verification.md`, not asserted here.
-- **Publish the shared rate-limit fix as a closed product item, not a
-  performance number.** `claude_dev/postseed-transient-investigation.md`
-  §7.1's two asks (the `GET /api/v1/users` bucket bug and the synchronous
-  shared-store write) are both implemented on
-  `claude/g-benchmark-improvements-n5mjmj` — see the §1 UPDATE above and
-  `claude_dev/rate-limit-posture-decision.md` §8 for the design rationale.
-  **Do NOT publish any post-fix throughput number yet** — none has been
-  measured; it lands in `claude_dev/rate-limit-fix-verification.md` first,
-  produced by a separate task, and only then flows into a future draft of
-  the public matrix.
-- Do NOT chart: AXIAM/Zitadel refresh (fallback), Zitadel/KC-p2 login
-  (gate), any first-cell-after-seed number (§1), the B2 h1 cell.
-- The new "recommended production settings" section (public §6) is the
-  maintainer-requested addition; keep values in sync with code defaults.
-
-## 7. Order of execution
-
-G1 → G2 (they unblock clean batch/B2 data) → re-measure the 5 corrupted
-cells → G3/G4/G5 in parallel → G6/G7 → run-4 full protocol (matrix +
-sensitivity + SDK benches, G9) → E4 public refresh v4. Details, models and
-acceptance criteria: `claude_dev/improvement-after-serious-benchmark.md`.
+- Publish the run-4 matrix as **the** headline numbers (first uncontaminated
+  run): CC 7.7×/6.4×, introspection 2.4×/4.7×, jwks 5.8×/12.6×, userinfo
+  1.2×/4.5× (+ AXIAM gRPC userinfo 12.7 k/s), login only-valid-at-both-
+  profiles, refresh under protocol-variant label.
+- Publish the **resource-usage story with graphs** (server RSS bars, peak
+  RSS, cpu·ms/req, thr/GiB) — it is now AXIAM's cleanest differentiator
+  (≤140 MiB server vs 1 070 MiB KC at higher throughput).
+- Publish batch ONLY as: matrix = labeled `concurrent` (non-default,
+  harness pin, now fixed); default's verdict remains G3's coalesced
+  4.98× table. Do not chart run-4 batch as the default.
+- Publish the gRPC prod-limiter bug openly (found by our own bench, fix
+  tracked) — same honesty pattern as the H2 write.
+- Do NOT chart: Zitadel login/refresh (gate/fallback), KC login (1/3 valid;
+  say why + the 4 GiB plan), cache-ON in head-to-heads (labeled pass only).
+- Refresh comparability, cc-token-setup, and protocol-confound (h1→h2)
+  labels: carry over verbatim from draft-4 practice.

--- a/benchmarks/PUBLIC_BENCH_ANALYSIS.md
+++ b/benchmarks/PUBLIC_BENCH_ANALYSIS.md
@@ -1,769 +1,543 @@
-# AXIAM Benchmark Analysis — Fourth Draft
+# AXIAM Benchmark Analysis — Fifth Draft (Run 4: the first clean matrix)
 
-> **Status: fourth benchmark draft.** This updates draft 3 (2026-07-26, the
-> first statistically grounded run) with the outcomes of the **Phase H**
-> follow-up work (2026-07-28/29): a settle gate that can actually detect the
-> clamp draft 3 tripped over, the root-caused explanation for what that clamp
-> is, four decided defaults (batch strategy, allocator, decision cache, DB
-> pool), a closed TLS/HTTP-2 investigation, and a validated SDK
-> client-overhead table. **The published performance numbers in §3/§4/§7
-> below are unchanged from draft 3** — they are still the G-box's
-> 2026-07-25/26 median-of-3 run against the released **AXIAM 1.0.0-alpha19**
-> container image. What changed is which of those numbers we stand behind as
-> verdicts, and why: draft 3 withdrew the batch numbers and left the TLS
-> penalty, the cache default and the pool default all open; this draft closes
-> four of those five (§2). The fifth — a true publishable *run-4* matrix
-> re-measured end-to-end on the settled protocol — could not be produced
-> on the sandbox host this round of work ran on, for a specific, measured,
-> and product-relevant reason explained in §1 and §5. Numbers are
-> reproducible from the published raw data; platform is named at every
-> number below.
+> **Status: fifth benchmark draft, and the first whose headline numbers come
+> from an uncontaminated end-to-end run.** Draft 4 (2026-07-29) explained why
+> no publishable "run 4" existed yet: every prior AXIAM number on the six
+> hottest endpoints was bounded by one synchronous datastore write (the
+> shared rate-limit counter), a product defect we found, root-caused, and
+> fixed in the open. **Run 4 (2026-08-01/02) is the re-measurement on the
+> fixed build** — full median-of-3 matrix, three targets, two TLS profiles,
+> five labeled sensitivity passes, and the first complete 11-language SDK
+> pass. The fix is confirmed at matrix scale: the affected endpoints gained
+> +47% to +284% with no regression anywhere else (§2). This draft also adds
+> a first-class **resource usage** section (§5) — memory and CPU during the
+> tests, per container, graph-ready — and updated **production rate-limit
+> guidance** (§7) derived from the measured capacity of each endpoint.
+> Numbers are reproducible from the published raw data; the platform is
+> named at every number.
 
-## 0. What this draft is and is not
+## 0. Setup at a glance
 
-- **Is:** a decision record. Four defaults that draft 3 left pending now have
-  measured, criteria-based verdicts (batch → `coalesced`, allocator →
-  jemalloc, decision cache → stays opt-in, DB pool → stays `1`), the TLS
-  investigation that draft 3's §5 opened is closed, the refresh comparison
-  is restored with an honest comparability label, and the SDK
-  client-overhead table exists with real data for the first time.
-- **Is not:** a new published performance level. Every throughput/latency
-  number in §3, §4 and §7 is the **same G-box run-3 number as draft 3**
-  (labeled "G-box" below, per the platform table in §1.1). The Phase H work
-  ran on a *second*, different host — a resource-constrained sandbox — whose
-  purpose was to validate the harness fixes (the settle gate, the report
-  refusal machinery, the protocol-variant label, the SDK table) end-to-end,
-  not to produce a competing performance number. That host cannot produce
-  *any* settled AXIAM authz/token/introspect/login/revoke cell at all (§1),
-  so it could not have supplied a run-4 matrix even if the schedule had
-  allowed one. §1 explains why in one paragraph, and the full mechanism is
-  in `claude_dev/postseed-transient-investigation.md`.
+| | |
+|---|---|
+| Hardware | Dell XPS 15 9570 ("G-box": i7-8750H, 12 logical CPUs, ~31 GiB RAM) — same box as every prior draft; consumer laptop, server-class re-run still pending |
+| Load | k6 v2.1.0, 50 VUs closed-loop, 30 s warmup + 120 s measure, median-of-3 repeats per cell |
+| Caps | every *server* container: 2 CPUs / **2048 MiB**; every DB container: 2 CPUs / 1024 MiB; brokers 1 CPU / 512 MiB |
+| Targets | AXIAM (post-fix build, SurrealDB + RabbitMQ) vs Keycloak 26 (Postgres) vs Zitadel v4 (Postgres) |
+| Profiles | p0-plaintext, p2-tls13 (in-process TLS 1.3); p3-mtls as a labeled sensitivity pass |
+| Validity | 42/48 matrix cells valid; every invalid cell listed with its reason (§8); settle gate cleared first-probe on every session, zero refused cells — a first |
 
-### 1.1 Platforms named in this draft
+**Why the memory cap changed since draft 4** (was 1024 MiB): Keycloak
+could not reliably survive sustained password-login load at 1 GiB (it was
+OOM-killed in diagnostics, and its container **peaked at 1 070 MiB in this
+run** — above the old cap). We raised the cap to 2 GiB *for all three
+targets equally* so Keycloak competes at its best. AXIAM's server peaked at
+**172 MiB** — 8% of the same allowance (§5).
 
-| Label | Machine | Role |
-|---|---|---|
-| **G-box** | Dell XPS 15 9570 (i7-8750H, 12 logical CPUs, ~31 GiB RAM), same box as drafts 1–3 | Source of every headline number in §3/§4/§7 |
-| **sandbox** | Phase H investigation host (2 vCPU-class container sandbox) | Source of the H2 root-cause investigation, the H6 TLS/protocol measurements, the H7/H8 harness validation, and the harness-validation matrix in §1.2 — **never** a source of headline numbers |
-
-## 1. Why there is no run-4 publishable matrix yet
-
-Every AXIAM deployment pays one synchronous datastore write — an `UPSERT` of
-a shared rate-limit bucket record — in front of six endpoints:
-`POST /api/v1/authz/check`, `POST /oauth2/token`, `POST /oauth2/introspect`,
-`POST /oauth2/revoke`, `POST /api/v1/auth/login`, and (a separate bug,
-tracked) `GET /api/v1/users`. Draft 3 called the effect this write produces
-a **"post-seed database transient"** because on the G-box it appears for
-roughly 5–7 minutes after a fresh seed and then recovers. The Phase H
-investigation (`claude_dev/postseed-transient-investigation.md`, task H2)
-reproduced the same signature on a second host and found it is **neither
-post-seed nor reliably transient**: it is a permanent, per-request cost that
-exists on every request to those six endpoints, on any host, indefinitely.
-What differs between hosts is only how expensive that one datastore write
-is — on the G-box it is cheap enough (~22 ms) that the six endpoints still
-clear hundreds of requests per second once whatever made it briefly
-expensive after a seed subsides; on the sandbox host the same write costs
-~40 ms and **never subsides**, pinning those six endpoints at
-**16–21 ops/s at any concurrency from 1 to 40 clients, indefinitely** — idle
-time, server restarts, datastore restarts, connection-pool size, and even
-swapping the datastore for a pure in-memory backend all leave it unchanged.
-Section 5 has the full honesty write-up; the short version is: **this is a
-product property, not a benchmark artifact**, and it is the reason a true
-run-4 median-of-3 matrix — the kind draft 3 promised for its successor —
-cannot be produced on a host where that one write is expensive. It has to
-run on a host where it isn't (the G-box, or any host after the tracked fix
-lands — see §5's "moved to fixed" list for what's already shipped and what
-remains open).
-
-**Status: the design fix has since shipped**, on branch
-`claude/g-benchmark-improvements-n5mjmj` — the synchronous per-request write
-described above is replaced by a write-behind counter
-(`axiam_db::rate_limit_counter::SharedRateLimitCounter`; §5 "moved to fixed"
-has the details and the security trade it makes). **The numbers in §3, §4
-and §7 below remain the pre-fix G-box measurements and are not updated by
-this note** — the fix has not yet been re-measured end-to-end on any host.
-When that re-measurement runs, its numbers land in
-`claude_dev/rate-limit-fix-verification.md`, not in this file, until a future
-draft folds them into a published matrix.
-
-### 1.2 What *was* run this round: a harness-validation matrix (sandbox, bounded)
-
-To validate the new settle gate (§5), the `report.py` refusal machinery, the
-`protocol-variant` label, and the SDK table end-to-end, one bounded,
-single-repeat pass of the full scenario matrix (`axiam` + `keycloak`,
-`p0-plaintext` + `p2-tls13`) ran on the sandbox host, with the settle-gate
-timeout deliberately shortened to 120 s (`BENCH_SETTLE_TIMEOUT_SECS=120`,
-down from the 600 s default) — the sandbox host's clamp was already known
-from H2 to be permanent, so waiting the full 10-minute default before every
-one of the four clamped sessions would have added ~30 minutes of pure wait
-with a foregone conclusion. This is a **harness validation, not a
-publishable run**: it is a single pass, not a median-of-3, and every
-AXIAM cell that touches the six `RateLimitShared` endpoints is expected —
-and required — to come back **refused** with `settle_timeout: true`, exactly
-as `report.py`'s H1 refusal logic is supposed to do. Its numbers are not
-cited anywhere in §3/§4/§7; its purpose was to prove the harness tells the
-truth about its own limits rather than silently publishing a clamped cell as
-a level, and to catch any remaining harness bugs while doing it. Results:
-`benchmarks/results/tasks/h10-validate/`.
-
-## 2. What changed since draft 3 (decisions closed, corrections included)
-
-**Batch strategy — decided and shipped.** Draft 3 withdrew the "batch is
-slow" claim as an unproven measurement-order artifact and promised a
-re-measurement. That re-measurement happened (task G3, on settled cells from
-runs 2–3 of the same G-box session): `coalesced` batch REST measured
-**744 ops/s = 3 721 checks/s = 4.98× single checks** (748/s); `coalesced`
-batch gRPC **866–872 ops/s ≈ 4 330 checks/s**, p95 74 ms — comfortably inside
-the ≤2 s gate. `concurrent`, the previous default, reached only 1.37×
-singles on REST (200 ops/s = 1 000 checks/s) with a 282 ms p95 on gRPC.
-`coalesced` won decisively and **is now the shipped default**
-(`AXIAM__AUTHZ__BATCH_STRATEGY=coalesced`,
-`crates/axiam-authz/src/config.rs`; `concurrent` stays selectable). See
-`claude_dev/authz-batch-investigation.md` for the closing table.
-
-**Memory retention — fixed.** Draft 3 flagged ~360 MiB of RSS retained after
-a login burst that never returned to baseline, and queued a scripted A/B.
-That A/B ran (task G6): default allocator retained **376 MiB** above
-baseline (peak 491 MiB); jemalloc retained **86 MiB** (peak 126 MiB) — a
-**94% reduction** in the retention gap, with no throughput or latency cost
-measured. The released container image now links jemalloc as its default
-allocator (task H4). AXIAM's mem column no longer needs the caveat draft 3
-carried.
-
-**The TLS token-issuance halving — investigated to a documented position,
-not fully closed.** Draft 3's §5 reported `client_credentials` losing
-**−50.5%** at p2 (1823 → 903 ops/s) and, after a first follow-up, narrowed
-the field of suspects to "not HTTP/2, not TLS-in-general, something
-endpoint-specific" without naming the cause. Task H6 closed the HTTP/2
-question directly: **acquitted**. The hypothesis that concurrent clients
-collapse onto one HTTP/2 connection pinned to one worker thread does not
-hold with any normal client — 10/50/100 concurrent clients open 10/50/100
-h2 connections, and both actix worker threads stay CPU-balanced at every
-level (`claude_dev/b2-tls-h2-investigation.md` §2.1). TLS 1.3 termination
-in-process is priced at 10–13% on a cheap endpoint, shrinking as the
-endpoint does more work — a normal, publishable cost, not 50%. What remains
-open is *why specifically* `client_credentials` loses 50% while
-`token_introspection` — wrapped by the exact same `RateLimitShared`
-middleware — loses only 0.2%: the shared rate-limit write is the leading
-candidate (it is a real, per-request synchronous cost that both endpoints
-pay), but introspection's near-zero TLS delta is a real objection against
-it fully explaining the asymmetry, so it is stated as an **open question**,
-not a closed one. Settling it needs one VU-sweep on a host where
-`/oauth2/token` is not itself clamped by that write — the G-box, or any host
-after the fix in §5 lands. See `claude_dev/b2-tls-h2-investigation.md` §6.
-
-**The "post-seed transient" — reframed, and it is the most important
-correction in this draft.** See §1 and §5.
-
-**Decision cache — evaluated against explicit criteria and stays opt-in.**
-Draft 3 reported a K=1 ceiling of 3.0–3.15× and a realistic K=10 000 result
-of +32%, and called the 3× number "a ceiling, not an expectation." Task H5
-fixed three defects the sweep had surfaced (unbounded internal-list growth,
-a lock-contention hotspot in revocation, an undocumented multi-replica
-revocation bound) and then walked the clean data against seven pre-agreed
-criteria, agreed *before* the numbers arrived. The ship bar for the
-K=10 000 throughput ratio was **≥1.5×**; the best clean measurement anywhere
-is **1.32×** (the same +32% draft 3 already published) — below the bar. The
-default **stays `false`** (`claude_dev/decision-cache-decision.md` §7–8);
-nothing about the measured numbers changed, only the decision built on top
-of them.
-
-**DB connection pool — evaluated and stays at 1.** Draft 3 reported
-`pool_size=4` at +7% on client-credentials, neutral elsewhere, with the
-default left at 1 "pending an open-loop harness." Task H9 could not obtain
-the pre-agreed confirm cell (it needs a settled CC cell, which requires a
-host where the shared rate-limit write is cheap) but closed the question on
-independent evidence instead: `AXIAM__DB__POOL_SIZE` 1→8 moved authz
-throughput by **0 ops/s** at both 1 and 20 VUs on the sandbox host — the
-underlying connection model does not buy DB concurrency from more pooled
-handles, so the G-box's "+7%" reads as noise from an unconfirmed,
-never-proven-settled cell rather than a real effect. Default stays
-`pool_size=1`; no code change needed. `claude_dev/db-pool-design.md` §11.
-
-**Refresh-token comparison — restored, with an honest comparability label.**
-Draft 3 excluded AXIAM's refresh cells entirely (a harness cookie-handling
-bug made every AXIAM refresh cell measure a client-credentials fallback,
-`bench_fallback` ≈ 100%). That bug is fixed (task G4: the root cause was the
-refresh cookie's `Path` attribute) and AXIAM's refresh cell now measures the
-real operation — **0% fallback, 1.00 HTTP request per iteration**, same as
-Keycloak's already-real rotation cell. But fixing the harness surfaced a
-semantic fact that was always true and had gone unlabeled: AXIAM has no
-ROPC/password grant by design, so its refresh cell exercises **session
-cookie refresh** (`POST /api/v1/auth/refresh`), while Keycloak's exercises
-the **OAuth2 refresh-token grant**. These are two different protocols doing
-related jobs, not the same request against two servers. `report.py` now
-carries a `protocol-variant` comparability label (task H7) — the same
-family of caveat as `fallback-op`/`cc-token-setup` — and the pair is
-published in §3/§7 side by side **under that label**, not as a like-for-like
-head-to-head.
-
-**A p0-plaintext harness bug fixed along the way.** Every cookie-based
-p0-plaintext scenario (login, authz checks, batch) was silently dying in k6
-`setup()` because the server's auth cookies are marked `Secure` by default
-and k6's cookie jar will not replay a `Secure` cookie over `http://`. The
-bench harness now sets `AXIAM__AUTH__COOKIE_SECURE=false` for the
-p0-plaintext profile only (an operator override still wins, and the
-production default stays `true` everywhere else) — task H6. This does not
-change any published number (the affected cells were already excluded or
-re-derived under TLS), but it unblocks p0 authz/login measurement for any
-future run.
-
-**SDK client-overhead table — exists for the first time with real data.**
-Draft 3 noted the SDK benches existed but had never produced a validated
-run. Task H8 fixed one mechanical, per-language cause for each of the seven
-original SDKs (env plumbing, missing package installs, concurrency
-mismatches, a server-side CSRF gap) and ran them all against a seeded
-target. **6 of 7** validated end-to-end (rust, python, typescript, go, java,
-php); **csharp** stays an honest `pending` (host toolchain not installed).
-See §7.1.
-
-## 3. Headline results (G-box, capped matrix, median-of-3, valid cells)
-
-*Unchanged from draft 3 — same numbers, same platform (G-box), reproduced
-here for continuity. Full matrix in §7.*
+## 1. Headline results (median-of-3, valid cells, whole numbers rounded)
 
 ### Machine-to-machine token issuance (`oauth2_client_credentials`)
 
-| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | req/s per stack core | server-only req/s per core |
+| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | req/s per stack core | cpu·ms per request |
 |---|---|---|---|---|---|---|
-| p0 | **AXIAM** | **1823** | 25.4 | **31.9** | **637** | **1880** |
-| p0 | Zitadel | 423 | 110.0 | 134.2 | 115 | 235 |
-| p0 | Keycloak | 351 | 103.6 | 208.1 | 170 | 176 |
-| p2 | **AXIAM** | **903** | 54.2 | **62.8** | 567 | 1624 |
-| p2 | Zitadel | 415 | 113.1 | 137.5 | 111 | 226 |
-| p2 | Keycloak | 346 | 104.0 | 209.1 | 167 | 173 |
+| p0 | **AXIAM** | **2 727** | 9.1 | **58.1** | **835** | **1.20** |
+| p0 | Zitadel | 425 | 108.7 | 139.9 | 122 | 8.20 |
+| p0 | Keycloak | 354 | 103.0 | 208.4 | 171 | 5.84 |
+| p2 | **AXIAM** | **1 180** | 42.6 | **43.9** | 571 | 1.75 |
+| p2 | Zitadel | 419 | 110.9 | 138.7 | 118 | 8.46 |
+| p2 | Keycloak | 346 | 104.1 | 208.5 | 168 | 5.97 |
 
-AXIAM issues **5.2× more tokens/s than Keycloak and 4.3× more than
-Zitadel** at plaintext and stays 2.2–2.6× ahead under TLS 1.3. The p2 gap on
-this one scenario is **not a TLS or HTTP/2 cost** — HTTP/2 is acquitted by
-direct measurement and TLS 1.3 termination is priced separately at 10–13%
-elsewhere in this matrix (§2) — the mechanism is endpoint-specific and still
-open (§5).
+AXIAM issues **7.7× more tokens/s than Keycloak and 6.4× more than
+Zitadel** at plaintext (up from 5.2×/4.3× in draft 4 — the rate-limit fix,
+§2), and stays **2.8–3.4× ahead under TLS 1.3**. AXIAM's p2 drop on this
+one endpoint (−57%) is a known open question — not a TLS/HTTP-2 cost in
+general (introspection loses 1.6% under identical TLS) — see §6.
 
 ### Token introspection (RFC 7662)
 
-| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | req/s per stack core | cpu·ms/req |
+| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | req/s per stack core | cpu·ms per request |
 |---|---|---|---|---|---|---|
-| p0 | **AXIAM** | **2230** | 20.4 | **27.1** | **907** | **1.10** |
-| p0 | Keycloak | 1908 | 7.2 | 81.7 | 807 | 1.24 |
-| p0 | Zitadel | 910 | 47.8 | 68.7 | 248 | 4.04 |
-| p2 | **AXIAM** | **2225** | 20.4 | **27.2** | 839 | 1.19 |
-| p2 | Keycloak | 1758 | 7.9 | 82.5 | 748 | 1.34 |
-| p2 | Zitadel | 899 | 50.1 | 67.7 | 238 | 4.19 |
+| p0 | **AXIAM** | **4 387** | 5.9 | **48.5** | **1 288** | **0.78** |
+| p0 | Keycloak | 1 860 | 7.5 | 81.9 | 786 | 1.27 |
+| p0 | Zitadel | 932 | 48.2 | 66.1 | 250 | 4.00 |
+| p2 | **AXIAM** | **4 316** | 6.2 | **45.6** | 1 232 | 0.81 |
+| p2 | Keycloak | 1 715 | 8.1 | 83.0 | 733 | 1.36 |
+| p2 | Zitadel | 909 | 50.4 | 67.8 | 239 | 4.19 |
 
-The closest head-to-head: AXIAM leads Keycloak 1.17× on throughput with a
-3× better p95 and **zero TLS penalty** (−0.2%). Keycloak's p50 is the
-lowest of the field; its JVM tail is what separates them.
+Draft 4's closest head-to-head is no longer close: **2.4× Keycloak, 4.7×
+Zitadel**, with a 1.7–1.8× better p95 than Keycloak and a near-zero TLS
+penalty (−1.6%).
 
 ### JWKS fetch (RFC 7517)
 
 | profile | target | thr (req/s) | p50 (ms) | p95 (ms) | req/s per stack core |
 |---|---|---|---|---|---|
-| p0 | **AXIAM** | **27 784** | 1.3 | **2.9** | **16 850** |
-| p0 | Keycloak | 3764 | 3.1 | 75.2 | 1881 |
-| p0 | Zitadel | 2071 | 11.2 | 65.1 | 698 |
-| p2 | **AXIAM** | **24 309** | 1.6 | **2.9** | 12 349 |
-| p2 | Keycloak | 3042 | 3.8 | 77.6 | 1514 |
-| p2 | Zitadel | 2023 | 12.8 | 61.1 | 650 |
+| p0 | **AXIAM** | **26 371** | 1.3 | **3.1** | **16 184** |
+| p0 | Keycloak | 4 565 | 2.7 | 72.5 | 2 278 |
+| p0 | Zitadel | 2 096 | 11.2 | 64.7 | 703 |
+| p2 | **AXIAM** | **23 716** | 1.6 | **3.2** | 12 219 |
+| p2 | Keycloak | 4 261 | 3.1 | 72.0 | 2 125 |
+| p2 | Zitadel | 2 057 | 12.9 | 59.9 | 655 |
 
-A 7–13× gap, still limited by the load generator, not by AXIAM (server at
-~1.3/2 cores while k6 neared its own budget).
+A 5.8–12.6× gap, still limited by the load generator rather than AXIAM
+(k6 itself burned ~5 CPU cores; the AXIAM server sat at 1.6/2).
 
-### OIDC userinfo
+### OIDC userinfo — REST and gRPC
 
 | profile | target | thr (req/s) | p50 (ms) | p95 (ms) | req/s per stack core | server-only cpu·ms/req |
 |---|---|---|---|---|---|---|
-| p0 | **AXIAM** | **5008** | 4.8 | **50.2** | 1452 | **0.25** |
-| p0 | Keycloak | 3742 | 3.0 | 77.0 | **1873** | 0.53 |
-| p0 | Zitadel* | 943 | 25.7 | 82.6 | 333 | 0.87 |
-| p2 | **AXIAM** | **4822** | 5.2 | **49.2** | 1345 | 0.28 |
-| p2 | Keycloak | 3489 | 3.2 | 77.9 | **1740** | 0.57 |
-| p2 | Zitadel* | 950 | 27.4 | 80.8 | 324 | 0.96 |
+| p0 | **AXIAM (gRPC)** | **12 665** | 3.0 | **6.0** | **6 067** | — |
+| p0 | **AXIAM (REST)** | **4 547** | 5.4 | 51.4 | 1 376 | **0.25** |
+| p0 | Keycloak | 3 783 | 3.0 | 76.8 | **1 891** | 0.53 |
+| p0 | Zitadel* | 1 000 | 24.8 | 80.0 | 348 | 0.86 |
+| p2 | **AXIAM (gRPC)** | **12 148** | 4.0 | **6.0** | 5 828 | — |
+| p2 | **AXIAM (REST)** | **4 439** | 5.6 | 50.7 | 1 252 | 0.27 |
+| p2 | Keycloak | 3 499 | 3.3 | 77.5 | **1 747** | 0.57 |
+| p2 | Zitadel* | 998 | 26.6 | 78.3 | 336 | 0.96 |
 
-*\* Zitadel's cells use a machine-user token (its user-login flow returns a
-session token the harness can't yet convert); measured endpoint and
-semantics are the same.*
+*\* Zitadel authenticated with a machine-user token minted once in setup
+(its user-login flow returns a session token the harness can't convert);
+the measured endpoint and semantics are the same.*
 
-AXIAM leads throughput (1.34× Keycloak, 5.3× Zitadel) while its DB is
-saturated (uncapped it reaches **7457 req/s**, §4). On whole-stack req/s
-per core Keycloak wins this cell (AXIAM's figure carries a pegged SurrealDB
-plus RabbitMQ); on the **server-only** measure AXIAM's server is 2.1×
-cheaper per request — both facts published.
+On REST, AXIAM leads 1.2× Keycloak / 4.5× Zitadel while its DB is pegged
+(uncapped: 7 215/s, §4). On whole-stack req/s-per-core Keycloak wins the
+REST cell; on server-only CPU per request AXIAM is 2.1× cheaper — both
+published. The real story is gRPC: **12.7 k identity reads/s at p95 6 ms**
+— 2.8× AXIAM's own REST and 3.3× Keycloak's best number — where draft 4
+measured 3.3 k/s (§2). Zitadel's own gRPC userinfo measured 180–185/s
+(−82% vs its REST) on the same harness.
 
-### Session/token refresh — restored, published under the protocol-variant label
+### Session/token refresh — published under the protocol-variant label
 
 > ⚠️ **Comparability: protocol-variant.** AXIAM has no ROPC/password grant by
 > design; its cell measures **session cookie refresh**
-> (`POST /api/v1/auth/refresh`). Keycloak's cell measures the **OAuth2
-> refresh-token grant**. These are two different protocols solving a related
-> problem, not the same request. Do not read this pair as a like-for-like
-> head-to-head; the throughput comparison below is informational only.
+> (`POST /api/v1/auth/refresh`, CSRF double-submit, single-use rotation).
+> Keycloak's cell measures the **OAuth2 refresh-token grant**. Two different
+> protocols doing a related job — informational, not a like-for-like race.
 
-| profile | target | thr (req/s) | fallback | req/iteration | note |
+| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | fallback |
 |---|---|---|---|---|---|
-| p0 | AXIAM | **910** | 0% | 1.00 | session refresh; single confirm run (task G4), not median-of-3 |
-| p0 | Keycloak | **379** | 0% | 1.00 | OAuth2 refresh grant; median-of-3, real single-use rotation |
-| p2 | Keycloak | **367** | 0% | 1.00 | OAuth2 refresh grant; median-of-3, real single-use rotation |
+| p0 | AXIAM | **839** | 47.5 | 80.6 | 0% |
+| p0 | Keycloak | 377 | 101.5 | 204.9 | 0% |
+| p2 | AXIAM | **834** | 48.0 | 80.6 | 0% |
+| p2 | Keycloak | 370 | 102.3 | 203.8 | 0% |
 
-AXIAM's session-refresh cell was independently reproduced at **914 ops/s**
-in the G8 diagnostic session. Both AXIAM numbers are single confirmatory
-runs from the harness-fix tasks, not the median-of-3 protocol the rest of
-this section uses — flagged here rather than presented at the same
-confidence level as the matrix cells. Zitadel's refresh needs an
-`offline_access` flow the harness doesn't implement yet and is excluded.
+New since draft 4: AXIAM's refresh is now a full **median-of-3** cell (the
+draft-4 number was a single confirm run). Zitadel's refresh needs an
+`offline_access` flow the harness doesn't implement and stays excluded.
 
 ### Password login (all targets hash for real)
 
 AXIAM **Argon2id** (OWASP params), Keycloak 26 **Argon2id** (default),
-Zitadel **bcrypt** (default cost — much more expensive per verification;
-tunable). Hash configuration dominates this scenario; compare accordingly.
+Zitadel **bcrypt** (default cost — far more expensive per verification;
+tunable). Hash configuration dominates this scenario.
 
-| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | valid (p95 < 2 s) |
+| profile | target | thr (req/s) | p50 (ms) | p95 (ms) | valid (p95 < 2 s, ≥2/3 runs) |
 |---|---|---|---|---|---|
-| p0 | **AXIAM** | **69** | 695 | **774** | ✓ (3/3 runs) |
-| p0 | Keycloak | 52 | 919 | 1070 | ✓ (2/3 runs) |
-| p0 | Zitadel | 2 | 22 605 | 25 388 | ✗ gate breach |
-| p2 | **AXIAM** | **69** | 692 | **816** | ✓ (3/3 runs) |
-| p2 | Keycloak | 23 | 2115 | 2249 | ✗ gate breach |
-| p2 | Zitadel | 2 | 21 823 | 25 529 | ✗ gate breach |
+| p0 | **AXIAM** | **69** | 698 | **774** | ✓ 3/3 |
+| p0 | Keycloak | (44) | (1 031) | (1 301) | ✗ 1/3 runs valid |
+| p0 | Zitadel | (2) | (22 079) | (25 533) | ✗ 0/3 |
+| p2 | **AXIAM** | **67** | 706 | **850** | ✓ 3/3 |
+| p2 | Keycloak | (53) | (856) | (1 010) | ✗ 1/3 runs valid |
+| p2 | Zitadel | (2) | (22 197) | (25 314) | ✗ 0/3 |
 
-Keycloak's p0-vs-p2 login asymmetry (52 valid vs 23 gate-breaching) was
-diagnosed in follow-up work (task H7): a one-off diagnostic run with more
-container memory headroom (4 GiB instead of the shared 1 GiB default) reproduced
-both profiles as clean, 0%-error passes (p0 27.9 req/s, p2 13.6 req/s,
-legitimately slower under TLS, not gate-invalid) after twice reproducing an
-outright `OOMKilled` at the matrix's own memory cap. The likely explanation
-for the original matrix's asymmetry is Keycloak-on-Quarkus needing more than
-1 GiB of headroom under sustained Argon2/PBKDF2-class hashing load, not a
-TLS-specific defect — a harness sizing gap, not a fairness problem. AXIAM
-remains the fastest and the only target valid at both profiles, with
-**bounded memory** during the burst (and, as of this draft, the retention
-after the burst is fixed — see §2).
+AXIAM is the only target valid at both profiles, at **≤ 140 MiB of server
+memory** during the burst (§5). Keycloak's cells are excluded by our own
+validity gate, not by failure to function: even at the raised 2 GiB cap it
+completed only 1 of 3 runs cleanly per profile (parenthesized numbers are
+that single run, shown for transparency). Prior diagnostics showed
+Keycloak wants ~3.5–4 GiB under sustained hashing load; the next run will
+give its login cells exactly that, labeled. Zitadel's exclusion is its
+default bcrypt cost (~22 s p50 at 50 VUs) — expected and tunable.
 
-### AXIAM-only: authorization decisions
+### Authorization decisions (AXIAM-only — no competitor equivalent)
 
-No head-to-head exists (competitors expose no equivalent decision
-endpoint). Full RBAC evaluation (tenant-scoped roles, resource hierarchy,
-scopes) against live data, median-of-3:
+Full RBAC evaluation (tenant-scoped roles, resource hierarchy, scopes)
+against live data:
 
-| scenario | profile | thr (req/s) | p50 (ms) | p95 (ms) | p99 (ms) |
+| scenario | profile | thr | p50 (ms) | p95 (ms) | p99 (ms) |
 |---|---|---|---|---|---|
-| authz_check_rest | p0 | 737 | 68.4 | 85.2 | 94.1 |
-| authz_check_rest | p2 | 747 | 67.1 | 84.5 | 94.1 |
-| authz_check_grpc | p0 | 603 | 62.0 | 75.0 | 217.0 |
-| authz_check_grpc | p2 | 622 | 61.0 | 74.0 | 112.0 |
+| authz_check_grpc | p0 | **887** | 38 | 86 | 92 |
+| authz_check_grpc | p2 | **892** | 37 | 86 | 92 |
+| authz_check_rest | p0 | 753 | 74 | 93 | 99 |
+| authz_check_rest | p2 | 760 | 73 | 92 | 99 |
 
-Single checks are DB-saturated at ~740/s on a 2-core DB and scale to
-1013/s with 4 DB cores (§4). With the **decision cache** enabled (§4,
-opt-in) single checks reach **2322 req/s REST / 1822 gRPC** at the most
-favorable key space measured (K = 1, ~100% hit rate); §4 has the realistic
-key-space number and the reason the default stays off.
+gRPC now leads REST by **+18% throughput at half the p50** (draft 4 had
+gRPC 18% *behind* — that deficit was the fixed rate-limit write, §2). Both
+are DB-saturated at the 2-core DB cap and scale to 1 434–1 678/s with 4 DB
+cores (§4).
 
-**Batch checks — the decided verdict (§2), not a withdrawal.** With the
-shipped `coalesced` default, batch REST measured **744 batches/s
-(3 721 checks/s, 4.98× singles)**, p50/p95 comfortably inside the gate;
-batch gRPC **866–872 batches/s (≈4 330 checks/s)**, p95 74 ms. The
-`concurrent` alternative reached only 1.37× on REST. Full table:
-`claude_dev/authz-batch-investigation.md`.
+**Batch checks — an honest labeling note.** This run's batch cells
+accidentally measured the *non-default* `concurrent` strategy (a benchmark
+compose file still pinned the pre-decision default; now fixed): 199 batch
+ops/s REST = 995 checks/s, ~1.3× singles. The shipped default is
+`coalesced`, whose settled measurement remains the draft-4 verdict —
+**744 batch ops/s = 3 721 checks/s = 4.98× singles (REST), 866–872 ops/s
+≈ 4 330 checks/s (gRPC)**. Run 5 will re-measure `coalesced` at full
+matrix scale; until then, treat 4.98× as the default's number and this
+run's batch cells as the labeled alternative strategy.
+
+## 2. The fix this run verifies (and what it changed)
+
+Draft 4's most important finding was a defect, published openly: six hot
+endpoints (token, introspect, revoke, authz check, login, users-list) paid
+**one synchronous datastore write** (the shared rate-limit counter) before
+the handler ran — and on the gRPC listener *every* call paid it. The fix
+(a write-behind counter: decisions in-memory, one coalesced write per
+bucket per interval) shipped after draft 4. Run 4 measures it end-to-end:
+
+| endpoint (p0) | draft 4 (pre-fix) | **run 4 (post-fix)** | Δ |
+|---|---|---|---|
+| oauth2_client_credentials | 1 823 | **2 727** | +50% |
+| token_introspection | 2 230 | **4 387** | +97% |
+| authz_check_grpc | 603 | **887** | +47% |
+| userinfo_grpc | 3 294 | **12 665** | **+284%** |
+| authz_check_rest | 737 | 753 | +2% (DB-bound either way) |
+| userinfo / jwks / login | ~flat | ~flat | unaffected paths, as expected |
+
+The trade, restated from draft 4: cross-replica rate-limit enforcement is
+now eventual rather than synchronous — bounded overshoot
+`(replicas − 1) × arrival_rate_per_replica × sync_interval`, zero on a
+single replica. The settle-gate machinery built to detect the old clamp
+found nothing to refuse in this entire run — the first time that has ever
+been true.
+
+## 3. Security cost of TLS 1.3 (p2 vs p0, valid cells)
+
+| target / scenario | Δ throughput |
+|---|---|
+| axiam / token_introspection | −1.6% |
+| axiam / userinfo (REST) | −2.4% |
+| axiam / userinfo (gRPC) | −4.1% |
+| axiam / authz_check REST / gRPC | +0.9% / +0.6% |
+| axiam / token_refresh | −0.6% |
+| axiam / oauth2_password_login | −2.6% |
+| axiam / jwks_fetch | −10.1% |
+| axiam / oauth2_client_credentials | **−56.7%** — endpoint-specific, mechanism still open (§6) |
+| keycloak (all valid cells) | −1.6% … −7.8% |
+| zitadel (all valid cells) | −2.5% … +2.4% |
+
+Most rows measure TLS 1.3 *plus* an HTTP/1.1→2 protocol change together
+(the plaintext profile negotiates h1, the TLS profile h2); they are
+labeled as such in the raw report. **Native mTLS (p3, client certificates
+verified in-process, no proxy) again measured at parity with plain TLS 1.3
+on every scenario** — client-cert verification is free on top of TLS,
+which remains unique in this field and is the IoT headline.
 
 ## 4. Sensitivity passes (labeled, never mixed into head-to-heads)
 
-**DB-uncapped (4 CPUs / 2 GiB for every DB; servers stay at 2):**
+**DB-uncapped (DB 2→4 cores; servers stay at 2).** Post-fix, DB CPU is the
+product's main ceiling:
 
-| cell | capped → uncapped | what limits it now |
+| cell (p0) | capped → uncapped | Δ |
 |---|---|---|
-| AXIAM authz_check_rest | 737 → **1013** (+37%) | round-trip latency; nothing saturated |
-| AXIAM userinfo | 5008 → **7457** (+49%) | **AXIAM server itself, for the first time** |
-| AXIAM tokens/jwks | ±1% | not DB-bound at all |
-| Keycloak (every cell) | ±2% | Keycloak server (pegged in every cell) |
-| Zitadel jwks / userinfo | +70% / +85% | Postgres, even at 4 cores |
-| Zitadel introspection | +13% | Zitadel server |
+| authz_check_rest / _grpc | 753 → **1 434** / 887 → **1 678** | +90% / +89% |
+| oauth2_client_credentials | 2 727 → **4 484** | +64% |
+| token_introspection | 4 387 → **6 249** | +42% |
+| userinfo (REST) | 4 547 → **7 215** | +59% |
+| token_refresh | 839 → 1 089 | +30% |
+| jwks / login / userinfo_grpc | ±1% | not DB-bound |
 
-**Decision cache — measured, and now a closed decision (default stays
-off).** `AXIAM__AUTHZ__DECISION_CACHE_ENABLED=true`, TTL 5 s: authz checks
-**3.0–3.15×** at the most favorable key space (REST 2322/s, gRPC 1822/s,
-K = 1 — every VU sending the same `(subject, resource, action, scope)`
-tuple, ~100% hit rate). **Read that as a ceiling, not an expectation.** The
-one trustworthy larger-K measurement (K = 10 000, exceeding the per-tenant
-entry cap) is **+32%**, not +200%. Task H5 walked this data against seven
-criteria agreed before the numbers arrived; the ship bar for K = 10 000 was
-**≥1.5×**, and +32% does not clear it (`claude_dev/decision-cache-decision.md`
-§7–8). **Decision: stays opt-in.** Two caveats that belong with the number
-regardless of default: revocation is enforced by event-driven invalidation
-on the mutation path plus the 5 s TTL backstop (integration- and
-live-stack-tested) — but the cache is **process-local**, so with more than
-one replica a revocation only invalidates the replica that handled it, and
-the deployment's worst-case revocation latency is the TTL. The cache's own
-`AuthZ decision cache stats (D7)` log line reports the live `hit_rate_pct`
-so an operator can measure their own key-space win rather than assume one.
+Rule of thumb, confirmed harder than ever: **if your workload is
+authz/identity-read heavy, give the database cores first.**
 
-**DB connection pool — measured, closed negative (default stays 1).**
-`AXIAM__DB__POOL_SIZE=4`: token issuance **+7%** (1823→1955) in the one
-sample that exists; everything else within noise. That sample was never
-confirmed to run outside the settle-gate-blind window (§1/§5), and a direct
-mechanism test (pool 1→8, 0 ops/s change at 1 or 20 VUs) says the
-connection model doesn't buy DB concurrency from more pooled handles
-anyway. **Default stays `pool_size=1`.** `claude_dev/db-pool-design.md` §11.
+**Decision cache (opt-in, TTL 5 s) — measured at its best case.** With the
+rate-limit fix in place, cache-ON at the bench's favorable keyspace lifts
+gRPC checks to **11 598/s (13.1×)** and batch to ~26 000–45 000 checks/s —
+but REST checks only +5% (791/s): the REST path's per-request session-
+cookie validation (a DB read the decision cache deliberately does not
+cover) becomes its own limiter. Read 13× as a ceiling at ~100% hit rate,
+not an expectation — the realistic-keyspace measurement from draft 4
+(+32% at K=10 000) still stands, the default **stays off**, and the server
+logs its live hit rate so you can measure your own workload before opting
+in. The REST-path session cost is now a tracked optimization target.
 
-**Native mTLS (p3)** — AXIAM terminates **client-certificate TLS 1.3
-in-process** (no proxy in front; the verified peer certificate is the
-identity source). Result: **parity with plain TLS 1.3 across the entire
-matrix** (CC 903.6 vs 903, introspection 2201 vs 2225, userinfo 4826 vs
-4822, jwks 24 146 vs 24 309…). For IoT/mTLS fleets: client-cert
-verification is free on top of TLS.
+**Production rate-limit posture.** With shipped (`internet`) limits, a
+single-IP 50-VU flood is throttled to the configured trickle on every
+limited REST endpoint (token 20/min, introspect 10/min, authz 300/min,
+login 10/min — all enforced within measurement error) while unlimited
+paths run at full speed beside it (userinfo 4 572/s, jwks 26 324/s — the
+429 path is cheap). Two findings from this pass:
 
-**Production rate-limit posture:** with AXIAM's shipped per-IP limits
-active (token 20/min/IP, introspect 10/min/IP, …) a 50-VU single-IP
-generator is throttled to near-zero on every limited endpoint — the
-defaults do exactly what they're for (blunt single-source abuse), and this
-pass is the measured evidence that AXIAM ships enforcing limits by default
-while the competitors ship none. It is **not** a performance measurement.
-Follow-up work (task H7) re-measured the `gateway` preset
-(`AXIAM__RATE_LIMIT__PROFILE=gateway`) on the sandbox host: switching a
-single machine client from per-IP to per-`client_id` keying moved its
-admitted rate from 8.5%/3.7%/68.9% ok (heavily throttled) to
-**96.6%/100%/100% ok** on token/introspect/authz respectively — the preset
-does exactly what §6 recommends it for. It does **not** touch the
-per-request shared-rate-limit write from §1/§5: admitted throughput under
-`gateway` landed at 22–24 ops/s on that host, the same band H2 measured for
-those endpoints under every other posture — a rate-limit *policy* change
-cannot make a synchronous datastore write cheaper. (That write is itself
-fixed as of `claude/g-benchmark-improvements-n5mjmj`, per §1/§5 — this
-measurement predates the fix and is left as the honest pre-fix record.) See
-§6 for what to set instead.
+1. The defaults do their abuse-stopping job, and remain far too strict for
+   real machine fleets — §7 gives the numbers-backed sizing guidance.
+2. **It caught a real bug: the gRPC limiter admits ~1/60th of its
+   configured rate** (a per-second limit is enforced against a per-minute
+   window by one of the two cooperating limiter layers). Found by this
+   benchmark, root-caused in code, fix tracked. Until it ships, treat
+   `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` as effectively per-minute in
+   production postures — or keep gRPC behind the neutral default and limit
+   at the mesh/gateway layer.
 
-## 5. Weaknesses and caveats (the honest section)
+## 5. Resource usage during the tests (new in this draft — graph-ready)
 
-**What we called a "post-seed database transient" was never post-seed, and
-on some hosts it never clears.** The Phase H investigation
-(`claude_dev/postseed-transient-investigation.md`, task H2) traced it to a
-real, permanent design property of AXIAM: six endpoints —
-`POST /api/v1/authz/check`, `POST /oauth2/token`, `POST /oauth2/introspect`,
-`POST /oauth2/revoke`, `POST /api/v1/auth/login` and `GET /api/v1/users` —
-perform **one synchronous SurrealDB write (the shared rate-limit counter)
-before the handler runs**, on every request, forever. That round trip is
-the throughput ceiling for those endpoints. On the sandbox investigation
-host it cost ~40 ms and pinned all six at **16–21 ops/s at any concurrency
-from 1 to 40 clients, indefinitely** — unaffected by seeding, data volume,
-uptime, traffic, server or datastore restarts, connection-pool size, or
-even swapping the datastore to a pure in-memory backend (all tested
-directly). On the G-box the same write cost only ~22 ms, cheap enough that
-the endpoints still ran hundreds of requests per second once whatever made
-it briefly more expensive right after a fresh seed (still not fully
-explained — see below) subsided. On the gRPC listener the same write is
-applied server-wide as a tower layer, so **every** gRPC call pays it, not
-just the six REST paths. **Readers should treat every AXIAM number on those
-six endpoints (client_credentials, introspection, authz_check, login,
-revoke) as bounded by the cost of one datastore write in your deployment's
-environment, not by AXIAM's request handling** — on a fast datastore that
-ceiling is high (hundreds to low thousands of ops/s, as this draft's own
-G-box numbers show); on a slow one it is the whole story. **Both fixes
-written up as a maintainer issue in
-`claude_dev/postseed-transient-investigation.md` §7.1 have since shipped**,
-on branch `claude/g-benchmark-improvements-n5mjmj`: `GET /api/v1/users` no
-longer inherits the *registration* rate-limit bucket (it was the separate,
-already-understood bug — 5/min/IP in the production posture, now unlimited
-like its sibling list endpoints), and the shared-store round trip is off the
-synchronous critical path — a write-behind counter
-(`axiam_db::rate_limit_counter::SharedRateLimitCounter`) now decides
-in-memory and coalesces one datastore write per bucket per sync interval
-instead of one per request. See the "Moved to fixed" list below for what
-that trades: cross-replica enforcement becomes eventual rather than
-synchronous, bounded by a stated, quotable overshoot formula. **Neither fix
-changes the numbers in this draft** — they were measured before the fix
-existed, and no post-fix run has happened yet; that measurement will land in
-`claude_dev/rate-limit-fix-verification.md`, not here. **What remains
-genuinely unresolved, stated plainly:** the G-box's specific recovery
-pattern — a ~5–7 minute window that ends in a sharp cliff back to full
-throughput — has not been reproduced on the second host, which never
-recovers at all. Two readings are possible and this draft does not pick
-between them: the G-box's write occasionally drops from ~22 ms to ~1 ms for
-some SurrealDB-side reason not yet identified, or the G-box's "recovered"
-cells were measuring something subtly different from the clamped ones. This
-is the single largest open item carried into the next investigation round.
+Same load, same 2-CPU / 2-GiB envelope for every server. Two ways to look
+at it, both worth a chart on the site:
 
-**The TLS token-issuance halving is priced but not fully explained.** See
-§2 and §3 — HTTP/2 is acquitted by direct measurement, TLS 1.3 itself costs
-10–13% elsewhere in the matrix, and the shared rate-limit write above is the
-leading candidate for the remaining `client_credentials`-specific penalty —
-but `token_introspection`, wrapped by the identical middleware, loses only
-0.2% under the same conditions, which is a real objection the current
-evidence has not resolved. Even with the unexplained penalty, AXIAM's TLS
-token numbers lead the field 2.2–2.6×.
+### 5.1 Server memory (MiB, p0 matrix, median-of-3)
 
-**Moved to fixed since draft 3:**
+| scenario | AXIAM avg | AXIAM peak | Keycloak avg | Keycloak peak | Zitadel avg | Zitadel peak |
+|---|---|---|---|---|---|---|
+| jwks_fetch | 97 | 98 | 726 | 973 | 158 | 163 |
+| oauth2_client_credentials | 99 | 106 | 900 | 979 | 143 | 147 |
+| token_introspection | 103 | 104 | 794 | 795 | 157 | 161 |
+| token_refresh | 104 | 106 | 797 | 804 | — | — |
+| userinfo | 104 | 105 | 798 | 806 | 157 | 162 |
+| oauth2_password_login | 131 | 140 | 969 | 796* | 157 | 131* |
+| **worst case, whole run** | — | **172** | — | **1 070** | — | **216** |
 
-- **Memory retention** (~360 MiB retained after a login burst) — fixed via
-  jemalloc as the release-container default allocator; 94% of the gap
-  closed, no throughput cost (§2, task H4/G6).
-- **Batch verdict** — no longer withdrawn pending re-measurement; `coalesced`
-  measured, decided, and shipped as the default (§2/§3, task H3/G3).
-- **Refresh harness** — the cookie `Path` bug that made every AXIAM refresh
-  cell measure a client-credentials fallback is fixed; the cell is restored
-  under the `protocol-variant` comparability label (§2/§3, task G4/H7).
-- **p0-plaintext `Secure`-cookie bug** — every cookie-based p0 scenario used
-  to die in harness `setup()`; fixed for the bench profile only, production
-  default unchanged (§2, task H6).
-- **The shared rate-limit write named above** — `GET /api/v1/users`'s
-  rate-limit bucket bug and the synchronous shared-store write on the six
-  hottest endpoints are both fixed on `claude/g-benchmark-improvements-n5mjmj`
-  (write-behind `SharedRateLimitCounter`; `AXIAM__RATE_LIMIT__SHARED`/
-  `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` env knobs). Cross-replica enforcement is
-  now eventual (bounded by `(replicas − 1) × arrival_rate_per_replica ×
-  sync_interval`, zero on a single replica) instead of synchronous — a
-  deliberate, documented trade, not a regression. **Not yet re-measured**:
-  the numbers in this draft predate the fix; post-fix throughput lands in
-  `claude_dev/rate-limit-fix-verification.md` when that run completes, not in
-  this file.
+*\* peak medians differ from avg medians across runs on the partially
+valid login cells; the whole-run worst case row is the honest summary.*
 
-**Other caveats, stated plainly:** consumer-laptop hardware (server-class
-re-run still pending budget — see "next round" below); AXIAM stack figures
-include RabbitMQ (~0.1–0.3 cores); k6 skips cert verification at p2/p3
-(throwaway CA; handshake and record crypto are real); closed-loop 50 VUs
-floors the fastest endpoints (JWKS) and measures latency, not capacity, when
-nothing saturates; the decision cache and the DB connection pool are both
-measured, decided, and stay off/at-default (§4) — neither is oversold as a
-"just turn this on" win; the SDK client-side overhead table (§7.1) has real
-data now but from one un-repeated pass, not a median-of-3.
+**AXIAM's server never exceeded 172 MiB — 8% of its allowance — while
+delivering the throughput numbers in §1. Keycloak needed the cap raised to
+2 GiB just to run (peak 1 070 MiB, above the old 1 GiB cap), and was still
+excluded on login validity.** Zitadel's Go server is respectably small
+(≤ 216 MiB) — its costs show up in CPU-per-request and its Postgres
+instead. Whole-stack memory (server + DB + broker): AXIAM 415–590 MiB
+(includes SurrealDB and RabbitMQ), Keycloak 814–1 129 MiB, Zitadel
+293–443 MiB — Zitadel's stack is the smallest, AXIAM's the most
+throughput per byte (below).
 
-## 6. Recommended settings by deployment (measured, not guessed)
+### 5.2 CPU efficiency (p0, whole stack, median-of-3)
 
-The production-posture pass (§4) showed the shipped defaults are tuned for
-one thing: stopping single-source abuse on a small internet-facing
-deployment. Every knob below is a runtime environment variable; the
-recommendations derive directly from this run's measurements on
-2-core/1-GiB-per-container hardware (G-box; the `gateway`-preset admitted-rate
-numbers are sandbox-host, §4) — scale linearly with your envelope where the
-data says the path scales (authz/userinfo with DB CPU; login with server
-CPU; token issuance with neither until ~1.8k/s per 2 cores).
-
-### Sizing quick reference (what a given envelope measured)
-
-| Envelope (server / DB) | Token issuance | Introspection | Authz checks (cache off / on) | Userinfo | Logins (Argon2id, OWASP) |
-|---|---|---|---|---|---|
-| 2 cores / 2 cores | ~1 800/s | ~2 200/s | ~740 / ~2 300/s | ~5 000/s | ~69/s |
-| 2 cores / 4 cores | ~1 800/s | ~2 200/s | ~1 000 / higher | ~7 500/s (server-bound) | ~69/s |
-
-**Whatever your envelope, one fact matters more than the table above for the
-six `RateLimitShared` endpoints (token, introspect, authz_check, login,
-revoke, and the `users` list — §5): their real ceiling is set by your
-deployment's cost for one small SurrealDB `UPSERT`, not by AXIAM's request
-handling.** The numbers above assume a datastore where that write is cheap
-(the G-box's measured ~22 ms); if your datastore is slower, size expectations
-down accordingly and watch the `AuthZ`/`RateLimit` metrics rather than
-trusting this table blind.
-
-### Knob-by-knob
-
-| Setting (env var) | Shipped default | Small internet-facing (2c/1GiB) | M2M / microservices / IoT fleet | Large multi-tenant (8c+) |
+| scenario | metric | AXIAM | Keycloak | Zitadel |
 |---|---|---|---|---|
-| `AXIAM__RATE_LIMIT__PROFILE` | `internet` | `internet` | **`gateway`** — moves the whole machine-traffic family coherently from one variable; measured (§4): single-client_id admitted rate 8.5%→96.6% (token), 3.7%→100% (introspect), 68.9%→100% (authz) | `mesh` |
-| `AXIAM__RATE_LIMIT__KEY` | `ip` | `ip` | **`client_id`** (or `ip_client_id`) — per-IP buckets collide behind NAT/gateways — **but read the security caveat below first** | `ip_client_id` |
-| `AXIAM__RATE_LIMIT__TOKEN_PER_MIN` | 20 | 60–120 | **per-client peak × 60 × 2** (a 2-core server sustains ~108k issuances/min total on a fast datastore — §5 caveat applies) | budget per tenant SLA |
-| `AXIAM__RATE_LIMIT__INTROSPECT_PER_MIN` | 10 | 60 | 10–20× your token limit (resource servers introspect per request) | same rule |
-| `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN` | 300 | 600 | **6 000–60 000** per client (checks are cheap reads; 300/min starves any real service) | size to cache-on ceiling |
-| `AXIAM__RATE_LIMIT__LOGIN_PER_MIN` | 10 (per IP) | keep 10 | 60+ if users arrive through a shared NAT/proxy (always per-IP by design) | 60+, front with WAF |
-| `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` | `false` | `false` | `false` (measured but not shipped ON — §4/§2: +32% at a realistic key space, below the ship bar) | `false`, evaluate per tenant hit-rate |
-| `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` | 5 | 5 | 5 (raise only if a ≤TTL revocation delay is acceptable, if you turn the cache on) | 5 |
-| `AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES` | 10 000/tenant | default | default | raise with RAM (entries are small, ~276 B measured) |
-| `AXIAM__AUTHZ__BATCH_STRATEGY` | `coalesced` (shipped default, decided task H3/G3) | default | default — `coalesced` measured 744 REST batch ops/s (3 721 checks/s, 4.98× singles) and 866–872 gRPC batch ops/s (≈4 330 checks/s, p95 74 ms) vs `concurrent`'s 1.37× / 282 ms p95 | default |
-| `AXIAM__DB__POOL_SIZE` | 1 | 1 | 1 — measured no benefit; the one +7% sample was never confirmed settled and a direct mechanism test found 0 change (§4/§2, task H9) | 1 |
-| `AXIAM__DB__POOL_MAX_IN_FLIGHT` | 0 (off) | 0 | 0 (never bound in tests at 50 VUs) | set only with evidence |
-| `AXIAM__AUTH__MAX_CONCURRENT_HASHES` | 0 = auto (min(cpus, 4)) | auto | auto | ≈ physical cores reserved for auth; keeps login RAM bounded (~19 MiB per concurrent hash) |
-| DB CPU allocation | — | DB ≥ server cores | DB ≥ server cores if authz/userinfo-heavy (they scale with DB CPU; tokens don't) | 2× server cores for read-heavy |
+| oauth2_client_credentials | cpu·ms per request | **1.20** | 5.84 | 8.20 |
+| token_introspection | 〃 | **0.78** | 1.27 | 4.00 |
+| jwks_fetch | 〃 | **0.06** | 0.44 | 1.42 |
+| userinfo (REST) | 〃 | 0.73 | **0.53** | 2.88 |
+| userinfo (server-only) | 〃 | **0.25** | 0.53 | 0.86 |
+| oauth2_client_credentials | req/s per GiB of stack RAM | **5 988** | 338 | 1 218 |
+| token_introspection | 〃 | **8 709** | 1 939 | 2 199 |
+| userinfo | 〃 | **8 948** | 3 999 | 2 312 |
+| jwks_fetch | 〃 | **60 723** | 5 741 | 7 330 |
 
-**Security caveat on `client_id` keying — read before changing the key mode.**
-The `client_id` a request is bucketed by is read from the request body
-*before* the client credential is verified (that is what the OAuth2 spec puts
-there). So an attacker who simply varies the `client_id` string gets a fresh
-bucket each time and is effectively unlimited on the token, revoke and
-introspect endpoints. **`client_id` keying is a fairness control between
-well-behaved clients, not an abuse control.** `ip` is the only mode whose key
-an attacker cannot mint at will, which is why it stays the shipped default.
-Use `client_id`/`ip_client_id` only where something else is already
-authenticating callers at the edge — mTLS, an API gateway, a WAF, or an IP
-allow-list — which is exactly the topology the M2M column assumes.
+One asterisk kept in the open: whole-stack userinfo CPU-per-request is the
+single efficiency cell Keycloak wins (AXIAM's figure carries a pegged
+SurrealDB plus RabbitMQ; server-only, AXIAM is 2.1× cheaper). Every other
+cell, both axes, AXIAM leads by 1.6× to 17×.
 
-Two rules of thumb the data supports: (1) if your traffic is
-authorization-check-heavy, spend hardware on the **database** first — the
-decision cache is measured but does not clear its own ship bar at a
-realistic key space (§4), so it is a "measure your own hit rate before
-opting in" knob, not a default lever; (2) if it's token-heavy, the
-limits — not the hardware — are what you'll hit first on a fast datastore,
-and the datastore's own cost for the shared rate-limit write is what you'll
-hit first on a slow one (§5): raise `TOKEN_PER_MIN` from your real
-per-client peak and, *if and only if* you have edge authentication per the
-caveat above, switch the key mode; keep the defaults on genuinely
-internet-exposed endpoints (login, register, password-reset, MFA), which
-stay per-IP in every configuration.
+Suggested site charts from this section: (a) grouped bars of server RSS
+peak per scenario (log scale not needed — 172 vs 1 070 speaks), (b)
+cpu·ms/request grouped bars, (c) a scatter of throughput vs stack RAM
+(req/s per GiB). All values above are final medians, chartable as-is.
 
-## 7. Full result matrix (G-box, capped run, median-of-3, graph-ready)
+## 6. Weaknesses and caveats (the honest section)
+
+- **The TLS client-credentials drop (−57%) is still unexplained.** New
+  post-fix evidence narrows it: under TLS the endpoint shows a flat ~43 ms
+  per request with *nothing saturated* — a serialization plateau, not a
+  crypto cost — and the old prime suspect (the rate-limit write) is gone.
+  A dedicated VU-sweep is the next-round task. Even with the penalty,
+  AXIAM's TLS token issuance leads the field 2.8–3.4×.
+- **Batch cells this run measured the non-default strategy** due to a
+  benchmark-harness pin (now fixed); the shipped default's number remains
+  draft 4's 4.98× table until run 5 re-measures it (§1).
+- **The gRPC production rate limiter under-admits ×60** (units bug, found
+  by this run's posture pass, fix tracked) — §4/§7.
+- **Keycloak's login cells are excluded by our validity gate at 2 GiB**;
+  next run gives them 4 GiB, labeled. Zitadel's login/refresh exclusions
+  are its default bcrypt cost / a missing harness flow — stated, not
+  hidden.
+- **Consumer-laptop hardware**, package temperatures hit 96–100 °C on hot
+  cells and clock varied 3.2–3.9 GHz — medians-of-3 keep spreads at
+  ±0.2–2.8% on AXIAM cells, but a server-class re-run remains the standing
+  caveat on absolute numbers.
+- AXIAM stack figures include RabbitMQ (~0.1–0.3 cores, ~110–130 MiB) and
+  SurrealDB; k6 skips cert verification at p2/p3 (handshake and record
+  crypto are real); closed-loop 50 VUs floors the fastest endpoints (JWKS)
+  — those cells measure latency, not capacity.
+- **SDK table caveats**: single pass (not median-of-3); no wire-baseline
+  was captured this run, so SDK-vs-wire overhead is not published; the C
+  and PHP harnesses run at concurrency 1 (their numbers are not comparable
+  with the concurrency-16 SDKs); the C# `refresh` row measures a cached
+  no-op (1 µs — its auth helper correctly skips the network when the token
+  is still valid; the harness must force expiry next run) and one C++ tail
+  anomaly is under investigation (§9).
+
+## 7. Production rate limits: measured capacity, and what to set
+
+AXIAM ships enforcing abuse limits by default; the competitors ship none.
+This run measured both the enforcement (§4) and — for the first time on a
+clean build — the actual capacity headroom behind those limits on a modest
+2-core envelope:
+
+| endpoint | shipped default (`internet`, per-IP) | measured capacity (this run, 2c server / 2c DB) | default as % of capacity |
+|---|---|---|---|
+| `POST /oauth2/token` | 20/min | ~2 727/s ≈ 163 000/min | 0.012% |
+| `POST /oauth2/introspect` | 10/min | ~4 387/s ≈ 263 000/min | 0.004% |
+| `POST /api/v1/authz/check` | 300/min | ~753/s ≈ 45 000/min (REST) | 0.7% |
+| gRPC authz | 100/s | ~887/s (checks), 12 665/s (reads) | 11% (nominal — see bug note §4) |
+| `POST /api/v1/auth/login` | 10/min | ~69/s ≈ 4 100/min (Argon2id-bound) | 0.2% |
+
+The gap is deliberate on an internet edge — but it means the defaults
+*will* throttle any legitimate machine fleet, and a NAT'd fleet shares one
+IP bucket. Recommendations, updated for run 4:
+
+### 7.1 Pick a posture first (one variable)
+
+| Deployment | Set | What it does |
+|---|---|---|
+| Small internet-facing | *(nothing — defaults)* | strict per-IP limits on everything |
+| M2M / microservices / IoT behind NAT or gateway | `AXIAM__RATE_LIMIT__PROFILE=gateway` | per-`client_id` buckets; token 600/min, introspect 6 000/min, authz 6 000/min per client — measured (draft 4): admitted rate for a single well-behaved client 8.5% → 96.6% (token), 3.7% → 100% (introspect), 68.9% → 100% (authz) |
+| Private network / service mesh | `AXIAM__RATE_LIMIT__PROFILE=mesh` | ceilings as runaway-loop guards: token 6 000/min, introspect/authz 60 000/min per client |
+
+Human endpoints (login, register, password-reset, MFA) stay at their
+strict per-IP defaults in **every** profile, by design — raise those
+individually and deliberately or not at all.
+
+### 7.2 Suggested revisions to the shipped defaults (proposal, sized from this run)
+
+The measured data supports modestly raising the machine-endpoint
+`internet` defaults — each suggestion stays ≥ 500× below measured capacity
+(so the abuse posture is intact) while no longer breaking a single healthy
+integration:
+
+| knob | today | suggested | why (measured) |
+|---|---|---|---|
+| `TOKEN_PER_MIN` | 20 | **120** | one service refreshing a 15-min token for a handful of workers exhausts 20/min behind NAT; 120/min is 0.07% of measured capacity |
+| `INTROSPECT_PER_MIN` | 10 | **600** | resource servers introspect per *request*; 10/min breaks the first real API behind AXIAM; 600/min = 10/s = 0.2% of capacity |
+| `AUTHZ_CHECK_PER_MIN` | 300 | **1 800** | 300/min = 5/s starves a single modest service; 1 800/min = 30/s = 4% of a 2-core envelope |
+| `REVOKE_PER_MIN` | 10 | **60** | logout bursts from one gateway IP hit 10/min immediately |
+| `GRPC_AUTHZ_PER_SEC` | 100/s | keep value; **fix enforcement first** and scope it to authz methods | currently admits ~100/min (×60 units bug, §4) and throttles non-authz gRPC (userinfo) under the same server-wide bucket |
+| login / register / password-reset / MFA | 10 / 5 / 3 / 5 per min | **unchanged** | these gate credential-guessing; capacity is irrelevant to their sizing |
+
+Sizing rule for your own values: take your real per-key peak (per IP or
+per client_id, whichever mode you run), double it, and check it against
+the capacity column scaled to your hardware (authz/introspect/userinfo
+scale with DB cores — +42–90% from 2→4 DB cores, §4; login scales with
+server cores; token issuance is ahead of both until ~2.7 k/s per 2 cores).
+And the standing security caveat: `client_id`-keyed modes are fairness
+controls between authenticated well-behaved clients, not abuse controls —
+the client_id is attacker-mintable before authentication — so use them
+only behind an edge that authenticates callers (mTLS, gateway, WAF,
+allow-list). `ip` remains the only attacker-resistant key and stays the
+default.
+
+## 8. Full result matrix (graph-ready)
 
 One row per (scenario, profile, target); `±` is the throughput spread
-across the three runs; `http` is the negotiated protocol
-(`bench_http_proto`, k6's `res.proto`) where captured. Rows failing a
-validity gate or measuring a fallback/protocol-variant are labeled and
-**must not be charted as an unqualified head-to-head**.
+across the three runs; cpu = whole-stack cores avg; mem = whole-stack MiB
+avg. Rows failing a validity gate or carrying a comparability label say
+so and **must not be charted as an unqualified head-to-head**.
 
-| scenario | profile | target | thr (req/s) | ± | p50 | p95 | p99 | cpu (cores) | mem (MiB) | valid |
+| scenario | profile | target | thr (req/s) | ± | p50 (ms) | p95 (ms) | p99 (ms) | cpu | mem | valid / label |
 |---|---|---|---|---|---|---|---|---|---|---|
-| oauth2_client_credentials | p0 | axiam | 1823 | 0.1% | 25.4 | 31.9 | 35.8 | 2.86 | 516 | ✓ |
-| oauth2_client_credentials | p0 | keycloak | 351 | 1.4% | 103.6 | 208.1 | 301.4 | 2.07 | 764 | ✓ |
-| oauth2_client_credentials | p0 | zitadel | 423 | 0.3% | 110.0 | 134.2 | 171.3 | 3.68 | 362 | ✓ |
-| oauth2_client_credentials | p2 | axiam | 903 | 0.1% | 54.2 | 62.8 | 65.0 | 1.59 | 523 | ✓ |
-| oauth2_client_credentials | p2 | keycloak | 346 | 0.9% | 104.0 | 209.1 | 300.4 | 2.07 | 804 | ✓ |
-| oauth2_client_credentials | p2 | zitadel | 415 | 0.6% | 113.1 | 137.5 | 168.7 | 3.73 | 356 | ✓ |
-| token_introspection | p0 | axiam | 2230 | 0.3% | 20.4 | 27.1 | 29.8 | 2.46 | 922 | ✓ |
-| token_introspection | p0 | keycloak | 1908 | 2.0% | 7.2 | 81.7 | 85.5 | 2.36 | 973 | ✓ |
-| token_introspection | p0 | zitadel | 910 | 1.2% | 47.8 | 68.7 | 76.2 | 3.67 | 441 | ✓ |
-| token_introspection | p2 | axiam | 2225 | 0.5% | 20.4 | 27.2 | 30.2 | 2.65 | 927 | ✓ |
-| token_introspection | p2 | keycloak | 1758 | 2.4% | 7.9 | 82.5 | 86.8 | 2.35 | 873 | ✓ |
-| token_introspection | p2 | zitadel | 899 | 0.9% | 50.1 | 67.7 | 76.8 | 3.77 | 424 | ✓ |
-| token_refresh | p0 | keycloak | 379 | 2.0% | 101.5 | 204.6 | 299.5 | 2.05 | 983 | ✓ real rotation ⚠ protocol-variant |
-| token_refresh | p2 | keycloak | 367 | 1.1% | 102.3 | 205.2 | 298.5 | 2.05 | 881 | ✓ real rotation ⚠ protocol-variant |
-| token_refresh | p0 | axiam | 910 | n=1 | — | — | — | — | — | ✓ session refresh, 0% fallback ⚠ protocol-variant, single confirm run not median-of-3 |
-| token_refresh | p0/p2 | zitadel | — | — | — | — | — | — | — | ✗ fallback + gate |
-| jwks_fetch | p0 | axiam | 27784 | 0.3% | 1.3 | 2.9 | 4.2 | 1.65 | 503 | ✓ |
-| jwks_fetch | p0 | keycloak | 3764 | 2.0% | 3.1 | 75.2 | 79.9 | 2.00 | 631 | ✓ |
-| jwks_fetch | p0 | zitadel | 2071 | 0.6% | 11.2 | 65.1 | 67.4 | 2.97 | 261 | ✓ |
-| jwks_fetch | p2 | axiam | 24309 | 0.9% | 1.6 | 2.9 | 4.0 | 1.97 | 502 | ✓ |
-| jwks_fetch | p2 | keycloak | 3042 | 1.5% | 3.8 | 77.6 | 82.9 | 2.01 | 681 | ✓ |
-| jwks_fetch | p2 | zitadel | 2023 | 0.8% | 12.8 | 61.1 | 64.1 | 3.11 | 258 | ✓ |
-| oauth2_password_login | p0 | axiam | 69 | 1.0% | 694.7 | 774.1 | 1055.5 | 2.09 | 897 | ✓ |
-| oauth2_password_login | p0 | keycloak | 52 | 7.8% | 919.3 | 1069.7 | 1161.6 | 2.05 | 911 | ✓ (2/3 runs) |
-| oauth2_password_login | p0 | zitadel | 2 | 1.0% | 22604.7 | 25388.0 | 27052.2 | 2.02 | 418 | ✗ p95>2s |
-| oauth2_password_login | p2 | axiam | 69 | 0.6% | 691.5 | 815.8 | 1116.5 | 2.30 | 918 | ✓ |
-| oauth2_password_login | p2 | keycloak | 23 | 0.4% | 2115.1 | 2248.6 | 2315.0 | 2.03 | 854 | ✗ p95>2s (diagnosed OOM-sizing, not TLS — §3) |
-| oauth2_password_login | p2 | zitadel | 2 | 1.5% | 21822.6 | 25529.0 | 27744.6 | 2.02 | 411 | ✗ p95>2s |
-| userinfo | p0 | axiam | 5008 | 0.6% | 4.8 | 50.2 | 54.4 | 3.45 | 765 | ✓ |
-| userinfo | p0 | keycloak | 3742 | 1.9% | 3.0 | 77.0 | 80.6 | 2.00 | 961 | ✓ |
-| userinfo | p0 | zitadel | 943 | 1.4% | 25.7 | 82.6 | 88.7 | 2.83 | 451 | ✓ (machine-user token) |
-| userinfo | p2 | axiam | 4822 | 0.2% | 5.2 | 49.2 | 54.0 | 3.59 | 638 | ✓ |
-| userinfo | p2 | keycloak | 3489 | 1.1% | 3.2 | 77.9 | 81.4 | 2.01 | 858 | ✓ |
-| userinfo | p2 | zitadel | 950 | 1.8% | 27.4 | 80.8 | 89.0 | 2.93 | 443 | ✓ (machine-user token) |
-| userinfo_grpc (AXIAM-only) | p0 | axiam | 3294 | 0.2% | 14.0 | 22.0 | 25.0 | 1.61 | 757 | ✓ |
-| userinfo_grpc (AXIAM-only) | p2 | axiam | 3254 | 0.3% | 14.0 | 22.0 | 25.0 | 1.51 | 606 | ✓ |
-| zitadel_userinfo_grpc | p0 | zitadel | 183 | 1.2% | 233.0 | 503.0 | 887.0 | 1.16 | 445 | ✓ (machine-user token) |
-| zitadel_userinfo_grpc | p2 | zitadel | 187 | 1.7% | 232.0 | 328.0 | 843.0 | 1.19 | 440 | ✓ (machine-user token) |
-| authz_check_rest (AXIAM-only) | p0 | axiam | 737 | 0.9% | 68.4 | 85.2 | 94.1 | 2.92 | 481 | ✓ |
-| authz_check_rest (AXIAM-only) | p2 | axiam | 747 | 0.0% | 67.1 | 84.5 | 94.1 | 2.86 | 474 | ✓ |
-| authz_check_grpc (AXIAM-only) | p0 | axiam | 603 | 2.8% | 62.0 | 75.0 | 217.0 | 2.55 | 468 | ✓ |
-| authz_check_grpc (AXIAM-only) | p2 | axiam | 622 | 1.1% | 61.0 | 74.0 | 112.0 | 2.47 | 465 | ✓ |
-| authz_batch_rest (coalesced, AXIAM-only) | settled | axiam | 744 | — | 49 | — | — | — | — | ✓ 3 721 checks/s, 4.98× singles |
-| authz_batch_grpc (coalesced, AXIAM-only) | settled | axiam | 866–872 | — | — | 74 | — | — | — | ✓ ≈4 330 checks/s |
-| authz_batch_rest (concurrent, AXIAM-only) | settled | axiam | 200 | — | — | — | — | — | — | ✓ 1 000 checks/s, 1.37× singles |
-| authz_batch_grpc (concurrent, AXIAM-only) | settled | axiam | 216 | — | — | 282 | — | — | — | ✓ |
+| oauth2_client_credentials | p0 | axiam | 2727 | 0.4% | 9.1 | 58.1 | 62.5 | 3.26 | 466 | ✓ |
+| oauth2_client_credentials | p0 | keycloak | 354 | 11.5% | 103.0 | 208.4 | 301.3 | 2.07 | 1074 | ✓ |
+| oauth2_client_credentials | p0 | zitadel | 425 | 2.8% | 108.7 | 139.9 | 169.2 | 3.48 | 357 | ✓ |
+| oauth2_client_credentials | p2 | axiam | 1180 | 0.0% | 42.6 | 43.9 | 44.8 | 2.07 | 471 | ✓ |
+| oauth2_client_credentials | p2 | keycloak | 346 | 14.5% | 104.1 | 208.5 | 300.4 | 2.07 | 910 | ✓ |
+| oauth2_client_credentials | p2 | zitadel | 419 | 1.6% | 110.9 | 138.7 | 164.5 | 3.54 | 353 | ✓ |
+| token_introspection | p0 | axiam | 4387 | 0.6% | 5.9 | 48.5 | 53.4 | 3.41 | 516 | ✓ |
+| token_introspection | p0 | keycloak | 1860 | 2.6% | 7.5 | 81.9 | 85.7 | 2.37 | 982 | ✓ |
+| token_introspection | p0 | zitadel | 932 | 1.6% | 48.2 | 66.1 | 73.7 | 3.73 | 434 | ✓ |
+| token_introspection | p2 | axiam | 4316 | 0.7% | 6.2 | 45.6 | 51.3 | 3.50 | 539 | ✓ |
+| token_introspection | p2 | keycloak | 1715 | 7.1% | 8.1 | 83.0 | 87.7 | 2.34 | 976 | ✓ |
+| token_introspection | p2 | zitadel | 909 | 2.0% | 50.4 | 67.8 | 76.0 | 3.81 | 437 | ✓ |
+| jwks_fetch | p0 | axiam | 26371 | 1.2% | 1.3 | 3.1 | 4.5 | 1.63 | 445 | ✓ |
+| jwks_fetch | p0 | keycloak | 4565 | 4.8% | 2.7 | 72.5 | 76.7 | 2.00 | 814 | ✓ |
+| jwks_fetch | p0 | zitadel | 2096 | 1.9% | 11.2 | 64.7 | 66.8 | 2.98 | 293 | ✓ |
+| jwks_fetch | p2 | axiam | 23716 | 0.8% | 1.6 | 3.2 | 4.4 | 1.94 | 455 | ✓ |
+| jwks_fetch | p2 | keycloak | 4261 | 10.8% | 3.1 | 72.0 | 76.2 | 2.01 | 869 | ✓ |
+| jwks_fetch | p2 | zitadel | 2057 | 0.8% | 12.9 | 59.9 | 62.8 | 3.14 | 295 | ✓ |
+| userinfo | p0 | axiam | 4547 | 0.3% | 5.4 | 51.4 | 55.8 | 3.30 | 520 | ✓ |
+| userinfo | p0 | keycloak | 3783 | 0.8% | 3.0 | 76.8 | 80.5 | 2.00 | 969 | ✓ |
+| userinfo | p0 | zitadel | 1000 | 2.3% | 24.8 | 80.0 | 82.6 | 2.87 | 443 | ✓ machine-user token |
+| userinfo | p2 | axiam | 4439 | 0.2% | 5.6 | 50.7 | 55.5 | 3.55 | 545 | ✓ |
+| userinfo | p2 | keycloak | 3499 | 1.1% | 3.3 | 77.5 | 81.3 | 2.00 | 989 | ✓ |
+| userinfo | p2 | zitadel | 998 | 2.5% | 26.6 | 78.3 | 82.6 | 2.97 | 438 | ✓ machine-user token |
+| userinfo_grpc (AXIAM-only) | p0 | axiam | 12665 | 0.4% | 3.0 | 6.0 | 7.0 | 2.09 | 516 | ✓ |
+| userinfo_grpc (AXIAM-only) | p2 | axiam | 12148 | 0.6% | 4.0 | 6.0 | 7.0 | 2.08 | 532 | ✓ |
+| zitadel_userinfo_grpc | p0 | zitadel | 180 | 4.6% | 233.0 | 645.0 | 831.0 | 1.13 | 438 | ✓ machine-user token |
+| zitadel_userinfo_grpc | p2 | zitadel | 185 | 6.3% | 233.0 | 379.0 | 803.0 | 1.23 | 437 | ✓ machine-user token |
+| oauth2_password_login | p0 | axiam | 69 | 1.8% | 698.4 | 774.3 | 1155.9 | 2.06 | 507 | ✓ |
+| oauth2_password_login | p0 | keycloak | 44 | n=1 | 1031.2 | 1300.6 | 1447.4 | 2.04 | 969 | ✗ 1/3 runs valid |
+| oauth2_password_login | p0 | zitadel | 2 | — | 22079 | 25533 | 27185 | 2.02 | 410 | ✗ p95>2s (bcrypt) |
+| oauth2_password_login | p2 | axiam | 67 | 0.6% | 705.8 | 850.1 | 1173.9 | 2.01 | 532 | ✓ |
+| oauth2_password_login | p2 | keycloak | 53 | n=1 | 856.0 | 1009.7 | 1119.2 | 2.06 | 1129 | ✗ 1/3 runs valid |
+| oauth2_password_login | p2 | zitadel | 2 | — | 22197 | 25314 | 26897 | 2.02 | 411 | ✗ p95>2s (bcrypt) |
+| token_refresh | p0 | axiam | 839 | 0.4% | 47.5 | 80.6 | 93.2 | 2.74 | 509 | ✓ ⚠ protocol-variant (session refresh) |
+| token_refresh | p0 | keycloak | 377 | 1.1% | 101.5 | 204.9 | 298.9 | 2.05 | 991 | ✓ ⚠ protocol-variant (OAuth2 grant) |
+| token_refresh | p2 | axiam | 834 | 0.7% | 48.0 | 80.6 | 94.2 | 2.90 | 510 | ✓ ⚠ protocol-variant |
+| token_refresh | p2 | keycloak | 370 | 2.0% | 102.3 | 203.8 | 296.6 | 2.04 | 987 | ✓ ⚠ protocol-variant |
+| token_refresh | p0/p2 | zitadel | — | — | — | — | — | — | — | ✗ fallback-op (no offline_access flow) |
+| authz_check_rest (AXIAM-only) | p0 | axiam | 753 | 1.0% | 73.6 | 92.5 | 98.7 | 2.75 | 416 | ✓ |
+| authz_check_rest (AXIAM-only) | p2 | axiam | 760 | 0.8% | 73.2 | 92.1 | 98.5 | 2.72 | 425 | ✓ |
+| authz_check_grpc (AXIAM-only) | p0 | axiam | 887 | 0.3% | 38.0 | 86.0 | 92.0 | 2.57 | 415 | ✓ |
+| authz_check_grpc (AXIAM-only) | p2 | axiam | 892 | 0.7% | 37.0 | 86.0 | 92.0 | 2.70 | 422 | ✓ |
+| authz_batch_rest (AXIAM-only) | p0 | axiam | 199 (=995 checks/s) | 9.7% | 219.9 | 323.4 | 387.0 | 2.51 | 472 | ✓ ⚠ `concurrent` strategy, NOT the shipped default |
+| authz_batch_rest (AXIAM-only) | p2 | axiam | 199 | 10.8% | 219.7 | 323.9 | 387.6 | 2.65 | 460 | ✓ ⚠ 〃 |
+| authz_batch_grpc (AXIAM-only) | p0 | axiam | 175 | 12.2% | 273.0 | 400.0 | 475.0 | 2.38 | 556 | ✓ ⚠ 〃 |
+| authz_batch_grpc (AXIAM-only) | p2 | axiam | 176 | 13.5% | 271.0 | 398.0 | 468.0 | 2.55 | 590 | ✓ ⚠ 〃 |
+| authz_batch_rest (`coalesced`, shipped default) | settled | axiam | 744 (=3 721 checks/s) | — | 49 | — | — | — | — | ✓ from the draft-4 decision run; re-measure in run 5 |
+| authz_batch_grpc (`coalesced`, shipped default) | settled | axiam | 866–872 | — | — | 74 | — | — | — | ✓ 〃 |
 
-### Security cost of TLS 1.3 (p2 vs p0, valid cells, median-of-3)
+## 9. SDK client benchmarks (first full 11-language pass)
 
-| target / scenario | Δ throughput | http (p0 → p2) |
-|---|---|---|
-| axiam / token_introspection | −0.2% | h1 → h2 |
-| axiam / userinfo | −3.7% | h1 → h2 |
-| axiam / userinfo_grpc | −1.2% | h2 → h2 |
-| axiam / authz_check_rest / _grpc | +1.3% / +3.1% | h1 → h2 / h2 → h2 |
-| axiam / oauth2_password_login | −0.5% | h1 → h2 |
-| axiam / jwks_fetch | −12.5% (reproduced independently on a second machine — §2) | h1 → h2 |
-| axiam / oauth2_client_credentials | **−50.5%** — **not an HTTP/2 cost** (acquitted, §2); mechanism still open, §5 | h1 → h2 |
-| keycloak / oauth2_client_credentials | −1.5% | — |
-| keycloak / token_introspection | −7.9% | — |
-| keycloak / jwks_fetch | −19.2% | — |
-| keycloak / userinfo | −6.8% | — |
-| keycloak / token_refresh | −3.3% | — |
-| zitadel / all scenarios | −2.3% … +2.0% | — |
+All eleven SDKs — Rust, TypeScript, Python, Java, Kotlin, C#, Go, PHP,
+Swift, C, C++ — ran the same four ops (login, refresh, check_access,
+batch_check) against the same seeded AXIAM at p0, p2 **and p3 (mTLS)**,
+zero errors in 132 op-cells. Selected p0 rows (concurrency 16 unless
+noted; single pass, not median-of-3):
 
-And the p3 result in one line: **mTLS (client certificates, verified
-in-process) ≈ p2 within noise on every scenario.**
+| sdk | login p50 (ms) | refresh p50 (ms) | check p50 (ms) | check p95 (ms) | check thr (rps) |
+|---|---|---|---|---|---|
+| rust | 247.9 | 17.5 | 10.0 | 59.7 | 868 |
+| go | 254.4 | 17.4 | 10.9 | 61.1 | 779 |
+| csharp | 228.2 | *(cached no-op)* | 10.6 | 61.6 | 786 |
+| java | 243.0 | 17.3 | 11.1 | 61.8 | 767 |
+| kotlin | 228.6 | 17.3 | 11.4 | 61.9 | 738 |
+| swift | 229.1 | 17.6 | 13.3 | 63.2 | 634 |
+| typescript | 256.2 | 16.8 | 17.8 | 55.6 | 638 |
+| python | 231.0 | 17.3 | 30.3 | 76.1 | 444 |
+| cpp | 230.0 | 17.4 | 3.3 | 283.2* | 312 |
+| c *(concurrency 1)* | 36.0 | 17.4 | 3.1 | 3.8 | 317 |
+| php *(concurrency 1)* | 31.2 | 17.3 | 3.5 | 4.4 | 273 |
 
-### 7.1 SDK client-overhead table (E1.3, sandbox host, single pass — H8)
+What the table shows: **the server, not the SDKs, sets the floor** — ten
+of eleven SDKs measure refresh at 17.3 ± 0.3 ms p50 and the concurrency-16
+SDKs measure login at 228–256 ms (server-side Argon2id dominates,
+identically from every language). TLS (p2) and mTLS (p3) added no
+measurable client-side cost in any SDK — matching the server-side p2/p3
+parity. Honest flags, kept visible: the C# refresh row measures its auth
+helper's (correct) token cache, not the wire, until the harness forces
+expiry; C++ shows a reconnect-shaped p95 tail under investigation; C and
+PHP run serially, so their rows aren't comparable with the rest; and no
+matched-concurrency wire baseline was captured this run, so the
+"SDK overhead vs raw HTTP" column returns in run 5.
 
-*New in this draft.* Measured with a matched-concurrency wire baseline
-(the SDK bench's own `SDK_BENCH_CONCURRENCY`, not an unrelated default VU
-count — an unmatched baseline produces misleading negative "overhead"
-numbers purely from the load-shape mismatch). **Host clamp caveat applies
-here too:** `login`/`refresh`/`check_access` touch the same
-`RateLimitShared`-wrapped endpoints as §1/§5, so absolute op numbers on this
-host are bounded by the same datastore-write cost, not by SDK overhead —
-read the **p95-overhead-vs-wire** column (a same-host, same-window
-differential) as the informative number, not the raw throughput columns.
-6 of 7 original SDKs validated (rust, python, typescript, go, java, php);
-**csharp** stays `pending` (host toolchain not installed;
-`sdk/csharp/TODO.md` has the install commands). One un-repeated pass, not
-median-of-3 — a future run-4-class matrix should repeat this table.
+## 10. Summary and what happens next
 
-**profile: p0-plaintext** (selected rows; full table in the raw report)
+**Strengths.** The first clean, median-of-3, fully labeled matrix:
+token issuance **7.7×/6.4×** (Keycloak/Zitadel), introspection
+**2.4×/4.7×**, JWKS **5.8–12.6×**, userinfo **1.2×/4.5×** REST and
+**12.7 k/s** over gRPC; the only valid login at both profiles; refresh
+restored as a full median-of-3 cell (labeled); native mTLS still free;
+and a resource profile to match — **≤ 172 MiB server RSS at peak, 1.2–17×
+less CPU per request** on the envelope where Keycloak needed its memory
+cap doubled.
 
-| sdk | op | sdk p50(ms) | sdk p95(ms) | wire p95(ms) | thr(rps) | errors | p95 overhead vs wire(ms) |
-|---|---|---|---|---|---|---|---|
-| go | check_access | 18.58 | 27.57 | 30.44 | 414 | 0 | −2.87 |
-| java | check_access | 25.33 | 39.43 | 30.44 | 293 | 0 | +8.99 |
-| php | check_access | 12.31 | 23.07 | 30.44 | 73 | 0 | −7.36 |
-| python | check_access | 20.42 | 30.84 | 30.44 | 359 | 0 | +0.40 |
-| rust | check_access | 17.23 | 23.52 | 30.44 | 444 | 0 | −6.92 |
-| typescript | check_access | 26.71 | 34.87 | 30.44 | 291 | 0 | +4.43 |
-| go | batch_check | 32.53 | 45.89 | 78.67 | 229 | 0 | −32.78 |
-| rust | batch_check | 36.00 | 49.73 | 78.67 | 214 | 0 | −28.94 |
-| python | login | 556.35 | 738.17 | 252.22 | 14 | 0 | +485.95 (outlier — see raw report) |
-| rust | login | 220.05 | 249.49 | 252.22 | 35 | 0 | −2.73 |
+**Weaknesses, stated as plainly.** The TLS client-credentials plateau
+(−57%) remains the one open performance mystery; batch cells this run
+measured the non-default strategy through a harness slip (default's
+verdict unchanged, re-measurement queued); the gRPC prod rate limiter has
+a ×60 units bug (found by this run, fix tracked); Keycloak's login cells
+need a 4 GiB labeled envelope to be fair; everything is still
+laptop-hosted.
 
-Most SDKs sit within roughly ±30 ms of the wire baseline on `check_access`
-and beat it on `batch_check` (client-side batching amortizes better than
-the matched-concurrency wire baseline assumes); `login`'s spread is wide
-and dominated by the shared clamp plus one un-repeated outlier (`python`,
-+486 ms) that a median-of-3 would very likely resolve — flagged rather than
-smoothed over. Full per-op table for both profiles:
-`benchmarks/results/sdk-report.md`.
-
-## 8. Summary and what happens next
-
-**Strengths.** G-box numbers reproduced across four decision rounds now:
-token issuance 4.3–5.2×, introspection 1.17–2.45×, JWKS 7–13×, userinfo
-1.34–5.3×; the only login that stays under 2 s p95 at both profiles; native
-mTLS at zero measured cost (unique in this field); batch authorization now
-a *decided* 4.98× win (`coalesced`, shipped default, not a withdrawn
-number); memory retention fixed (jemalloc, shipped default); the refresh
-comparison restored under an honest label instead of excluded; and a real,
-validated SDK-overhead table for the first time.
-
-**Weaknesses, stated as plainly as the strengths.** The TLS
-token-issuance halving is priced (not a transport cost) but not fully
-explained — one open mechanism question remains. The decision cache and the
-DB connection pool were both evaluated against pre-agreed criteria and both
-stay at their conservative defaults — real, useful knobs for the right
-workload, not blanket wins. And the most consequential finding of this
-round was a limitation, not a feature: **the "post-seed transient" was a
-permanent, product-relevant synchronous datastore write in front of six
-hot endpoints, whose cost set those endpoints' ceiling on any given
-deployment's hardware** (§1/§5) — this draft's own numbers show that ceiling
-was high on a fast datastore (the G-box), and the fix to get the write off
-the synchronous path (plus the separate `GET /api/v1/users` bucket bug) has
-now **shipped** on `claude/g-benchmark-improvements-n5mjmj`, though it has
-not yet been re-measured end-to-end. Everything here remains laptop-hosted.
-
-**Next round (E3/E5):** re-measure the shared rate-limit write's fix
-end-to-end (numbers land in `claude_dev/rate-limit-fix-verification.md`
-first, then fold into a future draft's matrix here), then a true run-4
-median-of-3 matrix — on the G-box, on a server-class host, or on the
-sandbox host now that the fix has landed, whichever comes first — covering
-the full protocol including a repeated (not single-pass) SDK overhead
-table; and, if budget allows, the server-class re-run that has been tracked
-and deferred since draft 2.
+**Next round:** run 5 with the batch default actually exercised, the gRPC
+limiter fixed, a 4 GiB Keycloak login cell, the SDK wire-baseline and
+median-of-3 SDK repeats — and, budget permitting, the long-promised
+server-class hardware re-run.
 
 ---
-*Sources: G-box benchmark runs of 2026-07-25/26 (median-of-3 capped matrix ×
-p0/p2 × 3 targets; labeled sensitivity passes: DB-uncapped ×3 targets,
-decision-cache ON, pool A/B ×2, native-mTLS p3, prod rate-limit posture,
-batch-strategy A/B, TLS-h1 isolation; per-cell k6 summaries, 1 s container
-+ host telemetry, digest-recorded metadata); G4/G8 single-run refresh
-confirm cells; Phase H follow-up work of 2026-07-28/29 on a second
-(sandbox) host: H2 root-cause investigation
-(`claude_dev/postseed-transient-investigation.md`), H3/G3 batch decision
-(`claude_dev/authz-batch-investigation.md`), H4/G6 allocator decision
-(`claude_dev/memory-retention-experiment.md`), H5 cache decision
-(`claude_dev/decision-cache-decision.md`), H6 TLS/HTTP-2 investigation
-(`claude_dev/b2-tls-h2-investigation.md`), H7 rate-limit-posture
-re-measurement (`claude_dev/rate-limit-posture-decision.md`), H8 SDK-bench
-validation (`benchmarks/results/sdk-report.md`), H9 pool decision
-(`claude_dev/db-pool-design.md`), H10 harness-validation matrix
-(`benchmarks/results/tasks/h10-validate/`); aggregated by `runner/report.py`.
-Metric definitions: [`docs/methodology.md`](docs/methodology.md).*
+*Sources: G-box run-4 of 2026-08-01/02 (median-of-3 capped matrix × p0/p2 ×
+3 targets; labeled sensitivity passes: DB-uncapped, decision-cache ON,
+native-mTLS p3, prod rate-limit posture, batch-strategy; 11-SDK pass at
+p0/p2/p3; per-cell k6 summaries, 1 s container + host telemetry,
+digest-recorded metadata), aggregated by `runner/report.py`; draft-4
+carry-overs where labeled (batch `coalesced` decision run; gateway-preset
+admitted-rate measurements). Metric definitions:
+[`docs/methodology.md`](docs/methodology.md).*

--- a/benchmarks/targets/axiam/docker-compose.yml
+++ b/benchmarks/targets/axiam/docker-compose.yml
@@ -83,11 +83,13 @@ services:
       AXIAM__AUTHZ__DECISION_CACHE_ENABLED: "${AXIAM__AUTHZ__DECISION_CACHE_ENABLED:-false}"
       AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS: "${AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS:-5}"
       AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES: "${AXIAM__AUTHZ__DECISION_CACHE_MAX_ENTRIES:-10000}"
-      # --- Authz batch strategy (D10) ---------------------------------------------
-      # Default `concurrent` (per-item parallel evaluation — the run-2 fix for the
-      # coalesced path's DB serialization). Set `coalesced` for the labeled A/B
-      # sensitivity pass; decisions are identical either way.
-      AXIAM__AUTHZ__BATCH_STRATEGY: "${AXIAM__AUTHZ__BATCH_STRATEGY:-concurrent}"
+      # --- Authz batch strategy (D10/H3) ------------------------------------------
+      # Default `coalesced` — MUST track the product default decided in H3/G3
+      # (crates/axiam-authz/src/config.rs). The old `concurrent` fallback here
+      # silently overrode the shipped default for the whole run-4 matrix (see
+      # PRIVATE_BENCH_ANALYSIS.md §1.1 / task I14). Set `concurrent` only for
+      # the labeled A/B sensitivity pass; decisions are identical either way.
+      AXIAM__AUTHZ__BATCH_STRATEGY: "${AXIAM__AUTHZ__BATCH_STRATEGY:-coalesced}"
       AXIAM__AUTHZ__BATCH_MAX_CONCURRENCY: "${AXIAM__AUTHZ__BATCH_MAX_CONCURRENCY:-16}"
       # --- SurrealDB connection pool (F2/F3) --------------------------------------
       # Defaults (1 handle, cap disabled) are byte-for-byte the pre-pool behavior.

--- a/claude_dev/improvement-after-run4-benchmark.md
+++ b/claude_dev/improvement-after-run4-benchmark.md
@@ -1,0 +1,269 @@
+# Improvement plan after benchmark run 4 (2026-08-02)
+
+Derived from `benchmarks/PRIVATE_BENCH_ANALYSIS.md` (run-4 edition) and the
+raw archive `results20260802` (matrix run-1..3, sens-*, sdk/). Companion to
+the published `benchmarks/PUBLIC_BENCH_ANALYSIS.md` fifth draft. This is the
+run-4 successor to `improvement-after-serious-benchmark.md` (G-tasks) and
+`improvement-after-g-benchmark.md` (H-tasks); task IDs here are **I-tasks**.
+
+Context in one line: run 4 confirmed the H2 write-behind rate-limit fix at
+matrix scale (+47%…+284% on the previously clamped endpoints, zero refused
+cells), so the remaining work splits into (A) production rate-limit posture
+fixes, (B) product performance levers, (C) SDK fixes, (D) benchmark-harness
+fixes for run 5.
+
+---
+
+## A. Production rate limits (the user-facing posture)
+
+### I1 — Fix the gRPC shared-limiter ×60 units bug ⚠ product bug, highest priority
+
+**Evidence (sens-rl-prod):** with `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC=100`, all
+three gRPC scenarios admitted ~100 ops per **60 s** window (bench_ok totals:
+check 400, batch 300, userinfo 400 over the session) — 1/60th of the
+configured per-second rate. REST limits enforced exactly as configured in
+the same pass (authz 300/min ✓, token 20/min ✓, introspect 10/min ✓,
+login 10/min ✓).
+
+**Root cause (found in code):**
+`crates/axiam-api-grpc/src/middleware/rate_limit.rs` wires two layers; the
+in-memory `build_grpc_governor_layer(authz_per_sec)` is correctly quota'd
+(`Quota::per_second`), but the cross-replica pre-check
+`GrpcSharedRateLimitLayer::new(db, "grpc_authz", grpc_config.grpc_authz_per_sec, …)`
+enforces its `limit` against `WINDOW_SECS = 60` (the REST per-minute
+window) while being handed the per-**second** number verbatim. The stricter
+layer wins, so the effective limit is `per_sec` requests **per minute**.
+
+**Fix:** convert units at the boundary (`limit = grpc_authz_per_sec * 60`
+for the 60-s shared window — saturating mul), or give the gRPC layer a
+per-second shared window. Prefer the ×60 conversion: it keeps one shared
+bucket schema and the write-behind flusher cadence unchanged.
+
+**Acceptance:** integration test driving sustained overload through the
+full layered stack asserts admitted-per-minute ≈ configured×60 (±10%);
+`sens-rl-prod` re-run shows gRPC check admitted ≈ 100/s. Unit test pinning
+the call-site units so a refactor can't reintroduce it.
+
+### I2 — Scope the gRPC limiter per-method (design fix)
+
+The shared layer + governor apply **server-wide**, so `GetUserInfo` (an
+identity read measured at 12.7 k/s) is throttled by the *authz* limit.
+Under prod posture, gRPC userinfo collapsed to the same ~100/min as authz.
+Fix: split buckets per service/method family (authz-check vs identity-read
+vs admin), with an explicit unlimited/neutral default for reflection and
+health. Sizing per family can then follow §7.2 of the public doc.
+
+### I3 — Revise the shipped `internet` machine-endpoint defaults (proposal)
+
+Run-4 measured capacity vs shipped defaults (2-core envelope): token
+20/min vs ~163 k/min capacity; introspect 10/min vs ~263 k/min; authz
+300/min vs ~45 k/min. Proposal published in PUBLIC doc §7.2 —
+**token 20→120/min, introspect 10→600/min, authz_check 300→1 800/min,
+revoke 10→60/min; human endpoints (login/register/reset/MFA) unchanged.**
+Each suggested value stays ≥500× below measured capacity, preserving the
+abuse posture while no longer breaking a single healthy integration behind
+NAT. Implementation notes:
+
+- Change only `RateLimitConfig::default()`; the `gateway`/`mesh` presets
+  are already sized (600/6 000/6 000 and 6 000/60 000/60 000) and validated
+  (H7: admitted rate 96.6–100% for a single client under `gateway`).
+- Update `docs/deployment/rate-limit-sizing.md` and the config-reference
+  table generator/tests that assert the defaults
+  (`rate_limit.rs` has default-pinning tests around lines 500–550).
+- Keep the D8 security caveat (client_id is attacker-mintable) verbatim
+  wherever the new numbers appear.
+- Consider a startup log line when `internet` defaults are active and
+  sustained 429 ratio on machine endpoints exceeds ~50% over 5 min —
+  "your limits are throttling what looks like legitimate machine traffic;
+  see rate-limit-sizing" — cheap to add on top of the write-behind
+  counter's existing stats.
+
+### I4 — Refresh-under-prod errors (harness or product ergonomics)
+
+`token_refresh` under prod posture: 2 833 failures (2.4%) at 694/s vs 839
+neutralized. Refresh is unlimited; the failures line up with the harness's
+periodic re-login tripping the 10/min login bucket mid-run. Action:
+(a) harness — budget re-logins inside the login limit or pre-mint session
+pools in setup; (b) product docs — note that session-refresh capacity is
+effectively coupled to the login limit for short-session deployments.
+
+---
+
+## B. AXIAM product performance levers (post-fix priorities)
+
+### I5 — The TLS client-credentials plateau (−57%) — final open perf mystery
+
+New run-4 evidence: p2 CC = 1 180/s with **bottleneck: none** and a flat
+p50/p95/p99 of 42.6/43.9/44.8 ms — every request pays a near-constant
+~43 ms with nothing saturated; p0 CC = 2 727/s through the same middleware
+(rate-limit write exonerated — it no longer exists). This is a
+serialization/latency plateau specific to CC-over-TLS.
+
+Plan (the H6 §6 VU-sweep, finally runnable since nothing else clamps):
+1. Sweep VUs 1→100 at p0 and p2 on CC. Constant per-request cost ⇒
+   throughput scales with VUs; serialization point ⇒ pinned throughput.
+2. Instrument the CC handler path with per-stage timings (client-secret
+   verify, token mint/sign, token persist, response) under both profiles.
+3. Check connection behavior under h2: are token responses closing
+   streams/connections (`Connection`/GOAWAY behavior, k6 conn-reuse
+   counters — `bench_http_proto` already recorded)?
+Prime suspects: client-secret Argon2 verification queueing on the
+`MAX_CONCURRENT_HASHES` semaphore (login shows 69/s ≈ hash-bound; CC
+verifies a secret per request too — at p0 why is it 2 727/s then? check
+whether CC uses the same hasher pool or a cheaper compare), and TLS
+session-cache locking.
+
+### I6 — REST authz-check session-read serialization (cache asymmetry)
+
+`sens-cache-on`: gRPC checks 887 → 11 598/s (13.1×) but REST checks only
+753 → 791 (+5%) despite p50 halving. Hypothesis: the REST path
+authenticates via session cookie + CSRF ⇒ one SurrealDB session read per
+request that the decision cache doesn't cover; gRPC authenticates via JWT
+(no DB). Actions:
+1. Confirm with a JWT-authenticated REST check variant (or trace).
+2. If confirmed, add a short-TTL process-local session-validation cache
+   (same invalidation discipline as the decision cache: logout/rotation
+   events + TTL backstop; document the ≤TTL staleness bound), or support
+   Bearer-JWT auth on `/api/v1/authz/check` for service callers — likely
+   the cleaner fix and consistent with the gRPC surface.
+3. Re-run the post-fix decision-cache K-sweep (the H5 evaluation predates
+   the rate-limit fix; the ceiling moved from 3× to 13×, so the ship-bar
+   arithmetic deserves a re-check even if the default stays opt-in).
+
+### I7 — SurrealDB is now the product's ceiling — invest there
+
+DB-uncapped deltas post-fix: checks +89/90%, CC +64%, userinfo +59%,
+introspection +42%, refresh +30%. Candidate work, in order of expected
+value: (a) profile the per-check query plan (the authz read path) for
+index-only satisfaction; (b) batch/pipeline the hot reads already known to
+coalesce well (the `coalesced` batch result shows the DB rewards it);
+(c) evaluate SurrealDB read-replica topology for authz reads;
+(d) revisit `surrealdb-tuning-report.md` items against the current
+SurrealDB release. Success metric: capped-envelope authz_check ≥ 1 000/s
+REST without cache.
+
+### I8 — Watch items (cheap re-checks in run 5, no work now)
+
+- userinfo REST 5 008 (run 3) → 4 547 (run 4): −9% between runs on a
+  DB-pegged cell; confirm or dismiss as env drift.
+- `sens-cache-on` introspection 3 438 vs matrix 4 387 (−21%) on a
+  cache-irrelevant endpoint: run-order/DB variance suspect.
+- Thermal: hot cells hit 96–100 °C, mhz_avg spread 3.16–3.87 GHz.
+  Consider inter-cell cooldown or a cell-order shuffle sensitivity check.
+
+---
+
+## C. SDK work (from the first full 11-language pass)
+
+### I9 — C# `refresh` measures a cached no-op (harness + contract clarification)
+
+p50 1.2 µs / "752 k rps": the .NET auth helper correctly returns the
+still-valid token without a network call; the bench never forces expiry.
+Fix in the SDK bench harness (`axiam-csharp-sdk` bench runner): force
+refresh via an explicit `ForceRefreshAsync`/expiry override, or mint a
+token with ~1 s TTL for the refresh loop. Audit the other ten SDK bench
+runners for the same trap (their ~17.3 ms p50s indicate they do hit the
+wire today — add an assertion: refresh op must record ≥1 HTTP call per
+iteration, mirroring the k6 `bench_fallback` lesson from G4).
+
+### I10 — C and PHP benches run at concurrency 1 — parity or explicit labels
+
+Their records honestly say so (`notes` field), but the report table
+renders them beside concurrency-16 rows. Either implement multi-process
+drivers (PHP: `pcntl_fork` N workers; C: pthreads) or make `report.py`
+render a `conc=1` label in the SDK table and exclude them from any
+cross-SDK throughput chart. Labeling is the cheap correct first step.
+
+### I11 — C++ bimodal tail (p95 ~264–336 ms on check/batch at every profile)
+
+p50 is excellent (3.3 ms — libcurl, same class as the C SDK), but a subset
+of iterations pays ~280 ms. Signature: connection re-establishment (handle
+churn / no keep-alive reuse on some code path), possibly one reconnect per
+worker per interval. Investigate `axiam-cplusplus-sdk`'s transport: shared
+`CURLM`/handle pool reuse, `CURLOPT_FORBID_REUSE`/`FRESH_CONNECT` flags,
+and Expect:100-continue behavior on POST bodies (a classic ~200 ms+ curl
+tail: disable `Expect` header). Acceptance: p95 within 3× p50 at p0.
+
+### I12 — Python check_access ~3× slower than peer SDKs at equal concurrency
+
+p50 30.3 ms vs 10–11 ms (go/java/rust/…), thr 444 vs ~770–870. Profile the
+async client: event-loop-per-thread setup, JSON (de)serialization, or
+sync-over-async bridging in `check_access`. Not a correctness issue;
+medium priority.
+
+### I13 — SDK bench telemetry gaps
+
+`client_rss_mib_peak` and `client_cpu_ms_total` recorded 0.0 for every
+SDK — the sampler isn't wired. Client-side efficiency is half the E1.3
+story (an SDK that burns 2× CPU at equal latency matters for IoT); fix the
+collector in the shared SDK-bench driver.
+
+---
+
+## D. Benchmark harness (for run 5)
+
+### I14 — Batch strategy pin — **fixed on this branch**
+
+`benchmarks/targets/axiam/docker-compose.yml` defaulted
+`AXIAM__AUTHZ__BATCH_STRATEGY` to `concurrent`, silently overriding the
+shipped `coalesced` default for the whole matrix (and making
+`sens-batch-concurrent` a duplicate of the matrix instead of an A/B).
+Changed to `coalesced`. Run 5 therefore measures the real default; keep
+`sens-batch-concurrent` as the labeled alternative (it will finally
+differ). Expectation to verify: batch REST ≈ 4–5× singles per G3.
+
+### I15 — SDK wire baseline
+
+The E1.3 overhead column (`p95 overhead vs wire`) was empty this run — no
+matched-concurrency k6 wire baseline was captured. Wire the baseline step
+back into `just sdk-bench-all` (BENCH_VUS = SDK_BENCH_CONCURRENCY, per the
+draft-4 lesson that an unmatched baseline produces bogus negative
+overheads), and repeat the SDK pass median-of-3.
+
+### I16 — Keycloak login envelope
+
+2 048 MiB was necessary (KC peaked at 1 070 MiB) but not sufficient: login
+cells still 1/3 valid per profile. Per the H7 diagnosis (3.28 GiB peak
+observed), run 5 should run KC login cells at `BENCH_MEM=4096m`, labeled
+as such in meta.json (the C2 cap-recording machinery already supports it).
+Keep all other cells at the shared 2 048 cap.
+
+### I17 — Zitadel gaps (unchanged, carried)
+
+(a) refresh needs an `offline_access` device/PKCE seed flow in the
+harness; (b) login is bcrypt-dominated — consider one labeled
+sensitivity cell with a reduced-cost Zitadel hash config for a
+latency-comparable row, clearly marked non-default, or keep excluding
+with the current label. (c) `zitadel_userinfo_grpc` records no
+`bench_http_proto` — cosmetic, fix the scenario's metric emission.
+
+### I18 — Provenance
+
+Run-4's `build_ref 6875e4b` is not an ancestor of `origin/main` (image was
+built from the fix branch pre-merge). No material doubt about content, but
+A9 discipline: run 5 must pull an image whose build_ref resolves on main
+(add a preflight check to the runbook — `git merge-base --is-ancestor`).
+
+### I19 — Prod-posture pass ergonomics
+
+Add per-endpoint expected-admission assertions to `sens-rl-prod` (the
+"admitted ≈ configured" check that caught I1 was done by hand this time);
+emit a small `rl-prod-summary.md` with configured-vs-admitted per endpoint
+so the next units bug is caught by the harness, not the analyst.
+
+---
+
+## Suggested order of execution
+
+1. **I1 + I2** (gRPC limiter correctness) — product bug, small diff, big
+   trust win; unblocks advertising gRPC prod posture.
+2. **I3** (defaults revision + docs) — pairs naturally with I1 in one PR
+   ("rate-limit posture v2"); public §7.2 already states the proposal.
+3. **I5** (CC/TLS plateau sweep) and **I6** (REST session read) — the two
+   remaining perf unknowns; both are measurement-first tasks.
+4. **C-block SDK fixes** (I9–I13) — independent, parallelizable per repo.
+5. **D-block harness items** (I15–I19; I14 done) — before run 5.
+6. **Run 5**: full matrix + fixed batch default + KC-login 4 GiB cell +
+   SDK median-of-3 with wire baseline + re-run `sens-rl-prod` post-I1.
+7. **I7** (SurrealDB ceiling) — the long-pole product investment, start
+   after the quick wins land.


### PR DESCRIPTION
- PRIVATE_BENCH_ANALYSIS.md rewritten for run 4: rate-limit write-behind fix
  confirmed at matrix scale (+47%..+284% on formerly clamped endpoints, zero
  refused cells); three new discoveries root-caused: gRPC shared-limiter x60
  units bug (per-second limit enforced over a 60s window), bench compose
  pinning batch strategy to 'concurrent', decision-cache REST/gRPC asymmetry
  (session-read serialization hypothesis).
- PUBLIC_BENCH_ANALYSIS.md fifth draft: first publishable run-4 matrix
  (CC 7.7x/6.4x, introspection 2.4x/4.7x, jwks 5.8-12.6x, userinfo gRPC
  12.7k/s), new graph-ready resource-usage section (server RSS peak 172 MiB
  vs Keycloak 1070 MiB at the shared 2 GiB cap; cpu-ms/req and thr/GiB
  tables), and measured production rate-limit sizing with proposed default
  revisions (token 20->120/min, introspect 10->600/min, authz 300->1800/min,
  revoke 10->60/min; human endpoints unchanged).
- claude_dev/improvement-after-run4-benchmark.md: I-task plan (prod-limit
  fixes I1-I4, product perf I5-I8, SDK fixes I9-I13, harness I14-I19).
- benchmarks/targets/axiam/docker-compose.yml: batch-strategy fallback now
  tracks the shipped 'coalesced' default (I14) so run 5 measures the real
  default.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EGnFHQm13YsCeAZx3KPgEq