### PR TITLE
fix(security): SEC-079 admin ceiling posture, bound infra family, tenant-filter member_of, reorder cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`axiam.v1.UserService`), with gRPC reflection and health explicitly never limited and
   an unrecognized path failing safe into the strictest bucket. Two new knobs,
   `AXIAM__GRPC__GRPC_IDENTITY_PER_SEC` (default 5x the authz ceiling = 500/s) and
-  `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` (default 1x = 100/s); leaving them unset derives both
-  from `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC`, so a posture preset still moves the whole family
-  with one variable. Previously a `GetUserInfo` read — measured at 12 665/s — was throttled
+  `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` (default a flat 10/s — see the posture note under
+  *Security* below); leaving `GRPC_IDENTITY_PER_SEC` unset derives it from
+  `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC`, so a posture preset still moves that pair with one
+  variable. Previously a `GetUserInfo` read — measured at 12 665/s — was throttled
   by the *authz* ceiling, because a single server-wide bucket made an authorization sizing
   decision into a userinfo sizing decision
 - Startup advisory for mis-sized machine limits: when the shipped `internet` defaults are
@@ -131,7 +132,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   admitted ~100 requests per *minute*. The per-second → per-window conversion now happens
   once, at the layer boundary, with a saturating multiply, and the production constructor
   takes per-second ceilings so a caller cannot get the units wrong again. Found by benchmark
