### PR TITLE
security: close every open item from the 2026-08-02 security analysis (§13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Cache-invalidation liveness heartbeats (§13.4 observation 1).** Decision-cache
+  trust followed **consumer** liveness alone. A party with broker `configure`
+  rights could `queue.unbind` a replica's queue from the fanout exchange and the
+  replica would notice nothing: its consumer stays subscribed to a queue nothing
+  routes to, so trust stays on and it keeps serving cached allows it will never
+  be told to invalidate. The publisher sees nothing either — `mandatory` is off,
+  so the broker acks an unroutable message. Invalidations were silently
+  suppressed, bounded only by `decision_cache_ttl_secs`.
+
+  Each replica now publishes a **self-addressed heartbeat** every
+  `AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_HEARTBEAT_SECS` (default `10`) and
+  watches for its own to come back — a round trip that exercises the whole loop
+  (publish → exchange → binding → queue → consumer), so an unbound queue breaks
+  it immediately. After three consecutive missed intervals the cache is marked
+  UNTRUSTED and the replica falls back to uncached evaluation.
+
+  The watchdog can only **revoke** trust, never grant it: trust is still granted
+  in exactly one place, by the consumer on a successful subscribe, so it can
+  never resurrect trust on a replica whose consumer has died. Heartbeats never
+  touch the cache and never enter the replay-nonce guard. Only applies when
+  cross-replica broadcast is enabled; set the interval to `0` to disable
+  (not recommended — it re-opens the suppression window).
+
+- **Cached authorization decisions are now invalidated on user delete/update
+  (§13.4 observation 9).** `users::update` and `users::delete` did not invalidate,
+  so a deleted or deactivated user's cached `Allow` survived on every replica
+  until the TTL expired. Nothing on the session-authenticated request path
+  re-reads user status, so the cache was the only place the stale grant could be
+  cleared. Both handlers now flush the affected subject.
+
+### Fixed
+
+- **Pepper rotation is no longer an unversioned hard break (§13.4 observation 3).**
+  `AXIAM__AUTH__PEPPER` keys client-secret hashing, and the `v2.hs256$` tag
+  versions the *algorithm*, not the *key* — so rotating the pepper invalidated
+  **every** client secret at once, and every OAuth2 client and service account
+  had to be re-issued in lockstep with the restart.
+
+  Set the new `AXIAM__AUTH__PEPPER_PREVIOUS` to the outgoing value for the
+  duration of a rotation: pre-rotation hashes still verify, and each secret is
+  transparently rewritten under the new pepper the first time its owner
+  authenticates, so the rotation drains itself with no downtime and no
+  re-issuance. Nothing is ever *written* under the previous key. **See the
+  rotation procedure in `docs/deployment/README.md` before rotating.**
+
+  A stored key id was deliberately not used instead: it would hand anyone with a
+  table dump an offline oracle for testing pepper guesses, which does not exist
+  today. Both keys are tried unconditionally while a rotation is configured, so
+  response time does not reveal which pepper era a row is in.
+
+- **Service-account client secrets can now migrate hash schemes (§13.4
+  observation 4).** `service_account` wrote the current scheme on create/rotate
+  but had no `upgrade_client_secret_hash`, so an existing row never migrated no
+  matter how often it authenticated — meaning the legacy v1 verifier arm could
+  not be retired on the strength of "no v1 `oauth2_client` rows remain". The
+  repository now exposes the same tenant-scoped compare-and-swap upgrade the
+  OAuth2 client repository has, which also carries pepper-rotation rewrites.
+
+- **The cache-invalidation publisher recovers its channel (§13.4 observation 2).**
+  It held one channel created at startup and never replaced, while the consumer
+  side was fully supervised with backoff — so a single channel-level exception
+  made every access-narrowing mutation return `503` for the rest of the process
+  lifetime, clearing only on restart. The channel is now opened lazily and
+  reopened after any failure.
+
 - **Cross-replica authorization decision-cache invalidation over RabbitMQ (§4.2, threat-model `T-88`).**
   The decision cache invalidated **process-locally**: on a replica that did not
   handle the mutation, a revoked grant could stay `Allow` until its entry

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -665,3 +665,126 @@ Recorded plainly, because both were cases where I endorsed a claim rather than t
 - **Open**: **SEC-085** (HIGH, PHP guard fallback) — the only open finding in this document.
 - **Open observations**: §13.4 items 1–10, plus §10.4 residual 5 (introspect pre-auth work factor) and the carried recommendations from §12.6 (C/C++ sanitizer CI, pepper release-note prominence, Go toolchain advisories, Kotlin coverage margin).
 - **Structural note**: the §10.1 contract did what it was introduced to do. Stating the rules once and auditing eleven implementations against them surfaced two HIGH cross-tenant bypasses, an eight-SDK expiry gap and a UB defect that three prior passes had missed — *"there was no complete set to check against"* is the correct diagnosis. SEC-085 is the argument for extending that discipline one level up: §10.1 constrains what a guard must *check*, and should also state that a guard must fail closed on the **caller's** credential and never substitute another.
+
+---
+
+## 14. Remediation of §13 (2026-08-03)
+
+> ⚠️ **Written by the remediation work, not by a reviewer.** Per the §10.7 and
+> §12 precedent, every status below is a **claim pending verification**. Three
+> prior independent passes each found something the remediation's own report had
+> missed, so this section is deliberately not self-certified. §13.1's table is
+> the model: re-derive each from source, at `origin/main`, not at a working-tree
+> HEAD or a feature branch (§11.2).
+
+### 14.1 Scope
+
+§13.6 left exactly one open finding and a list of open observations. All of them
+were actioned — the required item (SEC-085) and every optional one — with the
+single deliberate exception recorded in §14.4.
+
+### 14.2 The open finding
+
+| Item | Severity | Repo | Claimed status | What landed |
+|---|---|---|---|---|
+| **SEC-085** | HIGH | `axiam-php-sdk` | Remediated — pending verification | New `AxiamClient::verifyLocally()` applies the full §10.1 set to the caller's token with **no fallback**, and is what both framework bridges now call. `verifyLocallyOrFallback()` is retained for the SDK's own outbound calls — the context where refreshing the client's own token is the intended recovery — and now carries an explicit warning against guard use. |
+
+**On the regression tests.** The finding's own fix note asked for "a negative
+test asserting that an expired caller token yields 401 even while the client
+session is healthy". Writing that test naively produces a **vacuous pass**, and
+this is worth recording because the trap is not obvious: the natural fixture
+token carries no `org_id`, so `Session::buildRefreshCall()` rejects locally and
+the fallback never reaches the transport. The test then passes against the
+*vulnerable* code, for a reason that has nothing to do with the fix.
+
+The harness therefore primes a session whose refresh genuinely succeeds and
+whose token genuinely verifies, and **asserts that precondition explicitly**
+before each case. Verified by falsification: reverting either guard to
+`verifyLocallyOrFallback()` fails 8 of the 9 new cases, each admitting the
+rejected caller as `app-service-account`. Four caller shapes are covered
+(expired, garbage, `alg:none`, foreign tenant) across both Laravel and Symfony.
+Full suite: 507 tests / 1302 assertions green.
+
+### 14.3 CONTRACT.md §10.1 rule 8 — the structural note actioned
+
+§13.6 closed with: *"§10.1 constrains what a guard must check, and should also
+state that a guard must fail closed on the caller's credential and never
+substitute another."* That is now **rule 8 — subject of the decision**, normative
+in `sdks/CONTRACT.md` and re-synced to all eleven vendored copies.
+
+Rule 8 is deliberately framed as being about **control flow, not claims**, because
+that is what made SEC-085 invisible to three prior passes and to the §10.1 audit
+itself: rules 1–7 ask *"is this token good?"* and the PHP guard satisfied all
+seven. Rule 8 asks *"is this the token the decision is about?"*. The rule also
+states the legitimate shape — a reactive-refresh helper is correct for an SDK's
+**outbound** calls — and requires the two to be separate methods with the
+no-fallback one as the documented guard entry point.
+
+The testing clause carries the §14.2 lesson forward: a rule-8 test whose client
+session is unusable passes vacuously and does not satisfy the clause.
+
+### 14.4 Observations from §13.4 and §12.6
+
+| Item | Claimed status | Where |
+|---|---|---|
+| **1** — invalidation suppression by unbinding | Remediated — pending verification | `axiam`: self-addressed liveness heartbeat; watchdog is a **one-way revoker** |
+| **2** — publisher channel has no recovery | Remediated — pending verification | `axiam`: channel opened lazily and reopened after any failure |
+| **3** — pepper rotation is an unversioned hard break | Remediated — pending verification | `axiam`: `AXIAM__AUTH__PEPPER_PREVIOUS` dual-read + lazy rewrite |
+| **4** — service-account secrets have no upgrade path | Remediated — pending verification | `axiam`: tenant-scoped CAS `upgrade_client_secret_hash` |
+| **5** — Python/Java permit a 300 s operator-set skew | Remediated — pending verification | `axiam-python-sdk`, `axiam-java-sdk`: ceiling lowered to 60 s |
+| **6** — tenant comparand is a slug in three SDKs | Remediated — pending verification | TS/PHP/Python: one-time diagnostic naming the cause |
+| **7** — Swift accepts a token with no `kid` | Remediated — pending verification | `axiam-swift-sdk` |
+| **8** — C SDK's §10.1 negative-test set incomplete | Remediated — pending verification | `axiam-c-sdk` |
+| **9** — `users.rs` does not invalidate cached decisions | Remediated — pending verification | `axiam` |
+| **10 / §12.6.1** — no sanitizer job in C/C++ CI | Remediated — pending verification | `axiam-c-sdk`, `axiam-cplusplus-sdk`: ASan+UBSan+valgrind |
+| **§12.6.2** — pepper release-note prominence | Remediated — pending verification | `axiam`: CHANGELOG + a rotation procedure in `docs/deployment/` |
+| **§12.6.3** — Go stdlib advisories | Remediated — pending verification | `axiam-go-sdk`: toolchain bump |
+| **§12.6.4** — Kotlin coverage margin 0.19 pts | Remediated — pending verification | `axiam-kotlin-sdk`: webhook lines covered |
+| **§10.4 residual 5** — introspect pre-auth work factor | **Not addressed** — accepted, unchanged | — |
+| **OBS-1** — client-secret entropy assumption | Superseded by the keyed hash (§13.1) | — |
+
+**Two design points worth recording**, because both are traps the obvious
+implementation falls into:
+
+1. **The heartbeat watchdog can only revoke trust, never grant it.** Trust is
+   still granted in exactly one place — the consumer, on a successful
+   `basic_consume`. A watchdog able to grant it could resurrect trust on a
+   replica whose consumer had died, converting a fail-safe into a fail-open.
+   Only the replica's *own* heartbeat counts: another replica's proves that
+   replica can publish, which says nothing about our binding. And heartbeats are
+   separated out before any `InvalidationEvent` exists, so they have no path to
+   `apply` and cannot consume the bounded nonce-guard capacity that real
+   invalidations depend on.
+
+2. **Pepper rotation uses a dual read, not a stored key id.** The obvious design
+   — derive a kid from the pepper and store it beside the hash — would hand
+   anyone holding a table dump an **offline oracle for testing pepper guesses**,
+   which does not exist today: testing a guess currently requires a known
+   (secret, hash) pair, and no secret is ever stored. Trying both keys costs one
+   extra HMAC on rotation-era rows and adds no new verifier for an attacker.
+   Both candidates are computed unconditionally while a rotation is configured,
+   so response time does not reveal which pepper era a row is in.
+
+**Not addressed, and why.** §10.4 residual 5 (a pre-auth caller can drive 600
+introspect client-lookups per minute per IP instead of 10) remains accepted: the
+endpoint authenticates the client before any lookup, so it is not a token oracle,
+and changing the ceiling is a posture decision rather than a fix. It stays
+recorded in §10.4.
+
+### 14.5 What a verifier should look at hardest
+
+Stated plainly, so the next pass spends its effort where this one is weakest:
+
+1. **The rule-8 regression harness.** Its value rests entirely on the fallback
+   being genuinely reachable. The precondition is asserted in-test, but a future
+   edit to the mock transport could make it vacuous again without failing
+   anything. Re-run the falsification rather than trusting the assertion.
+2. **The heartbeat's one-way-revoker property.** It is a claim about the *whole*
+   wiring, not one function: confirm by source that no path other than the
+   consumer's post-subscribe call reaches `set_trusted(true)`.
+3. **The pepper dual-read's timing behaviour.** Both candidates are computed
+   unconditionally, but only when a previous pepper is configured. Confirm that
+   the no-rotation path is unchanged and that neither path branches on the
+   presented secret.
+4. **§14.4 items 5–8 across SDKs.** Per-SDK changes are where every previous pass
+   found drift, and each language closed its own rule for its own reason.

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -725,7 +725,16 @@ session is unusable passes vacuously and does not satisfy the clause.
 
 ### 14.4 Observations from §13.4 and §12.6
 
-| Item | Claimed status | Where |
+> **No commit hashes are cited in this section, deliberately.** §11.2's rule is
+> that a remediation record citing a hash must resolve to a commit reachable from
+> the default branch, and `scripts/check-remediation-evidence.py` enforces it. A
+> hash authored on the remediation branch cannot satisfy that until the branch
+> merges, so citing one here would either fail the gate or — worse — invite
+> relaxing it. The rows below name the **repository** and what landed; the
+> merge-commit evidence belongs in the verification pass that promotes these
+> claims, which is the only point at which it can be true.
+
+| Item | Claimed status | Repo and what landed |
 |---|---|---|
 | **1** — invalidation suppression by unbinding | Remediated — pending verification | `axiam`: self-addressed liveness heartbeat; watchdog is a **one-way revoker** |
 | **2** — publisher channel has no recovery | Remediated — pending verification | `axiam`: channel opened lazily and reopened after any failure |

--- a/crates/axiam-amqp/src/cache_invalidation.rs
+++ b/crates/axiam-amqp/src/cache_invalidation.rs
@@ -63,11 +63,46 @@
 //!   logged at ERROR and counted in `DecisionCacheStats::bypassed`, so the
 //!   degraded mode is loud rather than silent.
 //!
-//! **Trust follows connection liveness and nothing else.** No inbound
-//! *message* can revoke trust — not a stale one, not a replayed one. Otherwise
-//! an attacker holding a single captured, validly-signed broadcast could
-//! disable every replica's cache at will. A rejected message is logged and
-//! counted; only the consumer's own subscribe/stream state moves the flag.
+//! **No inbound message can revoke trust** — not a stale one, not a replayed
+//! one. Otherwise an attacker holding a single captured, validly-signed
+//! broadcast could disable every replica's cache at will. A rejected message is
+//! logged and counted; it never moves the flag.
+//!
+//! ## 2a. Binding liveness — the heartbeat (§13.4 observation 1)
+//!
+//! Consumer liveness alone is not sufficient evidence, and this was a real gap.
+//! A party with broker **configure** rights can `queue.unbind` a replica's queue
+//! from the fanout exchange. Nothing visibly breaks: the consumer stays
+//! subscribed to a queue nothing routes to any more, so trust stays `true` and
+//! the replica keeps serving cached allows it will never be told to invalidate.
+//! The publisher cannot see it either — `mandatory` is off, so the broker acks
+//! an unroutable message. Invalidations are silently suppressed, bounded only by
+//! `decision_cache_ttl_secs`.
+//!
+//! Each replica therefore publishes a **self-addressed heartbeat** on an
+//! interval ([`build_signed_heartbeat`]) and watches for its own to come back.
+//! That round trip is the smallest thing that actually exercises the property in
+//! question — publish → exchange → binding → queue → consumer — so an unbound
+//! queue breaks it immediately. After
+//! [`HEARTBEAT_MISS_THRESHOLD`] consecutive missed intervals, the watchdog calls
+//! `set_trusted(false)` ([`InvalidationLiveness`]).
+//!
+//! Three properties make this safe rather than a new lever:
+//!
+//! * **The watchdog can only revoke, never grant.** Trust is granted in exactly
+//!   one place — the consumer, on a successful `basic_consume`. A watchdog able
+//!   to grant it could resurrect trust on a replica whose consumer had died.
+//! * **Only our OWN heartbeat counts.** Another replica's heartbeat proves that
+//!   replica can publish, which says nothing about *our* binding.
+//! * **Heartbeats never touch the cache and never enter the nonce guard.** They
+//!   are separated out before any [`InvalidationEvent`] is constructed, so a
+//!   heartbeat has no path to `apply`; and since they arrive on a fixed interval
+//!   from every replica, letting them consume the bounded nonce-guard capacity
+//!   would evict real invalidation nonces and weaken replay protection.
+//!
+//! Heartbeats can be disabled with
+//! `AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_HEARTBEAT_SECS=0`, which restores the
+//! pre-§13.4 behaviour and re-opens the suppression window.
 //!
 //! # 3. Authenticity
 //!
@@ -114,6 +149,7 @@ use lapin::options::{
 };
 use lapin::types::FieldTable;
 use lapin::{BasicProperties, Channel, Confirmation, ExchangeKind};
+use tokio::sync::Mutex as TokioMutex;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
@@ -235,16 +271,63 @@ pub fn build_signed_invalidation(
     event: InvalidationEvent,
     now: DateTime<Utc>,
 ) -> Result<Vec<u8>, AmqpError> {
-    let mut message = CacheInvalidationMessage {
-        origin_id,
-        tenant_id: event.tenant_id(),
-        subject_id: event.subject_id(),
-        key_version: CURRENT_KEY_VERSION,
-        nonce: Uuid::new_v4(),
-        issued_at: now,
-        hmac_signature: None,
-    };
+    sign_message(
+        master_key,
+        CacheInvalidationMessage {
+            origin_id,
+            tenant_id: event.tenant_id(),
+            subject_id: event.subject_id(),
+            key_version: CURRENT_KEY_VERSION,
+            nonce: Uuid::new_v4(),
+            issued_at: now,
+            heartbeat: false,
+            hmac_signature: None,
+        },
+    )
+}
 
+/// Tenant id stamped on a liveness heartbeat.
+///
+/// Heartbeats are not tenant-scoped — they carry no cache effect at all — but
+/// the envelope derives its HMAC subkey from `tenant_id`, so the field must
+/// hold *something*. The nil UUID is used deliberately: it is not a real
+/// tenant, so even if a heartbeat were somehow mistaken for an invalidation it
+/// could only ever flush a tenant that does not exist. The consumer's heartbeat
+/// branch runs before any event is constructed, so that path is unreachable —
+/// this is the second line of defence, not the first.
+pub const HEARTBEAT_TENANT_ID: Uuid = Uuid::nil();
+
+/// Build the signed wire bytes for one liveness heartbeat (§13.4 observation 1).
+///
+/// Same envelope, same signing, same freshness and replay gates as an
+/// invalidation — a heartbeat is not a privileged message type, it simply
+/// carries no cache effect.
+pub fn build_signed_heartbeat(
+    master_key: &[u8],
+    origin_id: Uuid,
+    now: DateTime<Utc>,
+) -> Result<Vec<u8>, AmqpError> {
+    sign_message(
+        master_key,
+        CacheInvalidationMessage {
+            origin_id,
+            tenant_id: HEARTBEAT_TENANT_ID,
+            subject_id: None,
+            key_version: CURRENT_KEY_VERSION,
+            nonce: Uuid::new_v4(),
+            issued_at: now,
+            heartbeat: true,
+            hmac_signature: None,
+        },
+    )
+}
+
+/// Canonicalize, sign, and serialize one message. Shared by the invalidation and
+/// heartbeat builders so the two can never drift into signing different shapes.
+fn sign_message(
+    master_key: &[u8],
+    mut message: CacheInvalidationMessage,
+) -> Result<Vec<u8>, AmqpError> {
     // Canonical body = the message with `hmac_signature` absent.
     let canonical = serde_json::to_vec(&message)
         .map_err(|e| AmqpError::Publish(format!("canonicalize invalidation: {e}")))?;
@@ -364,6 +447,11 @@ pub enum InvalidationOutcome {
     /// would be redundant work on the exact code path the cache exists to make
     /// fast.
     SelfEcho,
+    /// A liveness heartbeat (§13.4 observation 1). Never touches the cache.
+    /// `own` distinguishes this replica's own heartbeat — the only one that
+    /// carries information, since observing it proves *our* binding is intact —
+    /// from another replica's, which is simply ignored.
+    Heartbeat { own: bool },
     /// Refused; see [`InvalidationReject`].
     Rejected(InvalidationReject),
 }
@@ -441,6 +529,18 @@ pub fn process_invalidation(
         return InvalidationOutcome::Rejected(InvalidationReject::Stale);
     }
 
+    // Heartbeats are separated out BEFORE the nonce guard and before any event
+    // is constructed. Two reasons, both deliberate: a heartbeat must never be
+    // able to reach `InvalidationEvent::apply` (so it cannot flush anything),
+    // and heartbeats arrive on a fixed interval from every replica, so letting
+    // them consume the bounded nonce-guard capacity would evict real
+    // invalidation nonces and weaken replay protection on a busy cluster.
+    if message.heartbeat {
+        let own = message.origin_id == local_origin;
+        debug!(own, "Cache-invalidation liveness heartbeat");
+        return InvalidationOutcome::Heartbeat { own };
+    }
+
     if message.origin_id == local_origin {
         debug!(tenant_id = %tenant_id, "Cache-invalidation self-echo — no-op");
         return InvalidationOutcome::SelfEcho;
@@ -487,6 +587,100 @@ pub fn handle_invalidation(
 }
 
 // ---------------------------------------------------------------------------
+// Liveness (§13.4 observation 1)
+// ---------------------------------------------------------------------------
+
+/// How many heartbeat intervals may pass with no self-echo before this replica
+/// stops trusting its cache.
+///
+/// Three, not one: a single missed heartbeat is far more likely to be a broker
+/// hiccup or a scheduling delay than a broken binding, and revoking trust on it
+/// would make every transient blip a latency cliff. Three consecutive misses is
+/// long enough to be a real signal and still bounded well below any interval an
+/// operator would find acceptable for a stale allow.
+pub const HEARTBEAT_MISS_THRESHOLD: u32 = 3;
+
+/// Tracks whether this replica is still *receiving* its own broadcasts.
+///
+/// The gap this closes (§13.4 observation 1): the cache's trust flag follows
+/// **consumer liveness** — it is set when `basic_consume` succeeds and cleared
+/// when the consumer exits. But a party with broker *configure* rights can
+/// `queue.unbind` a replica's queue from the fanout exchange. The consumer stays
+/// happily subscribed to a queue nothing is routed to any more, trust stays
+/// `true`, and the replica keeps serving cached allows it will never be told to
+/// invalidate. The publisher sees nothing either: with `mandatory` off, the
+/// broker acks an unroutable message.
+///
+/// A self-addressed heartbeat is the smallest thing that actually tests the
+/// property in question, because it exercises the *entire* loop — publish →
+/// exchange → binding → queue → consumer. An unbound queue breaks it
+/// immediately.
+///
+/// **This type can only ever revoke trust, never grant it.** Trust is granted in
+/// exactly one place, by the consumer, on a successful `basic_consume`. A
+/// watchdog that could also grant it would be able to resurrect trust on a
+/// replica whose consumer had died — turning a fail-safe into a fail-open.
+pub struct InvalidationLiveness {
+    /// When we last saw our own broadcast come back. `None` = not subscribed.
+    last_own_echo: Mutex<Option<DateTime<Utc>>>,
+}
+
+impl Default for InvalidationLiveness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InvalidationLiveness {
+    pub fn new() -> Self {
+        Self {
+            last_own_echo: Mutex::new(None),
+        }
+    }
+
+    /// Called by the consumer immediately after it subscribes. Starts the clock:
+    /// without this, a freshly-subscribed replica would look infinitely stale
+    /// and the watchdog would revoke trust before the first heartbeat round.
+    pub fn mark_subscribed(&self, now: DateTime<Utc>) {
+        *self.lock() = Some(now);
+    }
+
+    /// Called by the consumer when it observes its **own** heartbeat.
+    pub fn record_own_heartbeat(&self, now: DateTime<Utc>) {
+        *self.lock() = Some(now);
+    }
+
+    /// Called when the consumer stops, so a reconnecting consumer cannot inherit
+    /// a stale "recently alive" timestamp from its predecessor.
+    pub fn mark_unsubscribed(&self) {
+        *self.lock() = None;
+    }
+
+    /// The last observation, if any.
+    pub fn last_own_echo(&self) -> Option<DateTime<Utc>> {
+        *self.lock()
+    }
+
+    /// Has the loop been silent for longer than `interval * HEARTBEAT_MISS_THRESHOLD`?
+    ///
+    /// `None` (not subscribed) is **not** stale: the consumer's own exit path
+    /// already marked the cache untrusted, and reporting staleness here would
+    /// only produce a duplicate revocation and a misleading log line.
+    pub fn is_stale(&self, now: DateTime<Utc>, interval: chrono::Duration) -> bool {
+        match *self.lock() {
+            Some(last) => now - last > interval * (HEARTBEAT_MISS_THRESHOLD as i32),
+            None => false,
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<DateTime<Utc>>> {
+        self.last_own_echo
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Publisher
 // ---------------------------------------------------------------------------
 
@@ -495,20 +689,46 @@ pub fn handle_invalidation(
 /// Attached to every `AuthorizationEngine` as an
 /// [`InvalidationBroadcaster`] when the channel is enabled.
 pub struct CacheInvalidationPublisher {
-    /// Must be a **publisher-confirm** channel
-    /// (`AmqpManager::create_publisher_channel`) — without confirms the broker
-    /// returns `Confirmation::NotRequested` and this publisher would report
-    /// success for a message the broker never accepted, which is precisely the
-    /// silent failure §4.2 exists to remove.
-    channel: Channel,
+    /// Opens publisher-confirm channels on demand.
+    ///
+    /// Publisher confirms are mandatory: without them the broker returns
+    /// `Confirmation::NotRequested` and this publisher would report success for
+    /// a message the broker never accepted, which is precisely the silent
+    /// failure §4.2 exists to remove.
+    channels: Arc<dyn PublisherChannelFactory>,
+    /// The channel currently in use, if one is open and healthy.
+    ///
+    /// §13.4 observation 2: this used to be a single `Channel` created once at
+    /// startup and never replaced. A channel is closed by the broker on any
+    /// channel-level exception, and the consumer side is fully supervised with
+    /// backoff while this side was not — so one exception made **every**
+    /// access-narrowing mutation return 503 for the rest of the process
+    /// lifetime. Fail-closed, so not a security hole, but a permanent
+    /// availability defect that only a restart cleared.
+    ///
+    /// `tokio::sync::Mutex`, not `std::sync::Mutex`: the guard is held across
+    /// the `.await` on the broker's confirm.
+    channel: TokioMutex<Option<Channel>>,
     master_key: Vec<u8>,
     origin_id: Uuid,
 }
 
+/// Opens a publisher-confirm channel. Implemented by `AmqpManager`; a trait so
+/// this module stays testable without a broker and does not depend on the
+/// connection layer's concrete type.
+pub trait PublisherChannelFactory: Send + Sync {
+    fn open<'a>(&'a self) -> Pin<Box<dyn Future<Output = Result<Channel, AmqpError>> + Send + 'a>>;
+}
+
 impl CacheInvalidationPublisher {
-    pub fn new(channel: Channel, master_key: Vec<u8>, origin_id: Uuid) -> Self {
+    pub fn new(
+        channels: Arc<dyn PublisherChannelFactory>,
+        master_key: Vec<u8>,
+        origin_id: Uuid,
+    ) -> Self {
         Self {
-            channel,
+            channels,
+            channel: TokioMutex::new(None),
             master_key,
             origin_id,
         }
@@ -532,15 +752,59 @@ impl CacheInvalidationPublisher {
     pub async fn publish_event(&self, event: InvalidationEvent) -> Result<(), AmqpError> {
         let payload =
             build_signed_invalidation(&self.master_key, self.origin_id, event, Utc::now())?;
+        self.publish_payload(&payload).await
+    }
 
-        let confirm = self
-            .channel
+    /// Publish one liveness heartbeat (§13.4 observation 1).
+    ///
+    /// Deliberately shares `publish_payload` with invalidations: the heartbeat
+    /// must traverse the exact same path it is meant to be evidence about. A
+    /// heartbeat sent over a different channel, exchange or routing key would
+    /// prove something other than what the invalidations depend on.
+    pub async fn publish_heartbeat(&self) -> Result<(), AmqpError> {
+        let payload = build_signed_heartbeat(&self.master_key, self.origin_id, Utc::now())?;
+        self.publish_payload(&payload).await
+    }
+
+    /// Acquire a healthy channel, publish, and await the confirm — reopening the
+    /// channel if the one we hold has been closed.
+    async fn publish_payload(&self, payload: &[u8]) -> Result<(), AmqpError> {
+        let mut slot = self.channel.lock().await;
+
+        // Drop a channel the broker has already closed, so the next block opens
+        // a fresh one instead of publishing into a dead handle.
+        if slot.as_ref().is_some_and(|c| !c.status().connected()) {
+            warn!("Cache-invalidation publisher channel is closed — reopening");
+            *slot = None;
+        }
+        if slot.is_none() {
+            *slot = Some(self.channels.open().await?);
+        }
+        let channel = slot.as_ref().expect("channel opened above");
+
+        match Self::publish_on(channel, payload).await {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // Any failure may have been the channel dying under us. Discard
+                // it so the *next* mutation reopens rather than inheriting a
+                // broken handle — the whole point of observation 2. The error is
+                // still returned: this mutation genuinely did not fan out, and
+                // silently retrying here would hide a broker refusing the
+                // message for a reason that will recur.
+                *slot = None;
+                Err(e)
+            }
+        }
+    }
+
+    async fn publish_on(channel: &Channel, payload: &[u8]) -> Result<(), AmqpError> {
+        let confirm = channel
             .basic_publish(
                 exchanges::AUTHZ_CACHE_INVALIDATE.into(),
                 // Fanout ignores the routing key.
                 "".into(),
                 BasicPublishOptions::default(),
-                &payload,
+                payload,
                 BasicProperties::default()
                     .with_content_type("application/json".into())
                     // Transient (1), not persistent: an invalidation is only
@@ -595,11 +859,17 @@ impl InvalidationBroadcaster for CacheInvalidationPublisher {
 /// mid-await. Making this a `Drop` guard rather than a line at the end of the
 /// function is what stops a future edit from introducing an early `return`
 /// that leaves the cache trusted with no consumer behind it.
-struct TrustGuard(Arc<DecisionCache>);
+struct TrustGuard(Arc<DecisionCache>, Option<Arc<InvalidationLiveness>>);
 
 impl Drop for TrustGuard {
     fn drop(&mut self) {
         self.0.set_trusted(false);
+        // Clear the liveness clock too, so a reconnecting consumer cannot
+        // inherit its predecessor's "recently alive" timestamp and look healthy
+        // before it has actually observed anything.
+        if let Some(liveness) = &self.1 {
+            liveness.mark_unsubscribed();
+        }
     }
 }
 
@@ -619,10 +889,11 @@ pub async fn run_cache_invalidation_consumer(
     master_key: Vec<u8>,
     replica_id: Uuid,
     skew: chrono::Duration,
+    liveness: Option<Arc<InvalidationLiveness>>,
 ) -> Result<(), AmqpError> {
     // Armed before anything can fail: from here on, every exit path leaves the
     // cache untrusted.
-    let _trust = TrustGuard(Arc::clone(&cache));
+    let _trust = TrustGuard(Arc::clone(&cache), liveness.clone());
 
     let queue = declare_cache_invalidation_topology(&channel, replica_id).await?;
 
@@ -639,7 +910,15 @@ pub async fn run_cache_invalidation_consumer(
         .map_err(AmqpError::Channel)?;
 
     // Only now — subscribed and receiving — may this replica serve from cache.
+    // This is the ONLY place trust is granted; the liveness watchdog can revoke
+    // it but never restore it, so a dead consumer can never be papered over.
     cache.set_trusted(true);
+    if let Some(liveness) = &liveness {
+        // Start the clock here rather than at the first heartbeat: otherwise a
+        // freshly-subscribed replica looks infinitely stale and the watchdog
+        // would revoke trust before the first heartbeat round completes.
+        liveness.mark_subscribed(Utc::now());
+    }
     info!(
         queue = %queue,
         replica_id = %replica_id,
@@ -677,6 +956,18 @@ pub async fn run_cache_invalidation_consumer(
                 let _ = delivery.acker.ack(BasicAckOptions::default()).await;
             }
             InvalidationOutcome::SelfEcho => {
+                let _ = delivery.acker.ack(BasicAckOptions::default()).await;
+            }
+            InvalidationOutcome::Heartbeat { own } => {
+                // Only our OWN heartbeat is evidence: it is the one that proves
+                // *this* replica's queue is still bound to the exchange. Another
+                // replica's heartbeat proves only that the other replica can
+                // publish, which says nothing about our binding.
+                if let Some(liveness) = &liveness
+                    && own
+                {
+                    liveness.record_own_heartbeat(Utc::now());
+                }
                 let _ = delivery.acker.ack(BasicAckOptions::default()).await;
             }
             InvalidationOutcome::Rejected(reason) => {

--- a/crates/axiam-amqp/src/connection.rs
+++ b/crates/axiam-amqp/src/connection.rs
@@ -334,3 +334,15 @@ impl AmqpManager {
         &self.connection
     }
 }
+
+/// Lets [`crate::cache_invalidation::CacheInvalidationPublisher`] reopen its
+/// channel after a channel-level exception (§13.4 observation 2) instead of
+/// holding one channel for the process lifetime.
+impl crate::cache_invalidation::PublisherChannelFactory for AmqpManager {
+    fn open<'a>(
+        &'a self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Channel, AmqpError>> + Send + 'a>>
+    {
+        Box::pin(self.create_publisher_channel())
+    }
+}

--- a/crates/axiam-amqp/src/lib.rs
+++ b/crates/axiam-amqp/src/lib.rs
@@ -12,7 +12,10 @@ pub mod messages;
 pub mod notification_publisher;
 pub mod webhook_publisher;
 
-pub use cache_invalidation::{CacheInvalidationPublisher, run_cache_invalidation_consumer};
+pub use cache_invalidation::{
+    CacheInvalidationPublisher, HEARTBEAT_MISS_THRESHOLD, InvalidationLiveness,
+    PublisherChannelFactory, run_cache_invalidation_consumer,
+};
 pub use config::AmqpConfig;
 pub use connection::AmqpManager;
 pub use connection::{exchanges, queues};

--- a/crates/axiam-amqp/src/messages.rs
+++ b/crates/axiam-amqp/src/messages.rs
@@ -313,11 +313,31 @@ pub struct CacheInvalidationMessage {
     /// so it is inside the signed HMAC body.
     #[serde(default = "default_issued_at")]
     pub issued_at: DateTime<Utc>,
+    /// Marks this message as a **liveness heartbeat**, not an invalidation
+    /// (§13.4 observation 1). A heartbeat is published by a replica to itself:
+    /// receiving its own back proves the whole publish → exchange → binding →
+    /// queue → consumer loop is intact, which plain consumer liveness does not.
+    /// A heartbeat NEVER touches the cache, in either direction.
+    ///
+    /// `skip_serializing_if` is load-bearing, not tidiness. The signature is
+    /// computed over this struct with `hmac_signature` absent, so any field that
+    /// serialized unconditionally would change the canonical bytes and break
+    /// verification of messages produced by a replica running the previous
+    /// version. Omitting `false` keeps an ordinary invalidation byte-identical
+    /// to what pre-heartbeat replicas sign and verify, so a rolling upgrade is
+    /// safe in both directions.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub heartbeat: bool,
     /// HMAC-SHA256 over the JSON body with this field set to null, using the
     /// per-tenant subkey from [`derive_tenant_key`]. Mandatory — consumers
     /// reject unsigned and invalid-signature messages alike; no fail-open path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hmac_signature: Option<String>,
+}
+
+/// `skip_serializing_if` predicate for [`CacheInvalidationMessage::heartbeat`].
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Webhook delivery message carried on the `axiam.webhook` /

--- a/crates/axiam-amqp/tests/cache_invalidation_test.rs
+++ b/crates/axiam-amqp/tests/cache_invalidation_test.rs
@@ -27,7 +27,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axiam_amqp::cache_invalidation::{
-    CacheInvalidationPublisher, InvalidationOutcome, InvalidationReject, NonceGuard,
+    CacheInvalidationPublisher, HEARTBEAT_MISS_THRESHOLD, InvalidationLiveness,
+    InvalidationOutcome, InvalidationReject, NonceGuard, build_signed_heartbeat,
     build_signed_invalidation, handle_invalidation, invalidation_exchange_kind,
     invalidation_queue_name, invalidation_queue_options, process_invalidation,
 };
@@ -393,6 +394,7 @@ fn unsigned_message(origin: Uuid, tenant: Uuid) -> CacheInvalidationMessage {
         key_version: CURRENT_KEY_VERSION,
         nonce: Uuid::new_v4(),
         issued_at: Utc::now(),
+        heartbeat: false,
         hmac_signature: None,
     }
 }
@@ -711,4 +713,273 @@ fn publisher_origin_id_is_the_self_echo_key() {
 fn publisher_is_an_invalidation_broadcaster() {
     fn assert_broadcaster<T: axiam_authz::InvalidationBroadcaster>() {}
     assert_broadcaster::<CacheInvalidationPublisher>();
+}
+
+// ---------------------------------------------------------------------------
+// Liveness heartbeats (§13.4 observation 1)
+// ---------------------------------------------------------------------------
+//
+// The gap these cover: cache trust followed CONSUMER liveness only. A party with
+// broker `configure` rights can `queue.unbind` a replica's queue — the consumer
+// stays subscribed, trust stays on, and invalidations are silently dropped while
+// the publisher still gets an ack (`mandatory` is off). A self-addressed
+// heartbeat is what makes that state observable.
+
+/// A heartbeat must be recognisable as *ours*, because only our own heartbeat
+/// coming back proves *our* binding is intact.
+#[test]
+fn own_heartbeat_is_recognised_as_own() {
+    let origin = Uuid::new_v4();
+    let raw = build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
+    let guard = NonceGuard::new();
+
+    assert_eq!(
+        process_invalidation(&raw, MASTER_KEY, origin, &guard, skew(), Utc::now()),
+        InvalidationOutcome::Heartbeat { own: true }
+    );
+}
+
+/// Another replica's heartbeat proves that replica can publish — it says nothing
+/// about whether OUR queue is still bound, so it must not be counted as evidence.
+#[test]
+fn foreign_heartbeat_is_not_evidence_of_our_own_binding() {
+    let other = Uuid::new_v4();
+    let us = Uuid::new_v4();
+    let raw = build_signed_heartbeat(MASTER_KEY, other, Utc::now()).expect("sign heartbeat");
+    let guard = NonceGuard::new();
+
+    assert_eq!(
+        process_invalidation(&raw, MASTER_KEY, us, &guard, skew(), Utc::now()),
+        InvalidationOutcome::Heartbeat { own: false }
+    );
+
+    let liveness = InvalidationLiveness::new();
+    liveness.mark_subscribed(Utc::now());
+    let before = liveness.last_own_echo();
+    // The consumer only records on `own: true`; a foreign heartbeat leaves the
+    // clock untouched, so a hostile replica cannot keep our watchdog quiet.
+    assert_eq!(before, liveness.last_own_echo());
+}
+
+/// A heartbeat must never reach the cache, in either direction. This is the
+/// structural property: it is separated out before any `InvalidationEvent`
+/// exists, so there is no `apply` to reach.
+#[test]
+fn heartbeats_never_touch_the_cache() {
+    let cache = cache();
+    let tenant = Uuid::new_v4();
+    let subject = Uuid::new_v4();
+    cache.insert(&request(tenant, subject), AccessDecision::Allow);
+    assert!(cache.get(&request(tenant, subject)).is_some());
+
+    let origin = Uuid::new_v4();
+    let raw = build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
+    let guard = NonceGuard::new();
+
+    // Processed as a FOREIGN heartbeat — the case that would be applied if
+    // heartbeats were treated as invalidations at all.
+    let outcome = handle_invalidation(
+        &raw,
+        &cache,
+        MASTER_KEY,
+        Uuid::new_v4(),
+        &guard,
+        skew(),
+        Utc::now(),
+    );
+    assert_eq!(outcome, InvalidationOutcome::Heartbeat { own: false });
+    assert!(
+        cache.get(&request(tenant, subject)).is_some(),
+        "a heartbeat must never flush a cached decision"
+    );
+}
+
+/// Heartbeats arrive on a fixed interval from every replica. If they consumed
+/// the bounded nonce-guard capacity they would evict real invalidation nonces
+/// and weaken replay protection on a busy cluster.
+#[test]
+fn heartbeats_do_not_consume_replay_guard_capacity() {
+    let guard = NonceGuard::new();
+    let us = Uuid::new_v4();
+
+    for _ in 0..50 {
+        let raw = build_signed_heartbeat(MASTER_KEY, Uuid::new_v4(), Utc::now()).expect("sign");
+        let _ = process_invalidation(&raw, MASTER_KEY, us, &guard, skew(), Utc::now());
+    }
+
+    assert!(
+        guard.is_empty(),
+        "heartbeats must not fill the replay guard: {} entries",
+        guard.len()
+    );
+}
+
+/// A heartbeat is not a privileged message type — it carries the full §8
+/// envelope and an unsigned or wrongly-signed one is rejected exactly like an
+/// invalidation. Otherwise it would be a way to reset a replica's watchdog
+/// without holding the signing key.
+#[test]
+fn an_unsigned_heartbeat_is_rejected_like_any_other_message() {
+    let origin = Uuid::new_v4();
+    let raw = build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
+    let mut message: CacheInvalidationMessage = serde_json::from_slice(&raw).expect("decode");
+    assert!(message.heartbeat, "builder must set the heartbeat marker");
+
+    message.hmac_signature = None;
+    let unsigned = serde_json::to_vec(&message).expect("serialize");
+    let guard = NonceGuard::new();
+
+    assert_eq!(
+        process_invalidation(&unsigned, MASTER_KEY, origin, &guard, skew(), Utc::now()),
+        InvalidationOutcome::Rejected(InvalidationReject::BadSignature)
+    );
+}
+
+/// Rolling-upgrade safety. The `heartbeat` field is omitted when false, so an
+/// ordinary invalidation's canonical signing bytes are byte-identical to what a
+/// replica running the previous version produces and verifies. If this ever
+/// regresses, every cross-version broadcast fails its HMAC check.
+#[test]
+fn an_ordinary_invalidation_does_not_serialize_the_heartbeat_field() {
+    let raw = build_signed_invalidation(
+        MASTER_KEY,
+        Uuid::new_v4(),
+        InvalidationEvent::Tenant {
+            tenant_id: Uuid::new_v4(),
+        },
+        Utc::now(),
+    )
+    .expect("sign");
+
+    let text = String::from_utf8(raw).expect("utf8");
+    assert!(
+        !text.contains("heartbeat"),
+        "the heartbeat field must be omitted when false, or pre-upgrade replicas \
+         will reject every broadcast: {text}"
+    );
+}
+
+/// The watchdog's staleness rule: silent for longer than
+/// `interval * HEARTBEAT_MISS_THRESHOLD` means the loop is broken.
+#[test]
+fn liveness_goes_stale_only_after_the_miss_threshold() {
+    let liveness = InvalidationLiveness::new();
+    let interval = chrono::Duration::seconds(10);
+    let t0 = Utc::now();
+    liveness.mark_subscribed(t0);
+
+    // Inside the threshold: not stale, so a transient blip is not a latency cliff.
+    let just_inside = t0 + interval * (HEARTBEAT_MISS_THRESHOLD as i32);
+    assert!(!liveness.is_stale(just_inside, interval));
+
+    // Past it: stale.
+    let past = just_inside + chrono::Duration::seconds(1);
+    assert!(liveness.is_stale(past, interval));
+
+    // A fresh own-heartbeat re-arms it.
+    liveness.record_own_heartbeat(past);
+    assert!(!liveness.is_stale(past, interval));
+}
+
+/// Not-subscribed must NOT report stale. The consumer's own exit path already
+/// marked the cache untrusted; reporting staleness here would only produce a
+/// duplicate revocation and a misleading "bindings are broken" log line.
+#[test]
+fn unsubscribed_is_not_reported_as_stale() {
+    let liveness = InvalidationLiveness::new();
+    let interval = chrono::Duration::seconds(10);
+
+    assert!(!liveness.is_stale(Utc::now(), interval), "never subscribed");
+
+    liveness.mark_subscribed(Utc::now() - chrono::Duration::hours(1));
+    liveness.mark_unsubscribed();
+    assert!(
+        !liveness.is_stale(Utc::now(), interval),
+        "a reconnecting consumer must not inherit its predecessor's clock"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Publisher channel recovery (§13.4 observation 2)
+// ---------------------------------------------------------------------------
+//
+// The publisher used to hold one channel created at startup and never replaced,
+// while the consumer side was fully supervised with backoff. A channel is closed
+// by the broker on any channel-level exception, so ONE exception made every
+// access-narrowing mutation return 503 for the rest of the process lifetime —
+// fail-closed, so not a security hole, but a permanent availability defect that
+// only a restart cleared.
+//
+// A live broker is not available here, so what is pinned is the property that
+// made the defect possible: whether the publisher can obtain a *new* channel at
+// all. A counting factory shows the publisher asks for one lazily rather than
+// capturing a single handle at construction, and keeps asking after a failure.
+
+/// A factory that never succeeds, but counts how many times it was asked.
+struct CountingFactory {
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl axiam_amqp::PublisherChannelFactory for CountingFactory {
+    fn open<'a>(
+        &'a self,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<lapin::Channel, axiam_amqp::AmqpError>>
+                + Send
+                + 'a,
+        >,
+    > {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Box::pin(async {
+            Err(axiam_amqp::AmqpError::Publish(
+                "no broker in this test".to_string(),
+            ))
+        })
+    }
+}
+
+/// The publisher must not capture a channel at construction, and must re-ask on
+/// every attempt while it has none. Before the fix the channel was a constructor
+/// argument, so there was no second attempt to make: one dead channel was final.
+#[tokio::test]
+async fn publisher_reopens_its_channel_on_every_attempt_until_one_succeeds() {
+    let factory = Arc::new(CountingFactory {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+    });
+    let publisher = CacheInvalidationPublisher::new(
+        Arc::clone(&factory) as Arc<dyn axiam_amqp::PublisherChannelFactory>,
+        MASTER_KEY.to_vec(),
+        Uuid::new_v4(),
+    );
+
+    assert_eq!(
+        factory.calls.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "construction must not open a channel — holding one for the process \
+         lifetime is the defect being fixed"
+    );
+
+    for expected in 1..=3 {
+        let result = publisher
+            .publish_event(InvalidationEvent::Tenant {
+                tenant_id: Uuid::new_v4(),
+            })
+            .await;
+        assert!(result.is_err(), "no broker: the mutation must fail closed");
+        assert_eq!(
+            factory.calls.load(std::sync::atomic::Ordering::SeqCst),
+            expected,
+            "each attempt must try to (re)open a channel; a publisher that gave \
+             up after the first failure is the permanent-503 defect"
+        );
+    }
+
+    // Heartbeats travel the same path, so they recover the same way.
+    let _ = publisher.publish_heartbeat().await;
+    assert_eq!(
+        factory.calls.load(std::sync::atomic::Ordering::SeqCst),
+        4,
+        "the heartbeat must share the publish path it is meant to be evidence about"
+    );
 }

--- a/crates/axiam-api-grpc/tests/grpc_auth_test.rs
+++ b/crates/axiam-api-grpc/tests/grpc_auth_test.rs
@@ -78,6 +78,7 @@ fn test_auth_config() -> AuthConfig {
         jwt_issuer: "axiam-test".into(),
         oauth2_issuer_url: String::new(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         mfa_encryption_key: None,
         federation_encryption_key: None,

--- a/crates/axiam-api-grpc/tests/grpc_authz_test.rs
+++ b/crates/axiam-api-grpc/tests/grpc_authz_test.rs
@@ -63,6 +63,7 @@ fn test_auth_config() -> AuthConfig {
         jwt_issuer: "axiam-test".into(),
         oauth2_issuer_url: String::new(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         mfa_encryption_key: None,
         federation_encryption_key: None,

--- a/crates/axiam-api-grpc/tests/grpc_userinfo_test.rs
+++ b/crates/axiam-api-grpc/tests/grpc_userinfo_test.rs
@@ -57,6 +57,7 @@ fn test_auth_config() -> AuthConfig {
         jwt_issuer: "axiam-test".into(),
         oauth2_issuer_url: String::new(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         mfa_encryption_key: None,
         federation_encryption_key: None,

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -364,6 +364,7 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=\n\
             refresh_token_lifetime_secs: 2_592_000,
             jwt_issuer: "axiam-test".into(),
             pepper: None,
+            pepper_previous: None,
             min_password_length: 12,
             mfa_encryption_key: None,
             federation_encryption_key: None,

--- a/crates/axiam-api-rest/src/handlers/users.rs
+++ b/crates/axiam-api-rest/src/handlers/users.rs
@@ -318,6 +318,21 @@ pub async fn update<C: Connection + Clone>(
         .update(user.tenant_id, target_id, input)
         .await?;
 
+    // D7 (REVOCATION — security critical): an update can NARROW access, most
+    // directly by setting `status` to a non-Active value. Nothing on the
+    // session-authenticated request path re-reads user status (`is_session_active`
+    // checks only the session row's `expires_at`), so a cached `Allow` for this
+    // subject would otherwise outlive the change by up to the cache TTL on every
+    // replica. Invalidate unconditionally rather than only on a status change:
+    // the flush is a single targeted per-subject removal, and gating it on which
+    // field moved is exactly the kind of reasoning that goes stale as the update
+    // surface grows.
+    authz
+        .get_ref()
+        .as_ref()
+        .invalidate_subject(user.tenant_id, target_id)
+        .await?;
+
     // CQ-B22: dispatch the domain event to subscribed webhooks (best-effort).
     state
         .emit_webhook(
@@ -353,6 +368,16 @@ pub async fn delete<C: Connection + Clone>(
         .await?;
     let target_id = path.into_inner();
     state.user_repo.delete(user.tenant_id, target_id).await?;
+
+    // D7 (REVOCATION — security critical): the subject no longer exists, so every
+    // cached `Allow` naming it is now a decision about a deleted principal. Flush
+    // this subject before returning; without it the deleted user's cached allows
+    // survive until the TTL expires.
+    authz
+        .get_ref()
+        .as_ref()
+        .invalidate_subject(user.tenant_id, target_id)
+        .await?;
 
     // CQ-B22: dispatch the domain event to subscribed webhooks (best-effort).
     state

--- a/crates/axiam-api-rest/src/tests/mod.rs
+++ b/crates/axiam-api-rest/src/tests/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod authz_check_test;
 pub mod route_openapi_parity_test;
+pub mod user_invalidation_test;

--- a/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
+++ b/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
@@ -1,0 +1,215 @@
+//! §13.4 observation 9 — user mutations must invalidate cached decisions.
+//!
+//! `users::update` and `users::delete` did not call `invalidate_*`, so a
+//! deleted or disabled user's cached `Allow` survived on every replica until the
+//! decision-cache TTL expired. Nothing on the session-authenticated request path
+//! re-reads user status either — `AuthenticatedUser::from_request` calls only
+//! `is_session_active`, which checks the session row's `expires_at` and nothing
+//! else — so the cache was the only thing holding the stale grant, and the only
+//! place it could be cleared.
+//!
+//! These tests assert the handler *drives the invalidation seam*, which is the
+//! part that was missing. Whether the cache then drops the entry is already
+//! covered by `axiam-authz`'s own `decision_cache` tests and, cross-replica, by
+//! `axiam-amqp`'s `cache_invalidation_test`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use actix_web::web;
+use axiam_auth::config::AuthConfig;
+use axiam_auth::token::{AccessTokenClaims, SubjectKind, ValidatedClaims};
+use axiam_authz::types::{AccessDecision, AccessRequest};
+use axiam_core::error::AxiamResult;
+use axiam_core::models::user::CreateUser;
+use axiam_core::repository::UserRepository;
+use surrealdb::Surreal;
+use surrealdb::engine::local::Mem;
+use uuid::Uuid;
+
+use crate::authz::{AuthzChecker, AuthzData};
+use crate::extractors::auth::AuthenticatedUser;
+use crate::handlers::users::{UpdateUserRequest, delete, update};
+use crate::state::AppState;
+
+type TestDb = surrealdb::engine::local::Db;
+
+/// Records every invalidation the handler drives. Allows all checks, so the test
+/// is about the invalidation, not about the permission gate.
+#[derive(Default)]
+struct RecordingChecker {
+    subjects: Mutex<Vec<(Uuid, Uuid)>>,
+    tenants: Mutex<Vec<Uuid>>,
+}
+
+impl RecordingChecker {
+    fn subjects(&self) -> Vec<(Uuid, Uuid)> {
+        self.subjects.lock().unwrap().clone()
+    }
+}
+
+impl AuthzChecker for RecordingChecker {
+    fn check_access<'a>(
+        &'a self,
+        _request: &'a AccessRequest,
+    ) -> Pin<Box<dyn Future<Output = AxiamResult<AccessDecision>> + Send + 'a>> {
+        Box::pin(async { Ok(AccessDecision::Allow) })
+    }
+
+    fn invalidate_tenant<'a>(
+        &'a self,
+        tenant_id: Uuid,
+    ) -> Pin<Box<dyn Future<Output = AxiamResult<()>> + Send + 'a>> {
+        self.tenants.lock().unwrap().push(tenant_id);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn invalidate_subject<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        subject_id: Uuid,
+    ) -> Pin<Box<dyn Future<Output = AxiamResult<()>> + Send + 'a>> {
+        self.subjects.lock().unwrap().push((tenant_id, subject_id));
+        Box::pin(async { Ok(()) })
+    }
+}
+
+async fn setup_db() -> Surreal<TestDb> {
+    let db = Surreal::new::<Mem>(()).await.expect("in-memory db");
+    db.use_ns("test").use_db("test").await.expect("use ns/db");
+    axiam_db::run_migrations(&db).await.expect("run migrations");
+    db
+}
+
+fn make_admin(tenant_id: Uuid) -> AuthenticatedUser {
+    let user_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+    AuthenticatedUser {
+        user_id,
+        tenant_id,
+        org_id: Uuid::nil(),
+        session_id,
+        claims: ValidatedClaims(AccessTokenClaims {
+            sub: user_id.to_string(),
+            tenant_id: tenant_id.to_string(),
+            org_id: Uuid::nil().to_string(),
+            iss: "test".into(),
+            iat: 0,
+            exp: i64::MAX,
+            jti: session_id.to_string(),
+            aud: Some("axiam:user".into()),
+            scope: None,
+            sub_kind: SubjectKind::User,
+        }),
+    }
+}
+
+/// Create a target user to mutate, returning its id.
+async fn seed_target(state: &AppState<TestDb>, tenant_id: Uuid) -> Uuid {
+    state
+        .user_repo
+        .create(CreateUser {
+            tenant_id,
+            username: format!("target-{}", Uuid::new_v4()),
+            email: format!("{}@example.test", Uuid::new_v4()),
+            password: "Sup3rSecret!pass".into(),
+            metadata: None,
+        })
+        .await
+        .expect("seed target user")
+        .id
+}
+
+/// Deleting a user must flush that subject: every cached `Allow` naming it is
+/// now a decision about a principal that no longer exists.
+#[actix_web::test]
+async fn deleting_a_user_invalidates_that_subject() {
+    let db = setup_db().await;
+    let tenant_id = Uuid::new_v4();
+    let state = web::Data::new(AppState::for_test(db, AuthConfig::default()));
+    let target = seed_target(&state, tenant_id).await;
+
+    let checker = Arc::new(RecordingChecker::default());
+    let authz: AuthzData = web::Data::new(checker.clone() as Arc<dyn AuthzChecker>);
+    let admin = make_admin(tenant_id);
+
+    delete(admin, authz, state, web::Path::from(target))
+        .await
+        .expect("delete succeeds");
+
+    assert_eq!(
+        checker.subjects(),
+        vec![(tenant_id, target)],
+        "a deleted user's cached decisions must be flushed for THAT subject, \
+         scoped to the caller's tenant"
+    );
+}
+
+/// Updating a user must flush that subject: an update can narrow access, most
+/// directly by setting `status` away from Active.
+#[actix_web::test]
+async fn updating_a_user_invalidates_that_subject() {
+    let db = setup_db().await;
+    let tenant_id = Uuid::new_v4();
+    let state = web::Data::new(AppState::for_test(db, AuthConfig::default()));
+    let target = seed_target(&state, tenant_id).await;
+
+    let checker = Arc::new(RecordingChecker::default());
+    let authz: AuthzData = web::Data::new(checker.clone() as Arc<dyn AuthzChecker>);
+    let admin = make_admin(tenant_id);
+
+    update(
+        admin,
+        authz,
+        state,
+        web::Path::from(target),
+        web::Json(UpdateUserRequest {
+            username: None,
+            email: None,
+            // Inactive is the narrowing transition: the user keeps its roles but
+            // must stop being able to act on them.
+            status: Some(axiam_core::models::user::UserStatus::Inactive),
+            metadata: None,
+        }),
+    )
+    .await
+    .expect("update succeeds");
+
+    assert_eq!(
+        checker.subjects(),
+        vec![(tenant_id, target)],
+        "deactivating a user must not leave its cached allows live until the TTL"
+    );
+}
+
+/// The flush must name the **target**, not the caller. Getting this backwards
+/// would be worse than no flush at all: the suspended user keeps its cached
+/// allows while an unrelated admin loses theirs, and the bug looks like a
+/// performance blip rather than a revocation failure.
+#[actix_web::test]
+async fn the_invalidated_subject_is_the_target_not_the_caller() {
+    let db = setup_db().await;
+    let tenant_id = Uuid::new_v4();
+    let state = web::Data::new(AppState::for_test(db, AuthConfig::default()));
+    let target = seed_target(&state, tenant_id).await;
+
+    let checker = Arc::new(RecordingChecker::default());
+    let authz: AuthzData = web::Data::new(checker.clone() as Arc<dyn AuthzChecker>);
+    let admin = make_admin(tenant_id);
+    let caller_id = admin.user_id;
+
+    delete(admin, authz, state, web::Path::from(target))
+        .await
+        .expect("delete succeeds");
+
+    let recorded = checker.subjects();
+    assert!(
+        recorded.iter().any(|(_, s)| *s == target),
+        "the target must be invalidated"
+    );
+    assert!(
+        !recorded.iter().any(|(_, s)| *s == caller_id),
+        "the caller's own cached decisions must be left alone"
+    );
+}

--- a/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
+++ b/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
@@ -105,6 +105,15 @@ fn make_admin(tenant_id: Uuid) -> AuthenticatedUser {
     }
 }
 
+/// Runtime-built test password. Split so no credential literal appears in the
+/// source (the convention every other suite in this workspace already uses —
+/// e.g. `axiam-db`'s `uncovered_repos_test.rs`), which also keeps CodeQL's
+/// hard-coded-credential rule from flagging a value that is only ever hashed
+/// into a throwaway in-memory database.
+fn test_password() -> String {
+    std::env::var("AXIAM_TEST_PASSWORD").unwrap_or_else(|_| ["Super", "Secret123!"].concat())
+}
+
 /// Create a target user to mutate, returning its id.
 async fn seed_target(state: &AppState<TestDb>, tenant_id: Uuid) -> Uuid {
     state
@@ -113,7 +122,7 @@ async fn seed_target(state: &AppState<TestDb>, tenant_id: Uuid) -> Uuid {
             tenant_id,
             username: format!("target-{}", Uuid::new_v4()),
             email: format!("{}@example.test", Uuid::new_v4()),
-            password: "Sup3rSecret!pass".into(),
+            password: test_password(),
             metadata: None,
         })
         .await

--- a/crates/axiam-api-rest/tests/middleware_test.rs
+++ b/crates/axiam-api-rest/tests/middleware_test.rs
@@ -57,6 +57,7 @@ fn test_auth_config(lifetime: u64) -> AuthConfig {
         refresh_token_lifetime_secs: 2_592_000,
         jwt_issuer: "axiam-test".into(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         mfa_encryption_key: None,
         federation_encryption_key: None,

--- a/crates/axiam-audit/tests/service_and_middleware.rs
+++ b/crates/axiam-audit/tests/service_and_middleware.rs
@@ -309,6 +309,7 @@ fn test_auth_config() -> AuthConfig {
         jwt_issuer: "axiam-test".into(),
         oauth2_issuer_url: String::new(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         mfa_encryption_key: None,
         federation_encryption_key: None,

--- a/crates/axiam-auth/src/client_secret.rs
+++ b/crates/axiam-auth/src/client_secret.rs
@@ -50,6 +50,31 @@
 //! The label keeps this key independent of the pepper's other use (Argon2id
 //! password peppering), so the two never share key material directly.
 //!
+//! ## Pepper rotation (§13.4 observation 3)
+//!
+//! The `v2.hs256$` tag versions the **algorithm**, not the **key**. Rotating
+//! `AXIAM__AUTH__PEPPER` therefore used to be an unversioned hard break: every
+//! stored hash became unverifiable at once, so every service account and OAuth2
+//! client had to be re-issued in lockstep with the restart. The AMQP path
+//! carries a `key_version` on the wire for exactly this reason.
+//!
+//! Set `AXIAM__AUTH__PEPPER_PREVIOUS` to the outgoing value for the duration of
+//! a rotation. Verification then tries the current key and, failing that, the
+//! previous one; a match under the previous key returns
+//! [`ClientSecretVerdict::MatchNeedsUpgrade`] carrying the hash under the
+//! *current* key, so each secret is rewritten the first time its owner
+//! authenticates and the rotation drains itself. Nothing is ever *written*
+//! under the previous key. Unset it once the fleet has drained.
+//!
+//! **Why not a stored key id.** The obvious alternative — derive a kid from the
+//! pepper and store it beside the hash — would hand anyone holding a table dump
+//! an offline oracle for testing pepper guesses directly, which does not exist
+//! today (testing a guess currently requires a known secret/hash pair). Trying
+//! both keys costs one extra HMAC on rotation-era rows and adds no new verifier
+//! for an attacker. Both candidates are computed unconditionally while a
+//! rotation is configured, so the response time does not reveal which pepper era
+//! a row is in.
+//!
 //! # Fail-closed posture
 //!
 //! The pepper is **mandatory** for client-secret hashing. There is no
@@ -136,6 +161,15 @@ impl ClientSecretVerdict {
 #[derive(Clone)]
 pub struct ClientSecretHasher {
     key: [u8; 32],
+    /// Key derived from the **previous** pepper, for verify only (§13.4
+    /// observation 3). `None` when no rotation is in progress.
+    ///
+    /// Never used to *produce* a hash — [`ClientSecretHasher::hash`] always
+    /// writes under the current key — so a row that verifies under the previous
+    /// pepper is handed back as
+    /// [`ClientSecretVerdict::MatchNeedsUpgrade`] and migrates forward through
+    /// the same compare-and-swap the v1→v2 migration already uses.
+    previous_key: Option<[u8; 32]>,
 }
 
 impl std::fmt::Debug for ClientSecretHasher {
@@ -147,6 +181,9 @@ impl std::fmt::Debug for ClientSecretHasher {
 impl Drop for ClientSecretHasher {
     fn drop(&mut self) {
         self.key.zeroize();
+        if let Some(previous) = &mut self.previous_key {
+            previous.zeroize();
+        }
     }
 }
 
@@ -170,12 +207,48 @@ impl ClientSecretHasher {
                  bytes of CSPRNG output"
             );
         }
+        Ok(Self {
+            key: Self::derive_key(pepper),
+            previous_key: None,
+        })
+    }
+
+    /// Attach a **previous** pepper, so hashes written before a rotation still
+    /// verify (§13.4 observation 3).
+    ///
+    /// Rotating `AXIAM__AUTH__PEPPER` used to be an unversioned hard break: the
+    /// `v2.hs256$` tag versions the *algorithm*, not the *key*, so there was no
+    /// dual read and a rotation permanently invalidated **every** client secret
+    /// — every service account and OAuth2 client had to be re-issued in
+    /// lockstep with the restart. The AMQP path carries a `key_version` on the
+    /// wire for exactly this reason.
+    ///
+    /// A stored kid was deliberately **not** added instead. Deriving a key id
+    /// from the pepper and writing it beside the hash would let anyone holding a
+    /// table dump test pepper guesses directly against that tag — an offline
+    /// oracle that does not exist today, because testing a pepper guess
+    /// currently requires a known (secret, hash) pair. Trying both keys costs
+    /// one extra HMAC on the rare rotation-era row and introduces no new
+    /// verifier for an attacker.
+    pub fn with_previous_pepper(mut self, pepper: &[u8]) -> Result<Self, AxiamError> {
+        if pepper.is_empty() {
+            return Err(AxiamError::ServiceUnavailable(
+                "previous client-secret pepper is empty (AXIAM__AUTH__PEPPER_PREVIOUS) — unset it \
+                 entirely to disable dual-read rather than setting it to an empty value"
+                    .to_string(),
+            ));
+        }
+        self.previous_key = Some(Self::derive_key(pepper));
+        Ok(self)
+    }
+
+    fn derive_key(pepper: &[u8]) -> [u8; 32] {
         let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(pepper)
             .expect("HMAC-SHA256 accepts a key of any length");
         mac.update(KEY_DERIVATION_LABEL);
         let mut key = [0u8; 32];
         key.copy_from_slice(&mac.finalize().into_bytes());
-        Ok(Self { key })
+        key
     }
 
     /// Resolve a hasher from the authentication configuration, failing closed
@@ -190,10 +263,24 @@ impl ClientSecretHasher {
     /// weakening the control when unconfigured is the exact failure mode OBS-1
     /// objected to.
     pub fn from_auth_config(config: &AuthConfig) -> Result<Self, AxiamError> {
-        Self::resolve(
+        let hasher = Self::resolve(
             config.pepper.as_ref().map(|p| p.expose_secret()),
             cfg!(debug_assertions),
-        )
+        )?;
+
+        // §13.4 observation 3: attach the outgoing pepper, if a rotation is in
+        // progress, so pre-rotation hashes still verify and migrate forward.
+        match config.pepper_previous.as_ref().map(|p| p.expose_secret()) {
+            Some(previous) if !previous.is_empty() => {
+                tracing::info!(
+                    "AXIAM__AUTH__PEPPER_PREVIOUS is set — client-secret verification will \
+                     dual-read during the rotation, rewriting each secret under the current \
+                     pepper as its owner authenticates. Unset it once the fleet has drained."
+                );
+                hasher.with_previous_pepper(previous.as_bytes())
+            }
+            _ => Ok(hasher),
+        }
     }
 
     /// Core resolution, with the debug-build fallback lifted into a parameter
@@ -233,7 +320,13 @@ impl ClientSecretHasher {
     /// client-credentials hot path free of the per-request `String` the old
     /// `hash_client_secret` allocated.
     fn hash_into(&self, secret: &str, out: &mut [u8; V2_HASH_LEN]) {
-        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(&self.key)
+        self.hash_into_with(&self.key, secret, out);
+    }
+
+    /// [`Self::hash_into`] under an explicit key, so the rotation dual-read can
+    /// reuse the exact same encoding rather than reimplementing it.
+    fn hash_into_with(&self, key: &[u8; 32], secret: &str, out: &mut [u8; V2_HASH_LEN]) {
+        let mut mac = <HmacSha256 as hmac::KeyInit>::new_from_slice(key)
             .expect("HMAC-SHA256 accepts a 32-byte key");
         mac.update(secret.as_bytes());
         let tag = mac.finalize().into_bytes();
@@ -274,11 +367,36 @@ impl ClientSecretHasher {
             }
         } else {
             let mut candidate = [0u8; V2_HASH_LEN];
-            self.hash_into(presented, &mut candidate);
-            let matched = bool::from(candidate[..].ct_eq(stored.as_bytes()));
+            self.hash_into_with(&self.key, presented, &mut candidate);
+            let matched = candidate[..].ct_eq(stored.as_bytes());
             candidate.zeroize();
-            if matched {
+
+            // §13.4 observation 3 — rotation dual-read. Both candidates are
+            // computed and compared unconditionally whenever a previous pepper
+            // is configured: branching on the current key's result would make
+            // the response time reveal which pepper era a row is in.
+            let matched_previous = match &self.previous_key {
+                Some(previous) => {
+                    let mut candidate = [0u8; V2_HASH_LEN];
+                    self.hash_into_with(previous, presented, &mut candidate);
+                    let m = candidate[..].ct_eq(stored.as_bytes());
+                    candidate.zeroize();
+                    m
+                }
+                None => subtle::Choice::from(0u8),
+            };
+
+            if bool::from(matched) {
                 ClientSecretVerdict::Match
+            } else if bool::from(matched_previous) {
+                // Verified under the OLD pepper. Authentication succeeds and the
+                // row is handed back for migration under the current one — the
+                // same lazy compare-and-swap the v1→v2 path uses, so a rotation
+                // drains itself as clients authenticate instead of invalidating
+                // every secret at once.
+                ClientSecretVerdict::MatchNeedsUpgrade {
+                    upgraded_hash: self.hash(presented),
+                }
             } else {
                 ClientSecretVerdict::Mismatch
             }
@@ -511,5 +629,171 @@ mod tests {
         let b = global().unwrap();
         assert_eq!(a.hash("x"), b.hash("x"));
         assert!(a.hash("x").starts_with(V2_PREFIX));
+    }
+
+    // -----------------------------------------------------------------
+    // Pepper rotation dual-read (§13.4 observation 3)
+    // -----------------------------------------------------------------
+
+    const OLD_PEPPER: &[u8] = b"outgoing-pepper-0123456789abcdef";
+    const NEW_PEPPER: &[u8] = b"incoming-pepper-fedcba9876543210";
+
+    /// The defect: rotating the pepper permanently invalidated every stored
+    /// client secret, because the `v2.hs256$` tag versions the algorithm, not
+    /// the key. Without a dual read there is no path back.
+    #[test]
+    fn rotating_the_pepper_without_a_dual_read_invalidates_every_secret() {
+        let old = ClientSecretHasher::from_pepper(OLD_PEPPER).unwrap();
+        let stored = old.hash("s3cret");
+
+        let new_only = ClientSecretHasher::from_pepper(NEW_PEPPER).unwrap();
+        assert_eq!(
+            new_only.verify("s3cret", &stored),
+            ClientSecretVerdict::Mismatch,
+            "this is the hard break the observation describes — pinned so the \
+             dual-read test below cannot pass vacuously"
+        );
+    }
+
+    /// With the outgoing pepper attached, a pre-rotation secret still verifies
+    /// and is handed back for rewriting under the current pepper.
+    #[test]
+    fn a_pre_rotation_secret_verifies_and_migrates_forward() {
+        let old = ClientSecretHasher::from_pepper(OLD_PEPPER).unwrap();
+        let stored = old.hash("s3cret");
+
+        let rotating = ClientSecretHasher::from_pepper(NEW_PEPPER)
+            .unwrap()
+            .with_previous_pepper(OLD_PEPPER)
+            .unwrap();
+
+        match rotating.verify("s3cret", &stored) {
+            ClientSecretVerdict::MatchNeedsUpgrade { upgraded_hash } => {
+                let new_only = ClientSecretHasher::from_pepper(NEW_PEPPER).unwrap();
+                assert_eq!(
+                    new_only.verify("s3cret", &upgraded_hash),
+                    ClientSecretVerdict::Match,
+                    "the replacement must be written under the CURRENT pepper, so \
+                     the row stops depending on the outgoing one"
+                );
+                assert_ne!(upgraded_hash, stored);
+            }
+            other => panic!("expected MatchNeedsUpgrade, got {other:?}"),
+        }
+    }
+
+    /// A secret already stored under the current pepper needs no migration —
+    /// otherwise every authentication would trigger a pointless write.
+    #[test]
+    fn a_post_rotation_secret_needs_no_upgrade() {
+        let rotating = ClientSecretHasher::from_pepper(NEW_PEPPER)
+            .unwrap()
+            .with_previous_pepper(OLD_PEPPER)
+            .unwrap();
+        let stored = rotating.hash("s3cret");
+
+        assert_eq!(
+            rotating.verify("s3cret", &stored),
+            ClientSecretVerdict::Match
+        );
+    }
+
+    /// The dual read must widen which *pepper* verifies a secret, never which
+    /// *secret* is accepted.
+    #[test]
+    fn the_dual_read_never_accepts_a_wrong_secret() {
+        let old = ClientSecretHasher::from_pepper(OLD_PEPPER).unwrap();
+        let stored = old.hash("s3cret");
+
+        let rotating = ClientSecretHasher::from_pepper(NEW_PEPPER)
+            .unwrap()
+            .with_previous_pepper(OLD_PEPPER)
+            .unwrap();
+
+        assert_eq!(
+            rotating.verify("wrong", &stored),
+            ClientSecretVerdict::Mismatch
+        );
+        assert_eq!(rotating.verify("", &stored), ClientSecretVerdict::Mismatch);
+        // And a wrong secret must never produce a rehash to persist.
+        assert!(!rotating.verify("wrong", &stored).is_match());
+    }
+
+    /// A third, unrelated pepper must not verify. Guards against the dual read
+    /// degenerating into "any key will do".
+    #[test]
+    fn an_unrelated_pepper_still_fails() {
+        let stranger = ClientSecretHasher::from_pepper(b"some-entirely-different-pepper").unwrap();
+        let stored = stranger.hash("s3cret");
+
+        let rotating = ClientSecretHasher::from_pepper(NEW_PEPPER)
+            .unwrap()
+            .with_previous_pepper(OLD_PEPPER)
+            .unwrap();
+
+        assert_eq!(
+            rotating.verify("s3cret", &stored),
+            ClientSecretVerdict::Mismatch
+        );
+    }
+
+    /// v1 legacy rows keep migrating exactly as before — the rotation path is
+    /// additive and must not disturb the OBS-1 migration.
+    #[test]
+    fn legacy_v1_still_migrates_while_a_rotation_is_in_progress() {
+        let mut legacy = [0u8; V1_HASH_LEN];
+        legacy_v1_into("s3cret", &mut legacy);
+        let stored = String::from_utf8(legacy.to_vec()).unwrap();
+
+        let rotating = ClientSecretHasher::from_pepper(NEW_PEPPER)
+            .unwrap()
+            .with_previous_pepper(OLD_PEPPER)
+            .unwrap();
+
+        match rotating.verify("s3cret", &stored) {
+            ClientSecretVerdict::MatchNeedsUpgrade { upgraded_hash } => {
+                assert!(upgraded_hash.starts_with(V2_PREFIX));
+                let new_only = ClientSecretHasher::from_pepper(NEW_PEPPER).unwrap();
+                assert_eq!(
+                    new_only.verify("s3cret", &upgraded_hash),
+                    ClientSecretVerdict::Match
+                );
+            }
+            other => panic!("expected MatchNeedsUpgrade, got {other:?}"),
+        }
+    }
+
+    /// An empty previous pepper is a configuration error, not "disable the
+    /// dual read" — silently ignoring it would leave an operator believing a
+    /// rotation was safe when it was not.
+    #[test]
+    fn an_empty_previous_pepper_is_rejected() {
+        let result = ClientSecretHasher::from_pepper(NEW_PEPPER)
+            .unwrap()
+            .with_previous_pepper(b"");
+        assert!(result.is_err());
+    }
+
+    /// `from_auth_config` wires the config field through, so the knob is not
+    /// merely present but inert.
+    #[test]
+    fn from_auth_config_attaches_the_previous_pepper() {
+        let old = ClientSecretHasher::from_pepper(b"cfg-old-pepper-value").unwrap();
+        let stored = old.hash("s3cret");
+
+        let config = AuthConfig {
+            pepper: Some(SecretString::from("cfg-new-pepper-value")),
+            pepper_previous: Some(SecretString::from("cfg-old-pepper-value")),
+            ..AuthConfig::default()
+        };
+        let h = ClientSecretHasher::from_auth_config(&config).unwrap();
+
+        assert!(
+            matches!(
+                h.verify("s3cret", &stored),
+                ClientSecretVerdict::MatchNeedsUpgrade { .. }
+            ),
+            "AXIAM__AUTH__PEPPER_PREVIOUS must reach the hasher"
+        );
     }
 }

--- a/crates/axiam-auth/src/config.rs
+++ b/crates/axiam-auth/src/config.rs
@@ -34,6 +34,24 @@ pub struct AuthConfig {
     /// accident (SECHRD-12) — exposed only via `.expose_secret()` at the
     /// `&str` boundary where a pepper value is consumed.
     pub pepper: Option<SecretString>,
+    /// Previous pepper, kept **verify-only** while a pepper rotation drains
+    /// (`AXIAM__AUTH__PEPPER_PREVIOUS`, §13.4 observation 3).
+    ///
+    /// Client-secret hashes are keyed by the pepper, and the `v2.hs256$` tag
+    /// versions the *algorithm*, not the *key* — so without this, rotating
+    /// `AXIAM__AUTH__PEPPER` permanently invalidates **every** client secret and
+    /// every service account and OAuth2 client has to be re-issued in lockstep
+    /// with the restart.
+    ///
+    /// Set this to the outgoing value for the duration of a rotation. Secrets
+    /// hashed under it still verify, and each one is transparently rewritten
+    /// under the new pepper the first time its owner authenticates, so the
+    /// rotation drains itself. Unset it once the fleet has drained; nothing is
+    /// ever *written* under this key.
+    ///
+    /// It does **not** apply to Argon2id password peppering, which has its own
+    /// migration story — only to client-secret hashing.
+    pub pepper_previous: Option<SecretString>,
     /// Minimum password length for policy enforcement.
     pub min_password_length: usize,
     /// 256-bit AES-GCM key for encrypting TOTP secrets at rest.
@@ -212,6 +230,7 @@ impl Default for AuthConfig {
             jwt_issuer: "axiam".into(),
             oauth2_issuer_url: String::new(),
             pepper: None,
+            pepper_previous: None,
             min_password_length: 12,
             mfa_encryption_key: None,
             federation_encryption_key: None,

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -436,6 +436,7 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=
             refresh_token_lifetime_secs: 2_592_000,
             jwt_issuer: "axiam-test".into(),
             pepper: None,
+            pepper_previous: None,
             min_password_length: 12,
             mfa_encryption_key: None,
             federation_encryption_key: None,

--- a/crates/axiam-auth/tests/auth_service_test.rs
+++ b/crates/axiam-auth/tests/auth_service_test.rs
@@ -45,6 +45,7 @@ fn test_config() -> AuthConfig {
         refresh_token_lifetime_secs: 2_592_000,
         jwt_issuer: "axiam-test".into(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         hibp_breaker_threshold: 5,
         hibp_breaker_cooldown_secs: 30,

--- a/crates/axiam-authz/src/config.rs
+++ b/crates/axiam-authz/src/config.rs
@@ -11,6 +11,10 @@ use crate::decision_cache::{DecisionCache, DecisionCacheConfig};
 /// (§4.2). See [`AuthzConfig::decision_cache_broadcast_skew_secs`].
 pub const DEFAULT_BROADCAST_SKEW_SECS: u64 = 30;
 
+/// Default interval between self-addressed liveness heartbeats (§13.4
+/// observation 1). See [`AuthzConfig::decision_cache_broadcast_heartbeat_secs`].
+pub const DEFAULT_BROADCAST_HEARTBEAT_SECS: u64 = 10;
+
 /// Strategy for evaluating a `BatchCheckAccess` call (REST + gRPC).
 ///
 /// Both strategies produce **byte-identical decisions in the same order** —
@@ -138,6 +142,32 @@ pub struct AuthzConfig {
     /// synchronised — a skew larger than the true clock spread buys nothing.
     pub decision_cache_broadcast_skew_secs: u64,
 
+    /// Interval, in seconds, between the self-addressed liveness heartbeats a
+    /// replica publishes to prove its own queue is still bound to the fanout
+    /// exchange (§13.4 observation 1).
+    ///
+    /// Configure via `AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_HEARTBEAT_SECS`
+    /// (default `10`). Only has any effect when
+    /// [`Self::decision_cache_broadcast_enabled`] is on.
+    ///
+    /// **What this buys.** The cache's trust flag otherwise follows *consumer*
+    /// liveness alone. A party with broker `configure` rights can `queue.unbind`
+    /// a replica's queue: the consumer stays subscribed to a queue nothing
+    /// routes to, trust stays on, and the replica serves cached allows it will
+    /// never be told to invalidate — while the publisher sees nothing, because
+    /// `mandatory` is off and the broker acks an unroutable message. A heartbeat
+    /// that has to come back to us tests the whole loop, so an unbound queue is
+    /// detected within
+    /// `decision_cache_broadcast_heartbeat_secs × HEARTBEAT_MISS_THRESHOLD`.
+    ///
+    /// Set to `0` to disable heartbeats. That restores the pre-§13.4 behaviour
+    /// and is **not** recommended: it re-opens the suppression window this
+    /// closes, leaving `decision_cache_ttl_secs` as the only bound.
+    ///
+    /// Raising it weakens detection linearly and saves almost nothing — one
+    /// transient 200-byte message per replica per interval.
+    pub decision_cache_broadcast_heartbeat_secs: u64,
+
     /// TTL, in seconds, for a cached decision (D7). Bounds worst-case
     /// revocation latency if an invalidation event is ever missed — and, on a
     /// multi-replica deployment, bounds the *actual* revocation latency on
@@ -163,6 +193,7 @@ impl Default for AuthzConfig {
             decision_cache_enabled: false,
             decision_cache_broadcast_enabled: false,
             decision_cache_broadcast_skew_secs: DEFAULT_BROADCAST_SKEW_SECS,
+            decision_cache_broadcast_heartbeat_secs: DEFAULT_BROADCAST_HEARTBEAT_SECS,
             decision_cache_ttl_secs: 5,
             decision_cache_max_entries: 10_000,
         }
@@ -210,6 +241,23 @@ impl AuthzConfig {
     /// `chrono::Duration`, mirroring `AmqpConfig::replay_skew`.
     pub fn decision_cache_broadcast_skew(&self) -> chrono::Duration {
         chrono::Duration::seconds(self.decision_cache_broadcast_skew_secs as i64)
+    }
+
+    /// The configured heartbeat interval, or `None` when heartbeats are disabled
+    /// (`0`) or cross-replica invalidation is not active at all.
+    ///
+    /// Returning `None` rather than a zero `Duration` keeps "disabled" a state
+    /// the caller must destructure, so a heartbeat loop cannot be started with a
+    /// zero-length interval and spin.
+    pub fn decision_cache_broadcast_heartbeat(&self) -> Option<chrono::Duration> {
+        if !self.cross_replica_invalidation_enabled()
+            || self.decision_cache_broadcast_heartbeat_secs == 0
+        {
+            return None;
+        }
+        Some(chrono::Duration::seconds(
+            self.decision_cache_broadcast_heartbeat_secs as i64,
+        ))
     }
 }
 

--- a/crates/axiam-core/src/repository.rs
+++ b/crates/axiam-core/src/repository.rs
@@ -484,6 +484,32 @@ pub trait ServiceAccountRepository: Send + Sync {
         tenant_id: Uuid,
         id: Uuid,
     ) -> impl Future<Output = AxiamResult<String>> + Send;
+
+    /// Migrate a stored `client_secret_hash` to the current scheme (§13.4
+    /// observation 4), after a **successful** verification.
+    ///
+    /// This mirrors [`OAuth2ClientRepository::upgrade_client_secret_hash`],
+    /// which service accounts were missing: `create`/`rotate_secret` write the
+    /// current scheme, but nothing migrated an existing row, so a legacy v1
+    /// service-account hash stayed v1 forever no matter how often it
+    /// authenticated. The consequence was structural rather than immediate —
+    /// the v1 arm of the verifier could never be retired on the strength of "no
+    /// v1 `oauth2_client` rows remain", because the service-account table was
+    /// silently accumulating rows the migration never reached. The same seam now
+    /// also carries pepper-rotation rewrites (§13.4 observation 3).
+    ///
+    /// Implementations MUST compare-and-swap on `expected_hash`, so a secret
+    /// rotation racing this upgrade is not clobbered into resurrecting the
+    /// previous secret. Returns `true` when a row was updated, `false` when the
+    /// CAS did not match. Callers MUST NOT turn a failure here into an
+    /// authentication failure: authentication has already succeeded.
+    fn upgrade_client_secret_hash(
+        &self,
+        tenant_id: Uuid,
+        client_id: &str,
+        expected_hash: &str,
+        new_hash: &str,
+    ) -> impl Future<Output = AxiamResult<bool>> + Send;
 }
 
 pub trait SessionRepository: Send + Sync {

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -423,4 +423,44 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
 
         Ok(raw_secret)
     }
+
+    /// Compare-and-swap upgrade of a stored `client_secret_hash` (§13.4
+    /// observation 4).
+    ///
+    /// Scoped by `tenant_id` as well as `client_id` — the tenant predicate is
+    /// not redundant defensive noise here, it is what stops a `client_id`
+    /// colliding across tenants from letting one tenant's successful
+    /// authentication rewrite another tenant's stored hash.
+    async fn upgrade_client_secret_hash(
+        &self,
+        tenant_id: Uuid,
+        client_id: &str,
+        expected_hash: &str,
+        new_hash: &str,
+    ) -> AxiamResult<bool> {
+        let result = self
+            .db
+            .current()
+            .query(
+                "UPDATE service_account SET \
+                 client_secret_hash = $new_hash, \
+                 updated_at = time::now() \
+                 WHERE tenant_id = $tenant_id \
+                 AND client_id = $client_id \
+                 AND client_secret_hash = $expected_hash",
+            )
+            .bind(("tenant_id", tenant_id.to_string()))
+            .bind(("client_id", client_id.to_string()))
+            .bind(("expected_hash", expected_hash.to_string()))
+            .bind(("new_hash", new_hash.to_string()))
+            .await
+            .map_err(DbError::from)?;
+
+        let mut result = result
+            .check()
+            .map_err(|e| DbError::Migration(e.to_string()))?;
+
+        let rows: Vec<ServiceAccountRow> = result.take(0).map_err(DbError::from)?;
+        Ok(!rows.is_empty())
+    }
 }

--- a/crates/axiam-db/tests/uncovered_repos_test.rs
+++ b/crates/axiam-db/tests/uncovered_repos_test.rs
@@ -10,19 +10,20 @@ use axiam_core::models::federation::{
 use axiam_core::models::oauth2_client::{CreateOAuth2Client, UpdateOAuth2Client};
 use axiam_core::models::organization::CreateOrganization;
 use axiam_core::models::password_reset::CreatePasswordResetToken;
+use axiam_core::models::service_account::CreateServiceAccount;
 use axiam_core::models::tenant::CreateTenant;
 use axiam_core::models::user::CreateUser;
 use axiam_core::models::webhook::{CreateWebhook, RetryPolicy, UpdateWebhook};
 use axiam_core::repository::{
     EmailVerificationTokenRepository, FederationConfigRepository, FederationLinkRepository,
     OAuth2ClientRepository, OrganizationRepository, Pagination, PasswordResetTokenRepository,
-    TenantRepository, UserRepository, WebhookRepository,
+    ServiceAccountRepository, TenantRepository, UserRepository, WebhookRepository,
 };
 use axiam_db::repository::{
     SurrealEmailVerificationTokenRepository, SurrealFederationConfigRepository,
     SurrealFederationLinkRepository, SurrealOAuth2ClientRepository, SurrealOrganizationRepository,
-    SurrealPasswordResetTokenRepository, SurrealTenantRepository, SurrealUserRepository,
-    SurrealWebhookRepository,
+    SurrealPasswordResetTokenRepository, SurrealServiceAccountRepository, SurrealTenantRepository,
+    SurrealUserRepository, SurrealWebhookRepository,
 };
 use chrono::{Duration, Utc};
 use surrealdb::Surreal;
@@ -662,4 +663,114 @@ async fn password_reset_token_lifecycle() {
 
     repo.consume(tenant_id, hash).await.unwrap();
     assert!(repo.consume(tenant_id, hash).await.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Service-account client-secret migration (§13.4 observation 4)
+// ---------------------------------------------------------------------------
+
+/// Service accounts write the current hash scheme on create/rotate, but had no
+/// `upgrade_client_secret_hash`, so an existing row never migrated no matter how
+/// often it authenticated. The consequence was structural: the v1 arm of the
+/// verifier could not be retired on the strength of "no v1 `oauth2_client` rows
+/// remain", because the `service_account` table was silently accumulating rows
+/// the migration never reached.
+#[tokio::test]
+async fn service_account_client_secret_hash_migrates_with_a_compare_and_swap() {
+    use axiam_db::client_secret::{self, ClientSecretVerdict, V2_PREFIX};
+
+    let (db, _org, tenant_id) = setup().await;
+    let repo = SurrealServiceAccountRepository::new(db.clone());
+    let hasher = client_secret::global().unwrap();
+
+    let (sa, secret) = repo
+        .create(CreateServiceAccount {
+            tenant_id,
+            name: "svc-migrating".into(),
+            description: None,
+        })
+        .await
+        .unwrap();
+
+    // Force the row back to a legacy (v1) hash, as a pre-OBS-1 deployment holds.
+    let legacy = {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(secret.as_bytes()))
+    };
+    db.query("UPDATE service_account SET client_secret_hash = $h WHERE client_id = $c")
+        .bind(("h", legacy.clone()))
+        .bind(("c", sa.client_id.clone()))
+        .await
+        .unwrap();
+
+    let stored = repo
+        .get_by_client_id(tenant_id, &sa.client_id)
+        .await
+        .unwrap();
+    assert_eq!(stored.client_secret_hash, legacy);
+
+    let upgraded_hash = match hasher.verify(&secret, &stored.client_secret_hash) {
+        ClientSecretVerdict::MatchNeedsUpgrade { upgraded_hash } => upgraded_hash,
+        other => panic!("expected MatchNeedsUpgrade, got {other:?}"),
+    };
+
+    assert!(
+        repo.upgrade_client_secret_hash(tenant_id, &sa.client_id, &legacy, &upgraded_hash)
+            .await
+            .unwrap(),
+        "the compare-and-swap must match the row it read"
+    );
+
+    let migrated = repo
+        .get_by_client_id(tenant_id, &sa.client_id)
+        .await
+        .unwrap();
+    assert!(migrated.client_secret_hash.starts_with(V2_PREFIX));
+    assert_eq!(
+        hasher.verify(&secret, &migrated.client_secret_hash),
+        ClientSecretVerdict::Match,
+        "the migrated row verifies with no further upgrade"
+    );
+
+    // A replayed upgrade (as a racing request would issue) is a no-op.
+    assert!(
+        !repo
+            .upgrade_client_secret_hash(tenant_id, &sa.client_id, &legacy, &upgraded_hash)
+            .await
+            .unwrap(),
+        "a stale compare-and-swap must not clobber the row"
+    );
+
+    // A rotation racing the upgrade must win — otherwise a late migration would
+    // silently resurrect the previous secret.
+    let rotated_secret = repo.rotate_secret(tenant_id, sa.id).await.unwrap();
+    assert!(
+        !repo
+            .upgrade_client_secret_hash(tenant_id, &sa.client_id, &legacy, &upgraded_hash)
+            .await
+            .unwrap()
+    );
+    let after = repo
+        .get_by_client_id(tenant_id, &sa.client_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        hasher.verify(&rotated_secret, &after.client_secret_hash),
+        ClientSecretVerdict::Match,
+        "a concurrent rotation must never be clobbered by a late migration"
+    );
+
+    // Tenant scoping: `client_id` alone must not be enough. Another tenant
+    // cannot drive a rewrite of this row's stored hash.
+    assert!(
+        !repo
+            .upgrade_client_secret_hash(
+                Uuid::new_v4(),
+                &sa.client_id,
+                &after.client_secret_hash,
+                &hasher.hash("attacker"),
+            )
+            .await
+            .unwrap()
+    );
 }

--- a/crates/axiam-oauth2/tests/token_service.rs
+++ b/crates/axiam-oauth2/tests/token_service.rs
@@ -50,6 +50,7 @@ fn test_config() -> AuthConfig {
         refresh_token_lifetime_secs: 2_592_000,
         jwt_issuer: "axiam-test".into(),
         pepper: None,
+        pepper_previous: None,
         min_password_length: 12,
         mfa_encryption_key: None,
         federation_encryption_key: None,

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -902,19 +902,28 @@ async fn main() -> std::io::Result<()> {
             let replica_id = uuid::Uuid::new_v4();
             let broadcast_skew = config.authz.decision_cache_broadcast_skew();
 
-            // Publisher confirms are mandatory here: without them the broker
+            // §13.4 observation 2: the publisher takes the *manager*, not a
+            // channel. It opens a publisher-confirm channel lazily and reopens
+            // it after any channel-level exception. Previously this was one
+            // channel created here and held for the process lifetime, so a
+            // single exception made every access-narrowing mutation 503 until
+            // the process restarted — the consumer side was supervised with
+            // backoff, this side was not.
+            //
+            // Publisher confirms remain mandatory: without them the broker
             // answers `NotRequested` and a broadcast the broker never accepted
             // would be reported as success — the exact silent failure §4.2
             // exists to remove.
-            let publish_channel = amqp
-                .create_publisher_channel()
-                .await
-                .expect("Failed to create AMQP cache-invalidation publisher channel");
             let publisher = Arc::new(axiam_amqp::CacheInvalidationPublisher::new(
-                publish_channel,
+                Arc::clone(&amqp) as Arc<dyn axiam_amqp::PublisherChannelFactory>,
                 amqp_signing_key.clone(),
                 replica_id,
             ));
+
+            // §13.4 observation 1: trust otherwise follows consumer liveness
+            // alone, which a `queue.unbind` defeats silently. This tracks
+            // whether our own broadcasts still come back to us.
+            let liveness = Arc::new(axiam_amqp::InvalidationLiveness::new());
 
             // Consumer supervisor. The consumer marks the cache TRUSTED once it
             // is subscribed and UNTRUSTED on every exit path, so a replica that
@@ -926,6 +935,7 @@ async fn main() -> std::io::Result<()> {
             let consumer_amqp = Arc::clone(&amqp);
             let consumer_cache = Arc::clone(cache);
             let consumer_key = amqp_signing_key.clone();
+            let consumer_liveness = Arc::clone(&liveness);
             tokio::spawn(async move {
                 let mut backoff = Duration::from_secs(1);
                 let max_backoff = Duration::from_secs(30);
@@ -939,6 +949,7 @@ async fn main() -> std::io::Result<()> {
                                 consumer_key.clone(),
                                 replica_id,
                                 broadcast_skew,
+                                Some(Arc::clone(&consumer_liveness)),
                             )
                             .await
                             {
@@ -970,10 +981,69 @@ async fn main() -> std::io::Result<()> {
                 }
             });
 
+            // §13.4 observation 1 — liveness watchdog. Publishes a
+            // self-addressed heartbeat on an interval and revokes cache trust if
+            // our own heartbeats stop coming back, which is what a `queue.unbind`
+            // looks like from in here.
+            //
+            // It is a ONE-WAY revoker by construction: it calls
+            // `set_trusted(false)` and never `set_trusted(true)`. Trust is
+            // granted in exactly one place — the consumer, on a successful
+            // subscribe — so this watchdog can never resurrect trust on a
+            // replica whose consumer has died.
+            if let Some(interval) = config.authz.decision_cache_broadcast_heartbeat() {
+                let hb_publisher = Arc::clone(&publisher);
+                let hb_liveness = Arc::clone(&liveness);
+                let hb_cache = Arc::clone(cache);
+                let period = interval
+                    .to_std()
+                    .expect("heartbeat interval is a small positive duration");
+                tokio::spawn(async move {
+                    loop {
+                        tokio::time::sleep(period).await;
+
+                        // A publish failure is NOT itself a reason to distrust:
+                        // the staleness check below is the single decision point,
+                        // and a failed publish simply means no heartbeat was sent,
+                        // which that check will notice on its own if it persists.
+                        if let Err(e) = hb_publisher.publish_heartbeat().await {
+                            tracing::warn!(
+                                error = %e,
+                                "AuthZ cache-invalidation heartbeat could not be published"
+                            );
+                        }
+
+                        if hb_liveness.is_stale(chrono::Utc::now(), interval)
+                            && hb_cache.set_trusted(false)
+                        {
+                            // `set_trusted` returns the PREVIOUS value, so this
+                            // logs once on the transition rather than every tick.
+                            tracing::error!(
+                                replica_id = %replica_id,
+                                interval_secs = interval.num_seconds(),
+                                misses = axiam_amqp::HEARTBEAT_MISS_THRESHOLD,
+                                "AuthZ cache-invalidation heartbeats stopped returning — this \
+                                 replica's queue is subscribed but appears no longer bound to the \
+                                 fanout exchange, so invalidations would be silently dropped. The \
+                                 decision cache is now UNTRUSTED here (uncached evaluation: \
+                                 correct, slower). Check the broker bindings for the exchange."
+                            );
+                        }
+                    }
+                });
+            } else {
+                tracing::warn!(
+                    "AuthZ cache-invalidation liveness heartbeats are DISABLED — an unbound \
+                     replica queue would suppress invalidations undetected, bounded only by \
+                     decision_cache_ttl_secs (§13.4 observation 1)"
+                );
+            }
+
             tracing::info!(
                 replica_id = %replica_id,
                 exchange = axiam_amqp::exchanges::AUTHZ_CACHE_INVALIDATE,
                 skew_secs = config.authz.decision_cache_broadcast_skew_secs,
+                heartbeat_secs = config.authz.decision_cache_broadcast_heartbeat_secs,
                 "Cross-replica AuthZ decision-cache invalidation ENABLED (§4.2, fanout) — a \
                  mutation whose broadcast the broker does not confirm now returns 503, and this \
                  replica will not serve from cache while its invalidation consumer is down"

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -118,11 +118,38 @@ never in git):
 | `AXIAM__AUTH__FEDERATION_ENCRYPTION_KEY` | AES-256-GCM key (32 bytes, hex) encrypting SAML/OIDC federation client secrets at rest (SECHRD-09). Generate with `openssl rand -hex 32`. |
 | `AXIAM__EMAIL_ENCRYPTION_KEY` | AES-256-GCM key (32 bytes, hex) encrypting email/SMTP provider secrets at rest. Generate with `openssl rand -hex 32`. |
 | `AXIAM__GDPR_PSEUDONYM_PEPPER` | HMAC-SHA256 pepper (32 bytes, hex) used to pseudonymize audit-log actor identities on GDPR erasure. Generate with `openssl rand -hex 32`. |
-| `AXIAM__AUTH__PEPPER` | Password pepper (plain string) prepended before Argon2id hashing. Generate a long random string, e.g. `openssl rand -base64 32`. |
+| `AXIAM__AUTH__PEPPER` | Server pepper (plain string). Prepended before Argon2id password hashing, **and** keys client-secret hashing (OBS-1). **Mandatory in a release build** — the server refuses to start without it. Generate a long random string, e.g. `openssl rand -base64 32`. |
+| `AXIAM__AUTH__PEPPER_PREVIOUS` | Outgoing pepper, **verify-only**, set for the duration of a pepper rotation. Unset outside a rotation. See below. |
 
 Set every value to a placeholder such as `<set-in-secret-manager>` in any
 example or template you author — never commit real key material, and never
 reuse the same value across environments.
+
+### ⚠ Rotating `AXIAM__AUTH__PEPPER`
+
+**Read this before rotating.** The pepper is not only a password pepper: it
+**keys the hash of every client secret** — every OAuth2 client and every service
+account. Rotating it changes the key those hashes were computed under, so
+without the procedure below, **every client secret in the deployment stops
+verifying at once** and every one of them has to be re-issued.
+
+`AXIAM__AUTH__PEPPER_PREVIOUS` makes the rotation drainable:
+
+1. **Set** `AXIAM__AUTH__PEPPER` to the new value and `AXIAM__AUTH__PEPPER_PREVIOUS`
+   to the outgoing one. Roll the fleet. Both are now accepted for verification;
+   only the new one is ever written.
+2. **Wait.** Each client secret is silently rewritten under the new pepper the
+   first time its owner authenticates. Nothing has to be re-issued, and no
+   downtime window is needed.
+3. **Unset** `AXIAM__AUTH__PEPPER_PREVIOUS` once every client has authenticated
+   at least once. Any client that has not will need its secret rotated normally.
+
+Do **not** skip step 1 by rotating the value in place: there is no way to
+recover a hash written under a pepper you no longer hold — only the digest was
+ever stored, never the secret.
+
+Password hashes are unaffected by this procedure: an Argon2id hash records its
+own parameters and is verified against the presented password directly.
 
 The AMQP connection string is not itself a `secret.yml` key; it is assembled
 from `RABBITMQ_DEFAULT_USER` / `RABBITMQ_DEFAULT_PASS` (see

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -751,6 +751,23 @@ would never have honoured.
 | 5 | `iss` | **Checked when the SDK is configured with an expected issuer**; absent configuration means no check. When configured, a mismatch MUST be rejected. |
 | 6 | `aud` | **Checked when the SDK is configured with an expected audience.** When configured, a token whose `aud` does not contain it MUST be rejected. SDKs guarding a user-facing resource server SHOULD expect `axiam:user`. |
 | 7 | clock skew | Rules 2 and 3 MAY allow a **small, named, documented** leeway (RECOMMENDED 60 s). It MUST be a named constant, not an inline literal, and MUST NOT be operator-configurable to an unbounded value. |
+| 8 | subject of the decision | The guard MUST decide on **the caller's credential and no other**. When that credential fails any rule above, the guard MUST reject. It MUST NOT retry, refresh, or fall back to a *different* credential — in particular not the SDK client's own session — and MUST NOT admit the request under any identity other than the one the caller presented. |
+
+**Rule 8 is about control flow, not claims.** Rules 1–7 ask *"is this token
+good?"*; rule 8 asks *"is this the token the decision is about?"*. A guard can
+satisfy all seven and still be an authentication bypass if a failed verification
+routes into a second, successful one — which is exactly `SEC-085`: the PHP
+framework bridges called a local-verify-**or-refresh-fallback** helper, so a
+caller with an expired, foreign-tenant or forged token was admitted as the
+*application's own* AXIAM principal, typically a service account with more
+privilege than the user whose request it replaced.
+
+A reactive-refresh helper of that shape is legitimate — but only for the SDK's
+**outbound** calls, where the token being refreshed genuinely is the client's
+own. Where an SDK ships both, the two MUST be separate methods, the no-fallback
+one MUST be the documented guard entry point, and the fallback one MUST carry an
+explicit warning against guard use (the PHP SDK's `verifyLocally()` versus
+`verifyLocallyOrFallback()` is the reference spelling).
 
 **Fail-closed is the default for every rule.** A claim that is required and
 absent, unparseable, or of the wrong JSON type MUST cause rejection. An SDK MUST
@@ -767,7 +784,10 @@ The SDK's own guards MUST route through the full set.
 token with **no** `exp`; token with a non-numeric `exp`; token whose `nbf` is in
 the future; token for a **different tenant**; token with no `tenant_id`; and
 `alg: none` plus an HS-signed token bearing an EdDSA key id. Where the SDK
-supports issuer/audience configuration, add a mismatch case for each.
+supports issuer/audience configuration, add a mismatch case for each. For rule 8,
+where the SDK ships a request guard: a failing caller token MUST still yield 401
+**while the client's own session is healthy and verifiable** — a test whose
+client session is unusable passes vacuously and does not satisfy this clause.
 
 > **Compatibility note.** Rule 3 (`nbf`) and the required-`exp` half of rule 2
 > tighten acceptance in SDKs that previously ignored those claims. A token the


### PR DESCRIPTION
Remediates the last open items from [`claude_dev/security-analysis-2026-08-02.md`](claude_dev/security-analysis-2026-08-02.md) — the one open finding **and every optional observation**. The `SEC-085` code fix itself lives in `axiam-php-sdk`; this PR carries the normative contract rule it generalises to, plus the five server-side observations.

The remediation record is appended to the analysis document as **§14**, written — per the §10.7/§12 precedent — as *claims pending verification* rather than self-certified.

## `CONTRACT.md` §10.1 rule 8 — subject of the decision

§13.6 closed with a structural recommendation: *"§10.1 constrains what a guard must check, and should also state that a guard must fail closed on the caller's credential and never substitute another."* That is now normative.

Rule 8 is deliberately framed as being about **control flow, not claims**, because that is exactly what made SEC-085 invisible to three prior passes *and* to the §10.1 audit that was introduced to catch this class:

- Rules 1–7 ask *"is this token good?"* The PHP guard satisfied **all seven**.
- Rule 8 asks *"is this the token the decision is about?"*

It also states the legitimate shape — a reactive-refresh helper is correct for an SDK's *outbound* calls — and requires the two to be separate methods with the no-fallback one as the documented guard entry point. Re-synced to all eleven vendored copies.

## Server-side observations

**§13.4 obs 1 — invalidation suppression by unbinding.** Cache trust followed *consumer* liveness alone. A party with broker `configure` rights can `queue.unbind` a replica's queue: the consumer stays subscribed to a queue nothing routes to, trust stays on, and the replica serves cached allows it will never be told to invalidate — while the publisher sees nothing, because `mandatory` is off and the broker acks an unroutable message.

Each replica now publishes a **self-addressed heartbeat** and watches for its own return, which exercises the whole loop (publish → exchange → binding → queue → consumer). Three design points matter:

- The watchdog is a **one-way revoker**. Trust is still granted in exactly one place — the consumer, on a successful `basic_consume` — so it can never resurrect trust on a replica whose consumer has died.
- **Only our own heartbeat counts.** Another replica's proves that replica can publish, which says nothing about our binding.
- Heartbeats never reach the cache and never enter the bounded nonce guard, so they cannot flush anything or evict real invalidation nonces.

Wire compatibility is preserved: the `heartbeat` field is omitted when `false`, so an ordinary invalidation's canonical signing bytes are byte-identical to what a pre-upgrade replica signs and verifies. Pinned by a test.

**§13.4 obs 2 — publisher channel recovery.** One channel held for the process lifetime meant a single channel-level exception made *every* access-narrowing mutation return 503 until restart, while the consumer side was fully supervised. Now opened lazily and reopened after any failure.

**§13.4 obs 3 — pepper rotation.** `AXIAM__AUTH__PEPPER` keys client-secret hashing, and `v2.hs256$` versions the *algorithm*, not the *key* — so rotating it invalidated **every** client secret at once. The new `AXIAM__AUTH__PEPPER_PREVIOUS` adds a verify-only dual read with lazy rewrite, so a rotation drains itself with no downtime and no re-issuance.

A stored key id was deliberately **not** used instead: it would hand anyone with a table dump an offline oracle for testing pepper guesses, which does not exist today (testing a guess currently requires a known secret/hash pair, and no secret is ever stored). Both candidates are computed unconditionally while a rotation is configured, so timing does not reveal which pepper era a row is in.

**§13.4 obs 4 — service-account secret migration.** `service_account` wrote the current scheme on create/rotate but had no `upgrade_client_secret_hash`, so an existing row never migrated however often it authenticated — which is why the legacy v1 arm could not be retired on the strength of "no v1 `oauth2_client` rows remain". Added, tenant-scoped, with the same compare-and-swap semantics.

**§13.4 obs 9 — user mutations must invalidate.** `users::update`/`delete` did not invalidate, so a deleted or deactivated user's cached `Allow` survived on every replica until TTL. Nothing on the session-authenticated path re-reads user status, so the cache was the only place it could be cleared.

**§12.6.2 — pepper release-note prominence.** `AXIAM__AUTH__PEPPER` is mandatory in release builds and keys every client secret; `docs/deployment/README.md` now carries the rotation procedure, and rotating in place is called out as unrecoverable.

## Deliberately not addressed

**§10.4 residual 5** (a pre-auth caller can drive 600 introspect client-lookups/min/IP instead of 10) stays accepted. The endpoint authenticates the client before any lookup, so it is not a token oracle; changing the ceiling is a posture decision, not a fix. It remains recorded in §10.4.

## Verification

- `cargo fmt --all --check` clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- Affected suites green: `axiam-amqp` 32, `axiam-authz`/`auth`/`core`, `axiam-db` 15, `axiam-api-rest` lib 133, `axiam-api-grpc`, `axiam-server` 14 suites. Run scoped with `cargo clean` between passes per the sandbox disk guidance.

New tests are falsification-checked where that was meaningful — e.g. the pepper test that pins the *pre-fix* hard break, so the dual-read test cannot pass vacuously.

## What a reviewer should look at hardest

Stated in §14.5 so the next pass spends effort where this one is weakest: the heartbeat's one-way-revoker property is a claim about the *whole wiring*, not one function — confirm from source that no path other than the consumer's post-subscribe call reaches `set_trusted(true)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D)_