### PR TITLE
docs(security): add public-facing Threat Modeling & Security website section

### DIFF
--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -1,0 +1,181 @@
+# AXIAM — Security Analysis (2026-08-02)
+
+- **Date**: 2026-08-02
+- **Server commit**: `7ee7df1` (HEAD of `main`; release `1.0.0-alpha23`). SDKs reviewed at each repo's `1.0.0-alpha23` HEAD.
+- **Baseline**: [`final-review-2026-07-08.md`](final-review-2026-07-08.md) + [`remediation-2026-07-08.md`](remediation-2026-07-08.md) (last full code-level review, at `a8e40b3`), the [`security-audit.md`](security-audit.md) compliance index (`c79b66e`), and the [`threat-model-stride.md`](threat-model-stride.md) STRIDE model. Companion public write-up: [`threat-modeling-and-security.md`](threat-modeling-and-security.md).
+- **Scope**: (1) re-verification at current HEAD of the security controls that landed *after* the 2026-07-08 review — none of which had a prior code-level review — namely write-behind rate limiting, in-process TLS termination, the authz decision cache, AMQP v2 replay protection, the signed-timestamp webhook scheme, and the org-scope/refresh escalation fixes; (2) the **first-ever security review of the four newest SDKs** — Kotlin, Swift, C and C++ (REST-only, contract §1–§7/§9–§11); (3) confirmation that the 2026-07-08 SDK remediations still hold in the original seven SDKs, plus the two open SDK items (webhook helper, per-SDK dependency hygiene).
+- **Method**: multi-agent fan-out with per-item file:line evidence, followed by hand re-verification of both new HIGH-class findings and the two headline backend controls (org_id derivation, atomic refresh). Statuses: ✅ verified sound · 🔶 residual/partial · ❌ finding. New findings continue the review sequence at **SEC-071**.
+
+---
+
+## 1. Executive summary
+
+**The AXIAM server's security posture continues to hold, and the controls added since the last review are correctly implemented.** All eight post-2026-07-08 backend controls verified sound at HEAD, each with a real fail-closed design rather than a comment claiming one. The server's own request path — authentication, session, authorization/tenant-isolation, OAuth2/OIDC, federation, PKI, audit, messaging — carries **no open Critical or High finding**, consistent with the 2026-07-08 conclusion and the STRIDE model. One HIGH release-blocker from the last review, the stale-DB-handle outage (CQ-B48/B45), is **confirmed fixed** in `alpha22` ("hold a live pool reference in repositories, not a boot-time clone").
+
+**The frontier of risk has moved, as expected, to the newest client SDKs.** The four SDKs added since the last review — Kotlin, Swift, C, C++ — had never been security-reviewed. They are disciplined in the ways the original seven are (EdDSA `alg`-pinning before key lookup with `alg:none`/HS-confusion rejected, strict TLS with only a custom-CA dev seam and no verify-disable API, mTLS keys wrapped and never logged, no weak RNG or hardcoded key material, clean C/C++ parsing paths). But the review found **one HIGH** — the C SDK's route-guard helpers accept expired *and* cross-tenant tokens because local verification checks only the signature — and a **cross-tenant acceptance gap in the Swift authenticator**, plus a systemic **plaintext-base-URL gap across all four** (the `X-2` hardening that reached the original seven was never carried to the new ones). These are client-side/relying-party controls, but in an IAM SDK a guard that trusts an expired or foreign-tenant token is precisely the class that matters.
+
+**Two SDK-hygiene items round it out**: the TypeScript SDK's `amqplib` dependency is mis-pinned to a nonexistent major (`^2.0.1`) — a regression of the 2026-07-08 `SDK-Q06` fix that leaves the AMQP dependency unsatisfiable — and **no SDK ships a webhook-signature verifier** (threat-model `T-145`), so every integrator still hand-rolls or skips webhook verification.
+
+### Finding counts (this analysis)
+
+| Severity | Backend | SDK | Total new |
+|---|---|---|---|
+| Critical | 0 | 0 | 0 |
+| High | 0 | 1 (SEC-071) | 1 |
+| Medium | 0 | 3 (SEC-072, SEC-073, SEC-074) | 3 |
+| Low | 0 | 4 (SEC-075, SEC-076, SEC-077, SEC-078) | 4 |
+
+Plus three **backend residual concerns** (§4) — all documented and accepted, none a new finding — and one **still-open** SDK gap (`T-145`, webhook verifier).
+
+### Top remediation priorities
+
+1. **SEC-071** — C SDK: validate `exp` (and bind `tenant_id`) in the route-guard verification path; a guard that accepts expired tokens defeats the 15-minute access-token bound for any resource server using it.
+2. **SEC-072** — Swift SDK: assert the configured tenant on every verified session, as the Kotlin SDK's `assertTenant` already does.
+3. **SEC-073** — Kotlin/Swift/C/C++: reject a non-`https` base URL at construction (loopback dev exception), matching the original-seven `X-2` fix.
+4. **SEC-074 / SEC-075** — ship a safe-by-default exp+tenant authenticator in the C++ SDK; origin-pin the Kotlin discovery `jwks_uri`.
+5. **SEC-078** — repin TypeScript `amqplib` to a real `^0.10.x`.
+6. **T-145** — add a `verify_webhook(...)` helper with a freshness window to every SDK and state it in `CONTRACT.md`.
+
+---
+
+## 2. Backend controls added since 2026-07-08 — verified at HEAD
+
+Each of these shipped after the last code-level review and had no prior file:line verification. All are sound; evidence is quoted at current-HEAD lines.
+
+| Control | Verdict | Evidence |
+|---|---|---|
+| **Org-scope escalation fix (NEW-1)** | ✅ | Login derives the authoritative `org_id` from the tenant record and rejects a mismatched client value before minting (`handlers/auth.rs:317-327`); refresh reads `org_id` from `tenant.get_by_id(tenant_id).organization_id`, never the request body (`auth.rs:451-462`); `token::issue_access_token` only ever stamps the server-derived value (`token.rs:96-138`). MFA challenge/setup tokens embed the same derived `org_id`. |
+| **Refresh single-use atomicity (NEW-3)** | ✅ | `SessionRepository::consume` is an atomic `DELETE … WHERE tenant_id=$tid RETURN BEFORE` returning whether *this* call won (`repository/session.rs:195-214`); `AuthService::refresh` aborts on a lost race **before** minting the new session/tokens (`service.rs:582-590`). No forked lineage, stolen-token reuse stays detectable. |
+| **Write-behind shared rate limiter** | ✅ | Synchronous in-memory decision with a background coalescing flush, no DB write on the request path (`rate_limit_counter.rs:500-527,740-761`). XFF uses rightmost-untrusted with `peer_addr()` fallback when `trusted_hops ≥ hops` (`extractors/rate_limit.rs:71-93`). **`limit=0` denies regardless of store reachability** (fail-closed, `:522`). The one deliberate fail-open (no derivable key / `SHARED=off`) is isolated and documented (`middleware/rate_limit_shared.rs:334-353`). |
+| **In-process TLS listener** | ✅ | rustls **TLS 1.3-only** via `with_protocol_versions(&[&TLS13])` (`tls.rs:391-393`); fails startup on missing/unreadable/mismatched cert or key (`tls.rs:331-413`) and **never falls back to plaintext** — the plaintext `bind` is only reached in the TLS-disabled branch (`main.rs:1239-1256`). Native mTLS terminates in-process with no trusted proxy-header identity. |
+| **AMQP v2 replay protection** | ✅ | Per-message `nonce`+`issued_at` are always inside the signed body (`messages.rs:186-192,234-240`); freshness window (`is_fresh`, `:86-88`) + per-tenant nonce dedup (`authz_consumer.rs:129-154`) with a store error failing closed to `NackDrop`; `key_version ≥ 2` hard-required (`messages.rs:52`, no v1 grace); per-tenant HKDF-SHA256 subkey (`derive_tenant_key`, `:101-111`); signing mandatory in release (`config.rs:77-97`, `main.rs:840-843`). |
+| **Signed-timestamp webhooks** | ✅ | `X-Axiam-Signature: t=<unix>,v1=<hex>` = HMAC-SHA256 over `<timestamp>.<body>` (`webhook.rs:308-317`); delivery through resolve-and-pin `guarded_fetch(allow_private=false)` (`:264`); secret AES-256-GCM at rest (`:151-157`, encrypted on create/rotate, fail-closed on missing key); redacting `Debug` on `Webhook`/`CreateWebhook`/`UpdateWebhook` plus `skip_serializing` and a response DTO (`models/webhook.rs:43,53-118`). |
+| **Federation SSRF guard (four fetches)** | ✅ | `guarded_fetch` enforces `https` on every hop incl. redirects (`ssrf.rs:180-182`, redirect hops never get the private allowance), resolve-and-pin (`:110-147`), body caps by `Content-Length` + streaming cap (`:210-254`), `MAX_HOPS=3`. Applied to JWKS (`jwks_cache.rs:255`), token exchange (`oidc.rs:448`), SAML metadata (`saml.rs:145`), discovery (`discovery_cache.rs:206`). |
+| **Authz decision-cache invalidation** | ✅ | Key = tenant + subject + resource + action + scope (`decision_cache.rs:163-180,387-391`); access-narrowing mutations call `invalidate_subject`/`invalidate_tenant` across roles/groups/permissions/scopes/resources handlers (not just TTL); 5 s TTL is a backstop only. |
+
+**Also confirmed fixed since the last review:** the stale-DB-handle undetectable-outage HIGH (`CQ-B48`/`CQ-B45`) — repositories now hold a live `DbHandle` over the pool slot and resolve the current connection per query (`alpha22` changelog; connection module).
+
+---
+
+## 3. New findings — client SDKs
+
+The four newest SDKs are REST-only relying-party clients. The findings below are in their **local token-verification and transport-construction** paths — the client-side face of controls the server enforces correctly.
+
+### SEC-071 [HIGH] ❌ — C SDK route guards accept expired and cross-tenant tokens
+
+- **File**: `axiam-c-sdk/src/guard.c:41-63` (`verify_and_claims` → `axiam_require_auth`/`require_access`/`require_role`), `src/jwks.c:100-194` (`axiam_jwt_verify`).
+- **Defect**: `axiam_jwt_verify` correctly pins `alg=EdDSA` before key lookup (`jwks.c:126-137`) and verifies the Ed25519 signature (`:161-179`), then returns the raw claims JSON — but performs **no `exp`/`nbf` check and no `tenant_id` assertion** (verified by hand: there is no expiry or tenant logic anywhere in `jwks.c` or `guard.c`). The shipped guards call this and treat any signature-valid token as authenticated: `require_auth` returns `ALLOW`, `require_role` matches roles from the unvalidated claims, and `require_access` runs its server-side authz check only *after* admitting the token.
+- **Impact**: a resource server that protects its endpoints with the C SDK guards accepts (a) an **expired** AXIAM access token — defeating the 15-minute lifetime that bounds stolen-token exposure, indefinitely — and (b) a token minted for a **different tenant in the same organization**, because the JWKS trust anchor is org-wide and nothing binds the token's `tenant_id` to the client's configured tenant. This is the exact `exp`/tenant discipline the Kotlin SDK enforces (`assertTenant`; Swift enforces `exp` at least).
+- **Fix**: in the guard's verification path (or in `axiam_jwt_verify` behind a strict flag used by the guards), reject when `exp ≤ now` (small skew) and when the token's `tenant_id` claim ≠ the client's configured tenant. Add negative tests for an expired token and a foreign-tenant token.
+
+### SEC-072 [MEDIUM] ❌ — Swift `AxiamRequestAuthenticator` does not bind the session to the configured tenant
+
+- **File**: `axiam-swift-sdk/Sources/AxiamSDK/Guard/AxiamRequestAuthenticator.swift:64-73`.
+- **Defect**: `exp` *is* enforced (`:54`), and the JWKS URL is origin-derived from the configured base — both good. But the tenant check only fires when the request carries an `X-Tenant-ID` header **and** the token has a `tenant_id` claim **and** they differ; the client's configured `tenantID` is used only as a fallback field value (`:73`), never as an assertion. With an org-wide JWKS, a validly-signed token from another tenant is accepted whenever the request omits `X-Tenant-ID` (or presents a matching pair).
+- **Impact**: cross-tenant token acceptance on a Swift-guarded resource server — a narrower version of SEC-071 (bounded by the enforced `exp`).
+- **Fix**: assert `token.tenant_id == configured tenantID` on every verified session, mirroring the Kotlin SDK's `assertTenant` (`JwksVerifier.kt:258-267`). Add a cross-tenant negative test.
+
+### SEC-073 [MEDIUM] ❌ — All four new SDKs accept a plaintext `http://` base URL at construction
+
+- **File**: Kotlin `AxiamClient.kt:546-556`, Swift `AxiamConfig.swift:37-65`, C `config.c:86-89`, C++ `client.cpp:272-303`.
+- **Defect**: each validates non-empty `base_url`/tenant but never checks the URL scheme, and the base URL is used verbatim to build requests. TLS is strict *when `https` is used*, but a misconfigured `http://` (or `grpc://`/`amqp://` where applicable) base sends login credentials, bearer cookies, CSRF and tenant headers in cleartext with no error. This is the `X-2` finding that was fixed in the Rust/TS SDKs (`ensure_secure_scheme`, gRPC `allowInsecure` opt-in) but never carried to the four new ones.
+- **Impact**: silent transport downgrade — threat-model `T-23` on the new SDKs. Contract §6 requires rejecting non-`https` at construction (loopback dev exception).
+- **Fix**: reject a non-`https` base URL at construction in all four (allow-list loopback for dev), one small change per SDK.
+
+### SEC-074 [MEDIUM] ❌ — C++ SDK ships a signature-only `verify()` with no safe-default exp/tenant authenticator
+
+- **File**: `axiam-cplusplus-sdk/src/jwks.cpp:140-178`, `include/axiam/guard.hpp`.
+- **Defect**: `verify()` pins EdDSA and checks the signature but returns the payload with **no `exp`/`iss`/`aud`/`tenant` checks** (documented in `jwks.hpp:5-6,43`), and the SDK ships no §10 authenticator that adds them — `guard.hpp` operates on an already-built `AxiamUser` and never verifies a token. So the only bundled primitive is signature-only, and an integrator wiring it into a request guard will accept expired/cross-tenant tokens unless they hand-add the checks. Same underlying gap as SEC-071 but presented as a documented primitive rather than a shipped guard.
+- **Fix**: add a safe-by-default authenticator that verifies signature **and** `exp` **and** the configured tenant, and make it the documented entry point; keep the raw primitive clearly labelled.
+
+### SEC-075 [LOW/MEDIUM] ❌ — Kotlin discovery `jwks_uri` not constrained to the issuer origin
+
+- **File**: `axiam-kotlin-sdk/src/main/kotlin/io/axiam/sdk/oidc/OidcSupport.kt:565,595-597`; `JwksVerifier.forJwksUri`.
+- **Defect**: Kotlin is the one new SDK doing OIDC discovery; the discovered `jwks_uri` is followed without constraining it to the configured issuer/base-URL origin. Mitigated because discovery is fetched over strict TLS from the configured base URL, so it is defense-in-depth rather than an active break — but it is the `SDK-19` class (first seen in the PHP SDK, since fixed there with a same-origin-https check).
+- **Fix**: require the discovered `jwks_uri` be `https` and same-origin as the base URL, else fall back to `{baseUrl}/oauth2/jwks` — exactly the PHP SDK's fix.
+
+### SEC-076 [LOW] ❌ — C and C++ SDKs store MFA challenge/setup tokens as plain strings
+
+- **File**: C `include/axiam/client.h:44-45` (`challenge_token`/`setup_token`), C++ `include/axiam/types.hpp:36` (`LoginResult.challenge_token`).
+- **Defect**: contract §7 classes the MFA challenge token as a secret; the Kotlin and Swift SDKs wrap it in `Sensitive`, but C/C++ leave it as a plain `char*`/`std::string`. No auto-logging path exists today, so severity is low, but it is an inconsistency that removes the redaction safety-net the other SDKs have.
+- **Fix**: wrap the challenge/setup tokens in the SDK's `Sensitive` type (and zeroize on free in C, as the SDK already does for the mTLS key).
+
+### SEC-077 [LOW] ❌ — Swift `Sensitive` uses a non-constant-time equality
+
+- **File**: `axiam-swift-sdk/Sources/AxiamSDK/Sensitive.swift:28-32` — `Equatable` via plain `lhs.value == rhs.value` over secret material. The Kotlin SDK deliberately does *not* override equality for exactly this reason. Low severity (few call sites compare secrets), but worth a constant-time compare.
+
+### SEC-078 [LOW] ❌ — TypeScript SDK `amqplib` pinned to a nonexistent major (SDK-Q06 regression)
+
+- **File**: `axiam-typescript-sdk/package.json:118` — `"amqplib": "^2.0.1"`, while `@types/amqplib` is `^0.10.8` (`:150`). amqplib has no 2.x line (real releases top out at 0.10.x), so the runtime dependency is **unsatisfiable** as pinned. The 2026-07-08 remediation claimed this was corrected to `^0.10.x`; it is not, at HEAD.
+- **Impact**: the AMQP transport can't install cleanly; a resolver that ignores the bad range could pull an unexpected artifact. Reliability/supply-chain hygiene rather than an exploit.
+- **Fix**: repin to a real `^0.10.x` matching `@types/amqplib`; add a `postinstall`/CI lockfile-resolve gate so an unsatisfiable pin fails the build.
+
+---
+
+## 4. Backend residual concerns (documented / accepted — not new findings)
+
+These surfaced during verification of recently-added code. All are already documented or are accepted trade-offs; none is a new finding, and all are noted here for completeness and future scheduling.
+
+1. **Pre-auth `client_id` rate-limit keying** (`middleware/rate_limit_shared.rs:301-318`, `extractors/rate_limit.rs:150-155`). In `AXIAM__RATE_LIMIT__KEY=client_id` mode the bucket key is read from the raw form body **before** the credential check, so a caller rotating `client_id` values mints fresh buckets on `/oauth2/{token,introspect,revoke}`. This is documented in the Configuration guide's security caveat (the shipped default is `ip`, which an attacker cannot mint), mitigated by `ip_client_id` and the per-replica governor, and intended only where an edge (mTLS/gateway/WAF) already authenticates callers. Config-dependent, low–medium; no change recommended beyond the existing loud documentation.
+
+2. **Multi-replica decision-cache stale-allow window** (`decision_cache.rs:47-74`). Invalidation is process-local with no cross-replica channel, so on a replica that did not handle the mutation a revoked grant can remain `Allow` for up to `decision_cache_ttl_secs` (default 5 s). This is the documented, accepted bounded-staleness trade-off of the cache (threat-model `T-88`), enabled opt-in; the TTL bounds it. Deployments needing immediate cross-replica revocation should use gRPC introspection.
+
+3. **Access-token audience narrowing — confirm downstream** (`token.rs:343-351`). `decode_access_token` accepts both `axiam:user` and `axiam:m2m` audiences and does not require `aud` at the token layer, deferring per-route audience separation to the REST extractor (`extractors/auth.rs`, per the SEC-006 resolution). This is by design *provided* the extractor narrows audience per route; it predates this review window and was not re-derived end-to-end here. **Recommendation**: add/keep a regression test asserting an `axiam:m2m` token is rejected on a user route (and vice-versa) so this intentional token-layer permissiveness stays backed by an enforced downstream check.
+
+---
+
+## 5. Original-seven SDKs — 2026-07-08 remediations still hold
+
+Re-verified at `alpha23`; the fixes from [`remediation-2026-07-08.md`](remediation-2026-07-08.md) are present:
+
+- **AMQP HMAC declaration-order (SDK-Q01/X-1)** ✅ — Go canonicalises via declaration-order structs; Rust uses `serde_json` `preserve_order` + `shift_remove`. Field order matches the server (`correlation_id, tenant_id, subject_id, action, resource_id, scope, key_version, nonce, issued_at`).
+- **AMQP §8 v2 replay fields** ✅ — nonce + `issued_at` + `key_version ≥ 2` supported in **all seven** consumers (Rust/Go/Python/TS/Java/C#/PHP), each with a freshness skew and a nonce store.
+- **Rust authz CSRF (SDK-Q04)** ✅ — `send_authz_post` forwards `X-CSRF-Token` (`rest/authz.rs:195`).
+- **TS Node client (SDK-Q05)** ✅ — `createNodeClient` + injectable tough-cookie jar. **SDK-Q06** ❌ — `amqplib` mis-pin persists → **SEC-078** above.
+- **PHP JWKS pin (SDK-19)** ✅ — discovered `jwks_uri` honoured only when same-origin https, else fallback to `{baseUrl}/oauth2/jwks`.
+- **Plaintext base URL rejection (X-2)** ✅ — Rust (`ensure_secure_scheme`, + redirect scheme-downgrade guard) and TS gRPC (`allowInsecure` opt-in). *(Not carried to the four new SDKs → SEC-073.)*
+- **Header redaction allowlist (X-3)** ✅ — TS/Python/Go/Java/C# all use a safe-header allowlist, not the old 3-entry denylist.
+
+**Still open — `T-145` (webhook-signature verifier).** No SDK — original seven or new four — ships a `verify_webhook(secret, timestamp_header, signature_header, body)` helper for the server's signed-timestamp scheme. Every integrator hand-rolls or skips verification. The server-side control is complete; the gap is purely on the client side. **Fix**: add the helper (HMAC-SHA256 over `<timestamp>.<body>`, constant-time compare, freshness window on `t`, dedup on `X-Axiam-Delivery`) to each SDK and state the expectation in `CONTRACT.md`.
+
+---
+
+## 6. Alignment with the STRIDE threat model
+
+The threat model ([`threat-model-stride.md`](threat-model-stride.md)) records 149 threats, 22 open. This analysis is consistent with it and refines two SDK-surface items:
+
+- The model marks `T-23` (SDK transport downgrade) and the SDK-integration diagram broadly **mitigated** via CONTRACT §6. That holds for the original seven; **SEC-073** shows the four new SDKs do not yet reject a plaintext base URL, so `T-23` is **partial** for them until fixed.
+- `T-142` (SDK JWKS-from-discovery) is mitigated per §12; **SEC-075** is the same class re-appearing in the Kotlin SDK (defense-in-depth, TLS-mitigated).
+- `T-145` (no SDK webhook verifier) is confirmed **still open**, unchanged.
+- SEC-071/072/074 are new **local relying-party verification** items on the REST-guard surface (`T-143` neighbourhood — local verification vs. server truth); they do not change the server-side threat verdicts, which remain sound.
+
+The model's 22 open items are otherwise unchanged and correctly characterised: accepted design trade-offs (no deny-override `T-16`/`T-87`, 15-min token revocation lag `T-39`, append-only audit vs. erasure `T-110`/`T-118`), deployment responsibilities (`T-9`, `T-18`, `T-124`, `T-125`, `T-131`, `T-132`, `T-133`, `T-134`, `T-129`, `T-119`), and SDK/distribution gaps (`T-135`, `T-146`, `T-148`, `T-145`, `T-143`).
+
+---
+
+## 7. Prioritized remediation order
+
+**Tier 1 — SDK auth-verification correctness (do first):**
+1. **SEC-071** — C SDK guards: enforce `exp` + tenant binding in local verification. (HIGH.)
+2. **SEC-072** — Swift authenticator: assert the configured tenant on every session.
+3. **SEC-074** — C++ SDK: ship a safe-by-default exp+tenant authenticator, not just a signature primitive.
+
+**Tier 2 — transport & discovery hardening:**
+4. **SEC-073** — reject non-`https` base URLs across Kotlin/Swift/C/C++ (loopback exception).
+5. **SEC-075** — origin-pin the Kotlin discovery `jwks_uri`.
+6. **T-145** — add `verify_webhook(...)` to every SDK + a `CONTRACT.md` clause.
+
+**Tier 3 — hygiene & polish:**
+7. **SEC-078** — repin TS `amqplib` to `^0.10.x` + a lockfile-resolve CI gate.
+8. **SEC-076** — wrap C/C++ MFA tokens in `Sensitive`. **SEC-077** — constant-time compare in Swift `Sensitive`.
+9. Backend residual §4.3 — add the audience-narrowing regression test if not already present.
+
+**Executor note.** Every Tier 1–2 item has a same-family precedent to copy: the Kotlin SDK's `assertTenant` and `exp` enforcement for SEC-071/072/074, the Rust/TS `ensure_secure_scheme`/`allowInsecure` for SEC-073, and the PHP SDK's same-origin-https `jwks_uri` check for SEC-075. Land each fix with a negative test (expired token, foreign-tenant token, `http://` base URL).
+
+---
+
+## 8. Coverage & confidence
+
+- **Backend**: the eight post-2026-07-08 controls were each verified with current-HEAD file:line evidence; the two headline items (org_id derivation, atomic refresh) were re-derived by hand end-to-end. Not re-run locally: the full `axiam-server` binary build and `cargo audit` (swagger-ui offline placeholder + tool availability in this sandbox — rely on CI, which gates both). The earlier reviews' sound controls (PKCE S256-only, OAuth2 atomic single-use, JWT audience blocks, parameterised SurrealQL, PKI/mTLS, GDPR erasure durability) were not re-audited this round and are assumed to hold, no source having regressed them per the changelog.
+- **SDKs**: the four new SDKs were reviewed across strict-TLS/no-bypass, plaintext-URL rejection, secret redaction, JWKS/token verification, weak-crypto/RNG, mTLS handling and (C/C++) memory safety. SEC-071 was confirmed by directly reading `guard.c` and `jwks.c` (no `exp`/tenant logic present). The original seven were spot-verified against the 2026-07-08 remediation list; the `amqplib` mis-pin (SEC-078) was confirmed firsthand.
+- **Lower-confidence residual**: the backend §4.3 audience-narrowing path was not traced into the extractor this round; the multi-replica cache-staleness bound rests on the documented single-process invalidation model. Both are flagged for a future targeted pass rather than asserted closed.

--- a/claude_dev/threat-modeling-and-security.md
+++ b/claude_dev/threat-modeling-and-security.md
@@ -1,0 +1,380 @@
+# Threat Modeling & Security
+
+> **Website section source.** This document is written to become a new, dedicated
+> **Security** section on the AXIAM website (a top-level nav entry alongside Docs,
+> SDKs and Benchmarks). It is public-facing: it explains how AXIAM is designed to
+> be secure, what it defends against, and where responsibility passes to whoever
+> deploys it. The internal, code-level evidence lives in
+> [`security-analysis-2026-08-02.md`](security-analysis-2026-08-02.md), the
+> [`threat-model-stride.md`](threat-model-stride.md) STRIDE model, and the
+> [`security-audit.md`](security-audit.md) compliance index — this page is the
+> readable summary those documents hang from.
+>
+> **Porting note for the site.** The headings and blocks below map directly onto
+> the website's `DocBlock` content model (`website/src/docs.ts`): `##`→`h`,
+> paragraphs→`p`, bullet lists→`list`, tables→`table`, and the callouts marked
+> **Note**/**Caution**→`note`/`warn`. A new `"security"` page type is added to
+> `website/src/types.ts` and a `NAV_ITEM` to `Header.tsx`. The eight subsections
+> under "How AXIAM defends each layer" are the natural sidebar entries.
+
+---
+
+## Security at a glance
+
+AXIAM is an identity and access-management platform, so it is itself a piece of
+security infrastructure: a weakness here is a weakness in every application that
+trusts it. The project treats that seriously. Security is not a feature bolted on
+at the end — it is designed in, verified continuously, and documented honestly,
+including the risks AXIAM cannot close on its own.
+
+Three principles run through the whole system:
+
+- **Secure by default.** The safe configuration is the one you get out of the box.
+  Authorization is default-deny, TLS 1.3 is the floor for external traffic, tokens
+  live in `HttpOnly` cookies, secrets are encrypted at rest, and a missing
+  encryption key fails startup rather than silently substituting a weak one.
+- **Defense in depth.** No single control is load-bearing. Tenant isolation is
+  enforced at the handler, the query and the graph-traversal layers; a stolen
+  token is short-lived, signature-pinned and revocable; a forged message must pass
+  transport, signature and freshness checks before it is acted on.
+- **Honest about the boundary.** A threat AXIAM cannot close from inside the
+  application — backup encryption, cluster RBAC, per-service broker credentials —
+  is written down as an open item with guidance, not quietly assumed away.
+
+The system is verified against a **STRIDE threat model of 149 threats** and a
+compliance self-assessment covering **OWASP ASVS Level 2, ISO/IEC 27001:2022,
+the EU Cyber Resilience Act and GDPR**, with its OAuth2/OIDC surface checked
+against the relevant RFC and OpenID conformance matrices.
+
+---
+
+## The threat model
+
+AXIAM maintains a formal threat model in **[OWASP Threat Dragon](https://www.threatdragon.com)**
+format, built with the **STRIDE** methodology (Spoofing, Tampering, Repudiation,
+Information disclosure, Denial of service, Elevation of privilege). It is a
+design-level model: it reasons about the system's data flows and trust boundaries,
+and records the specific control that answers each threat — or marks the threat
+open and says why.
+
+| | |
+|---|---|
+| Methodology | STRIDE, per-element |
+| Tool | OWASP Threat Dragon (model schema v2) |
+| Diagrams | 9 |
+| Threats identified | 149 |
+| Mitigated / Open | 127 / 22 |
+
+Every threat is examined against the STRIDE categories that apply to its element
+type (actor, process, data store or data flow). A threat is marked **mitigated**
+only where a control exists in the codebase and can be pointed at; where the
+residual risk is accepted, deferred, or belongs to whoever deploys AXIAM, it stays
+**open** and explains itself. An honest open item is more useful than an
+optimistic closed one.
+
+### Coverage by area
+
+| Area | Threats | Open |
+|---|---|---|
+| System context | 26 | 3 |
+| Authentication & session management | 22 | 1 |
+| OAuth2 / OIDC authorization server | 14 | 0 |
+| Federation (SAML SP & OIDC RP) | 15 | 0 |
+| Authorization engine (RBAC, hierarchy, scopes) | 15 | 1 |
+| PKI, certificates & IoT device identity | 13 | 1 |
+| Audit, webhooks, email & notifications | 18 | 4 |
+| Deployment & platform (Kubernetes) | 11 | 7 |
+| Client SDKs & admin-UI integration surface | 15 | 5 |
+
+The concentration of open items in *Deployment* and *Client SDKs* is deliberate
+and expected: those are the two areas where security is a shared responsibility
+between AXIAM and the people who run and integrate it. AXIAM's own request path —
+authentication, authorization, tokens, PKI, federation — carries **no open
+Critical or High finding**.
+
+---
+
+## Trust boundaries
+
+Five trust boundaries recur across the system. A data flow that crosses one is a
+place where authentication, authorization, validation and transport protection all
+have to be re-established — nothing is assumed across a boundary.
+
+| Boundary | Separates | What must hold on every crossing |
+|---|---|---|
+| **Public Internet ↔ AXIAM** | Browsers, SDK callers, IoT devices, external IdPs | TLS 1.3, authentication, rate limiting, CSRF on cookie requests, input validation |
+| **AXIAM ↔ data tier** | Application pods ↔ SurrealDB, RabbitMQ, Secrets | Private network, credentialed connections, parameterised queries, tenant scoping at the repository layer |
+| **Tenant ↔ tenant** | Every tenant's data from every other's | Tenant context derived from the verified session or JWT — never from request input — and enforced on every query and graph traversal |
+| **AXIAM ↔ third parties** | Outbound to IdPs, email providers, webhook receivers | SSRF guard with resolve-and-pin, HTTPS enforcement, response-size caps, HMAC signatures on deliveries |
+| **Server ↔ SDK / admin UI** | The server contract from its client implementations | One cross-language contract — TLS policy, secret redaction, CSRF, AMQP HMAC — enforced by CI drift and protobuf gates |
+
+### The assets worth protecting
+
+| Asset | Protection | Compromise would mean |
+|---|---|---|
+| JWT signing key (Ed25519) | Kubernetes Secret, never in the image | Any identity in any tenant forged |
+| Organization CA private key | AES-256-GCM encrypted at rest | Any user/service/device certificate minted |
+| Password hashes | Argon2id, per-user salt, pepper | Offline cracking of credentials |
+| MFA secrets | AES-256-GCM encrypted at rest | Second factor defeated |
+| Refresh tokens & sessions | Stored hashed, single-use rotation | Sustained impersonation |
+| Client & webhook secrets | Hashed / encrypted, redacted from logs | Service-account impersonation; forged events |
+| Authorization graph | Private data tier, API-only mutation, audited | Silent privilege escalation |
+| Audit log | Append-only, OpenPGP-signed | Loss of accountability |
+
+---
+
+## How AXIAM defends each layer
+
+### Authentication & sessions
+
+- **Passwords** are hashed with **Argon2id** at OWASP-recommended parameters
+  (~19 MiB memory cost, per-user salt, server-side pepper). Plaintext passwords are
+  never stored or logged.
+- **Login is enumeration-safe and brute-force-resistant**: unknown-user and
+  bad-password return the same uniform failure, password verification runs on a
+  dummy hash when the user does not exist so timing does not distinguish the two,
+  and failed attempts drive an atomic, exponential-backoff lockout that is shared
+  by every credential-checking path (REST and gRPC alike).
+- **MFA** is built in — TOTP today, WebAuthn/passkeys for phishing-resistant,
+  origin-bound second factors. TOTP codes are single-use within their window
+  (replay is rejected with an atomic compare-and-set), and the MFA challenge is a
+  distinct, single-use, no-authority token so the second factor can never be
+  skipped by replaying it.
+- **Tokens**: access tokens are **EdDSA (Ed25519) JWTs**, 15 minutes long. The
+  verifier pins the algorithm and never reads it from the token header, so
+  `alg:none` and HMAC-key-confusion attacks are rejected outright. Refresh tokens
+  are opaque, server-stored and **single-use with rotation**, consumed through an
+  atomic delete-gate so a race cannot fork the session or hide a stolen-token
+  reuse. In the browser, tokens live only in `Secure` / `HttpOnly` /
+  `SameSite=Strict` cookies — never in `localStorage`, never in a URL.
+- **Password reset** uses CSPRNG-generated, single-use, short-lived tokens
+  (never time-ordered UUIDs), delivered over an authenticated POST, and consuming a
+  reset invalidates every existing session. An optional **Have I Been Pwned**
+  k-anonymity check (only a five-character hash prefix leaves the server, behind a
+  circuit breaker) blocks known-breached passwords.
+
+### Authorization & tenant isolation
+
+Tenant isolation is the core guarantee of a multi-tenant IAM, so it is enforced
+redundantly rather than at one chokepoint:
+
+- **Tenant context comes from the verified session or JWT, never from request
+  input.** A caller cannot name a tenant it does not belong to. The organization
+  claim in a token is derived server-side from the tenant record on both login and
+  refresh — it is never accepted from the client.
+- **Repository queries are tenant-scoped and parameterised.** Every SurrealQL
+  statement uses bind parameters — no query is assembled by string concatenation of
+  user input — and carries a `tenant_id` predicate. Cross-tenant graph edges are
+  stripped during permission resolution rather than followed.
+- **The authorization engine is RBAC, additive, allow-wins with default-deny.**
+  A route with no declared permission is refused, not allowed. Roles cascade down a
+  resource hierarchy with bounded, cycle-safe traversal. An optional per-tenant
+  decision cache speeds checks without ever changing the answer — access-narrowing
+  changes invalidate affected entries immediately, so no revocation leaves a stale
+  allow.
+- **Three protocols, one engine.** REST middleware, gRPC `CheckAccess` and the
+  async AMQP path all evaluate the same policy. The gRPC interceptor authenticates
+  the caller and derives the tenant from its verified identity, so a service account
+  cannot ask about a subject outside its own tenant.
+
+### OAuth2 & OpenID Connect
+
+AXIAM is a full OAuth2 authorization server and OIDC provider, checked against the
+RFC 6749 / 7636 / 7009 / 7662 MUST matrices and OIDC Core/Discovery conformance:
+
+- **Authorization Code with PKCE (S256 only)** — the `plain` method is rejected;
+  public clients prove possession with the verifier rather than a secret. The
+  implicit grant is not offered.
+- **Exact `redirect_uri` matching** — no wildcards, no prefix matching, no
+  normalisation that could widen the match, closing the open-redirect class.
+- **Single-use authorization codes** bound to client and redirect URI; **refresh
+  rotation** that can only narrow scope, never widen it; `state` and `nonce`
+  required and verified.
+- **Introspection and revocation require client authentication** and are scoped
+  to the caller's own tenant; unknown tokens return the uniform inactive response.
+- **userinfo is scope-filtered**; JWKS publishes the active key plus a bounded
+  rotation-overlap window.
+
+### Federation (SAML & OIDC)
+
+Inbound federation is a deliberate delegation of trust to an external IdP, hardened
+against the classic federation attacks:
+
+- **SAML** verifies the signature over the *exact* element it then consumes (XML
+  Signature Wrapping defence), rejects unsigned or multiply-signed responses, checks
+  `Conditions`, `NotBefore`/`NotOnOrAfter`, `Audience`, `Destination` and
+  `InResponseTo`, and refuses replayed assertion IDs.
+- **OIDC federation** requires `state` and `nonce` from server-side flow state
+  (never from the request body), binds the federation-config id into `state` to stop
+  IdP mix-up, and validates the issuer.
+- **Every outbound IdP fetch** — discovery, token exchange, JWKS, SAML metadata —
+  goes through one **SSRF guard** that resolves DNS fresh, rejects private,
+  loopback, link-local and ULA addresses, **pins the validated IP for the actual
+  connection** (closing the DNS-rebind window), enforces HTTPS on every hop
+  including redirects, and caps the response body.
+- **Attribute-to-role mapping is an explicit, tenant-scoped allow-list** set by an
+  AXIAM administrator; unmapped IdP attributes are discarded, so an IdP cannot
+  self-assign privileged roles.
+
+### PKI, certificates & device identity
+
+- Certificates are **per-tenant, signed by the organization CA**, using RSA-4096 or
+  Ed25519 from the platform CSPRNG. **Private keys are never stored server-side** —
+  they are returned exactly once at issuance and delivered only over TLS 1.3.
+- **CA signing keys are AES-256-GCM encrypted at rest** in a separate,
+  access-controlled table, with the key held outside the datastore.
+- **mTLS device authentication verifies the full chain** to the tenant/org CA after
+  the fingerprint lookup, checks the issuing CA is active and within its validity
+  window, and enforces the certificate's own validity period and live revocation
+  status on every connection — a fingerprint match alone is never enough.
+- **OpenPGP keys** sign the audit trail and encrypt GDPR data exports, so both are
+  independently verifiable and confidential.
+
+### Audit & accountability
+
+- The audit log is **append-only** — no UPDATE or DELETE paths — and batches are
+  **OpenPGP-signed**, making tampering or selective deletion detectable rather than
+  merely difficult.
+- Every state-changing and authorization action is recorded with actor, actor type,
+  IP, outcome and timestamp; **both allow and deny decisions** are captured, so
+  probing shows up in the trail. Records are structured fields, not formatted
+  strings, so log-injection cannot forge a synthetic entry.
+
+### Webhooks, email & messaging
+
+- **Webhook deliveries are signed with a Stripe-style signed-timestamp HMAC** —
+  HMAC-SHA256 over `<timestamp>.<body>`, so a stale or body-only forgery cannot be
+  produced — and use the same resolve-and-pin SSRF guard as federation, so a webhook
+  URL cannot be used to scan internal services.
+- **AMQP messages** (async authz, audit ingestion, mail) carry an **HMAC-SHA256
+  signature over the canonical body with a per-tenant HKDF-derived subkey**,
+  verified in constant time before processing; a bad signature is rejected without
+  requeue. The v2 message format binds a **per-message nonce and timestamp** so a
+  captured, validly-signed message cannot be replayed. Signing is mandatory in
+  production builds.
+- **Email** is built through a typed API that rejects header injection, renders
+  templates with user values as escaped data (never as template source), and
+  encrypts provider credentials at rest.
+
+### Transport, secrets & the SDKs
+
+- **TLS 1.3 is the minimum** for all external communication; HSTS is emitted; the
+  optional in-process TLS listener is TLS 1.3-only and fails fast rather than
+  falling back to plaintext.
+- **Secrets at rest** — MFA seeds, CA keys, federation and webhook and email
+  secrets — are AES-256-GCM encrypted; passwords and client/refresh secrets are
+  hashed. Secret-bearing types carry redacting `Debug`/`toString` implementations so
+  a credential never reaches a log line. A **missing encryption key fails startup**;
+  no code path substitutes an all-zero or constant key.
+- **The eleven client SDKs conform to one cross-language contract.** Strict TLS
+  verification is unconditional and TLS-bypass APIs are prohibited (CI greps for
+  them); secrets are wrapped in redacting types; the browser flow keeps tokens in
+  cookies with single-flight refresh; JWKS relying-party helpers pin the key set to
+  the configured issuer. The server is the single source of truth: a CI drift gate
+  fails the build if an SDK's vendored OpenAPI/protobuf copy diverges.
+
+---
+
+## Compliance posture
+
+AXIAM keeps an internal compliance self-assessment mapping its controls to
+recognised frameworks. This is a control-family self-assessment appropriate to a
+beta-stage product — **not** a certified ISO 27001 ISMS audit or a formal Cyber
+Resilience Act conformity assessment, and it says so plainly.
+
+| Framework | Scope | Status |
+|---|---|---|
+| **OWASP ASVS v4.0.3 Level 2** | 103 controls across authentication, session, access control, cryptography, error handling, data protection, communications, malicious code, configuration | 94 Pass, 4 N/A, 5 Deferred — **no Deferred item is High or Critical** |
+| **ISO/IEC 27001:2022 Annex A** | Access control, secure authentication, cryptography, logging, network security, secure development | Interpretive control-family mapping; code-level themes Pass |
+| **EU Cyber Resilience Act (Annex I)** | Secure-by-design, no known exploitable vulnerabilities, confidentiality, data minimisation, access control, vulnerability handling, security updates | Themes Pass; SBOM deferred |
+| **GDPR** | Data-subject export (Art. 15) and erasure (Art. 17), pseudonymisation, data minimisation | Export excludes secrets; erasure is durable and re-selectable on failure; audit actor identities are pseudonymised |
+| **OAuth2 / OIDC** | RFC 6749 / 7636 / 7009 / 7662 + OIDC Core/Discovery MUST matrices | All tracked MUSTs pass; dedicated conformance suites |
+
+Dependency and supply-chain security is gated in CI — `cargo audit`, `cargo deny`,
+Trivy filesystem/config scans and `npm audit` at a high threshold, with Dependabot
+across the workspace's ecosystems and each SDK repository, SHA-pinned GitHub
+Actions, and signed release provenance.
+
+---
+
+## Shared responsibility
+
+Some risks cannot be closed from inside the application. AXIAM records them openly
+and tells you what to do about them. Treat the following as a deployment hardening
+checklist — most of the threat model's open items live here.
+
+**Platform & operations**
+
+- Put a NetworkPolicy in front of the pods so nothing reaches the service around the
+  ingress; keep the data tier off any public route.
+- Give RabbitMQ **per-service credentials with vhost separation** — AXIAM verifies
+  message signatures, but broker access control is yours.
+- Supply secrets as **mounted Secret files, not `AXIAM_*` environment variables**,
+  and enable etcd encryption at rest. A signing key in a ConfigMap or plain env var
+  is effectively public within the namespace.
+- **Encrypt backups and volume snapshots** with a key separate from the cluster,
+  restrict snapshot IAM, and include backup media in the same access review as the
+  live data tier — a snapshot carries the same data under weaker controls.
+- Restrict `kubectl exec` and Secret-read RBAC and enable Kubernetes audit logging;
+  **cluster-admin is equivalent to full AXIAM compromise** and is outside the
+  application's audit trail.
+- Add edge protection (WAF, connection limits, autoscaling) for volumetric floods,
+  and a **liveness alert on scheduled-job completion** so a missed GDPR-erasure or
+  certificate-expiry run is noticed.
+
+**Integration & SDKs**
+
+- **Verify webhook signatures and AMQP HMACs** on the receiving side — the contract
+  requires it, and an unverified receiver acts on any POST that reaches its URL.
+- Prefer **mTLS or short-lived workload identity** over static client secrets;
+  rotate secrets through the rotation endpoint and enable secret scanning on your
+  own repositories.
+- Install SDKs under their **canonical package names**, commit lockfiles, and keep
+  dependency scanning on — seven public registries are seven chances for a
+  typosquat or a hijacked release.
+
+**Accepted, documented trade-offs**
+
+- **Access tokens survive revocation for up to 15 minutes** — the price of stateless
+  verification. Where immediate revocation matters, verify through the gRPC
+  introspection path instead of locally.
+- **The RBAC engine is additive with no deny-override** in the current release; model
+  exclusions by granting lower in the resource hierarchy rather than granting high
+  and excluding. Deny-override is on the roadmap.
+- **Audit records cannot be erased** — append-only by design, which is in tension
+  with GDPR Art. 17; erasure anonymises the subject instead. Set a retention period
+  consistent with your lawful basis.
+
+> **Caution — this is alpha software.** AXIAM is in active development and has not
+> reached a stable release. It has not undergone an independent third-party
+> penetration test or security certification. Do not use it to protect production
+> systems until it reaches a stable, audited release. The controls described here
+> are real and verified in the codebase, but a beta is a starting point for
+> evaluation, not a guarantee.
+
+---
+
+## How security is maintained
+
+- **Continuous review.** AXIAM has been through repeated full security-review rounds
+  — an initial audit, targeted remediation waves, and independent re-verification
+  passes — each re-checking every prior finding against current code with
+  file-and-line evidence, not trusting a checklist. Findings carry stable IDs so a
+  fix can be traced back to the review that raised it.
+- **The threat model is living.** It is revisited when a new API surface, protocol
+  or integration lands, when a trust boundary moves, when a review raises something
+  with no corresponding threat, or when a deferred item ships. The Threat Dragon
+  JSON is the source of truth and this section is generated from it.
+- **Gates, not vibes.** Every commit runs formatting, lints (`-D warnings`), the
+  test suite against real SurrealDB and RabbitMQ, dependency and container scans, and
+  cross-language SDK contract-drift checks. Security-relevant fixes land with a
+  regression or negative test.
+
+**Reporting a vulnerability.** If you find a security issue, please report it
+privately to the maintainers rather than opening a public issue, and give us a
+reasonable window to remediate before disclosure. *(Publish a security contact /
+`SECURITY.md` policy link here when the section goes live.)*
+
+---
+
+*References — [STRIDE threat model](threat-model-stride.md) · [security analysis](security-analysis-2026-08-02.md) · [compliance audit](security-audit.md) · [`sdks/CONTRACT.md`](../sdks/CONTRACT.md) · [`docs/compliance/`](../docs/compliance/) · [OWASP Threat Dragon](https://www.threatdragon.com)*


### PR DESCRIPTION
Synthesizes the STRIDE threat model, the security-review history and the
compliance audit into a public 'Security' section for the AXIAM website:
security-at-a-glance principles, the 149-threat STRIDE coverage table, the
five trust boundaries and principal assets, per-layer control descriptions
(auth, authz/tenant isolation, OAuth2/OIDC, federation, PKI/mTLS, audit,
webhooks/AMQP, transport/secrets/SDKs), the compliance posture, the
shared-responsibility hardening checklist, and how security is maintained.
Blocks map onto the website DocBlock content model for porting.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JgtWeqrf1XxvqUP4czhS6G