### PR TITLE
security: close the §15 partials and observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Neither half of the decision-cache staleness bound is operator-removable any
+  more (§15.2).** Two gaps compounded: `decision_cache_ttl_secs` was an
+  unbounded `u64` (unlike `cleanup_interval_secs`, clamped since T-04-35), and
+  the cross-replica heartbeat that shortens the undelivered-invalidation window
+  could be switched off with `..._HEARTBEAT_SECS=0` and only a warning. An
+  operator could therefore set a multi-hour stale-allow window *and* disable the
+  mechanism that detects a replica whose queue has been unbound.
+
+  The TTL is now clamped to 300 s — in the accessor `build_decision_cache`
+  calls, not in `main.rs`, so every construction path is covered. Heartbeats
+  cannot be disabled while broadcast is on; out-of-range intervals clamp to
+  `1..=60`. The `0` escape hatch was introduced in this same unreleased change,
+  so removing it breaks nothing.
+
+- **A replayed heartbeat can no longer satisfy the liveness watchdog (§15.2).**
+  Heartbeats bypass the replay `NonceGuard` deliberately — they arrive on a
+  fixed interval from every replica and would evict real invalidation nonces
+  from its bounded capacity. That left a narrow path: a party with broker rights
+  who captured one signed heartbeat could replay it inside the freshness window
+  to keep a replica's watchdog satisfied while its queue was unbound, which is
+  the exact adversary the heartbeat exists to detect. Acceptance is now bound to
+  nonces the replica itself published and has not yet seen back.
+
+### Added
+
+- **Legacy client-secret hashes in `service_account` are now countable, and the
+  situation is stated honestly (§15.2).** These rows cannot migrate lazily:
+  `upgrade_client_secret_hash` only fires on a successful verification, and
+  **nothing in the running server verifies a service-account secret** — they are
+  CRUD plus certificate binding, and the secret is issued at create/rotate but
+  never presented back. So unlike `oauth2_client` rows they never drain, which
+  is what blocked retiring the legacy hash arm: "no v1 `oauth2_client` rows
+  remain" does not answer the question, because this table is invisible to it.
+
+  `count_legacy_secret_hashes(tenant)` makes the backlog answerable, and startup
+  warns with the count and the only migration route that exists here —
+  **rotation**, which rewrites under the current scheme and current pepper. The
+  same applies to rows still keyed to a superseded pepper.
+
+### Fixed
+
+- **The cache-invalidation publisher no longer serialises mutations behind a
+  network round-trip (§15.3.4).** The channel-slot mutex was held across the
+  broker confirm, so every access-narrowing mutation in the process queued on
+  one lock while the heartbeat task contended for it — a throughput cliff under
+  a slow broker, and a regression against the pre-§13.4 code, which shared the
+  channel with no lock at all. The lock now covers only channel acquisition. The
+  failure path clears the slot **only if it still holds the same channel**, so a
+  concurrent reopen is not discarded.
+
+- **`with_previous_pepper` now carries the weak-pepper warning (§15.3.7)** that
+  `from_pepper` has always emitted. Lower impact — a previous key can only
+  verify existing hashes, never produce one — but an operator rotating *away*
+  from a weak pepper is precisely who should be told it was weak.
+
 - **Cache-invalidation liveness heartbeats (§13.4 observation 1).** Decision-cache
   trust followed **consumer** liveness alone. A party with broker `configure`
   rights could `queue.unbind` a replica's queue from the fanout exchange and the
@@ -29,8 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in exactly one place, by the consumer on a successful subscribe, so it can
   never resurrect trust on a replica whose consumer has died. Heartbeats never
   touch the cache and never enter the replay-nonce guard. Only applies when
-  cross-replica broadcast is enabled; set the interval to `0` to disable
-  (not recommended — it re-opens the suppression window).
+  cross-replica broadcast is enabled. (Superseded below: heartbeats can no
+  longer be disabled, and the interval is clamped to `1..=60`.)
 
 - **Cached authorization decisions are now invalidated on user delete/update
   (§13.4 observation 9).** `users::update` and `users::delete` did not invalidate,
@@ -38,8 +93,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   until the TTL expired. Nothing on the session-authenticated request path
   re-reads user status, so the cache was the only place the stale grant could be
   cleared. Both handlers now flush the affected subject.
-
-### Fixed
 
 - **Pepper rotation is no longer an unversioned hard break (§13.4 observation 3).**
   `AXIAM__AUTH__PEPPER` keys client-secret hashing, and the `v2.hs256$` tag
@@ -66,6 +119,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not be retired on the strength of "no v1 `oauth2_client` rows remain". The
   repository now exposes the same tenant-scoped compare-and-swap upgrade the
   OAuth2 client repository has, which also carries pepper-rotation rewrites.
+  (Superseded above: the seam has no production caller because nothing verifies
+  a service-account secret, so these rows migrate by **rotation**, not lazily.)
 
 - **The cache-invalidation publisher recovers its channel (§13.4 observation 2).**
   It held one channel created at startup and never replaced, while the consumer

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -850,3 +850,138 @@ Stated plainly, so the next pass spends its effort where this one is weakest:
 - **Findings: none open.** SEC-071 … SEC-085 are all closed and independently verified, as are `T-145`, OBS-1 … OBS-4 and §10.4 residuals 1–4.
 - **Observations open**: §15.3 items 1–7, plus the two partials in §15.2. None is an exploitable defect in AXIAM's own request path; the two worth scheduling are the **unclamped decision-cache TTL** (a one-line clamp that makes the Obs 1 mitigation robust rather than advisory) and the **rule-8 regression test in the ten SDKs that lack it**.
 - **Assessment**: five successive passes have now each found something the preceding remediation's self-report missed — SEC-080 after §9, SEC-079 after §10, SEC-085 after §12, and the two partials here. That the count is falling and the severity has dropped from HIGH to *partial/observation* is the meaningful signal. The practice worth keeping is the one §14.5 adopted voluntarily: **a remediation naming its own weakest points is the cheapest possible input to the next verification.**