-  run 4's production-posture pass
+  run 4's production-posture pass. **Read the gRPC admin-ceiling entry under *Security*
+  below before upgrading** — correcting these units raised every gRPC ceiling 60x, which is
+  a posture change and not only a units fix
 - Stale DB handles after a reconnect: every repository was built at boot from a one-time
   `pool.handle_for_repo()` **clone** of the pooled SurrealDB connection, so when the pool's
   reconnect loop evicted a poisoned connection (observed ~7 minutes into a sustained load
@@ -145,6 +148,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docker version` against an unreachable daemon prints an empty line and *then* fails, so
   the `|| echo unknown` fallback produced a literal newline mid-string and took `report.py`
   down with an "Invalid control character" for the whole run
+
+### Security
+
+- **gRPC admin/credential-check ceiling is now an absolute 10/s (600/min per IP), not the
+  authz ceiling (SEC-079). This is a posture change — read it even if you skipped the
+  units fix above.** Correcting the gRPC rate-limit units (I1, under *Fixed*) changed what
+  every gRPC ceiling actually enforces from `N` per **minute** to `N` per **second**. The
+  units bug had been accidentally supplying 60x more protection than the configuration
+  said, so an operator who reads only "corrected gRPC units" will not realise their
+  deployed gRPC ceiling rose 60x on upgrade. That matters most on
+  `axiam.v1.UserService/ValidateCredentials`, which performs a real Argon2id password
+  verification (~19 MiB of memory arena each): its per-IP ceiling would have gone from
+  ~100/min to ~6 000/min — a 60x increase in online password-guessing throughput and in the
+  Argon2id CPU a caller can conscript. The admin family therefore no longer derives from
+  `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` at all; it takes a CPU-appropriate absolute default of
+  10/s, unchanged by `AXIAM__RATE_LIMIT__PROFILE`, so raising the authz ceiling for
+  service-mesh capacity can no longer widen credential guessing as a side effect. The
+  family holds only `GetUser` and `ValidateCredentials`; the high-volume identity read is
+  `GetUserInfo` on `UserInfoService`, which is in the identity-read family and unaffected.
+  **Action:** if a provisioning or admin workload legitimately exceeds 600 `UserService`
+  calls per minute from one source IP, pin `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` — explicit
+  configuration still wins over both the default and any posture preset. Per-account
+  lockout, the shared failure metering and the process-wide crypto semaphore are unchanged
+- gRPC reflection and health are no longer an **unlimited pass-through**. The family is
+  selected by prefix-matching the client-supplied gRPC `:path` (`/grpc.reflection.`,
+  `/grpc.health.`) and used to bypass both limiter layers entirely. Neither service is
+  registered today — requests terminate `Unimplemented`, so the practical effect was
+  unmetered HTTP/2 stream churn rather than database work — but registering a health
+  service would have made it a genuinely unmetered endpoint. It now has its own bucket at a
+  fixed 100/s per IP: orders of magnitude above any real probe cadence, so a liveness probe
+  still answers during an incident when every other family is saturated, while the surface
+  stops being unbounded
+- Group-membership traversal on the authorization read path now carries a read-time tenant
+  predicate. `get_user_role_assignments` resolved `member_of` edges with no
+  `out.tenant_id` filter; this was not exploitable — group membership is validated against
+  the tenant at write time and the outer `has_role` predicate still confined the resulting
+  role — but it left group-inherited roles as the one authorization edge with no read-time
+  tenant check, so a migration or bulk import writing `member_of` directly would have
+  bypassed it. The predicate is served by the existing `idx_member_of_unique` index; the
+  query-plan pins confirm the plan is still an `IndexScan`
+- Session-cache invalidation now runs immediately after the `DELETE` commits, before the
+  deleted rows are deserialized, in `consume` and `invalidate_user_sessions_except`. The
+  `DELETE` has already succeeded at the database once the await returns, so a deserialize
+  failure of the returned BEFORE image used to return early and leave a **positive**
+  session-validation cache entry live for up to the TTL — a deleted session that kept
+  validating. Only reachable with the opt-in
+  `AXIAM__AUTH__SESSION_VALIDATION_CACHE_TTL_SECS` enabled
 
 ## [1.0.0-alpha21] - 2026-07-30
 

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -371,3 +371,37 @@ Both commits landed after §9 and change security-relevant behaviour.
 3. **Residual 1** — add the `member_of` tenant predicate (free, closes the last read-time gap in the authz graph).
 4. **Residuals 2 and 4** — reorder the two cache invalidations; bound the `Unlimited` gRPC family.
 5. **OBS-1** — open a ticket recording the client-secret entropy assumption.
+
+### 10.7 Remediation of §10 — status (2026-08-03)
+
+> ⚠️ **This subsection was written by the remediation work, not by a reviewer.**
+> §9 is the cautionary precedent: it asserted "all fixed", and the independent
+> pass in §10 found one of its claims partial (SEC-072 → SEC-080) plus two
+> further findings in code the remediation itself had introduced. So the
+> statuses below are **claims pending verification**, deliberately *not* marked
+> ✅ CONFIRMED. Only an independent pass may promote them. Treat §10.1's table
+> as the model: re-derive each from source.
+
+| Item | Claimed status | Where |
+|---|---|---|
+| **SEC-079** | Remediated — pending verification | `axiam` `04dc674` |
+| **SEC-080** | Remediated — pending verification | `axiam-swift-sdk` `bc7c48d` |
+| **Residual 1** (`member_of` tenant predicate) | Remediated — pending verification | `axiam` `04dc674` |
+| **Residual 2** (cache invalidation ordering) | Remediated — pending verification, **no regression test** | `axiam` `04dc674` |
+| **Residual 4** (`Unlimited` family bounded) | Remediated — pending verification | `axiam` `04dc674` |
+| **Residual 3** (cache does not re-check user status) | **Not addressed** — accepted, documented | — |
+| **Residual 5** (introspect work factor rose 60×) | **Not addressed** — accepted, documented | — |
+| **OBS-1** (client-secret hashing) | Tracked, see below | — |
+
+**What was done.**
+
+- **SEC-079.** `admin_per_sec` no longer derives from `authz_per_sec` at all: a new absolute `ADMIN_PER_SEC_DEFAULT = 10` (600/min per IP) governs the family that holds the Argon2id `ValidateCredentials`. Only `identity_per_sec` still scales with authz, so a `gateway`/`mesh` preset raising mesh capacity can no longer widen credential-guessing breadth as a side effect. `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` still overrides. The CHANGELOG entry leads with *"This is a posture change — read it even if you skipped the units fix above"*, because the hazard SEC-079 identified is precisely an operator reading "corrected gRPC units" and not realising their deployed ceiling rose 60×. The pre-existing doc-drift test `documented_per_family_rows_match_the_derivation` failed as predicted (`left: 100, right: 10`) before the docs were updated — the guard worked.
+- **Residual 1.** `AND out.tenant_id = $tenant_id` added inside the `LET $group_records` sub-select. Query-plan pins re-run: still `IndexScan idx_member_of_unique`, and the `TableScan` witness test was updated to the same shape so it still witnesses a scan rather than going vacuous.
+- **Residual 2.** Cache invalidation moved above `result.take(0)?` in `consume` and `invalidate_user_sessions_except`. The other three session-deleting methods were audited and have no fallible step between the `.await` and the invalidation, so they were already correct. **No regression test was added, deliberately**: reaching the bug requires the database to commit the `DELETE … RETURN BEFORE` and then return a BEFORE image that fails to deserialize into `SessionRow`. With the real embedded SurrealDB the returned row is by construction the row it stored, and the repository takes a concrete `Surreal<C>` rather than a mockable trait, so there is no seam. An instrumented-cache call-order assertion would test the assertion, not the behaviour. **This is the weakest item in the set and the one most worth an independent look.**
+- **Residual 4.** `Unlimited` became `Infra` with an absolute `INFRA_PER_SEC = 100`. Rationale: a k8s liveness/readiness probe runs on the order of once per few seconds per prober, so even a large sidecar fleet behind one NAT egress IP stays orders of magnitude below 100/s — the ceiling can never be what breaks a probe during an incident (the property that motivated the original pass-through), while the surface stops being unbounded. The old `reflection_and_health_are_never_throttled` test was split into two that pin *both* halves: probes survive a fully saturated server, **and** a sustained flood is eventually rejected. New shared-counter endpoint `grpc_infra`; the other three bucket names are byte-identical, so an in-flight upgrade keeps counting against the same rows.
+
+**Not addressed, and why.** Residual 3 (the cache does not re-check user status, so a disabled user stays authenticated for up to the TTL) and residual 5 (a pre-auth caller can drive 600 introspect client-lookups per minute per IP instead of 10) are both **accepted trade-offs of features that are opt-in or already reviewed**, not defects introduced here. Residual 3 has the same semantics as the pre-cache inline check — the cache widens the window from "next request" to "TTL", which is the documented bounded-staleness contract the cache is opt-in for. Changing either is a posture decision, not a fix.
+
+**OBS-1 — client-secret hashing.** Client secrets are hashed with unsalted single-round SHA-256 (`repository/service_account.rs:36-40`). This is acceptable **only** while every secret is 32 CSPRNG bytes with no operator-supplied path — verified true at both creation and rotation, with no API accepting a caller-chosen secret. §10.4 makes the right point: `421e3e2a`'s doc comment now enshrines that as a design property, which is exactly when it stops being an implementation detail and needs a tracking item rather than a comment. **The trigger condition, stated so it cannot be missed: if any code path is ever added that accepts an operator-supplied, imported, or otherwise non-CSPRNG client secret, this must move to a salted KDF in the same change.** Until then it is not a finding.
+
+**Cross-SDK observation from the SEC-080 fix (new, not previously recorded).** While fixing the absent-`exp` case, every other optional claim in the Swift authenticator was audited. `tenant_id` and `sub` already use `guard let` and fail closed. But `JwtClaims` in `JwksVerifier.swift` **has no `nbf`, `iss` or `aud` fields at all** — the Swift SDK does not model them, so it cannot check them. That is not an `if let` leak (there is nothing to leak), but it is the same family as SEC-080: the three newest SDKs now enforce three different subsets of the same token contract — C honours `nbf`, the C++ `TokenAuthenticator` checks optional `iss`/`aud`, Swift checks neither. Recorded as an observation rather than fixed: adding `nbf` enforcement changes acceptance behaviour, and `iss`/`aud` need a decision about expected values. Worth a deliberate cross-SDK decision on what the minimum local-verification set is, ideally stated in `CONTRACT.md` §10 so it stops drifting per SDK.

--- a/crates/axiam-api-grpc/src/config.rs
+++ b/crates/axiam-api-grpc/src/config.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use crate::middleware::rate_limit::GrpcRateLimits;
 #[cfg(doc)]
-use crate::middleware::rate_limit::IDENTITY_PER_SEC_MULTIPLE;
+use crate::middleware::rate_limit::{ADMIN_PER_SEC_DEFAULT, IDENTITY_PER_SEC_MULTIPLE};
 
 /// gRPC rate-limit bucket-key mode (D8 parity with
 /// `axiam_api_rest::config::rate_limit::RateLimitKeyMode`).
@@ -74,10 +74,13 @@ pub struct GrpcConfig {
     /// `axiam.v1.UserService` (`GetUser`, `ValidateCredentials`) (I2).
     /// Configure via `AXIAM__GRPC__GRPC_ADMIN_PER_SEC`.
     ///
-    /// `None` (the default) tracks [`Self::grpc_authz_per_sec`] 1:1.
+    /// `None` (the default) resolves to the absolute
+    /// [`ADMIN_PER_SEC_DEFAULT`] (10/s = 600/min per IP), **independently of
+    /// [`Self::grpc_authz_per_sec`] and of any posture preset** (SEC-079).
     /// `ValidateCredentials` performs an Argon2id verification, so this
-    /// ceiling is a CPU guard and deliberately does NOT inherit the
-    /// identity-read multiplier.
+    /// ceiling is a CPU guard on an online-password-guessing surface, not a
+    /// throughput ceiling derived from read capacity. Set this env var to
+    /// override — explicit configuration always wins.
     #[serde(default)]
     pub grpc_admin_per_sec: Option<u32>,
     /// D8 parity field — see [`GrpcRateLimitKeyMode`]. Currently always
@@ -148,11 +151,12 @@ impl GrpcConfig {
     /// The per-family gRPC ceilings this config resolves to (I2), in
     /// requests **per second per IP**.
     ///
-    /// Unset knobs are derived from [`Self::grpc_authz_per_sec`] by
-    /// [`GrpcRateLimits::from_authz_per_sec`], so a deployment that only sets
-    /// `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` (or only selects a posture profile)
-    /// still gets a coherent family rather than a mix of preset and shipped
-    /// numbers.
+    /// Unset knobs go through [`GrpcRateLimits::from_authz_per_sec`], so a
+    /// deployment that only sets `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` (or only
+    /// selects a posture profile) still gets a coherent family rather than a
+    /// mix of preset and shipped numbers. Only the identity-read ceiling
+    /// actually scales with the authz base; the admin ceiling is the absolute
+    /// [`ADMIN_PER_SEC_DEFAULT`] (SEC-079).
     pub fn rate_limits(&self) -> GrpcRateLimits {
         let derived = GrpcRateLimits::from_authz_per_sec(self.grpc_authz_per_sec);
         GrpcRateLimits {
@@ -191,6 +195,7 @@ fn default_grpc_authz_per_sec() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::middleware::rate_limit::ADMIN_PER_SEC_DEFAULT;
 
     #[test]
     fn default_key_mode_is_ip() {
@@ -258,22 +263,28 @@ mod tests {
         assert_eq!(pinned.grpc_authz_per_sec, 100);
     }
 
-    /// I2: unset per-family knobs derive from the authz ceiling; set ones
+    /// I2: the unset identity knob derives from the authz ceiling; set ones
     /// win. This is what keeps a `gateway`/`mesh` deployment coherent when
     /// the operator only moves `AXIAM__RATE_LIMIT__PROFILE`.
+    ///
+    /// SEC-079: the admin knob is the one that does NOT move with the preset.
     #[test]
     fn per_family_limits_derive_from_authz_unless_pinned() {
         let shipped = GrpcConfig::default().rate_limits();
         assert_eq!(shipped.authz_per_sec, 100);
         assert_eq!(shipped.identity_per_sec, 500);
-        assert_eq!(shipped.admin_per_sec, 100);
+        assert_eq!(shipped.admin_per_sec, ADMIN_PER_SEC_DEFAULT);
 
         let mut preset = GrpcConfig::default();
         assert!(preset.apply_rate_limit_preset(1_000, |_| false));
         let preset = preset.rate_limits();
         assert_eq!(preset.authz_per_sec, 1_000);
         assert_eq!(preset.identity_per_sec, 5_000);
-        assert_eq!(preset.admin_per_sec, 1_000);
+        assert_eq!(
+            preset.admin_per_sec, ADMIN_PER_SEC_DEFAULT,
+            "a posture preset raising the authz ceiling must not drag the \
+             Argon2id-bound admin ceiling up with it (SEC-079)"
+        );
 
         let pinned = GrpcConfig {
             grpc_identity_per_sec: Some(7),
@@ -286,9 +297,42 @@ mod tests {
         assert_eq!(pinned.admin_per_sec, 9);
     }
 
+    /// SEC-079: `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` remains a working operator
+    /// override — it wins over the absolute default AND over a posture preset,
+    /// in either application order.
+    #[test]
+    fn explicit_admin_override_wins_over_the_default_and_the_preset() {
+        // Set by hand on top of the shipped posture.
+        let overridden = GrpcConfig {
+            grpc_admin_per_sec: Some(250),
+            ..GrpcConfig::default()
+        }
+        .rate_limits();
+        assert_eq!(overridden.admin_per_sec, 250);
+        assert_ne!(overridden.admin_per_sec, ADMIN_PER_SEC_DEFAULT);
+
+        // Set by hand while a `mesh`-shaped preset also applies.
+        let mut with_preset = GrpcConfig {
+            grpc_admin_per_sec: Some(250),
+            ..GrpcConfig::default()
+        };
+        assert!(with_preset.apply_rate_limit_preset(5_000, |_| false));
+        let with_preset = with_preset.rate_limits();
+        assert_eq!(with_preset.authz_per_sec, 5_000);
+        assert_eq!(
+            with_preset.admin_per_sec, 250,
+            "an explicit AXIAM__GRPC__GRPC_ADMIN_PER_SEC must survive a preset"
+        );
+    }
+
     /// The posture doc must document the I2 knobs in every column, and the
     /// documented numbers must be exactly what the derivation produces from
     /// the documented authz ceiling in the same column.
+    ///
+    /// Since SEC-079 the admin row is therefore expected to read the same
+    /// absolute number in all three columns — if the doc ever regains a
+    /// column-varying admin row, the derivation has been re-coupled to the
+    /// read-sized authz base and this test fails.
     #[test]
     fn documented_per_family_rows_match_the_derivation() {
         let md = std::fs::read_to_string(posture_doc_path())

--- a/crates/axiam-api-grpc/src/middleware/rate_limit.rs
+++ b/crates/axiam-api-grpc/src/middleware/rate_limit.rs
@@ -46,8 +46,19 @@
 //!   window again.
 //! - **I2 — scope.** Both layers used to be server-wide, so the *authz*
 //!   ceiling throttled identity reads and admin traffic too. Buckets are now
-//!   split per [`GrpcMethodFamily`] (authz-check / identity-read / admin),
-//!   with reflection and health explicitly unlimited.
+//!   split per [`GrpcMethodFamily`] (authz-check / identity-read / admin /
+//!   infrastructure).
+//!
+//! # SEC-079 — the admin ceiling is absolute, not derived
+//!
+//! The admin family contains `axiam.v1.UserService/ValidateCredentials`, an
+//! **Argon2id verification**. Its ceiling is a CPU guard, so it is an absolute
+//! constant ([`ADMIN_PER_SEC_DEFAULT`]) rather than a multiple of — or the
+//! same number as — the read-sized `authz_per_sec` base. See that constant's
+//! docs for the full reasoning; the short version is that when the I1 units
+//! bug was fixed the effective per-IP ceiling on that RPC rose 60x, and
+//! deriving it from a read-sized base would let a `gateway`/`mesh` posture
+//! raise it further still.
 
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
@@ -194,14 +205,23 @@ pub enum GrpcMethodFamily {
     IdentityRead,
     /// Administrative / user-management traffic: `axiam.v1.UserService`
     /// (`GetUser`, `ValidateCredentials`). `ValidateCredentials` hashes a
-    /// password, so this family is deliberately NOT sized from read capacity.
+    /// password, so this family is deliberately NOT sized from read capacity —
+    /// its ceiling is the absolute [`ADMIN_PER_SEC_DEFAULT`] (SEC-079).
     Admin,
-    /// Explicitly neutral — never rate-limited. gRPC **reflection** and
-    /// **health** endpoints: infrastructure probes whose whole job is to
-    /// answer during an incident, when the limited families are most likely
-    /// to be saturated. Throttling a liveness probe turns an overload into an
-    /// outage.
-    Unlimited,
+    /// Infrastructure probes: gRPC **reflection** and **health**. Their whole
+    /// job is to answer during an incident, when the limited families are most
+    /// likely to be saturated, so this family gets a deliberately generous
+    /// ceiling ([`INFRA_PER_SEC`]) — but a **finite** one.
+    ///
+    /// This family used to be a literal pass-through (`Unlimited`) that
+    /// bypassed BOTH limiter layers, selected by a prefix test on the
+    /// attacker-controlled `:path`. Neither service is registered today, so
+    /// the practical effect was unmetered HTTP/2 stream churn rather than DB
+    /// work — but registering a health service would have turned it into a
+    /// genuinely unmetered endpoint. A generous bucket keeps probes working
+    /// during an overload without leaving an unbounded surface behind
+    /// (security re-verification 2026-08-03, residual 4).
+    Infra,
 }
 
 /// gRPC reflection service package prefix (v1 and v1alpha).
@@ -217,7 +237,7 @@ impl GrpcMethodFamily {
     /// this function fails safe (throttled) rather than open (unlimited).
     pub fn classify(path: &str) -> Self {
         if path.starts_with(REFLECTION_PREFIX) || path.starts_with(HEALTH_PREFIX) {
-            return Self::Unlimited;
+            return Self::Infra;
         }
         match path.split('/').nth(1).unwrap_or_default() {
             "axiam.v1.UserInfoService" | "axiam.v1.TokenService" => Self::IdentityRead,
@@ -227,19 +247,21 @@ impl GrpcMethodFamily {
         }
     }
 
-    /// Shared-counter bucket-name prefix for this family, or `None` when the
-    /// family is never limited.
+    /// Shared-counter bucket-name prefix for this family.
     ///
     /// These names are part of the persisted `rate_limit_bucket` key space
     /// (`"{endpoint}:{ip}"`), so `grpc_authz` is kept byte-for-byte for the
     /// authz family — an in-flight upgrade keeps counting against the same
     /// rows.
-    pub const fn shared_endpoint(self) -> Option<&'static str> {
+    ///
+    /// Every family now has one: the infrastructure family is bucketed like
+    /// the rest rather than skipping the counter entirely (residual 4).
+    pub const fn shared_endpoint(self) -> &'static str {
         match self {
-            Self::AuthzCheck => Some("grpc_authz"),
-            Self::IdentityRead => Some("grpc_identity"),
-            Self::Admin => Some("grpc_admin"),
-            Self::Unlimited => None,
+            Self::AuthzCheck => "grpc_authz",
+            Self::IdentityRead => "grpc_identity",
+            Self::Admin => "grpc_admin",
+            Self::Infra => "grpc_infra",
         }
     }
 }
@@ -258,7 +280,9 @@ pub struct GrpcRateLimits {
     pub authz_per_sec: u32,
     /// `AXIAM__GRPC__GRPC_IDENTITY_PER_SEC` — userinfo / token reads.
     pub identity_per_sec: u32,
-    /// `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` — user management.
+    /// `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` — user management. Defaults to the
+    /// absolute [`ADMIN_PER_SEC_DEFAULT`], never to a multiple of
+    /// [`Self::authz_per_sec`] (SEC-079).
     pub admin_per_sec: u32,
 }
 
@@ -269,40 +293,89 @@ pub struct GrpcRateLimits {
 /// when `AXIAM__RATE_LIMIT__PROFILE` raises the authz ceiling.
 pub const IDENTITY_PER_SEC_MULTIPLE: u32 = 5;
 
+/// Default ceiling for the [`GrpcMethodFamily::Admin`] family, in requests per
+/// second per IP — **an absolute number, deliberately not derived from
+/// [`GrpcRateLimits::authz_per_sec`]** (SEC-079).
+///
+/// **Why absolute.** The admin family contains
+/// `axiam.v1.UserService/ValidateCredentials`, which performs a real Argon2id
+/// `verify_password` (~19 MiB of memory arena per verification). Its ceiling is
+/// therefore a **CPU/memory guard on an online-password-guessing surface**, not
+/// a throughput ceiling on a read. `authz_per_sec` is a read-sized base (100/s
+/// shipped, and `AXIAM__RATE_LIMIT__PROFILE=gateway`/`mesh` raise it to
+/// 1 000/s / 5 000/s); deriving the admin ceiling from it — even 1:1 — makes a
+/// service-mesh capacity decision silently also a credential-guessing-breadth
+/// decision. Decoupling the two is the entire point of this constant.
+///
+/// **Why 10/s (600/min per IP).** The family holds exactly two RPCs, `GetUser`
+/// and `ValidateCredentials`; the high-volume identity read is `GetUserInfo` on
+/// `UserInfoService`, which lives in [`GrpcMethodFamily::IdentityRead`] and is
+/// unaffected. 600 administrative calls per minute from one client IP is well
+/// above any real admin console or M2M provisioning loop, and roughly an order
+/// of magnitude below the point at which concurrent Argon2id verifications
+/// become the server's dominant cost. It also restores the protection the I1
+/// units fix accidentally removed: before that fix the shared window enforced
+/// the per-second number against a 60-second window, so the deployed ceiling
+/// was ~100/**minute**; correcting the units silently raised it to
+/// ~6 000/minute. 600/minute is the CPU-appropriate value the doc comment
+/// always claimed this family had.
+///
+/// Operators who genuinely need more can still pin
+/// `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` — explicit configuration always wins.
+pub const ADMIN_PER_SEC_DEFAULT: u32 = 10;
+
+/// Ceiling for the [`GrpcMethodFamily::Infra`] family (gRPC reflection and
+/// health), in requests per second per IP — generous, but finite.
+///
+/// Infrastructure probes are intrinsically low-rate: a Kubernetes liveness or
+/// readiness probe runs on the order of once every few seconds per prober, and
+/// even a large fleet of sidecars sharing one NAT egress IP stays orders of
+/// magnitude below 100/s. So this ceiling can never be the thing that breaks a
+/// health check during an incident — which is the property that made the family
+/// a pass-through in the first place — while still bounding the surface, so a
+/// health service registered later is not an unmetered endpoint reachable by
+/// prefix-matching an attacker-controlled `:path` (residual 4).
+///
+/// It is an absolute constant for the same reason as
+/// [`ADMIN_PER_SEC_DEFAULT`]: probe volume has nothing to do with authz
+/// capacity, so a posture preset must not move it.
+pub const INFRA_PER_SEC: u32 = 100;
+
 impl GrpcRateLimits {
     /// Derives the whole family from the authz ceiling alone — the shape an
     /// operator gets when only `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` (or a
     /// posture preset) is set.
     ///
-    /// Admin tracks the authz ceiling 1:1: `ValidateCredentials` is an
-    /// Argon2id verification, so its ceiling is a CPU guard and must not
-    /// inherit a read-sized multiplier.
+    /// Only [`Self::identity_per_sec`] actually scales: `ValidateCredentials`
+    /// is an Argon2id verification, so the admin ceiling is a CPU guard and
+    /// takes the absolute [`ADMIN_PER_SEC_DEFAULT`] rather than inheriting a
+    /// read-sized base (SEC-079).
     pub const fn from_authz_per_sec(authz_per_sec: u32) -> Self {
         Self {
             authz_per_sec,
             identity_per_sec: authz_per_sec.saturating_mul(IDENTITY_PER_SEC_MULTIPLE),
-            admin_per_sec: authz_per_sec,
+            admin_per_sec: ADMIN_PER_SEC_DEFAULT,
         }
     }
 
-    /// The per-second ceiling for `family`, or `None` when the family is
-    /// never limited ([`GrpcMethodFamily::Unlimited`]).
-    pub const fn per_sec(self, family: GrpcMethodFamily) -> Option<u32> {
+    /// The per-second ceiling for `family`.
+    ///
+    /// Every family is limited: [`GrpcMethodFamily::Infra`] takes the fixed
+    /// [`INFRA_PER_SEC`], which is why this is not configurable per instance
+    /// (residual 4).
+    pub const fn per_sec(self, family: GrpcMethodFamily) -> u32 {
         match family {
-            GrpcMethodFamily::AuthzCheck => Some(self.authz_per_sec),
-            GrpcMethodFamily::IdentityRead => Some(self.identity_per_sec),
-            GrpcMethodFamily::Admin => Some(self.admin_per_sec),
-            GrpcMethodFamily::Unlimited => None,
+            GrpcMethodFamily::AuthzCheck => self.authz_per_sec,
+            GrpcMethodFamily::IdentityRead => self.identity_per_sec,
+            GrpcMethodFamily::Admin => self.admin_per_sec,
+            GrpcMethodFamily::Infra => INFRA_PER_SEC,
         }
     }
 
     /// The ceiling for `family` expressed in the shared layer's 60-second
-    /// window (I1). `None` for the unlimited family.
-    pub const fn window_limit(self, family: GrpcMethodFamily) -> Option<u32> {
-        match self.per_sec(family) {
-            Some(per_sec) => Some(per_sec_to_window_limit(per_sec)),
-            None => None,
-        }
+    /// window (I1).
+    pub const fn window_limit(self, family: GrpcMethodFamily) -> u32 {
+        per_sec_to_window_limit(self.per_sec(family))
     }
 }
 
@@ -368,11 +441,13 @@ pub fn build_grpc_governor_layer(authz_per_sec: u32) -> GrpcGovernorLayer {
 
 /// Build the per-method-family in-memory governor stack (I2).
 ///
-/// One independent [`GovernorLayer`] per limited [`GrpcMethodFamily`], each
-/// with its own token bucket keyed by client IP, plus a pass-through path for
-/// [`GrpcMethodFamily::Unlimited`] (reflection / health). Replaces the single
-/// server-wide governor, which made the authz ceiling the ceiling for every
-/// gRPC surface.
+/// One independent [`GovernorLayer`] per [`GrpcMethodFamily`], each with its
+/// own token bucket keyed by client IP. Replaces the single server-wide
+/// governor, which made the authz ceiling the ceiling for every gRPC surface.
+///
+/// Since residual 4 the infrastructure family (reflection / health) gets a
+/// governor too — a generous [`INFRA_PER_SEC`] one — instead of a pass-through
+/// that bypassed both limiter layers.
 ///
 /// # Panics
 ///
@@ -383,9 +458,10 @@ pub fn build_grpc_method_scoped_governor_layer(
     limits: GrpcRateLimits,
 ) -> GrpcMethodScopedGovernorLayer {
     GrpcMethodScopedGovernorLayer {
-        authz: build_grpc_governor_layer(limits.authz_per_sec),
-        identity: build_grpc_governor_layer(limits.identity_per_sec),
-        admin: build_grpc_governor_layer(limits.admin_per_sec),
+        authz: build_grpc_governor_layer(limits.per_sec(GrpcMethodFamily::AuthzCheck)),
+        identity: build_grpc_governor_layer(limits.per_sec(GrpcMethodFamily::IdentityRead)),
+        admin: build_grpc_governor_layer(limits.per_sec(GrpcMethodFamily::Admin)),
+        infra: build_grpc_governor_layer(limits.per_sec(GrpcMethodFamily::Infra)),
     }
 }
 
@@ -396,6 +472,7 @@ pub struct GrpcMethodScopedGovernorLayer {
     authz: GrpcGovernorLayer,
     identity: GrpcGovernorLayer,
     admin: GrpcGovernorLayer,
+    infra: GrpcGovernorLayer,
 }
 
 impl<S: Clone> Layer<S> for GrpcMethodScopedGovernorLayer {
@@ -406,23 +483,24 @@ impl<S: Clone> Layer<S> for GrpcMethodScopedGovernorLayer {
             authz: self.authz.layer(inner.clone()),
             identity: self.identity.layer(inner.clone()),
             admin: self.admin.layer(inner.clone()),
-            neutral: inner,
+            infra: self.infra.layer(inner),
         }
     }
 }
 
-/// Dispatches each request to the governor for its [`GrpcMethodFamily`],
-/// or straight through for the unlimited family.
+/// Dispatches each request to the governor for its [`GrpcMethodFamily`].
 ///
 /// All four branches wrap clones of the SAME inner service, so this is a
 /// routing decision over rate-limit state only — the request itself reaches
-/// the identical tonic router whichever branch it takes.
+/// the identical tonic router whichever branch it takes. There is no
+/// pass-through branch: the infrastructure family has its own (generous)
+/// governor rather than bypassing the layer (residual 4).
 #[derive(Clone)]
 pub struct GrpcMethodScopedGovernor<S> {
     authz: GrpcGovernor<S>,
     identity: GrpcGovernor<S>,
     admin: GrpcGovernor<S>,
-    neutral: S,
+    infra: GrpcGovernor<S>,
 }
 
 impl<S> Service<Request<tonic::body::Body>> for GrpcMethodScopedGovernor<S>
@@ -446,7 +524,7 @@ where
         std::task::ready!(Service::poll_ready(&mut self.authz, cx))?;
         std::task::ready!(Service::poll_ready(&mut self.identity, cx))?;
         std::task::ready!(Service::poll_ready(&mut self.admin, cx))?;
-        self.neutral.poll_ready(cx)
+        Service::poll_ready(&mut self.infra, cx)
     }
 
     fn call(&mut self, req: Request<tonic::body::Body>) -> Self::Future {
@@ -469,9 +547,9 @@ where
                 let mut svc = std::mem::replace(&mut self.admin, clone);
                 Box::pin(async move { svc.call(req).await })
             }
-            GrpcMethodFamily::Unlimited => {
-                let clone = self.neutral.clone();
-                let mut svc = std::mem::replace(&mut self.neutral, clone);
+            GrpcMethodFamily::Infra => {
+                let clone = self.infra.clone();
+                let mut svc = std::mem::replace(&mut self.infra, clone);
                 Box::pin(async move { svc.call(req).await })
             }
         }
@@ -606,14 +684,16 @@ enum SharedScope {
 }
 
 impl SharedScope {
-    /// `(endpoint, window limit)` for `path`, or `None` when the request must
-    /// not be counted at all (the unlimited family).
-    fn resolve(self, path: &str) -> Option<(&'static str, u32)> {
+    /// `(endpoint, window limit)` for `path`.
+    ///
+    /// Every path resolves to a bucket — since residual 4 there is no family
+    /// that skips the shared counter.
+    fn resolve(self, path: &str) -> (&'static str, u32) {
         match self {
-            Self::Uniform { endpoint, limit } => Some((endpoint, limit)),
+            Self::Uniform { endpoint, limit } => (endpoint, limit),
             Self::PerFamily(limits) => {
                 let family = GrpcMethodFamily::classify(path);
-                Some((family.shared_endpoint()?, limits.window_limit(family)?))
+                (family.shared_endpoint(), limits.window_limit(family))
             }
         }
     }
@@ -704,12 +784,11 @@ impl GrpcSharedRateLimitLayer {
         }
     }
 
-    /// The `(bucket endpoint, window limit)` this layer would apply to
-    /// `path`, or `None` when `path` is never counted.
+    /// The `(bucket endpoint, window limit)` this layer applies to `path`.
     ///
     /// Exposed so the units at the composition root can be asserted directly
     /// by a test instead of by reading the call site (I1 acceptance).
-    pub fn resolve_for_path(&self, path: &str) -> Option<(&'static str, u32)> {
+    pub fn resolve_for_path(&self, path: &str) -> (&'static str, u32) {
         self.scope.resolve(path)
     }
 }
@@ -769,9 +848,9 @@ where
         // nothing).
         let counter = self.counter.clone();
         // I2: the bucket (and its ceiling) depend on which method family the
-        // request belongs to; `None` means this surface is never counted
-        // (reflection / health).
-        let bucket = self.scope.resolve(req.uri().path());
+        // request belongs to. Every family resolves to a bucket — reflection
+        // and health are counted too, against a generous one (residual 4).
+        let (endpoint, limit) = self.scope.resolve(req.uri().path());
         let key_extractor = GrpcTrustedHopsKeyExtractor::new(self.trusted_hops);
 
         // The rate-limit decision itself is now synchronous and taken BEFORE
@@ -779,8 +858,8 @@ where
         // this (server-wide!) layer. The returned future only awaits the inner
         // service.
         let ip = key_extractor.extract(&req).ok();
-        let allow = match (bucket, ip) {
-            (Some((endpoint, limit)), Some(ip)) => {
+        let allow = match ip {
+            Some(ip) => {
                 // Same bucket key shape as before — `{endpoint}:{ip}` — and
                 // the authz family keeps the `grpc_authz` endpoint name, so an
                 // in-flight upgrade keeps counting against the same
@@ -788,13 +867,11 @@ where
                 let key = format!("{endpoint}:{ip}");
                 counter.check(&key, window_start(Utc::now()), limit)
             }
-            // Unlimited family (reflection / health) — never counted.
-            (None, _) => true,
             // No client-IP key available — fail open; the in-memory governor
             // still makes the real decision. (A counter built with
             // `AXIAM__RATE_LIMIT__SHARED=off` also always allows, from inside
             // `check`.)
-            (_, None) => true,
+            None => true,
         };
 
         Box::pin(async move {
@@ -995,9 +1072,8 @@ mod tests {
             0,
         );
 
-        let (endpoint, limit) = layer
-            .resolve_for_path("/axiam.v1.AuthorizationService/CheckAccess")
-            .expect("authz is a limited family");
+        let (endpoint, limit) =
+            layer.resolve_for_path("/axiam.v1.AuthorizationService/CheckAccess");
         assert_eq!(endpoint, "grpc_authz", "bucket key must not change (I1)");
         assert_eq!(
             limit, 6_000,
@@ -1005,14 +1081,19 @@ mod tests {
              here is the ×60 units bug (I1)"
         );
 
-        // The same conversion applies to every limited family.
+        // The same conversion applies to every family.
         assert_eq!(
             layer.resolve_for_path("/axiam.v1.UserInfoService/GetUserInfo"),
-            Some(("grpc_identity", 100 * IDENTITY_PER_SEC_MULTIPLE * 60))
+            ("grpc_identity", 100 * IDENTITY_PER_SEC_MULTIPLE * 60)
         );
         assert_eq!(
             layer.resolve_for_path("/axiam.v1.UserService/GetUser"),
-            Some(("grpc_admin", 6_000))
+            ("grpc_admin", ADMIN_PER_SEC_DEFAULT * 60)
+        );
+        assert_eq!(
+            layer.resolve_for_path("/grpc.health.v1.Health/Check"),
+            ("grpc_infra", INFRA_PER_SEC * 60),
+            "the infrastructure family is bucketed, not skipped (residual 4)"
         );
     }
 
@@ -1032,7 +1113,7 @@ mod tests {
             "/grpc.health.v1.Health/Check",
             "/",
         ] {
-            assert_eq!(layer.resolve_for_path(path), Some(("grpc_authz", 42)));
+            assert_eq!(layer.resolve_for_path(path), ("grpc_authz", 42));
         }
     }
 
@@ -1054,15 +1135,15 @@ mod tests {
             ("/axiam.v1.TokenService/IntrospectToken", IdentityRead),
             ("/axiam.v1.UserService/GetUser", Admin),
             ("/axiam.v1.UserService/ValidateCredentials", Admin),
-            ("/grpc.health.v1.Health/Check", Unlimited),
-            ("/grpc.health.v1.Health/Watch", Unlimited),
+            ("/grpc.health.v1.Health/Check", Infra),
+            ("/grpc.health.v1.Health/Watch", Infra),
             (
                 "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
-                Unlimited,
+                Infra,
             ),
             (
                 "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
-                Unlimited,
+                Infra,
             ),
         ] {
             assert_eq!(GrpcMethodFamily::classify(path), expected, "{path}");
@@ -1070,8 +1151,9 @@ mod tests {
     }
 
     /// Fail-safe default: an unrecognized path lands in the STRICTEST limited
-    /// family, never in the unlimited one. Adding a service without updating
-    /// `classify` must not silently create an unlimited gRPC surface.
+    /// family, never in the most generous one. Adding a service without
+    /// updating `classify` must not silently create a loosely-limited gRPC
+    /// surface.
     #[test]
     fn unknown_paths_fall_back_to_the_strictest_family() {
         for path in [
@@ -1095,7 +1177,7 @@ mod tests {
         let limits = GrpcRateLimits::from_authz_per_sec(100);
         assert_eq!(limits.authz_per_sec, 100);
         assert_eq!(limits.identity_per_sec, 500);
-        assert_eq!(limits.admin_per_sec, 100);
+        assert_eq!(limits.admin_per_sec, ADMIN_PER_SEC_DEFAULT);
         assert!(
             limits.identity_per_sec > limits.authz_per_sec,
             "identity reads measured ~14x an authz check; their ceiling must not \
@@ -1106,29 +1188,90 @@ mod tests {
             GrpcMethodFamily::AuthzCheck,
             GrpcMethodFamily::IdentityRead,
             GrpcMethodFamily::Admin,
+            GrpcMethodFamily::Infra,
         ]
         .iter()
-        .map(|f| f.shared_endpoint().expect("limited family"))
+        .map(|f| f.shared_endpoint())
         .collect();
-        assert_eq!(endpoints, vec!["grpc_authz", "grpc_identity", "grpc_admin"]);
-        assert_eq!(GrpcMethodFamily::Unlimited.shared_endpoint(), None);
-        assert_eq!(limits.window_limit(GrpcMethodFamily::Unlimited), None);
+        assert_eq!(
+            endpoints,
+            vec!["grpc_authz", "grpc_identity", "grpc_admin", "grpc_infra"]
+        );
     }
 
-    /// A profile preset that raises the authz ceiling raises the derived
+    /// **SEC-079.** The admin ceiling is a CPU guard on an Argon2id RPC and
+    /// must NOT scale with the read-sized authz base — otherwise a
+    /// `gateway`/`mesh` posture (or any operator raising the authz ceiling for
+    /// service-mesh throughput) silently widens online password guessing.
+    #[test]
+    fn admin_ceiling_never_derives_from_the_authz_ceiling() {
+        for authz in [1, 100, 1_000, 5_000, 60_000, u32::MAX] {
+            let limits = GrpcRateLimits::from_authz_per_sec(authz);
+            assert_eq!(
+                limits.admin_per_sec, ADMIN_PER_SEC_DEFAULT,
+                "authz={authz}: the admin ceiling must stay at the absolute default \
+                 ({ADMIN_PER_SEC_DEFAULT}/s); deriving it from a read-sized base is SEC-079"
+            );
+            assert_eq!(
+                limits.per_sec(GrpcMethodFamily::Admin),
+                ADMIN_PER_SEC_DEFAULT
+            );
+        }
+
+        // And the absolute value is the CPU-appropriate one: 10/s = 600/min
+        // per IP through the 60-second shared window.
+        assert_eq!(ADMIN_PER_SEC_DEFAULT, 10);
+        assert_eq!(
+            GrpcRateLimits::from_authz_per_sec(100).window_limit(GrpcMethodFamily::Admin),
+            600,
+            "600 credential checks per minute per IP — not the 6 000 the units fix \
+             would have produced from the read-sized base"
+        );
+    }
+
+    /// A profile preset that raises the authz ceiling raises the **identity**
     /// family with it, so `gateway`/`mesh` cannot end up with identity reads
-    /// stricter than authz checks.
+    /// stricter than authz checks — and moves nothing else.
     #[test]
     fn derived_family_scales_with_the_authz_ceiling() {
         for authz in [100, 1_000, 5_000] {
             let limits = GrpcRateLimits::from_authz_per_sec(authz);
             assert_eq!(limits.identity_per_sec, authz * IDENTITY_PER_SEC_MULTIPLE);
-            assert_eq!(limits.admin_per_sec, authz);
+            assert_eq!(limits.admin_per_sec, ADMIN_PER_SEC_DEFAULT);
+            assert_eq!(limits.per_sec(GrpcMethodFamily::Infra), INFRA_PER_SEC);
             assert!(limits.identity_per_sec >= limits.authz_per_sec);
         }
         // Saturating, not wrapping.
         let huge = GrpcRateLimits::from_authz_per_sec(u32::MAX);
         assert_eq!(huge.identity_per_sec, u32::MAX);
+    }
+
+    /// **Residual 4.** The infrastructure family is generous but finite, and
+    /// its ceiling is fixed rather than posture-derived.
+    #[test]
+    fn infra_family_is_generous_but_finite() {
+        assert_eq!(INFRA_PER_SEC, 100);
+        for authz in [1, 100, 5_000] {
+            let limits = GrpcRateLimits::from_authz_per_sec(authz);
+            assert_eq!(limits.per_sec(GrpcMethodFamily::Infra), INFRA_PER_SEC);
+            assert_eq!(
+                limits.window_limit(GrpcMethodFamily::Infra),
+                INFRA_PER_SEC * 60
+            );
+        }
+        // Read through the accessor (not the constant) so these stay real
+        // assertions rather than const-folded no-ops.
+        let infra = GrpcRateLimits::from_authz_per_sec(1).per_sec(GrpcMethodFamily::Infra);
+        assert!(
+            infra >= 100,
+            "a liveness probe must never be the thing that breaks during an incident, \
+             got {infra}/s"
+        );
+        assert!(
+            infra < u32::MAX,
+            "…but the family must be bounded — an unbounded prefix match on the \
+             attacker-controlled :path is what residual 4 closed"
+        );
     }
 
     #[test]

--- a/crates/axiam-api-grpc/tests/rate_limit_units_test.rs
+++ b/crates/axiam-api-grpc/tests/rate_limit_units_test.rs
@@ -11,8 +11,12 @@
 //!   loudly against the old wiring.
 //! - `identity_reads_are_not_throttled_by_the_authz_ceiling`: an identity-read
 //!   method keeps flowing after the authz bucket is exhausted (I2).
-//! - `reflection_and_health_are_never_throttled`: the neutral family is
-//!   exempt from both layers.
+//! - `reflection_and_health_survive_a_saturated_server`: the infrastructure
+//!   family has its own generous bucket, so probes keep answering while every
+//!   other family is saturated.
+//! - `reflection_and_health_are_bounded`: …and that bucket is finite, so the
+//!   family is not an unmetered surface selected by prefix-matching the
+//!   attacker-controlled `:path` (security re-verification, residual 4).
 //!
 //! Run with: cargo test -p axiam-api-grpc --test rate_limit_units_test
 
@@ -22,7 +26,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axiam_api_grpc::middleware::rate_limit::{
-    GrpcRateLimits, GrpcSharedRateLimitLayer, build_grpc_method_scoped_governor_layer,
+    ADMIN_PER_SEC_DEFAULT, GrpcRateLimits, GrpcSharedRateLimitLayer, INFRA_PER_SEC,
+    build_grpc_method_scoped_governor_layer,
 };
 use axiam_db::repository::SurrealRateLimitBucketRepository;
 use axiam_db::{SharedRateLimitConfig, SharedRateLimitCounter};
@@ -34,6 +39,7 @@ use tower::{Layer, Service};
 
 const AUTHZ_PATH: &str = "/axiam.v1.AuthorizationService/CheckAccess";
 const IDENTITY_PATH: &str = "/axiam.v1.UserInfoService/GetUserInfo";
+const ADMIN_PATH: &str = "/axiam.v1.UserService/ValidateCredentials";
 const HEALTH_PATH: &str = "/grpc.health.v1.Health/Check";
 const REFLECTION_PATH: &str = "/grpc.reflection.v1.ServerReflection/ServerReflectionInfo";
 
@@ -206,24 +212,106 @@ async fn identity_reads_are_not_throttled_by_the_authz_ceiling() {
     );
 }
 
-/// Reflection and health are the explicit neutral default: never counted,
-/// never throttled, even when every limited family is saturated.
+/// **SEC-079 acceptance, through the full stack.** The Argon2id-bound admin
+/// family stays at its absolute CPU-guard ceiling even when the authz ceiling
+/// is raised to a service-mesh number — the decoupling is what stops a mesh
+/// posture from also widening online password guessing.
 #[tokio::test]
-async fn reflection_and_health_are_never_throttled() {
+async fn admin_family_is_capped_independently_of_the_authz_ceiling() {
+    // A `mesh`-shaped authz ceiling: 5 000/s.
+    let limits = GrpcRateLimits::from_authz_per_sec(5_000);
+    assert_eq!(limits.admin_per_sec, ADMIN_PER_SEC_DEFAULT);
+
+    let mut svc = stack(limits).await;
+    let peer: SocketAddr = "203.0.113.14:5000".parse().unwrap();
+
+    let mut admin_admitted = 0usize;
+    while call(&mut svc, request(ADMIN_PATH, peer)).await {
+        admin_admitted += 1;
+        assert!(
+            admin_admitted <= ADMIN_PER_SEC_DEFAULT as usize * 4,
+            "the admin family admitted {admin_admitted} back-to-back credential checks \
+             against a {ADMIN_PER_SEC_DEFAULT}/s ceiling — it is tracking the authz \
+             ceiling again (SEC-079)"
+        );
+    }
+    assert!(
+        admin_admitted >= ADMIN_PER_SEC_DEFAULT as usize,
+        "the admin bucket must still allow a full {ADMIN_PER_SEC_DEFAULT}-token burst, \
+         got {admin_admitted}"
+    );
+
+    // …while the authz family, sized for the mesh, is still wide open.
+    for i in 0..500 {
+        assert!(
+            call(&mut svc, request(AUTHZ_PATH, peer)).await,
+            "authz request {i} must not be throttled by the admin ceiling"
+        );
+    }
+}
+
+/// **Residual 4, half one.** Reflection and health have their own generous
+/// bucket, so an incident that saturates every other family still leaves the
+/// probes answering — a throttled liveness probe turns an overload into an
+/// outage.
+///
+/// The probe volume asserted here (30 per path, ~60 total) is far above any
+/// real probe cadence and far below [`INFRA_PER_SEC`]'s one-second burst.
+#[tokio::test]
+async fn reflection_and_health_survive_a_saturated_server() {
     let limits = GrpcRateLimits::from_authz_per_sec(1);
     let mut svc = stack(limits).await;
     let peer: SocketAddr = "203.0.113.12:5000".parse().unwrap();
 
+    // Saturate every *other* family.
     while call(&mut svc, request(AUTHZ_PATH, peer)).await {}
     assert!(!call(&mut svc, request(AUTHZ_PATH, peer)).await);
+    while call(&mut svc, request(IDENTITY_PATH, peer)).await {}
+    while call(&mut svc, request(ADMIN_PATH, peer)).await {}
 
     for path in [HEALTH_PATH, REFLECTION_PATH] {
-        for i in 0..200 {
+        for i in 0..30 {
             assert!(
                 call(&mut svc, request(path, peer)).await,
-                "{path} request {i} must never be rate-limited — a throttled liveness \
-                 probe turns an overload into an outage"
+                "{path} request {i} must still be served while every other family is \
+                 saturated — a throttled liveness probe turns an overload into an outage"
             );
         }
     }
+}
+
+/// **Residual 4, half two.** The infrastructure family is nonetheless
+/// *bounded*: it used to bypass both limiter layers entirely on a prefix match
+/// against the attacker-controlled `:path`. Sustained flooding must eventually
+/// be rejected.
+#[tokio::test]
+async fn reflection_and_health_are_bounded() {
+    let limits = GrpcRateLimits::from_authz_per_sec(100);
+    let mut svc = stack(limits).await;
+    let peer: SocketAddr = "203.0.113.13:5000".parse().unwrap();
+
+    let mut admitted = 0usize;
+    let mut rejected = false;
+    // A generous but finite bucket: `INFRA_PER_SEC` tokens of burst plus
+    // whatever replenishes during the loop. Well under 10x the ceiling is
+    // enough to prove the bucket exists at all.
+    for _ in 0..(INFRA_PER_SEC as usize * 10) {
+        if call(&mut svc, request(HEALTH_PATH, peer)).await {
+            admitted += 1;
+        } else {
+            rejected = true;
+            break;
+        }
+    }
+
+    assert!(
+        rejected,
+        "the infrastructure family admitted {admitted} consecutive requests without \
+         ever rejecting — it is still an unbounded pass-through (residual 4)"
+    );
+    assert!(
+        admitted >= INFRA_PER_SEC as usize,
+        "the infrastructure bucket must be generous: expected at least a full \
+         {INFRA_PER_SEC}-token burst, got {admitted}"
+    );
 }

--- a/crates/axiam-db/src/repository/role.rs
+++ b/crates/axiam-db/src/repository/role.rs
@@ -544,6 +544,19 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
         // the plan changes. Pinned by
         // `crates/axiam-db/tests/authz_query_plan_test.rs`.
         //
+        // Defence in depth (security re-verification 2026-08-03, residual 1):
+        // the `member_of` traversal carries its own `out.tenant_id =
+        // $tenant_id` predicate. It is not reachable today — `group.rs`
+        // validates BOTH endpoints against the tenant before writing a
+        // `member_of` edge, and the outer `has_role` predicate still confines
+        // the resulting role to the tenant — but without it this was the one
+        // authorization edge with no read-time tenant check, so a migration or
+        // bulk import writing `member_of` directly would have bypassed it.
+        // `out` is a `group` record and `idx_member_of_unique` still serves the
+        // `in =` half, so the added predicate is a post-filter on an already
+        // index-selected row set: no plan change (pinned by
+        // `authz_query_plan_test::group_membership_lookup_is_index_satisfied`).
+        //
         // Statement indices below: 0 = direct SELECT, 1 = LET, 2 = inherited
         // SELECT.
         let mut result = self
@@ -563,7 +576,8 @@ impl<C: Connection> RoleRepository for SurrealRoleRepository<C> {
                  AND out.tenant_id = $tenant_id; \
                  LET $group_records = (\
                      SELECT VALUE out FROM member_of \
-                     WHERE in = type::record('user', $user_id)\
+                     WHERE in = type::record('user', $user_id) \
+                     AND out.tenant_id = $tenant_id\
                  ); \
                  SELECT meta::id(out.id) AS record_id, \
                         out.tenant_id AS tenant_id, \

--- a/crates/axiam-db/src/repository/session.rs
+++ b/crates/axiam-db/src/repository/session.rs
@@ -279,12 +279,21 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
             .await
             .map_err(DbError::from)?;
 
-        let deleted: Vec<SessionRow> = result.take(0).map_err(DbError::from)?;
         // I6: invalidate unconditionally — whether or not this caller won the
         // single-use race, the row is gone once any caller consumed it.
+        //
+        // This MUST come before `take(0)` (security re-verification
+        // 2026-08-03, residual 2). The DELETE has already committed by the
+        // time the `.await` returns `Ok`; if the BEFORE image then failed to
+        // deserialize, an early `?` would leave a *positive* cache entry live
+        // for up to the TTL — i.e. a deleted session would keep validating.
+        // Invalidation is infallible and idempotent, so running it first is
+        // free.
         if let Some(cache) = &self.validation_cache {
             cache.invalidate(tenant_id, id);
         }
+
+        let deleted: Vec<SessionRow> = result.take(0).map_err(DbError::from)?;
         Ok(!deleted.is_empty())
     }
 
@@ -330,11 +339,18 @@ impl<C: Connection> SessionRepository for SurrealSessionRepository<C> {
             .await
             .map_err(DbError::from)?;
 
-        let deleted: Vec<SessionRow> = result.take(0).map_err(DbError::from)?;
         // I6: same set, minus the session the caller deliberately kept.
+        //
+        // Ordered before `take(0)` for the same reason as `consume` — the
+        // DELETE is already committed once the `.await` returns, so a
+        // deserialize failure of the BEFORE image must not be able to strand a
+        // positive cache entry for a session that no longer exists
+        // (residual 2).
         if let Some(cache) = &self.validation_cache {
             cache.invalidate_user(tenant_id, user_id, Some(current_session_id));
         }
+
+        let deleted: Vec<SessionRow> = result.take(0).map_err(DbError::from)?;
         Ok(deleted.len() as u64)
     }
 

--- a/crates/axiam-db/tests/authz_query_plan_test.rs
+++ b/crates/axiam-db/tests/authz_query_plan_test.rs
@@ -217,17 +217,27 @@ async fn direct_role_assignment_lookup_is_index_satisfied() {
 // 2. member_of — the group-membership sub-select
 // ---------------------------------------------------------------------------
 
+/// The shipped form carries the read-time tenant predicate added for
+/// residual 1 (`AND out.tenant_id = $tenant_id`). That predicate must remain
+/// free: `in =` still selects the row set through `idx_member_of_unique` and
+/// the tenant comparison is a post-filter, so the plan must stay an
+/// `IndexScan`, not degrade to a `TableScan`.
 #[tokio::test]
 async fn group_membership_lookup_is_index_satisfied() {
     let db = fresh_db().await;
     let mut res = db
         .query(
             "SELECT VALUE out FROM member_of \
-             WHERE in = type::record('user', $user_id) EXPLAIN",
+             WHERE in = type::record('user', $user_id) \
+             AND out.tenant_id = $tenant_id EXPLAIN",
         )
         .bind((
             "user_id",
             "11111111-1111-1111-1111-111111111111".to_string(),
+        ))
+        .bind((
+            "tenant_id",
+            "22222222-2222-2222-2222-222222222222".to_string(),
         ))
         .await
         .unwrap();
@@ -253,7 +263,9 @@ async fn inherited_role_assignment_lookup_is_index_satisfied() {
     let mut res = db
         .query(
             "LET $group_records = (\
-                 SELECT VALUE out FROM member_of WHERE in = type::record('user', $user_id)\
+                 SELECT VALUE out FROM member_of \
+                 WHERE in = type::record('user', $user_id) \
+                 AND out.tenant_id = $tenant_id\
              );",
         )
         .query(
@@ -284,7 +296,9 @@ async fn inlined_membership_subselect_would_be_a_full_table_scan() {
         .query(
             "SELECT resource_id FROM has_role \
              WHERE in IN (\
-                 SELECT VALUE out FROM member_of WHERE in = type::record('user', $user_id)\
+                 SELECT VALUE out FROM member_of \
+                 WHERE in = type::record('user', $user_id) \
+                 AND out.tenant_id = $tenant_id\
              ) AND out.tenant_id = $tenant_id EXPLAIN",
         )
         .bind(("user_id", user_id.to_string()))

--- a/docs/api/grpc.md
+++ b/docs/api/grpc.md
@@ -38,8 +38,12 @@ Rate limiting is **per method family**, not server-wide:
 `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` sizes `AuthorizationService`,
 `AXIAM__GRPC__GRPC_IDENTITY_PER_SEC` sizes `UserInfoService` +
 `TokenService`, `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` sizes `UserService`, and
-gRPC reflection/health are never limited. All three are per second per
-client IP; leaving the last two unset derives them from the authz ceiling.
+gRPC reflection/health share a fixed, deliberately generous 100/s bucket.
+All three knobs are per second per client IP. Leaving
+`GRPC_IDENTITY_PER_SEC` unset derives it as 5x the authz ceiling; leaving
+`GRPC_ADMIN_PER_SEC` unset gives a flat 10/s in **every** posture, because
+`UserService/ValidateCredentials` is an Argon2id verification and its
+ceiling is a CPU guard rather than a read ceiling (SEC-079).
 See [Sizing your rate limits § 3.1](../deployment/rate-limit-sizing.md).
 
 ## Consuming the API

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -334,13 +334,14 @@ unlimited, matching its siblings `GET /roles` and `GET /resources`.
 | `AXIAM__RATE_LIMIT__SHARED_SYNC_MS` | Write-behind flush interval for the shared counter, in milliseconds (default `1000`, clamped `50`–`60000`). Directly scales the cross-replica overshoot bound — see [Shared-store consistency model](#shared-store-consistency-model-write-behind) below. |
 
 The gRPC listener has its own per-second ceilings, one bucket per gRPC
-**method family** (reflection and health are never limited):
+**method family** (reflection and health share a fixed, deliberately
+generous 100/s bucket):
 
 | Key | Purpose |
 |---|---|
 | `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` | Max `axiam.v1.AuthorizationService` requests per second per IP (default `100`). |
 | `AXIAM__GRPC__GRPC_IDENTITY_PER_SEC` | Max `axiam.v1.UserInfoService` + `axiam.v1.TokenService` requests per second per IP. Unset = 5x the authz ceiling (default `500`). |
-| `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` | Max `axiam.v1.UserService` requests per second per IP. Unset = the authz ceiling (default `100`). `ValidateCredentials` is Argon2id-bound, so this is a CPU guard. |
+| `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` | Max `axiam.v1.UserService` requests per second per IP. Unset = a flat `10` (600/min per IP) in **every** posture — `ValidateCredentials` is Argon2id-bound, so this is a CPU guard on online password guessing and is deliberately not derived from the read-sized authz ceiling (SEC-079). |
 | `AXIAM__GRPC__KEY` | Reserved for D8 parity; currently a no-op (the gRPC limiters are always per-IP — see [Sizing your rate limits § 5](rate-limit-sizing.md)). |
 
 > **Which numbers should you actually run?** See

--- a/docs/deployment/rate-limit-sizing.md
+++ b/docs/deployment/rate-limit-sizing.md
@@ -127,7 +127,7 @@ yourself, the profile leaves it alone (and the startup log names it in
 | `AXIAM__RATE_LIMIT__AUTHZ_CHECK_PER_MIN` | 1800 | 6000 | 60000 |
 | `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` | 100 | 1000 | 5000 |
 | `AXIAM__GRPC__GRPC_IDENTITY_PER_SEC` | 500 | 5000 | 25000 |
-| `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` | 100 | 1000 | 5000 |
+| `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` | 10 | 10 | 10 |
 <!-- rate-limit-posture-table:end -->
 
 Per-minute values are **per bucket**, and the bucket is whatever
@@ -136,10 +136,17 @@ Per-minute values are **per bucket**, and the bucket is whatever
 `/oauth2/introspect` only; everything else is always per-IP).
 
 The three `AXIAM__GRPC__*_PER_SEC` values are per **second** per IP, one
-bucket per gRPC **method family** (see §3.1). Leave
-`GRPC_IDENTITY_PER_SEC` / `GRPC_ADMIN_PER_SEC` unset and they are derived
-from `GRPC_AUTHZ_PER_SEC` (identity = 5x, admin = 1x), which is why the
-`gateway`/`mesh` columns above move together with one variable.
+bucket per gRPC **method family** (see §3.1). Leave `GRPC_IDENTITY_PER_SEC`
+unset and it is derived as 5x `GRPC_AUTHZ_PER_SEC`, which is why those two
+rows move together with one variable.
+
+`GRPC_ADMIN_PER_SEC` deliberately **does not move with the posture**: it is
+a flat 10/s (600/min per IP) in every column. `UserService` holds
+`ValidateCredentials`, an Argon2id password verification, so its ceiling is
+a CPU guard on an online-guessing surface rather than a throughput number —
+raising the authz ceiling for service-mesh capacity must not silently widen
+password spraying (SEC-079). Set the env var explicitly if you need more;
+explicit configuration still wins.
 
 ### 3.1 gRPC buckets are per method family
 
@@ -154,20 +161,33 @@ posture. The buckets are now split:
 |---|---|---|---|
 | authz-check | `axiam.v1.AuthorizationService` | `AXIAM__GRPC__GRPC_AUTHZ_PER_SEC` | 100/s |
 | identity-read | `axiam.v1.UserInfoService`, `axiam.v1.TokenService` | `AXIAM__GRPC__GRPC_IDENTITY_PER_SEC` | 500/s (5x authz) |
-| admin | `axiam.v1.UserService` | `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` | 100/s (1x authz) |
-| unlimited | gRPC reflection (`grpc.reflection.*`), health (`grpc.health.*`) | *(none — never limited)* | — |
+| admin | `axiam.v1.UserService` | `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` | 10/s (absolute — see below) |
+| infrastructure | gRPC reflection (`grpc.reflection.*`), health (`grpc.health.*`) | *(none — fixed at 100/s)* | 100/s |
 
 Notes:
 
-- **Admin tracks authz 1:1 on purpose.** `UserService/ValidateCredentials`
-  performs an Argon2id verification, so its ceiling is a CPU guard, not a
-  read ceiling — it must not inherit the identity-read multiplier.
-- **Reflection and health are deliberately unlimited.** Their whole job is
-  to answer during an incident, exactly when the limited families are most
-  likely to be saturated; throttling a liveness probe turns an overload
-  into an outage.
+- **Admin is an absolute CPU guard, not a multiple of anything (SEC-079).**
+  `UserService/ValidateCredentials` performs an Argon2id verification
+  (~19 MiB of memory arena each), so its ceiling bounds online password
+  guessing and Argon2id CPU, not read throughput. It is therefore 10/s
+  (600/min per IP) regardless of the posture: a `gateway`/`mesh` preset
+  raising the authz ceiling for mesh capacity must not raise this one too.
+  The family contains only `GetUser` and `ValidateCredentials` — the
+  high-volume identity read is `GetUserInfo` on `UserInfoService`, which is
+  in the identity-read family and unaffected. Pin
+  `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` if your provisioning loop needs more.
+- **Reflection and health get a deliberately generous ceiling — but a
+  finite one.** Their whole job is to answer during an incident, exactly
+  when the other families are most likely to be saturated, and 100/s per IP
+  is orders of magnitude above any real probe cadence, so this ceiling can
+  never be what breaks a liveness check. It is not, however, a
+  pass-through: the family is selected by prefix-matching the client-
+  supplied gRPC `:path`, and an unmetered surface behind a client-chosen
+  string is not something to leave open against a health service being
+  registered later.
 - **An unrecognized gRPC path is counted against the authz bucket**, not
-  the unlimited one. Adding a service without classifying it fails safe.
+  the infrastructure one. Adding a service without classifying it fails
+  safe.
 - Both layers (the in-memory governor and the cross-replica shared counter)
   use the same split and the same per-second numbers. The shared counter
   runs a 60-second window and converts internally — before run 4 it did
@@ -343,7 +363,7 @@ The gRPC listener logs its own resolved family ceilings when it binds:
 ```json
 {"level":"INFO","fields":{"message":"Starting gRPC server",
  "bind":"127.0.0.1:50051","grpc_authz_per_sec":100,
- "grpc_identity_per_sec":500,"grpc_admin_per_sec":100}}
+ "grpc_identity_per_sec":500,"grpc_admin_per_sec":10}}
 ```
 
 ### Is the `internet` posture throttling your machine traffic?


### PR DESCRIPTION
## Summary

Remediates the backend findings from the independent re-verification pass (§10 of `claude_dev/security-analysis-2026-08-02.md`, commit `845c2cd`): **SEC-079** plus residuals 1, 2 and 4.

The headline is a **posture change, not just a bug fix** — see SEC-079 below. Reviewers who skim should read that section even if they skip everything else.

## SEC-079 [MEDIUM] — the gRPC admin ceiling derived from a read-sized base

The I2 doc comment said admin's ceiling "must not inherit a read-sized multiplier" because `ValidateCredentials` is an Argon2id verification. It correctly avoided the 5× identity multiplier — then assigned `admin_per_sec: authz_per_sec`, and `authz_per_sec` **is** the read-sized base. The code did not do what its own comment said.

**Consequence:** `axiam.v1.UserService` classifies as `Admin`, and `ValidateCredentials` performs a real Argon2id `verify_password` (~19 MiB arena each). When the I1 units bug was fixed, the effective per-IP ceiling on that RPC went from ~100/**minute** to ~6 000/**minute** — a 60× increase in online password-guessing throughput and in the Argon2 CPU an authenticated caller can conscript. **The units bug had been accidentally supplying 60× more protection than configured, and correcting it silently removed that.**

**Fix:** a new absolute `ADMIN_PER_SEC_DEFAULT = 10` (600/min per IP). Admin no longer derives from authz at all; only `identity_per_sec` still scales. A `gateway`/`mesh` preset raising mesh capacity can therefore no longer widen credential-guessing breadth as a side effect. `AXIAM__GRPC__GRPC_ADMIN_PER_SEC` still overrides.

Capping the family at 600/min is safe because `UserService` holds exactly two RPCs — `GetUser` and `ValidateCredentials` (verified, not assumed). The high-volume identity read is `GetUserInfo` on `UserInfoService`, which is in `IdentityRead` and untouched.

Why Medium and not High: lockout is checked *before* hashing (`user.rs:152-156`) and every failure is metered through the shared lockout helper (`:180`), so single-account guessing stays lockout-bound. The 60× bought password-spraying **breadth** and CPU headroom.

**Tests:** `admin_ceiling_never_derives_from_the_authz_ceiling` pins `admin_per_sec == 10` for authz ∈ {1, 100, 1 000, 5 000, 60 000, `u32::MAX`} and pins `window_limit(Admin) == 600` (not 6 000); an override test proves the env var wins over both default and preset; a new end-to-end test shows the admin path throttling while authz serves 500 consecutive requests at 5 000/s. Three existing tests that asserted `admin == authz` were updated — **those assertions encoded the bug**.

The pre-existing doc-drift guard `documented_per_family_rows_match_the_derivation` failed exactly as it should have (`left: 100, right: 10`) before the docs were updated.

**CHANGELOG** leads with *"This is a posture change — read it even if you skipped the units fix above"*, states plainly that correcting the units raised every gRPC ceiling 60×, and gives the action. That framing is the point of SEC-079: an operator reading "corrected gRPC units" would not otherwise realise their deployed ceiling rose.

## Residual 1 — `member_of` had no read-time tenant predicate

Added `AND out.tenant_id = $tenant_id` inside the `LET $group_records` sub-select. Not currently exploitable (write-time validation in `group.rs:355-389`, and the outer `has_role` still constrains `out.tenant_id`), but it left group-inherited roles as the one authz edge with no read-time check — a migration or bulk import writing `member_of` directly would have bypassed it.

Query-plan pins re-run: still `IndexScan idx_member_of_unique`, no regression to `TableScan`. The `TableScan` **witness** test was updated to the same shape so it still witnesses a scan rather than silently going vacuous.

## Residual 2 — session-cache invalidation ordering

In `consume` and `invalidate_user_sessions_except`, invalidation ran *after* `result.take(0)?`. The `DELETE` has already committed by then, so a BEFORE-image deserialize failure would return early and leave a **positive** cache entry live for up to the TTL — a deleted session continuing to validate. Invalidation moved above the `take`. The other three session-deleting methods were audited and were already correct.

⚠️ **Shipped without a regression test, deliberately.** Reaching the bug requires the database to commit the `DELETE … RETURN BEFORE` and then return a BEFORE image that fails to deserialize into `SessionRow`. With the real embedded SurrealDB the returned row is by construction the row it stored, and the repository takes a concrete `Surreal<C>` rather than a mockable trait, so there is no seam. An instrumented-cache call-order assertion would test the assertion, not the behaviour. **This is the weakest item in the PR and the one most worth reviewer attention.**

## Residual 4 — the `Unlimited` gRPC family was an unbounded prefix match

`/grpc.reflection.` and `/grpc.health.` bypassed **both** limiter layers, matched by prefix on the attacker-controlled `:path`. Harmless today (neither service is registered; requests terminate `Unimplemented`), but a genuinely unmetered endpoint the moment a health service is registered.

`Unlimited` → `Infra`, with an absolute `INFRA_PER_SEC = 100`. A k8s liveness/readiness probe runs on the order of once per few seconds per prober, so even a large sidecar fleet behind one NAT egress IP stays orders of magnitude under 100/s — the ceiling can never be what breaks a probe during an incident, which was the property motivating the original pass-through, while the surface stops being unbounded.

The old `reflection_and_health_are_never_throttled` was split so **both** halves are pinned: probes survive a fully saturated server, *and* a sustained flood is eventually rejected. New shared-counter endpoint `grpc_infra`; the other three bucket names are byte-identical, so an in-flight upgrade keeps counting against the same rows.

## Documentation

`claude_dev/security-analysis-2026-08-02.md` gains **§10.7**, which deliberately records these as **claims pending verification** rather than ✅ CONFIRMED — §9 asserted "all fixed" and the independent pass found one claim partial plus two new findings in code the remediation had introduced. Only an independent pass may promote them. It also records what was *not* done (residuals 3 and 5, both accepted trade-offs), OBS-1's explicit trigger condition, and one new cross-SDK observation: Swift's `JwtClaims` models no `nbf`/`iss`/`aud` at all, so the three newest SDKs now enforce three different subsets of the same token contract.

Also updated: `docs/deployment/rate-limit-sizing.md`, `docs/deployment/README.md`, `docs/api/grpc.md`.

## Verification

```
cargo test -p axiam-api-grpc --lib                          -> 23 passed, 0 failed
cargo test -p axiam-api-grpc --test rate_limit_units_test   -> 5 passed, 0 failed
cargo test -p axiam-api-grpc --test grpc_units              -> 32 passed, 0 failed
cargo test -p axiam-api-grpc --test rate_limit_shared_store_test -> 4 passed
cargo test -p axiam-db --lib                                -> 104 passed, 0 failed
cargo test -p axiam-db --test authz_query_plan_test         -> 8 passed, 0 failed
cargo test -p axiam-db --test session_validation_cache_test -> 10 passed, 0 failed
cargo test -p axiam-db (role/group/tenant-isolation suites) -> 46 passed, 0 failed
cargo test -p axiam-api-rest --lib                          -> 126 passed, 0 failed
clippy -D warnings (db, api-grpc, api-rest)                 -> clean
cargo fmt --check (all touched crates)                      -> clean
```

One clippy round-trip was needed: `assertions_on_constants` fired on two asserts comparing `INFRA_PER_SEC` against literals; rewritten to read through `GrpcRateLimits::per_sec()` so they remain real assertions rather than const-folded no-ops.

## Related

- Remediates §10 of `claude_dev/security-analysis-2026-08-02.md` (`845c2cd`).
- SEC-080 (the Swift `exp` half of this pass) is fixed separately in `ilpanich/axiam-swift-sdk`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0147He1cwegcPjN4bHQPZ5Qk)_