### PR TITLE
docs(website): update benchmarks page to run 4 and add resource usage

### DIFF
--- a/website/src/data.ts
+++ b/website/src/data.ts
@@ -4,6 +4,7 @@ import type {
   Phase,
   BenchScenario,
   BenchEfficiencyRow,
+  BenchResourceRow,
 } from "./types";
 
 /**
@@ -760,11 +761,12 @@ export const PHASES: Phase[] = [
 
 /**
  * Benchmark scenarios, transcribed from
- * `benchmarks/PUBLIC_BENCH_ANALYSIS.md` (third draft, run 3 of 2026-07-25/26,
- * AXIAM 1.0.0-alpha19 pulled release image vs Keycloak 26.7.0 vs Zitadel
- * v4.15.2). All figures are the p0-plaintext profile from the capped matrix
- * (§3/§7), **median of 3 runs** (per-cell throughput spread ±0.1–2.8%). Only
- * valid, comparable cells are charted.
+ * `benchmarks/PUBLIC_BENCH_ANALYSIS.md` (fifth draft, run 4 of 2026-08-01/02,
+ * AXIAM post-fix build vs Keycloak 26.7.0 vs Zitadel v4.15.2) — the first
+ * matrix measured after the shared rate-limit write-behind fix. All figures
+ * are the p0-plaintext profile from the capped matrix (§1/§8), **median of 3
+ * runs** (per-cell throughput spread ±0.2–2.8% on AXIAM cells). Only valid
+ * cells are charted; comparability labels are carried onto the chart.
  */
 export const BENCH_SCENARIOS: BenchScenario[] = [
   {
@@ -772,48 +774,59 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
     title: "Machine-to-machine token issuance",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 1823, display: "1,823", axiam: true },
-      { target: "Zitadel", value: 423, display: "423" },
-      { target: "Keycloak", value: 351, display: "351" },
+      { target: "AXIAM", value: 2727, display: "2,727", axiam: true },
+      { target: "Zitadel", value: 425, display: "425" },
+      { target: "Keycloak", value: 354, display: "354" },
     ],
     takeaway:
-      "AXIAM issues 4.3× more tokens/s than Zitadel and 5.2× more than Keycloak, at a p99 of 36 ms — reproduced within ±0.1% across three runs on the pinned release image.",
+      "AXIAM issues 7.7× more tokens/s than Keycloak and 6.4× more than Zitadel — up from 5.2×/4.3× in run 3, entirely from removing the synchronous rate-limit write (+50% on this endpoint). Reproduced within ±0.4% across three runs.",
   },
   {
     id: "introspection",
     title: "Token introspection (RFC 7662)",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 2230, display: "2,230", axiam: true },
-      { target: "Keycloak", value: 1908, display: "1,908" },
-      { target: "Zitadel", value: 910, display: "910" },
+      { target: "AXIAM", value: 4387, display: "4,387", axiam: true },
+      { target: "Keycloak", value: 1860, display: "1,860" },
+      { target: "Zitadel", value: 932, display: "932" },
     ],
     takeaway:
-      "The closest head-to-head: AXIAM leads Keycloak by 1.17× (2.45× vs Zitadel) with a 3× better p95 (27 vs 82 ms) and zero TLS penalty (−0.2%).",
+      "Run 3's closest head-to-head is no longer close: +97% post-fix puts AXIAM at 2.4× Keycloak and 4.7× Zitadel, with a 1.7× better p95 (48 vs 82 ms) and a near-zero TLS penalty (−1.6%).",
   },
   {
     id: "jwks",
     title: "JWKS fetch (RFC 7517)",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 27784, display: "27,784", axiam: true },
-      { target: "Keycloak", value: 3764, display: "3,764" },
-      { target: "Zitadel", value: 2071, display: "2,071" },
+      { target: "AXIAM", value: 26371, display: "26,371", axiam: true },
+      { target: "Keycloak", value: 4565, display: "4,565" },
+      { target: "Zitadel", value: 2096, display: "2,096" },
     ],
     takeaway:
-      "A 7–13× gap — and AXIAM's server sat under its CPU cap while the load generator neared its own limit, so its true ceiling is higher still.",
+      "A 5.8–12.6× gap — and still limited by the load generator rather than by AXIAM: k6 itself burned ~5 CPU cores while the AXIAM server sat at 1.6 of its 2, so the true ceiling is higher.",
   },
   {
     id: "userinfo",
-    title: "OIDC userinfo",
+    title: "OIDC userinfo — REST",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 5008, display: "5,008", axiam: true },
-      { target: "Keycloak", value: 3742, display: "3,742" },
-      { target: "Zitadel", value: 943, display: "943" },
+      { target: "AXIAM", value: 4547, display: "4,547", axiam: true },
+      { target: "Keycloak", value: 3783, display: "3,783" },
+      { target: "Zitadel", value: 1000, display: "1,000" },
     ],
     takeaway:
-      "AXIAM leads throughput (1.34× Keycloak, 5.3× Zitadel) while its database is saturated — with the DB uncapped it reaches 7,457 req/s. On whole-stack CPU per request Keycloak edges it here; on server-only CPU AXIAM's server is 2.1× cheaper.",
+      "AXIAM leads 1.2× Keycloak and 4.5× Zitadel while its database is pegged — uncapped to 4 DB cores the same cell reaches 7,215 req/s. On whole-stack req/s-per-core Keycloak wins this cell; on server-only CPU per request AXIAM is 2.1× cheaper. Both are published.",
+  },
+  {
+    id: "userinfo_grpc",
+    title: "OIDC userinfo — gRPC",
+    unit: "throughput · requests/s · plaintext · median of 3",
+    bars: [
+      { target: "AXIAM", value: 12665, display: "12,665", axiam: true },
+      { target: "Zitadel", value: 180, display: "180" },
+    ],
+    takeaway:
+      "The biggest single change in this run: 12,665 identity reads/s at a 6 ms p95 — 2.8× AXIAM's own REST path and 3.3× Keycloak's best number — where run 3 measured 3,294/s (every gRPC call used to pay the rate-limit write). Zitadel's own gRPC userinfo measured 180–185/s on the same harness, 82% below its REST cell; Keycloak exposes no gRPC equivalent.",
   },
   {
     id: "password_login",
@@ -821,16 +834,29 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
       { target: "AXIAM", value: 69, display: "69", axiam: true },
-      { target: "Keycloak", value: 52, display: "52" },
-      { target: "Zitadel", value: 2.0, display: "2.0" },
+      { target: "Keycloak", value: 44, display: "(44)" },
+      { target: "Zitadel", value: 2.0, display: "(2)" },
     ],
     takeaway:
-      "Keycloak's plaintext login cell is valid for the first time (52 req/s) — and AXIAM still leads at 69 req/s with a 774 ms p95, the only target under the 2 s gate at both TLS profiles. Hash configuration dominates this cell — Zitadel's default bcrypt cost is simply very expensive.",
+      "AXIAM is the only target valid at both profiles — 69 req/s at a 774 ms p95, on ≤ 140 MiB of server memory. Parenthesized numbers failed our own validity gate and are shown only for transparency: Keycloak completed 1 of 3 runs cleanly even at the raised 2 GiB cap (it wants ~3.5–4 GiB under sustained hashing; next run gives it exactly that, labeled), and Zitadel's default bcrypt cost puts it at ~22 s p50.",
+    note: "2 of 3 targets excluded by the validity gate",
+  },
+  {
+    id: "token_refresh",
+    title: "Session / token refresh",
+    unit: "throughput · requests/s · plaintext · median of 3",
+    bars: [
+      { target: "AXIAM", value: 839, display: "839", axiam: true },
+      { target: "Keycloak", value: 377, display: "377" },
+    ],
+    takeaway:
+      "Informational, not a like-for-like race: AXIAM has no ROPC/password grant by design, so its cell measures session-cookie refresh (CSRF double-submit, single-use rotation) while Keycloak's measures the OAuth2 refresh-token grant. Both are real, both rotate; new this run is that AXIAM's cell is a full median-of-3 (run 3 had a single confirm run). Zitadel needs an offline_access flow the harness doesn't implement.",
+    note: "protocol-variant — two different protocols doing a related job",
   },
 ];
 
 /**
- * Whole-stack efficiency, head-to-head (p0-plaintext, median-of-3).
+ * Whole-stack efficiency, head-to-head (p0-plaintext, median-of-3, run 4).
  * `req/s per core` is higher-is-better; `cpu·ms/req` is lower-is-better.
  * AXIAM's figures still carry its audit broker and, on some cells, a
  * saturated database inside them — which is why Keycloak edges it on the
@@ -838,32 +864,79 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
  * there; both breakdowns are published in the raw report).
  */
 export const BENCH_EFFICIENCY: BenchEfficiencyRow[] = [
-  { scenario: "Client credentials", perCore: ["637", "170", "115"], cpuMs: ["1.57", "5.89", "8.69"] },
-  { scenario: "Token introspection", perCore: ["907", "807", "248"], cpuMs: ["1.10", "1.24", "4.04"] },
-  { scenario: "JWKS fetch", perCore: ["16,850", "1,881", "698"], cpuMs: ["0.059", "0.53", "1.43"] },
-  { scenario: "OIDC userinfo", perCore: ["1,452", "1,873", "333"], cpuMs: ["0.69", "0.53", "3.00"] },
+  { scenario: "Client credentials", perCore: ["835", "171", "122"], cpuMs: ["1.20", "5.84", "8.20"] },
+  { scenario: "Token introspection", perCore: ["1,288", "786", "250"], cpuMs: ["0.78", "1.27", "4.00"] },
+  { scenario: "JWKS fetch", perCore: ["16,184", "2,278", "703"], cpuMs: ["0.06", "0.44", "1.42"] },
+  { scenario: "OIDC userinfo", perCore: ["1,376", "1,891", "348"], cpuMs: ["0.73", "0.53", "2.88"] },
 ];
 
 /**
  * AXIAM-only authorization decisions (no head-to-head — Keycloak and Zitadel
  * expose no equivalent endpoint). Each check is a full RBAC evaluation against
  * live data. Values are p0-plaintext throughput (requests/s, median-of-3; the
- * cache-ON rows are a labeled single-run sensitivity pass). The former batch
- * bars are withdrawn: run 3 found a measurement-order artifact that had
- * corrupted every batch cell (see the page's honesty section).
+ * cache-ON rows are a labeled best-case sensitivity pass, not the default).
  */
 export const BENCH_AUTHZ: BenchScenario = {
   id: "authz",
   title: "Authorization decisions (AXIAM-only)",
   unit: "throughput · requests/s · plaintext",
   bars: [
-    { target: "REST · single", value: 737, display: "737", axiam: true },
-    { target: "gRPC · single", value: 603, display: "603", axiam: true },
-    { target: "REST · cache ON", value: 2322, display: "2,322", axiam: true },
-    { target: "gRPC · cache ON", value: 1822, display: "1,822", axiam: true },
+    { target: "REST · single", value: 753, display: "753", axiam: true },
+    { target: "gRPC · single", value: 887, display: "887", axiam: true },
+    { target: "REST · cache ON", value: 791, display: "791", axiam: true },
+    { target: "gRPC · cache ON", value: 11598, display: "11,598", axiam: true },
   ],
   takeaway:
-    "Single checks run at database saturation (~740/s on a 2-core DB; 1,013/s with 4 DB cores). Enabling the optional decision cache triples them on the same hardware. Batch numbers are withdrawn pending re-measurement — a measurement-order artifact corrupted every previous batch cell, and the one clean cell so far measured 852 batches/s (≈4,260 checks/s), i.e. batch outperforming singles as designed.",
+    "gRPC now leads REST by 18% at half the p50 — run 3 had gRPC 18% behind, and that whole deficit was the rate-limit write. Both single-check paths are database-saturated at the 2-core DB cap and scale to 1,434 / 1,678 req/s with 4 DB cores. The optional decision cache is charted at its best case: 13.1× on gRPC at a favorable keyspace, but only +5% on REST, where per-request session-cookie validation (a database read the cache deliberately doesn't cover) becomes the limiter. It stays off by default; the realistic-keyspace measurement is +32%. Batch: the shipped `coalesced` default measured 744 batch ops/s = 3,721 checks/s (4.98× singles) — carried from run 3, because this run's batch cells accidentally exercised the non-default `concurrent` strategy.",
 };
+
+/**
+ * Resource usage during the tests (run 4 §5) — p0-plaintext, median-of-3,
+ * every server container capped identically at 2 CPUs / 2,048 MiB.
+ * Values are `[AXIAM, Keycloak, Zitadel]`.
+ */
+
+/** Per-server peak RSS in MiB, by scenario. */
+export const BENCH_MEMORY_PEAK: BenchResourceRow[] = [
+  { scenario: "JWKS fetch", values: [98, 973, 163] },
+  { scenario: "Client credentials", values: [106, 979, 147] },
+  { scenario: "Token introspection", values: [104, 795, 161] },
+  { scenario: "Token refresh", values: [106, 804, null] },
+  { scenario: "OIDC userinfo", values: [105, 806, 162] },
+  { scenario: "Password login", values: [140, 796, 131], marker: "*" },
+];
+
+/** Worst-case server RSS observed anywhere in the run, in MiB. */
+export const BENCH_MEMORY_WORST: BenchResourceRow = {
+  scenario: "Worst case, whole run",
+  values: [172, 1070, 216],
+};
+
+/** The identical per-server container memory cap, in MiB. */
+export const BENCH_MEMORY_CAP = 2048;
+
+/** Whole-stack memory range (server + database + broker), in MiB. */
+export const BENCH_STACK_MEMORY: [string, string, string][] = [
+  ["AXIAM", "415–590 MiB", "server + SurrealDB + RabbitMQ"],
+  ["Keycloak", "814–1,129 MiB", "server + PostgreSQL"],
+  ["Zitadel", "293–443 MiB", "server + PostgreSQL"],
+];
+
+/** CPU-milliseconds per request, whole stack unless noted (lower is better). */
+export const BENCH_CPU_PER_REQ: BenchResourceRow[] = [
+  { scenario: "Client credentials", values: [1.2, 5.84, 8.2] },
+  { scenario: "Token introspection", values: [0.78, 1.27, 4.0] },
+  { scenario: "JWKS fetch", values: [0.06, 0.44, 1.42] },
+  { scenario: "OIDC userinfo", values: [0.73, 0.53, 2.88] },
+  { scenario: "OIDC userinfo (server only)", values: [0.25, 0.53, 0.86] },
+];
+
+/** Requests per second per GiB of whole-stack RAM (higher is better). */
+export const BENCH_RPS_PER_GIB: BenchResourceRow[] = [
+  { scenario: "Client credentials", values: [5988, 338, 1218] },
+  { scenario: "Token introspection", values: [8709, 1939, 2199] },
+  { scenario: "OIDC userinfo", values: [8948, 3999, 2312] },
+  { scenario: "JWKS fetch", values: [60723, 5741, 7330] },
+];
 
 export const GITHUB_URL = "https://github.com/ilpanich/axiam";