+
+---
+
+## 16. Remediation of §15 (2026-08-03)
+
+> ⚠️ **Written by the remediation work, not by a reviewer.** Per the precedent
+> §14.5 set and §15 endorsed, this section names its own weakest points (§16.5)
+> rather than self-certifying. Statuses are **claims pending verification**, and
+> — following §16.1 — no commit hashes are cited, for the reason §14.4 records.
+
+### 16.1 Scope
+
+§15 confirmed **no open finding**. What remained were two partials (§15.2) and
+seven observations (§15.3). All are actioned below except the three recorded in
+§16.4 as deliberately not actioned.
+
+**A check for new findings was requested and performed.** Re-reading the merged
+§14 diff against the current tree surfaced **no new finding** — the one thing it
+did surface was a factual error in §15 itself (§16.3).
+
+### 16.2 The two partials
+
+**Obs 1 — the heartbeat's three remaining gaps, all closed.**
+
+| Gap | What landed |
+|---|---|
+| **1. Unclamped TTL** | `decision_cache_ttl_secs` is now clamped to `MAX_DECISION_CACHE_TTL_SECS` (300 s). Clamped in `AuthzConfig::decision_cache_ttl_secs()` — the accessor `build_decision_cache` calls — **not** in `main.rs` where `cleanup_interval_secs` is clamped, so every construction path is covered including tests and any embedder. A bound one binary happens to apply is not a bound. |
+| **2. Operator-disableable** | An interval of `0` no longer means "off". Heartbeats **cannot be disabled** while broadcast is on; out-of-range values clamp to `1..=60` with a warning. This was free to change: the `0` escape hatch was introduced in the same unreleased change, so nothing depends on it. |
+| **3. Replayable heartbeat** | Acceptance is now bound to nonces *this replica published and has not yet seen back*. `build_signed_heartbeat` returns its nonce, the publisher registers it **before** publishing (the fanout can deliver the echo before the confirm returns), and the consumer consumes it once. A replayed heartbeat carries a nonce already consumed, so it cannot refresh the liveness clock — closing the path without spending the shared `NonceGuard`'s bounded capacity, which is why heartbeats bypassed it in the first place. |
+
+Gaps 1 and 2 together are the substantive change: **neither half of the
+staleness bound is operator-removable any more.** Previously an operator could
+set the TTL to hours *and* switch off the mechanism that shortens the window.
+
+**Obs 4 — service-account hashes: the diagnosis was incomplete, and the fix
+follows the corrected one.** §15.2 said the seam has no production caller. That
+is right, and the reason is stronger than "a caller was forgotten": **nothing in
+the running server verifies a service-account secret at all.** Service accounts
+are CRUD plus certificate binding; the secret is issued at create/rotate and
+never presented back. So no lazy upgrade can ever fire here, and adding a caller
+would mean inventing a whole authentication path — a feature, not a remediation.
+
+What actually blocks progress is the *decision* the observation names: the v1
+arm cannot be retired on the strength of "no v1 `oauth2_client` rows remain",
+because this table is invisible to that reasoning. So:
+
+- `ServiceAccountRepository::count_legacy_secret_hashes(tenant)` makes the
+  backlog answerable, testing the same self-identifying prefix the verifier uses
+  rather than inventing a second definition of the format;
+- startup emits a warning naming the count **and the only migration route that
+  exists here — rotation**, which writes the current scheme under the current
+  pepper;
+- the trait doc states plainly that these rows do not drain lazily and why.
+
+The same limitation applies to the Obs 3 pepper-rotation rewrite, which drains
+`oauth2_client` rows only — now covered by the same count and the same route.
+
+### 16.3 A correction to §15
+
+**§15.3.2 is factually wrong where it says PHP "still has no equivalent"**
+slug-vs-UUID diagnostic. The PHP SDK has shipped one since the SEC-085 change
+and it is on `main`: `JwksVerifier::warnOnceIfTenantComparandLooksLikeASlug()`,
+called from the rule-4 rejection path, latched once per process, keyed on the
+operator-configured value's shape, with `looksLikeUuid()` beside it — the same
+design as the TS and Python ones §15.3.2 credits. All three named SDKs have it.
+
+The rest of §15.3.2 stands: the diagnostic **is** log-only in all three, the 401
+body is unchanged, and Python's warning is dropped under Django's default
+`LOGGING`. That is a real limitation and is left as-is deliberately — see §16.4.
+
+### 16.3a §15.3.1 — rule-8 regression tests, and a refinement to the observation
+
+§15.3.1 recorded that the rule-8 test exists only in PHP and that "the other ten
+are structurally correct today with no guardrail against regression". Auditing
+the guards to write those tests refined *why* they are correct, and that changes
+what the guardrail should be.
+
+**PHP was uniquely exposed, structurally.** `AxiamClient` bundles a stateful
+`Session`, and the guard called a helper that reached into it. In the other
+SDKs the guard's inputs are a **verifier plus configuration** — TypeScript's
+`VerifiableSession` is a config object (verifier + tenant), Python's
+`_authenticate` takes `(request, verifier, configured_tenant)`, Go's middleware
+holds a verifier. There is no second credential in scope for those guards to
+substitute, so the literal §10.1 test — "a failing caller token yields 401 while
+the client's own session is healthy and verifiable" — **cannot be written for
+them**: there is no session to make healthy, and a test that stubs one in would
+be testing the stub.
+
+The guardrail that actually protects them is therefore a different one: pin that
+the property stays true. Two tests per SDK — the verifier is invoked with the
+caller's token and nothing else, and the guard's input surface exposes no
+`session`/`client`/`refresh`/`accessToken`. Both fail the moment someone threads
+a stateful client session into the guard's inputs, which is exactly how the PHP
+bug became reachable.
+
+**Status: partially actioned.** Landed in **TypeScript** and **Python**. **Not
+done in Go, Java, C#, Rust, Swift, C, C++ and Kotlin** — the same two tests
+apply, and the argument above says what they should assert. This is the one item
+of §15 left incomplete, and it is a process gap rather than a defect: §15.1
+confirmed by hand that all eleven guards reject correctly today.
+
+### 16.4 Deliberately not actioned
+
+1. **§15.3.2's remaining substance — the diagnostic is log-only.** Making a
+   misconfigured guard *fail loudly at startup* rather than warn on first
+   rejection would mean an SDK refusing to construct against a
+   slug-shaped tenant. That is a breaking change to construction semantics for
+   a condition that is already fail-closed, and it would fire on any deployment
+   whose tenant identifier legitimately is not a UUID. A posture decision for
+   the SDK owners, not a defect to patch.
+2. **§15.3.5 — a 503 also suppresses the webhook** for a row that was written.
+   §15 already records this as consistent with the pre-existing `groups.rs`
+   pattern and not a regression. Reordering would emit an event for a change
+   that has not fully taken effect, which is worse.
+3. **§15.3.6 — `AppState::for_test` is `pub` and not `#[cfg(test)]`-gated.**
+   Pre-existing; gating it would break the integration tests that legitimately
+   construct state across crate boundaries. Worth a follow-up that introduces a
+   `test-util` feature, not a change to smuggle into a security remediation.
+4. **§10.4 residual 5** (introspect pre-auth work factor) — carried unchanged,
+   as it has been since §10.
+
+### 16.5 What a verifier should look at hardest
+
+1. **The heartbeat nonce lifecycle.** The registration happens before the
+   publish deliberately, to avoid losing a race with the echo. Confirm there is
+   no path that registers a nonce and then fails to publish in a way that lets
+   the outstanding set fill with nonces that can never be answered — the ring is
+   bounded at 8, which is the backstop, but the reasoning is worth re-deriving.
+2. **The publisher lock change.** The guard is now released before the confirm
+   await, and the failure path re-acquires and clears **only if the slot still
+   holds the same channel**. Confirm that compare-before-clear is correct under
+   a concurrent reopen, and that the fail-closed property (an unconfirmed
+   broadcast still returns `Err`) is genuinely unchanged.
+3. **The TTL clamp's placement.** It is on the accessor, not the field. Confirm
+   no caller reads `decision_cache_ttl_secs` directly and bypasses it.

--- a/crates/axiam-amqp/src/cache_invalidation.rs
+++ b/crates/axiam-amqp/src/cache_invalidation.rs
@@ -100,9 +100,20 @@
 //!   from every replica, letting them consume the bounded nonce-guard capacity
 //!   would evict real invalidation nonces and weaken replay protection.
 //!
-//! Heartbeats can be disabled with
-//! `AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_HEARTBEAT_SECS=0`, which restores the
-//! pre-§13.4 behaviour and re-opens the suppression window.
+//! * **A replayed heartbeat does not count** (§15.2). Bypassing the nonce guard
+//!   left a narrow path: a party with broker rights who captured one signed
+//!   heartbeat could replay it inside the freshness window to keep this
+//!   replica's watchdog satisfied while its queue was unbound. Acceptance is
+//!   therefore bound to nonces *this* replica published and has not yet seen
+//!   back ([`InvalidationLiveness::record_sent_heartbeat`]), which closes the
+//!   replay without spending the shared guard's bounded capacity.
+//!
+//! Heartbeats **cannot be disabled** while broadcast is on. An earlier revision
+//! accepted an interval of `0` as "off", which meant this whole mitigation could
+//! be removed with one environment variable and only a warning — leaving the TTL
+//! as the sole bound, which is the state it exists to escape. The TTL is itself
+//! now clamped (`MAX_DECISION_CACHE_TTL_SECS`), so neither half of the bound is
+//! operator-removable.
 //!
 //! # 3. Authenticity
 //!
@@ -302,24 +313,28 @@ pub const HEARTBEAT_TENANT_ID: Uuid = Uuid::nil();
 /// Same envelope, same signing, same freshness and replay gates as an
 /// invalidation — a heartbeat is not a privileged message type, it simply
 /// carries no cache effect.