--- a/website/src/docs.ts
+++ b/website/src/docs.ts
@@ -741,7 +741,7 @@ export const DOC_PAGES: DocPage[] = [
       { type: "h", id: "sizing", text: "Suggested settings by deployment (benchmark-derived)" },
       {
         type: "p",
-        text: "The shipped defaults are tuned for one thing: blunting single-source abuse on a small internet-facing deployment. The benchmark's production-posture run showed exactly that — and also that those defaults are far too strict for machine-to-machine topologies, where many clients share one source IP behind a NAT or gateway. The recommendations below derive directly from the run-3 measurements (median-of-3, 2-CPU/1-GiB-per-container envelope) in `benchmarks/PUBLIC_BENCH_ANALYSIS.md` §6.",
+        text: "The shipped defaults are tuned for one thing: blunting single-source abuse on a small internet-facing deployment. The benchmark's production-posture run showed exactly that — and also that those defaults are far too strict for machine-to-machine topologies, where many clients share one source IP behind a NAT or gateway. The recommendations below derive directly from the run-4 measurements (median-of-3, 2-CPU-per-container envelope) in `benchmarks/PUBLIC_BENCH_ANALYSIS.md` §7.",
       },
       {
         type: "warn",
@@ -750,15 +750,19 @@ export const DOC_PAGES: DocPage[] = [
       { type: "h", id: "sizing-throughput", text: "What a given envelope sustains" },
       {
         type: "p",
-        text: "Measured per-path ceilings, useful for sizing both hardware and limits. Authorization checks and userinfo scale with database CPU; token issuance and introspection are latency-structured (more DB CPU doesn't move them); logins scale with server CPU at fixed Argon2id cost.",
+        text: "Measured per-path ceilings, useful for sizing both hardware and limits. Post rate-limit fix, database CPU is the main ceiling: authorization checks, introspection, token issuance and userinfo all gain 42–90% from a second pair of DB cores. Logins scale with server CPU at fixed Argon2id cost, and JWKS is limited by the load generator rather than by the server.",
       },
       {
         type: "table",
-        headers: ["Envelope (server / DB)", "Token issuance", "Introspection", "Authz checks (cache off / on)", "Userinfo", "Logins"],
+        headers: ["Envelope (server / DB)", "Token issuance", "Introspection", "Authz checks REST / gRPC", "Userinfo REST / gRPC", "Logins"],
         rows: [
-          ["2 cores / 2 cores", "~1,800/s", "~2,200/s", "~740 / ~2,300/s", "~5,000/s", "~69/s"],
-          ["2 cores / 4 cores", "~1,800/s", "~2,200/s", "~1,000/s / higher", "~7,500/s (server-bound)", "~69/s"],
+          ["2 cores / 2 cores", "~2,700/s", "~4,400/s", "~750 / ~890/s", "~4,500 / ~12,700/s", "~69/s"],
+          ["2 cores / 4 cores", "~4,500/s", "~6,200/s", "~1,430 / ~1,680/s", "~7,200/s (server-bound) / ~12,700/s", "~69/s"],
         ],
+      },
+      {
+        type: "p",
+        text: "The optional decision cache sits on top of these: at a ~100% hit rate it lifts gRPC checks to ~11,600/s, but REST checks gain only ~5% because their per-request session-cookie validation is a database read the cache does not cover. Size for the cache-off numbers and treat the cache as headroom.",
       },
       { type: "h", id: "sizing-knobs", text: "Recommended values per scenario" },
       {
@@ -783,7 +787,7 @@ export const DOC_PAGES: DocPage[] = [
             "AXIAM__RATE_LIMIT__TOKEN_PER_MIN",
             "20",
             "60–120",
-            "per-client peak RPS × 60 × 2 (a 2-core server sustains ~108k issuances/min total)",
+            "per-client peak RPS × 60 × 2 (a 2-core server sustains ~163k issuances/min total)",
             "budget per tenant SLA",
           ],
           [
@@ -811,7 +815,7 @@ export const DOC_PAGES: DocPage[] = [
             "AXIAM__AUTHZ__DECISION_CACHE_ENABLED",
             "false",
             "true",
-            "true — measured 3× on checks, DB load down 40–75%",
+            "true if your checks go over gRPC — measured 13× there at a favourable keyspace, ~+32% at a realistic one; REST checks gain only ~5%",
             "true",
           ],
           [
@@ -823,10 +827,10 @@ export const DOC_PAGES: DocPage[] = [
           ],
           [
             "AXIAM__AUTHZ__BATCH_STRATEGY",
-            "concurrent",
+            "coalesced",
             "default",
-            "default for now — a clean A/B is in progress; `coalesced` showed 852 batches/s on a settled stack",
-            "follow the next benchmark draft",
+            "default — `coalesced` measured 744 batch ops/s ≈ 3,721 checks/s, about 5× single checks; a full-matrix re-measurement is queued",
+            "default",
           ],
           [
             "AXIAM__DB__POOL_SIZE",
@@ -861,7 +865,7 @@ export const DOC_PAGES: DocPage[] = [
       },
       {
         type: "note",
-        text: "Two rules of thumb the data supports: if your traffic is authorization-check-heavy, spend hardware on the database and enable the decision cache before anything else; if it's token-heavy, the limits — not the hardware — are what you'll hit first, so raise TOKEN_PER_MIN from your real per-client peak and — if and only if you have edge authentication per the caveat above — switch the key mode. The genuinely internet-exposed endpoints (login, register, password-reset, MFA) stay strict per-IP in every configuration, including under the gateway and mesh profiles.",
+        text: "Two rules of thumb the data supports: if your traffic is authorization-check-heavy, spend hardware on the database first (those paths gained ~90% from a second pair of DB cores), then try the decision cache and measure its logged hit rate — it is transformative on gRPC checks and marginal on REST ones; if it's token-heavy, the limits — not the hardware — are what you'll hit first, so raise TOKEN_PER_MIN from your real per-client peak and — if and only if you have edge authentication per the caveat above — switch the key mode. The genuinely internet-exposed endpoints (login, register, password-reset, MFA) stay strict per-IP in every configuration, including under the gateway and mesh profiles.",
       },
       { type: "h", id: "tls", text: "Direct TLS termination (opt-in)" },
       {

--- a/website/src/pages/Benchmarks.tsx
+++ b/website/src/pages/Benchmarks.tsx
@@ -1,15 +1,36 @@
 import type { ReactNode } from "react";
-import type { BenchScenario } from "../types";
+import type { BenchResourceRow, BenchScenario } from "../types";
 import {
   BENCH_SCENARIOS,
   BENCH_AUTHZ,
   BENCH_EFFICIENCY,
+  BENCH_MEMORY_PEAK,
+  BENCH_MEMORY_WORST,
+  BENCH_MEMORY_CAP,
+  BENCH_STACK_MEMORY,
+  BENCH_CPU_PER_REQ,
+  BENCH_RPS_PER_GIB,
 } from "../data";
 
 /* ---- shared bits ------------------------------------------------------- */
 
 const AXIAM_FILL = "linear-gradient(90deg,#00d4ff,#a855f7)";
 const OTHER_FILL = "rgba(148,163,184,.4)";
+
+/**
+ * Categorical series colours for the three-target resource charts, in
+ * `[AXIAM, Keycloak, Zitadel]` order. Fixed assignment — a target keeps its
+ * colour in every chart, and the order is never cycled. The triple is
+ * validated against the dark chart surface for the lightness band, chroma
+ * floor, colour-vision-deficiency separation (worst adjacent pair ΔE 18.4)
+ * and ≥ 3:1 contrast; every bar is also directly labelled, so identity is
+ * never carried by colour alone.
+ */
+const TARGET_SERIES = [
+  { label: "AXIAM", color: "#00a3bf" },
+  { label: "Keycloak", color: "#c9761b" },
+  { label: "Zitadel", color: "#8b5ce8" },
+] as const;
 
 function Pill({
   color,
@@ -75,6 +96,11 @@ function BarChart({ scenario }: { scenario: BenchScenario }) {
         }}
       >
         <h3 style={{ margin: 0, fontSize: 17, fontWeight: 700 }}>{scenario.title}</h3>
+        {scenario.note && (
+          <Pill color="#ffd98a" border="rgba(255,189,46,.4)" bg="rgba(255,189,46,.08)">
+            ⚠ {scenario.note}
+          </Pill>
+        )}
       </div>
       <div style={{ fontSize: 12.5, color: "#64748b", marginBottom: 20 }}>
         {scenario.unit}
@@ -145,30 +171,290 @@ function BarChart({ scenario }: { scenario: BenchScenario }) {
   );
 }
 
+/* ---- resource-usage charts --------------------------------------------- */
+
+function SeriesLegend() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 16,
+        marginBottom: 18,
+        fontSize: 12.5,
+        color: "#94a3b8",
+      }}
+    >
+      {TARGET_SERIES.map((s) => (
+        <span key={s.label} style={{ display: "inline-flex", alignItems: "center", gap: 7 }}>
+          <span
+            aria-hidden="true"
+            style={{
+              width: 11,
+              height: 11,
+              borderRadius: 3,
+              background: s.color,
+              flex: "none",
+            }}
+          />
+          {s.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** One target's bar inside a resource-chart row. */
+function ResourceBar({
+  label,
+  color,
+  value,
+  max,
+  text,
+}: {
+  label: string;
+  color: string;
+  value: number | null;
+  max: number;
+  text: string;
+}) {
+  return (
+    <div
+      style={{ display: "flex", alignItems: "center", gap: 10 }}
+      title={`${label}: ${text}`}
+    >
+      <div
+        style={{
+          flex: 1,
+          height: 12,
+          background: "rgba(255,255,255,.05)",
+          borderRadius: 4,
+          overflow: "hidden",
+          minWidth: 40,
+        }}
+      >
+        {value !== null && (
+          <div
+            style={{
+              height: "100%",
+              width: `${Math.max((value / max) * 100, 1.5)}%`,
+              background: color,
+              borderRadius: 4,
+            }}
+          />
+        )}
+      </div>
+      <div
+        style={{
+          width: 76,
+          flex: "none",
+          textAlign: "right",
+          fontSize: 12.5,
+          color: value === null ? "#64748b" : "#cbd5e1",
+          fontFamily: "ui-monospace,Menlo,monospace",
+        }}
+      >
+        {text}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Grouped bars: one group per scenario, one bar per target, in fixed series
+ * order. `scale: "row"` normalises each group to its own maximum — used where
+ * the values span three orders of magnitude and a shared axis would flatten
+ * every small group into nothing; every bar is labelled with its absolute
+ * value, and the caption says so.
+ */
+function ResourceChart({
+  title,
+  unit,
+  rows,
+  format,
+  scale = "shared",
+  footnote,
+}: {
+  title: string;
+  unit: string;
+  rows: BenchResourceRow[];
+  format: (n: number) => string;
+  scale?: "shared" | "row";
+  footnote?: string;
+}) {
+  const allValues = rows.flatMap((r) => r.values.filter((v): v is number => v !== null));
+  const sharedMax = Math.max(...allValues);
+  return (
+    <div className="glass-card" style={{ padding: 26 }}>
+      <h3 style={{ margin: 0, fontSize: 17, fontWeight: 700 }}>{title}</h3>
+      <div style={{ fontSize: 12.5, color: "#64748b", margin: "4px 0 20px" }}>{unit}</div>
+      <SeriesLegend />
+      <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
+        {rows.map((row) => {
+          const rowMax =
+            scale === "row"
+              ? Math.max(...row.values.filter((v): v is number => v !== null))
+              : sharedMax;
+          return (
+            <div key={row.scenario}>
+              <div
+                style={{
+                  fontSize: 13,
+                  color: "#e2e8f0",
+                  fontWeight: 600,
+                  marginBottom: 7,
+                }}
+              >
+                {row.scenario}
+                {row.marker && <span style={{ color: "#ffd98a" }}>{row.marker}</span>}
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                {TARGET_SERIES.map((s, i) => (
+                  <ResourceBar
+                    key={s.label}
+                    label={s.label}
+                    color={s.color}
+                    value={row.values[i]}
+                    max={rowMax}
+                    text={row.values[i] === null ? "—" : format(row.values[i] as number)}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p
+        style={{
+          margin: "20px 0 0",
+          fontSize: 12.5,
+          color: "#64748b",
+          lineHeight: 1.6,
+          borderTop: "1px solid rgba(0,212,255,.1)",
+          paddingTop: 16,
+        }}
+      >
+        {scale === "row"
+          ? "Bars are scaled within each scenario — the absolute values differ by orders of magnitude between scenarios, so the numbers, not the bar lengths, compare across groups. "
+          : "All bars share one scale. "}
+        {footnote}
+      </p>
+    </div>
+  );
+}
+
+/** Peak server memory drawn against the identical 2,048 MiB container cap. */
+function MemoryCapChart() {
+  return (
+    <div className="glass-card" style={{ padding: 26 }}>
+      <h3 style={{ margin: 0, fontSize: 17, fontWeight: 700 }}>
+        Peak server memory vs the container cap
+      </h3>
+      <div style={{ fontSize: 12.5, color: "#64748b", margin: "4px 0 22px" }}>
+        worst case over the whole run · MiB · the full track is the identical{" "}
+        {BENCH_MEMORY_CAP.toLocaleString("en-US")} MiB cap every server got
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        {TARGET_SERIES.map((s, i) => {
+          const value = BENCH_MEMORY_WORST.values[i] as number;
+          const pct = (value / BENCH_MEMORY_CAP) * 100;
+          return (
+            <div
+              key={s.label}
+              style={{ display: "flex", alignItems: "center", gap: 14 }}
+              title={`${s.label}: ${value} MiB of ${BENCH_MEMORY_CAP} MiB`}
+            >
+              <div
+                style={{
+                  width: 92,
+                  flex: "none",
+                  fontSize: 13.5,
+                  color: "#e2e8f0",
+                  fontWeight: 600,
+                }}
+              >
+                {s.label}
+              </div>
+              <div
+                style={{
+                  flex: 1,
+                  height: 22,
+                  background: "rgba(255,255,255,.05)",
+                  border: "1px dashed rgba(148,163,184,.28)",
+                  borderRadius: 6,
+                  overflow: "hidden",
+                  minWidth: 40,
+                }}
+              >
+                <div
+                  style={{
+                    height: "100%",
+                    width: `${pct}%`,
+                    background: s.color,
+                    borderRadius: 5,
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  width: 148,
+                  flex: "none",
+                  textAlign: "right",
+                  fontSize: 13,
+                  color: "#cbd5e1",
+                  fontFamily: "ui-monospace,Menlo,monospace",
+                }}
+              >
+                {value.toLocaleString("en-US")} MiB · {pct.toFixed(0)}%
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <p
+        style={{
+          margin: "20px 0 0",
+          fontSize: 13,
+          color: "#94a3b8",
+          lineHeight: 1.6,
+          borderTop: "1px solid rgba(0,212,255,.1)",
+          paddingTop: 16,
+        }}
+      >
+        The cap was <em>raised</em> from 1 GiB to 2 GiB for this run — for all
+        three targets equally — because Keycloak could not reliably survive
+        sustained password-login load at 1 GiB, and peaked at 1,070 MiB here.
+        AXIAM peaked at 172 MiB, 8% of the same allowance, while delivering the
+        throughput numbers above.
+      </p>
+    </div>
+  );
+}
+
 /* ---- headline stat cards ---------------------------------------------- */
 
 const HEADLINES = [
   {
     label: "Token issuance",
-    value: "4.3–5.2×",
-    sub: "more tokens/s than Zitadel / Keycloak — median of 3 runs, ±0.1%",
+    value: "6.4–7.7×",
+    sub: "more tokens/s than Zitadel / Keycloak — median of 3 runs, ±0.4%",
   },
   {
-    label: "JWKS fetch",
-    value: "27,784",
-    sub: "req/s — 7–13× the field (server not even saturated)",
+    label: "Identity reads over gRPC",
+    value: "12,665",
+    sub: "req/s at a 6 ms p95 — 3.3× Keycloak's best userinfo number",
   },
   {
-    label: "Native mTLS",
-    value: "≈ 0 cost",
-    sub: "client-certificate TLS 1.3 verified in-process, at parity with plain TLS on every scenario",
+    label: "Peak server memory",
+    value: "172 MiB",
+    sub: "8% of the 2 GiB the same envelope gave every target — Keycloak peaked at 1,070 MiB",
   },
 ];
 
 /* ---- environment facts ------------------------------------------------- */
 
 const TARGETS = [
-  ["AXIAM", "axiam-server 1.0.0-alpha19 (Rust, pulled release image, digest-recorded)", "SurrealDB v3 + RabbitMQ 4"],
+  ["AXIAM", "axiam-server, post-fix build (Rust, build_ref recorded per cell)", "SurrealDB v3 + RabbitMQ 4"],
   ["Keycloak", "Keycloak 26.7.0 (JVM)", "PostgreSQL 16 (uniformly tuned)"],
   ["Zitadel", "Zitadel v4.15.2 (Go)", "PostgreSQL 16 (uniformly tuned)"],
 ];
@@ -177,49 +463,57 @@ const TARGETS = [
 
 const SENSITIVITY = [
   {
-    title: "Native mTLS is free",
-    body: "The p3 profile terminates client-certificate TLS 1.3 inside the server process — no proxy in front, the verified peer certificate is the identity source — and lands at parity with plain TLS 1.3 across the entire matrix (token issuance 903.6 vs 903 req/s, userinfo 4,826 vs 4,822, …). For IoT and service-mesh fleets, certificate verification costs nothing measurable on top of TLS.",
+    title: "The defect we published, then fixed, then re-measured",
+    body: "The previous draft's most important finding was a bug in our own product: six hot endpoints paid one synchronous datastore write — the shared rate-limit counter — before the handler even ran, and on the gRPC listener every single call paid it. The fix (a write-behind counter: decisions in memory, one coalesced write per bucket per interval) shipped, and this run is the end-to-end re-measurement: token issuance +50%, introspection +97%, gRPC authz checks +47%, gRPC userinfo +284%, and no regression anywhere else. The trade is stated plainly: cross-replica rate-limit enforcement is now eventual rather than synchronous, with a bounded overshoot that is zero on a single replica.",
   },
   {
-    title: "The decision cache is worth 3×",
-    body: "With the optional per-tenant authorization decision cache enabled (5 s TTL, event-driven invalidation), single checks go from 737 to 2,322 req/s over REST and 603 to 1,822 req/s over gRPC on the same capped hardware, and the database stops being saturated. The benchmark's hit rate is favorable; a hit-rate sweep is queued before the default changes.",
+    title: "Native mTLS is still free",
+    body: "The p3 profile terminates client-certificate TLS 1.3 inside the server process — no proxy in front, the verified peer certificate is the identity source — and again lands at parity with plain TLS 1.3 on every scenario. For IoT and service-mesh fleets, certificate verification costs nothing measurable on top of TLS. It remains, as far as we can measure, unique in this field.",
   },
   {
-    title: "Where each product hits its wall",
-    body: "With every database uncapped to 4 CPUs: Keycloak doesn't move at all (its server is the wall in every cell), Zitadel gains 70–85% on reads (Postgres saturates even at 4 cores), and AXIAM's authz/userinfo paths scale with DB CPU (+37% / +49%) while its token endpoints don't need the DB at all. AXIAM's server saturated for the first time at 7,457 userinfo req/s.",
+    title: "Give the database cores first",
+    body: "Uncapping only the database from 2 to 4 CPUs (servers untouched) moves authz checks +90% / +89% (REST/gRPC), client credentials +64%, introspection +42% and userinfo +59%, while JWKS, login and gRPC userinfo don't move at all. Post-fix, database CPU is the product's main ceiling — so if your workload is authz- or identity-read heavy, that is where the next core belongs.",
   },
   {
-    title: "Shipped rate limits, measured",
-    body: "One pass ran AXIAM with its production per-IP rate limits active: a 50-user single-IP load generator is throttled to near-zero on every limited endpoint — the defaults do exactly what they ship for (blunting single-source abuse), and the competitors ship no equivalent defaults. It also showed those defaults must be re-keyed and resized for machine-to-machine fleets — see the new sizing guide in the docs.",
+    title: "The decision cache, at its best case and its worst",
+    body: "With the optional decision cache on (5 s TTL, opt-in), gRPC checks reach 11,598 req/s — 13.1× — at the bench's favourable keyspace, and batch reaches 26,000–45,000 checks/s. REST checks gain only 5%: their per-request session-cookie validation is a database read the decision cache deliberately does not cover, and it becomes the new limiter. Read 13× as a ceiling at ~100% hit rate, not an expectation; the realistic-keyspace measurement is +32%. The default stays off, the server logs its live hit rate, and the REST session cost is now a tracked optimisation target.",
+  },
+  {
+    title: "Shipped rate limits, measured — and a second bug found",
+    body: "One pass ran AXIAM with its production per-IP limits active: a 50-user single-IP flood is throttled to the configured trickle on every limited endpoint while unlimited paths run at full speed beside it, so the 429 path is cheap and the defaults do their abuse-stopping job. The same pass caught a real bug — the gRPC limiter admits about 1/60th of its configured rate, a per-second limit enforced against a per-minute window — found here, root-caused in code, fix tracked. Until it ships, treat the gRPC authz limit as per-minute, or limit at the mesh/gateway layer instead.",
   },
 ];
 
 const CAVEATS = [
   {
-    title: "TLS 1.3 still halves token issuance",
-    body: "Client-credentials throughput drops 50.5% at p2 (introspection −0.2%, userinfo −3.7%, login ~0%). Telemetry shows the handshake is ~free (resumption works); everything points at a connection-level ceiling — 50 users funnelled through multiplexed HTTP/2 — not crypto. The HTTP/1.1 isolation cell we queued for this run was invalidated by the measurement artifact below and is re-queued. Even with the penalty, AXIAM's TLS token numbers lead the field 2.2–2.6×.",
+    title: "The TLS client-credentials drop (−57%) is still unexplained",
+    body: "Client-credentials throughput falls 56.7% at p2, while introspection loses 1.6%, userinfo 2.4% and authz checks nothing at all under identical TLS — so this is not a crypto cost. New post-fix evidence narrows it: under TLS the endpoint shows a flat ~43 ms per request with nothing saturated, which is a serialization plateau, and the old prime suspect (the rate-limit write) is now gone. A dedicated VU-sweep is the next round's task. Even with the penalty, AXIAM's TLS token issuance leads the field 2.8–3.4×.",
   },
   {
-    title: "Correction: the batch verdict was a measurement artifact",
-    body: "Earlier drafts reported the authz batch endpoints as slower than single checks. Run 3 found why: for ~5–7 minutes after a stack is seeded, the database serves everything through a ~45 req/s serialization window — and the batch cells had always run first. A batch cell measured on a settled stack reaches 852 batches/s (≈4,260 checks/s), i.e. batch outperforms singles as designed. All batch numbers are withdrawn until the corrected protocol re-measures them; the transient itself is under investigation, including whether it can affect production cold-starts.",
+    title: "This run's batch cells measured the wrong strategy",
+    body: "A benchmark compose file still pinned the pre-decision default, so the batch cells accidentally exercised the non-default `concurrent` strategy (199 batch ops/s = 995 checks/s, ~1.3× singles). The shipped default is `coalesced`, whose settled measurement remains the previous draft's verdict — 744 batch ops/s = 3,721 checks/s = 4.98× singles over REST, ~4,330 checks/s over gRPC. The harness pin is fixed; run 5 re-measures the default at full matrix scale.",
   },
   {
-    title: "The refresh comparison is partially restored",
-    body: "Keycloak's refresh cells now measure real single-use rotation (379 req/s at p0). AXIAM's own refresh cells still measure a fallback — a harness cookie-handling bug the fallback tagging keeps catching, fix queued — and stay excluded. Zitadel's refresh needs an offline_access flow the harness doesn't implement yet.",
+    title: "Keycloak's login cells are excluded — by memory, not by function",
+    body: "Even at the raised 2 GiB cap, Keycloak completed only 1 of 3 password-login runs cleanly per profile, so our own validity gate excludes those cells (the single clean run is published in parentheses, not charted). Prior diagnostics show it wants ~3.5–4 GiB under sustained hashing load; the next run gives its login cells exactly that, clearly labeled. Zitadel's login exclusion is its default bcrypt cost — expected, and tunable — and its refresh exclusion is a flow our harness doesn't implement yet.",
   },
   {
-    title: "Median-of-3 now, but still a laptop",
-    body: "Every matrix cell is the median of three runs (observed spread ±0.1–2.8%, so deltas above ~5% are signal), on a digest-pinned release image. The hardware is still a consumer laptop (Dell XPS 15, i7-8750H) with per-cell CPU-frequency and temperature telemetry published; the thermal envelope was identical for all targets, so cross-target fairness holds and absolute numbers are, if anything, conservative. Memory figures for cells after the login burst include ~360 MiB of retained allocator memory (a scripted allocator experiment is scheduled).",
+    title: "Median-of-3, fully labeled — but still a laptop",
+    body: "42 of 48 matrix cells are valid and every invalid cell is listed with its reason; every cell is the median of three runs (spread ±0.2–2.8% on AXIAM cells, so deltas above ~5% are signal). The hardware is still a consumer laptop (Dell XPS 15, i7-8750H): package temperatures hit 96–100 °C on hot cells and the clock varied 3.2–3.9 GHz. The thermal envelope was identical for all targets, so cross-target fairness holds and absolute numbers are, if anything, conservative — but a server-class re-run remains the standing caveat.",
+  },
+  {
+    title: "The SDK pass is a first pass",
+    body: "All eleven SDKs ran the same four operations at all three profiles with zero errors in 132 op-cells — but it is a single pass, not a median-of-3, and no matched-concurrency wire baseline was captured, so we are not publishing an 'SDK overhead vs raw HTTP' number yet. The C and PHP harnesses run serially, so their rows aren't comparable with the concurrency-16 ones; the C# refresh row measures its auth helper's (correct) token cache rather than the wire; and one C++ tail anomaly is under investigation.",
   },
 ];
 
 const NEXT = [
-  "A post-seed settle gate + rotated cell order in the harness",
-  "Clean batch A/B (concurrent vs coalesced) under the corrected protocol",
-  "The TLS + HTTP/1.1 isolation cell, re-run on a settled stack",
-  "The AXIAM refresh-scenario harness fix",
-  "The allocator (jemalloc) A/B for post-burst memory retention",
-  "SDK client-side overhead tables (all 7 primary SDKs)",
+  "Re-measure the batch default (`coalesced`) at full matrix scale",
+  "Fix the ×60 gRPC rate-limiter units bug, then re-run the posture pass",
+  "A 4 GiB, clearly-labeled Keycloak password-login cell",
+  "The VU-sweep that explains the TLS client-credentials plateau",
+  "SDK median-of-3 repeats plus the missing wire baseline",
+  "Cut the REST session-validation database read the decision cache can't cover",
   "A server-class re-run to replace the laptop numbers",
 ];
 
@@ -244,8 +538,9 @@ export default function Benchmarks() {
       <p style={{ margin: "0 0 24px", fontSize: 17, color: "#94a3b8", maxWidth: 720 }}>
         A vendor-neutral harness drives the identical logical workload through a
         per-target adapter, comparing AXIAM against Keycloak and Zitadel across
-        OAuth2/OIDC flows. Below are the run-3 results — the first median-of-3
-        figures, on the digest-pinned release image.
+        OAuth2/OIDC flows. Below are the run-4 results — the first complete
+        matrix measured on a build with no known measurement-distorting defect
+        in it, and the first with a resource-usage profile to match.
       </p>
 
       {/* ---- Preliminary banner ---- */}
@@ -271,16 +566,18 @@ export default function Benchmarks() {
             Temporary results — the benchmark is still being improved
           </div>
           <p style={{ margin: 0, fontSize: 14, lineHeight: 1.65, color: "#e2e8f0" }}>
-            These numbers come from run 3 (2026-07-25/26, AXIAM&nbsp;1.0.0-alpha19,
-            digest-pinned release image) and are the first{" "}
-            <strong>median-of-3</strong> figures — run-to-run spread was
-            ±0.1–2.8% per cell, so they are statistically solid. They are still
-            temporary: the harness is being improved (a measurement-order
-            artifact found this run forced us to withdraw the batch and one TLS
-            diagnosis cell — see the honesty section), and everything still runs
-            on a consumer laptop rather than server-class hardware. Treat them as
-            a strong, reproducible signal, not a final verdict; this page is
-            updated as each improved run lands.
+            These numbers come from run 4 (2026-08-01/02) — a full{" "}
+            <strong>median-of-3</strong> matrix, three targets, two TLS
+            profiles, 42 of 48 cells valid with every invalid cell listed and
+            explained. It is the re-measurement on the build that fixes the
+            rate-limit defect the previous run found in AXIAM itself, so the
+            gains on the six affected endpoints (+47% to +284%) are the story of
+            this draft. They are still temporary: this run's batch cells
+            measured the wrong strategy through a harness slip, Keycloak's login
+            cells need a larger labeled memory envelope to be fair, and
+            everything still runs on a consumer laptop rather than server-class
+            hardware. Treat them as a strong, reproducible signal, not a final
+            verdict; this page is updated as each improved run lands.
           </p>
         </div>
       </div>
@@ -328,7 +625,8 @@ export default function Benchmarks() {
           legitimately differs between vendors — the exact endpoint paths and
           request shapes — so the work each server performs for a given scenario
           is the same. Scenarios cover the OAuth2/OIDC surface: machine-to-machine
-          token issuance, introspection, JWKS, userinfo and password login.
+          token issuance, introspection, JWKS, userinfo over both REST and gRPC,
+          session/token refresh and password login.
         </p>
         <div className="glass-card" style={{ padding: 4, marginTop: 20, overflowX: "auto" }}>
           <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5, minWidth: 480 }}>
@@ -380,16 +678,16 @@ export default function Benchmarks() {
           Everything ran on a single consumer laptop (Dell XPS 15 9570 — Intel
           i7-8750H, 12 logical CPUs, ~31&nbsp;GiB RAM), with the CPU governor
           pinned to <code style={{ color: "#67e8f9" }}>performance</code> and the
-          targets benchmarked sequentially, never concurrently. Each server and
-          its database run in containers capped identically at 2 CPUs and
-          1024&nbsp;MiB, so no target can buy throughput with extra hardware.
+          targets benchmarked sequentially, never concurrently. Each server runs
+          in a container capped identically at 2 CPUs and 2048&nbsp;MiB, so no
+          target can buy throughput with extra hardware.
         </p>
         <div className="ax-grid-2" style={{ marginTop: 20, gap: 14 }}>
           {[
             ["Load model", "Closed-loop, 50 virtual users. 30 s warm-up + 120 s measured window per scenario — repeated 3×, median reported."],
             ["Profiles", "p0-plaintext and p2-tls13 (TLS 1.3, terminated in-process by all three targets, gRPC included) — plus a labeled p3-mTLS pass for AXIAM."],
-            ["Validity gates", "A cell counts only if error rate ≤ 1% and p95 < 2000 ms. Failing cells are labelled, never charted as a head-to-head."],
-            ["Container caps", "IAM server 2 CPU / 1 GiB · database 2 CPU / 1 GiB · RabbitMQ (AXIAM only) 1 CPU / 512 MiB."],
+            ["Validity gates", "A cell counts only if error rate ≤ 1% and p95 < 2000 ms. Failing cells are labelled, never charted as a head-to-head — 42 of 48 cells passed this run."],
+            ["Container caps", "IAM server 2 CPU / 2 GiB · database 2 CPU / 1 GiB · RabbitMQ (AXIAM only) 1 CPU / 512 MiB. The server cap was raised from 1 GiB — for every target equally — because Keycloak could not reliably survive login load below it."],
           ].map(([t, b]) => (
             <div key={t} className="glass-card" style={{ padding: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 6, color: "#e2e8f0" }}>
@@ -416,9 +714,11 @@ export default function Benchmarks() {
           </li>
           <li style={{ marginBottom: 8 }}>
             <strong>Provenance recorded.</strong> Every container in every cell
-            records its image digest; AXIAM ran from the published, digest-pinned
-            release image — so improvements between runs are attributable to a
-            known binary.
+            records its image digest, and every AXIAM cell records the build ref
+            it ran — so improvements between runs are attributable to a known
+            binary. This run used a post-fix build rather than a published
+            release image; run 5 returns to a release image whose build ref is a
+            commit on <code>main</code>.
           </li>
           <li style={{ marginBottom: 8 }}>
             <strong>Competitors tuned, not hobbled.</strong> PostgreSQL is
@@ -445,8 +745,9 @@ export default function Benchmarks() {
         <SectionTitle kicker="Results" title="Head-to-head throughput" />
         <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 22 }}>
           Plaintext (p0) profile, capped matrix, median of three runs. Higher is
-          better. Each chart is a valid, comparable cell from the full result
-          matrix.
+          better. Each chart is a valid cell from the full result matrix; where
+          a cell is not a like-for-like race, the chart carries the label that
+          says so.
         </p>
         <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
           {BENCH_SCENARIOS.map((s) => (
@@ -532,6 +833,111 @@ export default function Benchmarks() {
         </p>
       </section>
 
+      {/* ---- Resource usage ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Resource usage" title="What it costs to run" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760 }}>
+          New in this run: memory and CPU were sampled per container, every
+          second, throughout every cell — so the throughput numbers above come
+          with the bill for producing them. Same load, same 2-CPU /
+          2&nbsp;GiB envelope for every server. All figures are the p0-plaintext
+          profile, median of three runs.
+        </p>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 20, marginTop: 22 }}>
+          <MemoryCapChart />
+
+          <ResourceChart
+            title="Server memory by scenario"
+            unit="peak resident memory · MiB · lower is better"
+            rows={BENCH_MEMORY_PEAK}
+            format={(n) => `${n.toLocaleString("en-US")} MiB`}
+            footnote="* On the partially valid password-login cells the peak medians and average medians diverge across runs, so the worst-case-over-the-whole-run figures in the chart above are the honest summary for that scenario. Zitadel has no refresh cell — its flow is excluded from this run."
+          />
+
+          <ResourceChart
+            title="CPU cost per request"
+            unit="cpu·ms per request · whole stack unless noted · lower is better"
+            rows={BENCH_CPU_PER_REQ}
+            format={(n) => n.toFixed(2)}
+            scale="row"
+            footnote="Whole-stack userinfo is the single efficiency cell Keycloak wins — AXIAM's figure there carries a pegged SurrealDB plus RabbitMQ. Measured server-only, the same request costs AXIAM 0.25 cpu·ms against Keycloak's 0.53. Both are published; neither is hidden."
+          />
+
+          <ResourceChart
+            title="Throughput per GiB of stack memory"
+            unit="requests/s per GiB of whole-stack RAM · higher is better"
+            rows={BENCH_RPS_PER_GIB}
+            format={(n) => n.toLocaleString("en-US")}
+            scale="row"
+            footnote="Whole-stack means server + database + broker: AXIAM's denominator includes SurrealDB and RabbitMQ, Keycloak's and Zitadel's include PostgreSQL."
+          />
+        </div>
+
+        <div className="glass-card" style={{ padding: 4, marginTop: 20, overflowX: "auto" }}>
+          <table
+            style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5, minWidth: 480 }}
+          >
+            <thead>
+              <tr>
+                {["Target", "Whole-stack memory", "What's in it"].map((h) => (
+                  <th
+                    key={h}
+                    style={{
+                      textAlign: "left",
+                      padding: "12px 16px",
+                      borderBottom: "1px solid rgba(0,212,255,.18)",
+                      color: "#67e8f9",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {BENCH_STACK_MEMORY.map((row) => (
+                <tr key={row[0]}>
+                  {row.map((cell, ci) => (
+                    <td
+                      key={ci}
+                      style={{
+                        padding: "11px 16px",
+                        borderBottom: "1px solid rgba(255,255,255,.06)",
+                        color: ci === 0 ? "#e2e8f0" : "#cbd5e1",
+                        fontWeight: ci === 0 ? 700 : 400,
+                        fontFamily: ci === 1 ? "ui-monospace,Menlo,monospace" : undefined,
+                      }}
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p
+          style={{
+            margin: "18px 0 0",
+            fontSize: 14,
+            color: "#94a3b8",
+            lineHeight: 1.7,
+            maxWidth: 760,
+          }}
+        >
+          Read plainly: <strong style={{ color: "#e2e8f0" }}>Zitadel's stack is the
+          smallest of the three</strong> — its Go server is respectably compact and its
+          costs surface as CPU per request instead. AXIAM's stack is not the
+          smallest, but it does the most work per byte and per core, by 1.6× to
+          17× on every cell except one. And where Keycloak needed its memory cap
+          doubled just to run the login scenario, AXIAM's server never exceeded
+          172 MiB of the same 2 GiB allowance.
+        </p>
+      </section>
+
       {/* ---- AXIAM-only authz ---- */}
       <section style={{ marginBottom: 52 }}>
         <SectionTitle kicker="AXIAM-only" title="Authorization decisions" />
@@ -539,9 +945,10 @@ export default function Benchmarks() {
           No head-to-head here — Keycloak and Zitadel expose no equivalent decision
           endpoint. Each check is a full RBAC evaluation (tenant-scoped roles,
           resource hierarchy, scopes) against live data, over REST and gRPC. The
-          cache-ON rows are a labeled sensitivity pass, not the default
-          configuration; batch numbers are withdrawn pending re-measurement (see
-          the honesty section).
+          cache-ON rows are a labeled best-case sensitivity pass, not the default
+          configuration; the batch figure quoted below is carried over from the
+          previous run, because this run's batch cells measured the wrong
+          strategy (see the honesty section).
         </p>
         <BarChart scenario={BENCH_AUTHZ} />
       </section>
@@ -550,9 +957,9 @@ export default function Benchmarks() {
       <section style={{ marginBottom: 52 }}>
         <SectionTitle kicker="Sensitivity" title="What the labeled passes showed" />
         <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 20 }}>
-          Beyond the head-to-head matrix, run 3 added labeled single-variable
-          passes — never mixed into the comparison tables — to find each
-          system's walls and AXIAM's tuning levers.
+          Beyond the head-to-head matrix, run 4 ran five labeled single-variable
+          passes — never mixed into the comparison tables — to verify the fix,
+          find each system's walls, and size AXIAM's tuning levers.
         </p>
         <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
           {SENSITIVITY.map((s) => (
@@ -630,8 +1037,11 @@ export default function Benchmarks() {
             <code style={{ color: "#67e8f9", fontFamily: "ui-monospace,Menlo,monospace" }}>
               benchmarks/docs/methodology.md
             </code>
-            . Sources: benchmark runs of 2026-07-25/26 (median-of-3 matrix +
-            labeled sensitivity passes).
+            . Sources: benchmark run 4 of 2026-08-01/02 (median-of-3 capped
+            matrix × two TLS profiles × three targets; labeled sensitivity
+            passes for DB-uncapped, decision-cache, native mTLS, production
+            rate-limit posture and batch strategy; an 11-language SDK pass;
+            per-cell k6 summaries with 1-second container and host telemetry).
           </p>
         </div>
       </section>

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -92,6 +92,11 @@ export interface BenchScenario {
   bars: BenchBar[];
   /** One-line, measured-tone takeaway shown under the chart. */
   takeaway: string;
+  /**
+   * Optional comparability warning shown as a chip next to the title — used
+   * where the cells are not a like-for-like race (e.g. protocol-variant).
+   */
+  note?: string;
 }
 
 /**
@@ -104,4 +109,16 @@ export interface BenchEfficiencyRow {
   perCore: [string, string, string];
   /** CPU-milliseconds per request (lower is better). */
   cpuMs: [string, string, string];
+}
+
+/**
+ * One scenario's resource-usage measurement across the three targets, in
+ * `[AXIAM, Keycloak, Zitadel]` order. `null` means the target has no valid
+ * cell for that scenario (e.g. Zitadel's excluded refresh flow).
+ */
+export interface BenchResourceRow {
+  scenario: string;
+  values: [number, number | null, number | null];
+  /** Optional footnote marker appended to the scenario label. */
+  marker?: string;
 }


### PR DESCRIPTION
Refresh the public benchmarks page from the fifth draft of
benchmarks/PUBLIC_BENCH_ANALYSIS.md (run 4 of 2026-08-01/02) — the first
matrix measured after the shared rate-limit write-behind fix.

- Head-to-head charts moved to run-4 medians: token issuance 2,727/s
  (7.7x Keycloak, 6.4x Zitadel), introspection 4,387/s, JWKS 26,371/s,
  userinfo 4,547/s REST, login 69/s.
- New charts: userinfo over gRPC (12,665/s vs Zitadel's 180/s) and
  session/token refresh, the latter carrying a protocol-variant label.
- BenchScenario gains an optional `note` rendered as a warning chip, used
  for the protocol-variant refresh cell and the partially excluded login
  cell (Keycloak/Zitadel figures shown parenthesized, never charted as a
  clean head-to-head).
- Authorization panel updated: gRPC now leads REST (887 vs 753), cache-ON
  charted as a labeled best case (11,598/s gRPC, +5% REST), batch verdict
  carried over from run 3 with the harness slip explained.
- New "Resource usage" section with four comparison graphs: peak server
  memory against the identical 2,048 MiB cap (172 / 1,070 / 216 MiB),
  per-scenario peak memory, cpu-ms per request, and req/s per GiB of
  stack RAM — plus the whole-stack memory table and the note that
  Zitadel's stack is the smallest of the three.
- Three-target series colours are a fixed, validated categorical triple
  (lightness band, chroma floor, CVD separation, contrast); every bar is
  also directly labelled so identity never rests on colour alone.
- Sensitivity/caveats/next-steps rewritten around what this run actually
  found: the fix verified end-to-end, the unexplained TLS
  client-credentials plateau, the wrong batch strategy, the x60 gRPC
  limiter units bug, and Keycloak's login cells needing 4 GiB.
- Rate-limit sizing doc: capacity table, cache guidance and the batch
  strategy default (coalesced) brought in line with the same run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GzuBQ8o1ZqrSRdGrDxYJ43