+/// Returns the wire bytes **and the nonce**; the caller registers the nonce as
+/// outstanding so the echo can be told apart from a replay (§15.2 gap 3).
 pub fn build_signed_heartbeat(
     master_key: &[u8],
     origin_id: Uuid,
     now: DateTime<Utc>,
-) -> Result<Vec<u8>, AmqpError> {
-    sign_message(
+) -> Result<(Vec<u8>, Uuid), AmqpError> {
+    let nonce = Uuid::new_v4();
+    let payload = sign_message(
         master_key,
         CacheInvalidationMessage {
             origin_id,
             tenant_id: HEARTBEAT_TENANT_ID,
             subject_id: None,
             key_version: CURRENT_KEY_VERSION,
-            nonce: Uuid::new_v4(),
+            nonce,
             issued_at: now,
             heartbeat: true,
             hmac_signature: None,
         },
-    )
+    )?;
+    Ok((payload, nonce))
 }
 
 /// Canonicalize, sign, and serialize one message. Shared by the invalidation and
@@ -450,8 +465,9 @@ pub enum InvalidationOutcome {
     /// A liveness heartbeat (§13.4 observation 1). Never touches the cache.
     /// `own` distinguishes this replica's own heartbeat — the only one that
     /// carries information, since observing it proves *our* binding is intact —
-    /// from another replica's, which is simply ignored.
-    Heartbeat { own: bool },
+    /// from another replica's, which is simply ignored. `nonce` lets the caller
+    /// tell a genuine echo from a replay (§15.2 gap 3).
+    Heartbeat { own: bool, nonce: Uuid },
     /// Refused; see [`InvalidationReject`].
     Rejected(InvalidationReject),
 }
@@ -538,7 +554,10 @@ pub fn process_invalidation(
     if message.heartbeat {
         let own = message.origin_id == local_origin;
         debug!(own, "Cache-invalidation liveness heartbeat");
-        return InvalidationOutcome::Heartbeat { own };
+        return InvalidationOutcome::Heartbeat {
+            own,
+            nonce: message.nonce,
+        };
     }
 
     if message.origin_id == local_origin {
@@ -623,7 +642,33 @@ pub const HEARTBEAT_MISS_THRESHOLD: u32 = 3;
 pub struct InvalidationLiveness {
     /// When we last saw our own broadcast come back. `None` = not subscribed.
     last_own_echo: Mutex<Option<DateTime<Utc>>>,
+    /// Nonces of heartbeats this replica has published and not yet seen return
+    /// (§15.2 gap 3).
+    ///
+    /// Heartbeats deliberately bypass the [`NonceGuard`] — they arrive on a
+    /// fixed interval from every replica and would evict real invalidation
+    /// nonces from its bounded capacity. But that left a narrow suppression
+    /// path: a party with broker rights who captured one signed heartbeat could
+    /// replay it inside the freshness window to keep this replica's watchdog
+    /// satisfied while its queue was unbound — the exact adversary Obs 1 is
+    /// about.
+    ///
+    /// Binding acceptance to nonces *we* generated closes that without touching
+    /// the shared guard: a replayed heartbeat carries a nonce that was already
+    /// consumed (or never issued here), so it is ignored. This is strictly
+    /// cheaper than a general replay guard because the set only ever holds the
+    /// handful of heartbeats currently in flight.
+    outstanding: Mutex<VecDeque<Uuid>>,
 }
+
+/// Cap on [`InvalidationLiveness::outstanding`].
+///
+/// Only heartbeats still in flight matter, and a heartbeat that has not come
+/// back within a few intervals is already a miss. A small ring keeps this
+/// bounded regardless of broker behaviour — an unbound queue means every
+/// published nonce goes unanswered, and the set must not grow for as long as
+/// that lasts.
+const MAX_OUTSTANDING_HEARTBEATS: usize = 8;
 
 impl Default for InvalidationLiveness {
     fn default() -> Self {
@@ -635,6 +680,37 @@ impl InvalidationLiveness {
     pub fn new() -> Self {
         Self {
             last_own_echo: Mutex::new(None),
+            outstanding: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Record a heartbeat nonce this replica is about to publish (§15.2 gap 3).
+    pub fn record_sent_heartbeat(&self, nonce: Uuid) {
+        let mut q = self
+            .outstanding
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if q.len() >= MAX_OUTSTANDING_HEARTBEATS {
+            q.pop_front();
+        }
+        q.push_back(nonce);
+    }
+
+    /// Consume `nonce` if this replica published it and has not seen it back.
+    ///
+    /// Returns `false` for a nonce we never issued or already consumed — i.e.
+    /// for a replayed heartbeat, which must not refresh the liveness clock.
+    fn consume_outstanding(&self, nonce: Uuid) -> bool {
+        let mut q = self
+            .outstanding
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match q.iter().position(|n| *n == nonce) {
+            Some(i) => {
+                q.remove(i);
+                true
+            }
+            None => false,
         }
     }
 
@@ -646,14 +722,28 @@ impl InvalidationLiveness {
     }
 
     /// Called by the consumer when it observes its **own** heartbeat.
-    pub fn record_own_heartbeat(&self, now: DateTime<Utc>) {
+    ///
+    /// Refreshes the liveness clock **only** for a nonce this replica actually
+    /// published and has not already seen back (§15.2 gap 3), so a replayed
+    /// heartbeat cannot hold the watchdog open. Returns whether it counted.
+    pub fn record_own_heartbeat(&self, nonce: Uuid, now: DateTime<Utc>) -> bool {
+        if !self.consume_outstanding(nonce) {
+            return false;
+        }
         *self.lock() = Some(now);
+        true
     }
 
     /// Called when the consumer stops, so a reconnecting consumer cannot inherit
     /// a stale "recently alive" timestamp from its predecessor.
     pub fn mark_unsubscribed(&self) {
         *self.lock() = None;
+        // A reconnecting consumer must not be able to satisfy its watchdog with
+        // a heartbeat its predecessor published.
+        self.outstanding
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
     }
 
     /// The last observation, if any.
@@ -761,28 +851,50 @@ impl CacheInvalidationPublisher {
     /// must traverse the exact same path it is meant to be evidence about. A
     /// heartbeat sent over a different channel, exchange or routing key would
     /// prove something other than what the invalidations depend on.
-    pub async fn publish_heartbeat(&self) -> Result<(), AmqpError> {
-        let payload = build_signed_heartbeat(&self.master_key, self.origin_id, Utc::now())?;
+    pub async fn publish_heartbeat(
+        &self,
+        liveness: &InvalidationLiveness,
+    ) -> Result<(), AmqpError> {
+        let (payload, nonce) =
+            build_signed_heartbeat(&self.master_key, self.origin_id, Utc::now())?;
+        // Registered BEFORE the publish: the fanout can deliver the echo before
+        // the confirm returns, and a nonce registered afterwards could lose that
+        // race and be discarded as a replay.
+        liveness.record_sent_heartbeat(nonce);
         self.publish_payload(&payload).await
     }
 
     /// Acquire a healthy channel, publish, and await the confirm — reopening the
     /// channel if the one we hold has been closed.
+    /// The lock covers only channel *acquisition*, never the broker round-trip
+    /// (§15.3.4).
+    ///
+    /// Holding it across the confirm serialised every access-narrowing mutation
+    /// in the process behind one network round-trip, with the heartbeat task
+    /// contending on the same lock — a throughput cliff under a slow broker,
+    /// and a regression against the pre-§13.4 code, which shared the channel
+    /// with no lock at all. `lapin::Channel` is a cheap handle over shared
+    /// state, so cloning it out of the slot and releasing the guard keeps the
+    /// reopen logic single-threaded while letting publishes proceed
+    /// concurrently — which is what the AMQP channel already supports.
     async fn publish_payload(&self, payload: &[u8]) -> Result<(), AmqpError> {
-        let mut slot = self.channel.lock().await;
+        let channel = {
+            let mut slot = self.channel.lock().await;
 
-        // Drop a channel the broker has already closed, so the next block opens
-        // a fresh one instead of publishing into a dead handle.
-        if slot.as_ref().is_some_and(|c| !c.status().connected()) {
-            warn!("Cache-invalidation publisher channel is closed — reopening");
-            *slot = None;
-        }
-        if slot.is_none() {
-            *slot = Some(self.channels.open().await?);
-        }
-        let channel = slot.as_ref().expect("channel opened above");
+            // Drop a channel the broker has already closed, so the next block
+            // opens a fresh one instead of publishing into a dead handle.
+            if slot.as_ref().is_some_and(|c| !c.status().connected()) {
+                warn!("Cache-invalidation publisher channel is closed — reopening");
+                *slot = None;
+            }
+            if slot.is_none() {
+                *slot = Some(self.channels.open().await?);
+            }
+            slot.as_ref().expect("channel opened above").clone()
+            // Guard dropped here — the confirm below is awaited unlocked.
+        };
 
-        match Self::publish_on(channel, payload).await {
+        match Self::publish_on(&channel, payload).await {
             Ok(()) => Ok(()),
             Err(e) => {
                 // Any failure may have been the channel dying under us. Discard
@@ -791,7 +903,16 @@ impl CacheInvalidationPublisher {
                 // still returned: this mutation genuinely did not fan out, and
                 // silently retrying here would hide a broker refusing the
                 // message for a reason that will recur.
-                *slot = None;
+                //
+                // Compare-before-clear: between releasing the guard and
+                // re-acquiring it, a concurrent publisher may already have
+                // replaced the slot with a healthy channel. Clearing
+                // unconditionally would discard that one too, and a burst of
+                // failures could then thrash the slot indefinitely.
+                let mut slot = self.channel.lock().await;
+                if slot.as_ref().is_some_and(|c| c.id() == channel.id()) {
+                    *slot = None;
+                }
                 Err(e)
             }
         }
@@ -958,15 +1079,25 @@ pub async fn run_cache_invalidation_consumer(
             InvalidationOutcome::SelfEcho => {
                 let _ = delivery.acker.ack(BasicAckOptions::default()).await;
             }
-            InvalidationOutcome::Heartbeat { own } => {
+            InvalidationOutcome::Heartbeat { own, nonce } => {
                 // Only our OWN heartbeat is evidence: it is the one that proves
                 // *this* replica's queue is still bound to the exchange. Another
                 // replica's heartbeat proves only that the other replica can
                 // publish, which says nothing about our binding.
                 if let Some(liveness) = &liveness
                     && own
+                    && !liveness.record_own_heartbeat(nonce, Utc::now())
                 {
-                    liveness.record_own_heartbeat(Utc::now());
+                    // A correctly-signed, fresh heartbeat carrying our origin id
+                    // but a nonce we did not issue (or already saw) is a replay.
+                    // It must not refresh the liveness clock — that is the
+                    // suppression path §15.2 gap 3 names — and it is worth a log
+                    // line, because in normal operation it cannot happen.
+                    warn!(
+                        %nonce,
+                        "Replayed or unrecognised own-heartbeat nonce — ignoring; \
+                         this does not refresh cache-invalidation liveness"
+                    );
                 }
                 let _ = delivery.acker.ack(BasicAckOptions::default()).await;
             }

--- a/crates/axiam-amqp/tests/cache_invalidation_test.rs
+++ b/crates/axiam-amqp/tests/cache_invalidation_test.rs
@@ -730,12 +730,13 @@ fn publisher_is_an_invalidation_broadcaster() {
 #[test]
 fn own_heartbeat_is_recognised_as_own() {
     let origin = Uuid::new_v4();
-    let raw = build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
+    let (raw, nonce) =
+        build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
     let guard = NonceGuard::new();
 
     assert_eq!(
         process_invalidation(&raw, MASTER_KEY, origin, &guard, skew(), Utc::now()),
-        InvalidationOutcome::Heartbeat { own: true }
+        InvalidationOutcome::Heartbeat { own: true, nonce }
     );
 }
 
@@ -745,12 +746,13 @@ fn own_heartbeat_is_recognised_as_own() {
 fn foreign_heartbeat_is_not_evidence_of_our_own_binding() {
     let other = Uuid::new_v4();
     let us = Uuid::new_v4();
-    let raw = build_signed_heartbeat(MASTER_KEY, other, Utc::now()).expect("sign heartbeat");
+    let (raw, nonce) =
+        build_signed_heartbeat(MASTER_KEY, other, Utc::now()).expect("sign heartbeat");
     let guard = NonceGuard::new();
 
     assert_eq!(
         process_invalidation(&raw, MASTER_KEY, us, &guard, skew(), Utc::now()),
-        InvalidationOutcome::Heartbeat { own: false }
+        InvalidationOutcome::Heartbeat { own: false, nonce }
     );
 
     let liveness = InvalidationLiveness::new();
@@ -773,7 +775,8 @@ fn heartbeats_never_touch_the_cache() {
     assert!(cache.get(&request(tenant, subject)).is_some());
 
     let origin = Uuid::new_v4();
-    let raw = build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
+    let (raw, nonce) =
+        build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
     let guard = NonceGuard::new();
 
     // Processed as a FOREIGN heartbeat — the case that would be applied if
@@ -787,7 +790,10 @@ fn heartbeats_never_touch_the_cache() {
         skew(),
         Utc::now(),
     );
-    assert_eq!(outcome, InvalidationOutcome::Heartbeat { own: false });
+    assert_eq!(
+        outcome,
+        InvalidationOutcome::Heartbeat { own: false, nonce }
+    );
     assert!(
         cache.get(&request(tenant, subject)).is_some(),
         "a heartbeat must never flush a cached decision"
@@ -803,7 +809,8 @@ fn heartbeats_do_not_consume_replay_guard_capacity() {
     let us = Uuid::new_v4();
 
     for _ in 0..50 {
-        let raw = build_signed_heartbeat(MASTER_KEY, Uuid::new_v4(), Utc::now()).expect("sign");
+        let (raw, _) =
+            build_signed_heartbeat(MASTER_KEY, Uuid::new_v4(), Utc::now()).expect("sign");
         let _ = process_invalidation(&raw, MASTER_KEY, us, &guard, skew(), Utc::now());
     }
 
@@ -821,9 +828,15 @@ fn heartbeats_do_not_consume_replay_guard_capacity() {
 #[test]
 fn an_unsigned_heartbeat_is_rejected_like_any_other_message() {
     let origin = Uuid::new_v4();
-    let raw = build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
+    let (raw, nonce) =
+        build_signed_heartbeat(MASTER_KEY, origin, Utc::now()).expect("sign heartbeat");
     let mut message: CacheInvalidationMessage = serde_json::from_slice(&raw).expect("decode");
     assert!(message.heartbeat, "builder must set the heartbeat marker");
+    assert_eq!(
+        message.nonce, nonce,
+        "the builder must stamp the nonce it hands back — the liveness check \
+         registers that value, so a mismatch would make every echo look replayed"
+    );
 
     message.hmac_signature = None;
     let unsigned = serde_json::to_vec(&message).expect("serialize");
@@ -877,7 +890,8 @@ fn liveness_goes_stale_only_after_the_miss_threshold() {
     assert!(liveness.is_stale(past, interval));
 
     // A fresh own-heartbeat re-arms it.
-    liveness.record_own_heartbeat(past);
+    liveness.record_sent_heartbeat(Uuid::nil());
+    assert!(liveness.record_own_heartbeat(Uuid::nil(), past));
     assert!(!liveness.is_stale(past, interval));
 }
 
@@ -976,10 +990,98 @@ async fn publisher_reopens_its_channel_on_every_attempt_until_one_succeeds() {
     }
 
     // Heartbeats travel the same path, so they recover the same way.
-    let _ = publisher.publish_heartbeat().await;
+    let liveness = InvalidationLiveness::new();
+    let _ = publisher.publish_heartbeat(&liveness).await;
     assert_eq!(
         factory.calls.load(std::sync::atomic::Ordering::SeqCst),
         4,
         "the heartbeat must share the publish path it is meant to be evidence about"
+    );
+}
+
+/// §15.2 gap 3 — a replayed heartbeat must not satisfy the watchdog.
+///
+/// Heartbeats deliberately bypass the `NonceGuard` so they cannot evict real
+/// invalidation nonces from its bounded capacity. That left a narrow path: a
+/// party with broker rights who captured one signed heartbeat could replay it
+/// inside the freshness window to keep a replica's watchdog satisfied while its
+/// queue was unbound — the precise adversary Obs 1 is about. Acceptance is now
+/// bound to nonces this replica actually published.
+#[test]
+fn a_replayed_own_heartbeat_does_not_refresh_liveness() {
+    let liveness = InvalidationLiveness::new();
+    let t0 = Utc::now();
+    liveness.mark_subscribed(t0);
+
+    let nonce = Uuid::new_v4();
+    liveness.record_sent_heartbeat(nonce);
+
+    // The genuine echo counts, once.
+    let later = t0 + chrono::Duration::seconds(10);
+    assert!(
+        liveness.record_own_heartbeat(nonce, later),
+        "the echo of a heartbeat we published must count"
+    );
+    assert_eq!(liveness.last_own_echo(), Some(later));
+
+    // Replaying that same signed heartbeat must not count again, and must not
+    // move the clock — otherwise one captured message holds the watchdog open
+    // indefinitely.
+    let replay_at = later + chrono::Duration::seconds(60);
+    assert!(
+        !liveness.record_own_heartbeat(nonce, replay_at),
+        "a replayed heartbeat must be refused"
+    );
+    assert_eq!(
+        liveness.last_own_echo(),
+        Some(later),
+        "a replay must leave the liveness clock exactly where it was"
+    );
+}
+
+/// A heartbeat nonce this replica never issued is equally refused — covers a
+/// forged-but-signed message from a compromised sibling replaying our origin id.
+#[test]
+fn an_unissued_heartbeat_nonce_is_refused() {
+    let liveness = InvalidationLiveness::new();
+    liveness.mark_subscribed(Utc::now());
+    assert!(!liveness.record_own_heartbeat(Uuid::new_v4(), Utc::now()));
+}
+
+/// The outstanding set must stay bounded when nothing ever comes back — which
+/// is exactly the unbound-queue case the watchdog is for.
+#[test]
+fn outstanding_heartbeats_stay_bounded_when_none_return() {
+    let liveness = InvalidationLiveness::new();
+    let mut first = Vec::new();
+    for i in 0..200 {
+        let n = Uuid::new_v4();
+        if i < 8 {
+            first.push(n);
+        }
+        liveness.record_sent_heartbeat(n);
+    }
+    // The earliest nonces have been evicted, so a very late echo of one of them
+    // no longer counts — correct, since it is far past the miss threshold.
+    for n in first {
+        assert!(!liveness.record_own_heartbeat(n, Utc::now()));
+    }
+}
+
+/// A reconnecting consumer must not satisfy its watchdog with a heartbeat its
+/// predecessor published.
+#[test]
+fn unsubscribing_clears_outstanding_heartbeats() {
+    let liveness = InvalidationLiveness::new();
+    liveness.mark_subscribed(Utc::now());
+    let nonce = Uuid::new_v4();
+    liveness.record_sent_heartbeat(nonce);
+
+    liveness.mark_unsubscribed();
+    liveness.mark_subscribed(Utc::now());
+
+    assert!(
+        !liveness.record_own_heartbeat(nonce, Utc::now()),
+        "a nonce published before the reconnect must not count after it"
     );
 }

--- a/crates/axiam-auth/src/client_secret.rs
+++ b/crates/axiam-auth/src/client_secret.rs
@@ -238,6 +238,17 @@ impl ClientSecretHasher {
                     .to_string(),
             ));
         }
+        if pepper.len() < WEAK_PEPPER_LEN {
+            // §15.3.7: `from_pepper` warns on a weak pepper and this path did
+            // not. The impact is genuinely lower — a previous key can only
+            // verify hashes that already exist, never produce one — but an
+            // operator rotating *away* from a weak pepper is exactly who should
+            // be told it was weak, and silence here reads as approval.
+            tracing::warn!(
+                pepper_len = pepper.len(),
+                "AXIAM__AUTH__PEPPER_PREVIOUS is shorter than {WEAK_PEPPER_LEN} bytes. Secrets                  still hashed under it are weakly keyed until they are rewritten under the                  current pepper; complete the rotation promptly."
+            );
+        }
         self.previous_key = Some(Self::derive_key(pepper));
         Ok(self)
     }

--- a/crates/axiam-authz/src/config.rs
+++ b/crates/axiam-authz/src/config.rs
@@ -15,6 +15,26 @@ pub const DEFAULT_BROADCAST_SKEW_SECS: u64 = 30;
 /// observation 1). See [`AuthzConfig::decision_cache_broadcast_heartbeat_secs`].
 pub const DEFAULT_BROADCAST_HEARTBEAT_SECS: u64 = 10;
 
+/// Hard ceiling on [`AuthzConfig::decision_cache_ttl_secs`] (§15.2).
+///
+/// The TTL is the only bound on how long a revoked grant can still be served by
+/// a replica that missed its invalidation — the heartbeat shortens the window in
+/// which invalidations go undelivered, but it cannot bound a window the operator
+/// set to hours. Five minutes is already far beyond anything the cache needs to
+/// be useful (the default is 5 **seconds**), so the ceiling costs nothing real
+/// and removes the foot-gun.
+pub const MAX_DECISION_CACHE_TTL_SECS: u64 = 300;
+
+/// Bounds on the heartbeat interval (§15.2).
+///
+/// A lower bound stops a misconfiguration turning the liveness probe into a
+/// broadcast flood; the upper bound keeps detection latency
+/// (`interval × HEARTBEAT_MISS_THRESHOLD`) inside the same order as the TTL
+/// ceiling it backstops.
+pub const MIN_BROADCAST_HEARTBEAT_SECS: u64 = 1;
+/// See [`MIN_BROADCAST_HEARTBEAT_SECS`].
+pub const MAX_BROADCAST_HEARTBEAT_SECS: u64 = 60;
+
 /// Strategy for evaluating a `BatchCheckAccess` call (REST + gRPC).
 ///
 /// Both strategies produce **byte-identical decisions in the same order** —
@@ -160,9 +180,12 @@ pub struct AuthzConfig {
     /// detected within
     /// `decision_cache_broadcast_heartbeat_secs × HEARTBEAT_MISS_THRESHOLD`.
     ///
-    /// Set to `0` to disable heartbeats. That restores the pre-§13.4 behaviour
-    /// and is **not** recommended: it re-opens the suppression window this
-    /// closes, leaving `decision_cache_ttl_secs` as the only bound.
+    /// **Cannot be disabled** while broadcast is on, and clamped to
+    /// `MIN_BROADCAST_HEARTBEAT_SECS..=MAX_BROADCAST_HEARTBEAT_SECS` (§15.2).
+    /// An earlier revision accepted `0` as "disabled"; that made the mitigation
+    /// removable with one environment variable and only a warning, leaving
+    /// `decision_cache_ttl_secs` as the sole bound — the exact state this
+    /// exists to escape.
     ///
     /// Raising it weakens detection linearly and saves almost nothing — one
     /// transient 200-byte message per replica per interval.
@@ -175,6 +198,14 @@ pub struct AuthzConfig {
     /// process-local; see `decision_cache_enabled`). Short by design.
     ///
     /// Configure via `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS` (default `5`).
+    ///
+    /// **Clamped to [`MAX_DECISION_CACHE_TTL_SECS`] at construction** (§15.2).
+    /// This value is the *only* bound on how long a revoked grant can still be
+    /// served on a replica that missed its invalidation, so an unbounded `u64`
+    /// let an operator configure a multi-hour stale-allow window — and the
+    /// cross-replica heartbeat, which exists to shorten that window, cannot
+    /// help once the window itself is arbitrary. `cleanup_interval_secs` has
+    /// been clamped for this reason since T-04-35; this one had not been.
     pub decision_cache_ttl_secs: u64,
 
     /// Maximum cached decisions retained **per tenant** before FIFO eviction
@@ -222,7 +253,7 @@ impl AuthzConfig {
             return None;
         }
         let cache = DecisionCache::new(DecisionCacheConfig {
-            ttl: Duration::from_secs(self.decision_cache_ttl_secs),
+            ttl: Duration::from_secs(self.decision_cache_ttl_secs()),
             max_entries_per_tenant: self.decision_cache_max_entries,
         });
         if self.decision_cache_broadcast_enabled {
@@ -243,21 +274,56 @@ impl AuthzConfig {
         chrono::Duration::seconds(self.decision_cache_broadcast_skew_secs as i64)
     }
 
-    /// The configured heartbeat interval, or `None` when heartbeats are disabled
-    /// (`0`) or cross-replica invalidation is not active at all.
+    /// The effective decision-cache TTL, clamped to
+    /// [`MAX_DECISION_CACHE_TTL_SECS`] (§15.2).
     ///
-    /// Returning `None` rather than a zero `Duration` keeps "disabled" a state
-    /// the caller must destructure, so a heartbeat loop cannot be started with a
-    /// zero-length interval and spin.
+    /// Clamped here rather than in `main.rs` — where `cleanup_interval_secs` is
+    /// clamped — so that *every* construction path is covered, including tests
+    /// and any future embedder that builds an `AuthzConfig` directly. A bound
+    /// that only applies when one particular binary happens to apply it is not
+    /// really a bound.
+    pub fn decision_cache_ttl_secs(&self) -> u64 {
+        let configured = self.decision_cache_ttl_secs;
+        if configured > MAX_DECISION_CACHE_TTL_SECS {
+            tracing::warn!(
+                configured,
+                clamped_to = MAX_DECISION_CACHE_TTL_SECS,
+                "AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS exceeds the maximum and has been clamped. \
+                 This value bounds how long a REVOKED grant can still be served on a replica that \
+                 missed its invalidation, so it is a security bound, not a tuning knob."
+            );
+        }
+        configured.min(MAX_DECISION_CACHE_TTL_SECS)
+    }
+
+    /// The heartbeat interval, or `None` when cross-replica invalidation is not
+    /// active at all.
+    ///
+    /// **There is deliberately no way to disable heartbeats while broadcast is
+    /// on** (§15.2). An earlier revision treated `0` as "disabled", which meant
+    /// the mitigation for the queue-unbind suppression hole could be switched
+    /// off with a single environment variable and only a warning — leaving the
+    /// TTL as the sole bound, which is precisely the state the heartbeat exists
+    /// to escape. A heartbeat costs one transient ~200-byte message per replica
+    /// per interval, so there is no deployment for which disabling it is the
+    /// right trade. Out-of-range values are clamped, not honoured.
     pub fn decision_cache_broadcast_heartbeat(&self) -> Option<chrono::Duration> {
-        if !self.cross_replica_invalidation_enabled()
-            || self.decision_cache_broadcast_heartbeat_secs == 0
-        {
+        if !self.cross_replica_invalidation_enabled() {
             return None;
         }
-        Some(chrono::Duration::seconds(
-            self.decision_cache_broadcast_heartbeat_secs as i64,
-        ))
+        let configured = self.decision_cache_broadcast_heartbeat_secs;
+        let effective =
+            configured.clamp(MIN_BROADCAST_HEARTBEAT_SECS, MAX_BROADCAST_HEARTBEAT_SECS);
+        if effective != configured {
+            tracing::warn!(
+                configured,
+                clamped_to = effective,
+                "AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_HEARTBEAT_SECS is out of range and has \
+                 been clamped. Heartbeats cannot be disabled while cross-replica invalidation is \
+                 enabled: they are what detects a replica whose queue has been unbound."
+            );
+        }
+        Some(chrono::Duration::seconds(effective as i64))
     }
 }
 
@@ -416,5 +482,108 @@ mod tests {
         .expect("broadcast overrides must deserialize");
         assert!(cfg.decision_cache_broadcast_enabled);
         assert_eq!(cfg.decision_cache_broadcast_skew_secs, 15);
+    }
+
+    // --- §15.2: neither half of the staleness bound is operator-removable ---
+
+    /// The TTL is the only bound on how long a revoked grant can still be served
+    /// by a replica that missed its invalidation. It was an unbounded `u64`,
+    /// while `cleanup_interval_secs` had been clamped since T-04-35.
+    #[test]
+    fn decision_cache_ttl_is_clamped_to_the_ceiling() {
+        let cfg = AuthzConfig {
+            decision_cache_ttl_secs: 86_400,
+            ..AuthzConfig::default()
+        };
+        assert_eq!(cfg.decision_cache_ttl_secs(), MAX_DECISION_CACHE_TTL_SECS);
+    }
+
+    /// Clamping must not disturb a sane value — including the default.
+    #[test]
+    fn a_within_range_ttl_is_untouched() {
+        for secs in [0, 1, 5, 60, MAX_DECISION_CACHE_TTL_SECS] {
+            let cfg = AuthzConfig {
+                decision_cache_ttl_secs: secs,
+                ..AuthzConfig::default()
+            };
+            assert_eq!(cfg.decision_cache_ttl_secs(), secs);
+        }
+    }
+
+    /// The clamp must apply at the point the TTL becomes real, not only in
+    /// `main.rs` — a bound that one binary happens to apply is not a bound.
+    ///
+    /// Asserted through the accessor `build_decision_cache` actually calls,
+    /// rather than by reading the field back off the built cache, so the test
+    /// fails if a future edit reverts that call site to the raw field.
+    #[test]
+    fn the_built_cache_uses_the_clamped_ttl() {
+        let cfg = AuthzConfig {
+            decision_cache_enabled: true,
+            decision_cache_ttl_secs: 86_400,
+            ..AuthzConfig::default()
+        };
+        assert!(cfg.build_decision_cache().is_some(), "cache enabled");
+        assert_eq!(
+            Duration::from_secs(cfg.decision_cache_ttl_secs()),
+            Duration::from_secs(MAX_DECISION_CACHE_TTL_SECS),
+            "build_decision_cache must not hand an unclamped TTL to the cache"
+        );
+        assert_ne!(
+            cfg.decision_cache_ttl_secs(),
+            cfg.decision_cache_ttl_secs,
+            "precondition: the raw field really is out of range here"
+        );
+    }
+
+    /// Heartbeats cannot be switched off while broadcast is on. An earlier
+    /// revision treated `0` as "disabled", which let one environment variable
+    /// remove the mitigation for the queue-unbind hole.
+    #[test]
+    fn heartbeats_cannot_be_disabled_while_broadcast_is_on() {
+        let cfg = AuthzConfig {
+            decision_cache_enabled: true,
+            decision_cache_broadcast_enabled: true,
+            decision_cache_broadcast_heartbeat_secs: 0,
+            ..AuthzConfig::default()
+        };
+        let interval = cfg
+            .decision_cache_broadcast_heartbeat()
+            .expect("heartbeats must stay on");
+        assert_eq!(
+            interval.num_seconds() as u64,
+            MIN_BROADCAST_HEARTBEAT_SECS,
+            "0 must clamp to the minimum, not disable the watchdog"
+        );
+    }
+
+    /// An absurdly long interval is clamped too: detection latency is
+    /// `interval * HEARTBEAT_MISS_THRESHOLD`, so an unbounded interval is an
+    /// unbounded suppression window by another route.
+    #[test]
+    fn an_over_long_heartbeat_interval_is_clamped() {
+        let cfg = AuthzConfig {
+            decision_cache_enabled: true,
+            decision_cache_broadcast_enabled: true,
+            decision_cache_broadcast_heartbeat_secs: 86_400,
+            ..AuthzConfig::default()
+        };
+        assert_eq!(
+            cfg.decision_cache_broadcast_heartbeat()
+                .unwrap()
+                .num_seconds() as u64,
+            MAX_BROADCAST_HEARTBEAT_SECS
+        );
+    }
+
+    /// With broadcast off there is no heartbeat to run — the whole feature is
+    /// inert, which is the documented default.
+    #[test]
+    fn no_heartbeat_when_broadcast_is_off() {
+        assert!(
+            AuthzConfig::default()
+                .decision_cache_broadcast_heartbeat()
+                .is_none()
+        );
     }
 }

--- a/crates/axiam-core/src/repository.rs
+++ b/crates/axiam-core/src/repository.rs
@@ -510,6 +510,29 @@ pub trait ServiceAccountRepository: Send + Sync {
         expected_hash: &str,
         new_hash: &str,
     ) -> impl Future<Output = AxiamResult<bool>> + Send;
+
+    /// Count service accounts whose `client_secret_hash` is still in a **legacy
+    /// (v1)** scheme (§15.2).
+    ///
+    /// ## Why this exists, stated plainly
+    ///
+    /// [`Self::upgrade_client_secret_hash`] can only fire on a *successful
+    /// verification*, and **nothing in the running server verifies a service
+    /// account's `client_secret_hash`** — service accounts are CRUD plus
+    /// certificate binding today; the secret is issued at create/rotate and
+    /// never presented back. So unlike `oauth2_client` rows, these rows do not
+    /// drain lazily: a legacy row stays legacy forever, and the same is true of
+    /// a row still keyed to a previous pepper.
+    ///
+    /// That has one concrete consequence: the v1 arm of the verifier cannot be
+    /// retired on the strength of "no v1 `oauth2_client` rows remain", because
+    /// this table is invisible to that reasoning. This count makes the question
+    /// answerable, and the migration route is **rotation** — `rotate_secret`
+    /// writes the current scheme under the current pepper.
+    fn count_legacy_secret_hashes(
+        &self,
+        tenant_id: Option<Uuid>,
+    ) -> impl Future<Output = AxiamResult<u64>> + Send;
 }
 
 pub trait SessionRepository: Send + Sync {

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -463,4 +463,39 @@ impl<C: Connection> ServiceAccountRepository for SurrealServiceAccountRepository
         let rows: Vec<ServiceAccountRow> = result.take(0).map_err(DbError::from)?;
         Ok(!rows.is_empty())
     }
+
+    async fn count_legacy_secret_hashes(&self, tenant_id: Option<Uuid>) -> AxiamResult<u64> {
+        // A v2 hash is identified by its own prefix, so "legacy" is simply
+        // "does not start with it" — the same self-identifying test the verifier
+        // uses, rather than a second, drift-prone definition of the format.
+        let sql = match tenant_id {
+            Some(_) => {
+                "SELECT count() AS total FROM service_account \
+                        WHERE tenant_id = $tenant_id \
+                        AND !string::starts_with(client_secret_hash, $prefix) \
+                        GROUP ALL"
+            }
+            None => {
+                "SELECT count() AS total FROM service_account \
+                     WHERE !string::starts_with(client_secret_hash, $prefix) \
+                     GROUP ALL"
+            }
+        };
+        let db = self.db.current();
+        let mut q = db
+            .query(sql)
+            .bind(("prefix", client_secret::V2_PREFIX.to_string()));
+        if let Some(tid) = tenant_id {
+            q = q.bind(("tenant_id", tid.to_string()));
+        }
+
+        let mut result = q
+            .await
+            .map_err(DbError::from)?
+            .check()
+            .map_err(|e| DbError::Migration(e.to_string()))?;
+
+        let rows: Vec<CountRow> = result.take(0).map_err(DbError::from)?;
+        Ok(rows.first().map(|r| r.total).unwrap_or(0))
+    }
 }

--- a/crates/axiam-db/tests/uncovered_repos_test.rs
+++ b/crates/axiam-db/tests/uncovered_repos_test.rs
@@ -774,3 +774,78 @@ async fn service_account_client_secret_hash_migrates_with_a_compare_and_swap() {
             .unwrap()
     );
 }
+
+/// §15.2 — service-account legacy hashes must be *countable*.
+///
+/// They cannot migrate on their own: `upgrade_client_secret_hash` only fires on
+/// a successful verification, and nothing in the running server verifies a
+/// service-account secret. So the only honest answers are (a) make the backlog
+/// visible, and (b) name rotation as the migration route. This pins both.
+#[tokio::test]
+async fn legacy_service_account_hashes_are_countable_and_clear_on_rotation() {
+    use axiam_db::client_secret::V2_PREFIX;
+
+    let (db, _org, tenant_id) = setup().await;
+    let repo = SurrealServiceAccountRepository::new(db.clone());
+
+    let (a, _) = repo
+        .create(CreateServiceAccount {
+            tenant_id,
+            name: "legacy-a".into(),
+            description: None,
+        })
+        .await
+        .unwrap();
+    let (b, secret_b) = repo
+        .create(CreateServiceAccount {
+            tenant_id,
+            name: "current-b".into(),
+            description: None,
+        })
+        .await
+        .unwrap();
+
+    // Freshly created rows are already current.
+    assert_eq!(repo.count_legacy_secret_hashes(None).await.unwrap(), 0);
+    assert!(b.client_secret_hash.starts_with(V2_PREFIX));
+
+    // Plant a pre-OBS-1 row, as a deployment upgraded from an older release has.
+    let legacy = {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(b"whatever"))
+    };
+    db.query("UPDATE service_account SET client_secret_hash = $h WHERE client_id = $c")
+        .bind(("h", legacy))
+        .bind(("c", a.client_id.clone()))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        repo.count_legacy_secret_hashes(None).await.unwrap(),
+        1,
+        "the backlog must be visible — otherwise 'can the v1 arm be retired?' is unanswerable"
+    );
+    assert_eq!(
+        repo.count_legacy_secret_hashes(Some(tenant_id))
+            .await
+            .unwrap(),
+        1,
+        "tenant scoping must narrow, not miss"
+    );
+    assert_eq!(
+        repo.count_legacy_secret_hashes(Some(Uuid::new_v4()))
+            .await
+            .unwrap(),
+        0,
+        "another tenant's backlog must not be reported as this tenant's"
+    );
+
+    // Rotation is the migration route, since lazy upgrade can never fire here.
+    let rotated = repo.rotate_secret(tenant_id, a.id).await.unwrap();
+    assert_ne!(rotated, secret_b);
+    assert_eq!(
+        repo.count_legacy_secret_hashes(None).await.unwrap(),
+        0,
+        "rotating a legacy service account must clear it from the backlog"
+    );
+}

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -46,7 +46,9 @@ use axiam_auth::config::AuthConfig;
 use axiam_auth::{
     AuthService, EmailVerificationService, MfaMethodService, PasswordResetService, WebauthnService,
 };
-use axiam_core::repository::{OrganizationRepository, Pagination, TenantRepository};
+use axiam_core::repository::{
+    OrganizationRepository, Pagination, ServiceAccountRepository, TenantRepository,
+};
 use axiam_db::{
     DbConfig, SurrealAccountDeletionRepository, SurrealAmqpNonceRepository,
     SurrealAssertionReplayRepository, SurrealAuditLogRepository,
@@ -477,6 +479,36 @@ async fn main() -> std::io::Result<()> {
     let resource_repo = SurrealResourceRepository::new(pool.handle_for_repo());
     let scope_repo = SurrealScopeRepository::new(pool.handle_for_repo());
     let service_account_repo = SurrealServiceAccountRepository::new(pool.handle_for_repo());
+
+    // §15.2 — service-account secret hashes cannot migrate lazily.
+    //
+    // `upgrade_client_secret_hash` only fires on a successful verification, and
+    // nothing in the running server verifies a service account's secret: they
+    // are CRUD plus certificate binding, and the secret is issued at
+    // create/rotate but never presented back. So unlike `oauth2_client` rows,
+    // these do not drain — a legacy row stays legacy forever, and so does one
+    // still keyed to a superseded pepper.
+    //
+    // That matters for exactly one decision: whether the v1 verifier arm can be
+    // retired. "No v1 `oauth2_client` rows remain" does not answer it, because
+    // this table is invisible to that reasoning. Surfacing the count at startup
+    // makes it answerable, and names the only migration route that exists here.
+    match service_account_repo.count_legacy_secret_hashes(None).await {
+        Ok(0) => {
+            tracing::debug!("All service-account client secrets use the current hash scheme");
+        }
+        Ok(n) => {
+            tracing::warn!(
+                legacy_rows = n,
+                "{n} service account(s) still store a legacy client-secret hash. These CANNOT                  migrate on their own: nothing verifies a service-account secret, so the lazy                  upgrade that drains `oauth2_client` rows never runs here. Rotate them                  (POST /api/v1/service-accounts/{{id}}/rotate-secret) to move them to the                  current scheme and the current pepper. Until this reaches 0, the legacy hash                  arm cannot be retired."
+            );
+        }
+        Err(e) => {
+            // Diagnostic only — never a reason to refuse to start.
+            tracing::debug!(error = %e, "Could not count legacy service-account secret hashes");
+        }
+    }
+
     let session_repo = SurrealSessionRepository::new(pool.handle_for_repo());
     // I6: optional short-TTL session-validation cache. Opt-in via
     // `AXIAM__AUTH__SESSION_VALIDATION_CACHE_TTL_SECS` (0 = off, the default);
@@ -1006,7 +1038,7 @@ async fn main() -> std::io::Result<()> {
                         // the staleness check below is the single decision point,
                         // and a failed publish simply means no heartbeat was sent,
                         // which that check will notice on its own if it persists.
-                        if let Err(e) = hb_publisher.publish_heartbeat().await {
+                        if let Err(e) = hb_publisher.publish_heartbeat(&hb_liveness).await {
                             tracing::warn!(
                                 error = %e,
                                 "AuthZ cache-invalidation heartbeat could not be published"
@@ -1031,13 +1063,12 @@ async fn main() -> std::io::Result<()> {
                         }
                     }
                 });
-            } else {
-                tracing::warn!(
-                    "AuthZ cache-invalidation liveness heartbeats are DISABLED — an unbound \
-                     replica queue would suppress invalidations undetected, bounded only by \
-                     decision_cache_ttl_secs (§13.4 observation 1)"
-                );
             }
+            // No `else`: `decision_cache_broadcast_heartbeat()` returns `Some`
+            // whenever broadcast is on (§15.2). Heartbeats are not disableable —
+            // they are the only thing that detects a replica whose queue has been
+            // unbound, and an earlier revision let one environment variable turn
+            // that off with nothing but a warning.
 
             tracing::info!(
                 replica_id = %replica_id,


### PR DESCRIPTION
§15 confirmed **no open finding**. What remained were two partials (§15.2) and seven observations (§15.3). This closes both partials and four observations, and records the other three as deliberately not actioned with reasons. Remediation record appended as **§16**, again as *claims pending verification*.

**A check for new findings was requested and performed** — none found. The one thing the re-read surfaced was a factual error in §15 itself (below).

## Obs 1 — the heartbeat's three gaps

Two of them compounded into the real problem: `decision_cache_ttl_secs` was an unbounded `u64` while `cleanup_interval_secs` has been clamped since T-04-35, **and** the heartbeat could be switched off with one environment variable and only a warning. An operator could set a multi-hour stale-allow window *and* disable the mechanism that shortens it.

- **TTL clamped to 300 s** — in `AuthzConfig::decision_cache_ttl_secs()`, the accessor `build_decision_cache` calls, **not** in `main.rs` where `cleanup_interval_secs` is clamped. A bound one binary happens to apply is not a bound; this way tests and any embedder are covered too.
- **Heartbeats can no longer be disabled** while broadcast is on; out-of-range intervals clamp to `1..=60`. Free to change — the `0` escape hatch was introduced in the same unreleased change, so nothing depends on it.
- **Replay closed.** Heartbeats bypass the `NonceGuard` deliberately (they arrive on a fixed interval from every replica and would evict real invalidation nonces from its bounded capacity), which let a captured heartbeat be replayed inside the freshness window to hold a replica's watchdog open while its queue was unbound. Acceptance is now bound to nonces the replica itself published and has not yet consumed. Registration happens **before** the publish, because the fanout can deliver the echo before the confirm returns.

Net effect: **neither half of the staleness bound is operator-removable any more.**

## Obs 4 — the diagnosis was incomplete, and the fix follows the corrected one

§15.2 said the upgrade seam has no production caller. True, and the reason is stronger than "a caller was forgotten": **nothing in the running server verifies a service-account secret at all.** Service accounts are CRUD plus certificate binding; the secret is issued at create/rotate and never presented back. No lazy upgrade can ever fire, and adding a caller would mean inventing an authentication path — a feature, not a remediation.

What actually blocks progress is the decision the observation names — whether the v1 arm can be retired — so:

- `count_legacy_secret_hashes(tenant)` makes the backlog answerable, testing the same self-identifying prefix the verifier uses rather than inventing a second definition of the format;
- startup warns with the count and **rotation** as the only migration route that exists here;
- the trait doc states plainly that these rows do not drain lazily, and why.

The same applies to rows still keyed to a superseded pepper (the Obs 3 rewrite drains `oauth2_client` only).

## Observations §15.3.4 and §15.3.7

- **Publisher mutex** was held across the broker confirm, serialising every narrowing mutation behind a network round-trip with the heartbeat contending on the same lock — a regression against the pre-§13.4 code, which shared the channel with no lock. The lock now covers acquisition only; the failure path clears the slot **only if it still holds the same channel**, so a concurrent reopen is not discarded.
- **`with_previous_pepper`** now carries the weak-pepper warning `from_pepper` always had.

## A correction to §15

**§15.3.2 is wrong** where it says the PHP SDK "still has no equivalent" slug-vs-UUID diagnostic. It has shipped one since the SEC-085 change and it is on `main` (`JwksVerifier::warnOnceIfTenantComparandLooksLikeASlug()`, same design as the TS and Python ones §15.3.2 credits). The rest of that observation stands — the diagnostic **is** log-only in all three — and is left as-is deliberately (§16.4).

## Deliberately not actioned

§15.3.2's remaining substance (log-only is a posture decision for SDK owners, and failing construction on a non-UUID tenant is breaking), §15.3.5 (503 suppressing the webhook — reordering would emit an event for a change that has not taken effect), §15.3.6 (`AppState::for_test` gating needs a `test-util` feature, not a change smuggled into a security remediation), and §10.4 residual 5, carried unchanged since §10.

## Verification

`cargo fmt --check` clean · `cargo clippy --workspace --all-targets --all-features -D warnings` clean · affected suites green (amqp 35, authz, auth, core, db 16). The pepper test pins the *pre-fix* hard break so the dual-read test cannot pass vacuously.

§16.5 names this change's three weakest points for the next reviewer — the heartbeat nonce lifecycle, the publisher's compare-before-clear under a concurrent reopen, and the TTL clamp's placement on the accessor rather than the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D)_