### PR TITLE
feat(oauth2): service accounts can authenticate via client-credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,19 +34,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Legacy client-secret hashes in `service_account` are now countable, and the
-  situation is stated honestly (§15.2).** These rows cannot migrate lazily:
-  `upgrade_client_secret_hash` only fires on a successful verification, and
-  **nothing in the running server verifies a service-account secret** — they are
-  CRUD plus certificate binding, and the secret is issued at create/rotate but
-  never presented back. So unlike `oauth2_client` rows they never drain, which
-  is what blocked retiring the legacy hash arm: "no v1 `oauth2_client` rows
-  remain" does not answer the question, because this table is invisible to it.
+- **Service accounts can now authenticate via OAuth2 client-credentials.**
+  `POST /api/v1/service-accounts` and `rotate-secret` have always returned a
+  `client_secret` to the operator — but **no flow accepted it**. A service
+  account's only working authentication path was mTLS
+  (`POST /api/v1/auth/device`); the client-credentials grant verified against
+  the `oauth2_client` table only, and nothing ever compared
+  `service_account.client_secret_hash` against a presented secret.
 
-  `count_legacy_secret_hashes(tenant)` makes the backlog answerable, and startup
-  warns with the count and the only migration route that exists here —
-  **rotation**, which rewrites under the current scheme and current pepper. The
-  same applies to rows still keyed to a superseded pepper.
+  The grant now dispatches on the `client_id` prefix — `oa_` for `oauth2_client`,
+  `sa_` for `service_account`, both server-generated and disjoint, so one lookup
+  still suffices. The prefix is **not** a security decision: it only selects the
+  table, and the presented secret must still verify against the row found.
+
+  Three deliberate properties:
+  - **The secret is verified before the status check**, so a caller cannot
+    distinguish "exists but disabled" from "does not exist" by timing. A
+    non-Active account returns the same generic `invalid_client`.
+  - **No scope may be requested.** A service account registers no scopes, and
+    the subset rule leaves the empty set as the only valid request; its
+    authorization comes from the roles assigned to it, as on the mTLS path.
+  - **The token's `sub` is the service-account id**, not the client id, and its
+    `aud` is `axiam:m2m` (not the `axiam:user` the device path stamps for
+    backwards compatibility) so §4.3/`SEC-006` route narrowing keeps it off user
+    routes. A service account is now the same principal however it authenticated.
+
+- **Legacy client-secret hashes in `service_account` are now countable
+  (§15.2).** `count_legacy_secret_hashes(tenant)` plus a startup warning.
+  With the grant above in place these rows now migrate lazily on first
+  authentication, exactly as `oauth2_client` rows do; the count covers the case
+  migration cannot reach — a service account that never authenticates — which is
+  what decides whether the legacy hash arm can be retired. **Rotation** clears
+  such a row.
 
 ### Fixed
 

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -886,11 +886,15 @@ set the TTL to hours *and* switch off the mechanism that shortens the window.
 
 **Obs 4 — service-account hashes: the diagnosis was incomplete, and the fix
 follows the corrected one.** §15.2 said the seam has no production caller. That
-is right, and the reason is stronger than "a caller was forgotten": **nothing in
-the running server verifies a service-account secret at all.** Service accounts
-are CRUD plus certificate binding; the secret is issued at create/rotate and
-never presented back. So no lazy upgrade can ever fire here, and adding a caller
-would mean inventing a whole authentication path — a feature, not a remediation.
+is right, and the reason is stronger than "a caller was forgotten": nothing in
+the running server compared `service_account.client_secret_hash` against a
+presented secret. So no lazy upgrade could fire, and supplying a caller meant
+adding an authentication path — a feature, not a remediation.
+
+> ⚠ **Both the wording and the disposition above were superseded — see §16.6.**
+> "Nothing verifies a service-account secret" was **imprecise as written** and is
+> corrected there, and the authentication path has since been added on the
+> owner's explicit instruction, which makes the lazy upgrade reachable after all.
 
 What actually blocks progress is the *decision* the observation names: the v1
 arm cannot be retired on the strength of "no v1 `oauth2_client` rows remain",
@@ -985,3 +989,128 @@ confirmed by hand that all eleven guards reject correctly today.
    broadcast still returns `Err`) is genuinely unchanged.
 3. **The TTL clamp's placement.** It is on the accessor, not the field. Confirm
    no caller reads `decision_cache_ttl_secs` directly and bypasses it.
+
+### 16.6 Correction and follow-up: service-account authentication
+
+Raised by the repository owner reviewing §16.2, and worth recording in full
+because the first half is a correction to my own wording and the second changes
+the disposition of Obs 4.
+
+**The wording was wrong.** §16.2, the CHANGELOG and two code comments said
+*"nothing in the running server verifies a service-account secret at all"*. Read
+plainly that says AXIAM never checks a machine credential, which is false twice
+over:
+
+- The OAuth2 **client-credentials** grant has always verified a client secret —
+  against the `oauth2_client` table (`TokenService::client_repo`, bound to
+  `OAuth2ClientRepository` and wired to `oauth2_client_repo`).
+- Service accounts have always **authenticated**, by mTLS:
+  `POST /api/v1/auth/device` resolves one from a bound client certificate and
+  mints a token with `sub_kind: service_account`.
+
+The accurate claim — and the one the fix actually rested on — is narrower:
+**nothing verified the `service_account` table's own `client_secret_hash`
+column.** Verified by exhaustion: every reference to it was a write
+(create/rotate/upgrade), a read into a DTO, or a schema/test line. There was no
+comparison against a presented secret anywhere, `axiam-oauth2` contained zero
+references to `service_account`, and creating a service account created no
+`oauth2_client` row. All four sites now name the column.
+
+**The follow-up this exposed.** `create` and `rotate_secret` returned a
+`client_secret` to the operator that **no flow accepted** — a credential the API
+issues and then refuses. Two readings were possible (service accounts are
+mTLS-only and the column is vestigial; or the client-credentials wiring is
+missing). The owner chose the second, so the grant now accepts an `sa_…`
+`client_id`.
+
+Design points worth re-deriving rather than trusting:
+
+1. **Dispatch is by `client_id` prefix** — `oa_` vs `sa_`, both server-generated
+   and disjoint — so the hot path keeps one lookup. This is *not* a security
+   decision: the prefix only selects which table to read, and the presented
+   secret must still verify against the row found. Guessing a prefix routes a
+   caller to a table where their `client_id` does not exist, i.e.
+   `invalid_client`. The constant lives in `axiam-core` beside the model, used by
+   both the generator and the dispatcher, so the two cannot drift.
+2. **Secret verified before the status check.** Rejecting a disabled account
+   first would let an unauthenticated caller separate "exists but disabled" from
+   "does not exist" by timing. Status is now consulted only for a caller who
+   already proved possession, and the error is the same generic
+   `invalid_client` either way.
+3. **`aud` is `axiam:m2m`, `sub` is the service-account id.** The device path's
+   `issue_service_account_token` stamps `axiam:user` for backwards
+   compatibility, which is the wrong shape for a secret-obtained machine token —
+   §4.3/`SEC-006` route narrowing must be able to keep it off user routes. And
+   `sub` must be the account id, not the opaque `sa_…` client id, or the token
+   would authenticate while carrying no resolvable grants. A service account is
+   now the same principal whichever way it authenticated.
+4. **Obs 4's disposition changes.** With a verification path, the lazy upgrade
+   is reachable and legacy service-account rows migrate on first authentication
+   exactly as `oauth2_client` rows do — pinned by a test. The startup count
+   remains useful for the case migration cannot reach: an account that never
+   authenticates. Rotation clears those.
+
+**What a verifier should check here.** That the prefix dispatch cannot be used
+to reach the wrong table with a matching secret; that the secret-then-status
+ordering has not been reversed by a later edit; and that no other call site
+mints a service-account token with `axiam:user` for a secret-obtained grant.
+
+### 16.7 Security review of the new grant against prior findings
+
+The new service-account client-credentials path was checked against every
+relevant finding and observation already closed in this document, rather than
+being assumed clean because it reuses existing machinery.
+
+| Prior item | Result for the new path |
+|---|---|
+| **§15.2 Obs 4** (SA hashes cannot migrate) | ✅ **Now genuinely closed.** The lazy upgrade is reachable at last: a legacy-scheme row authenticates and is rewritten via the tenant-scoped CAS. Pinned by a test, together with its converse — a **wrong secret never triggers a write**. |
+| **OBS-1** (client-secret hashing) | ✅ Same keyed HMAC-SHA256 + constant-time comparison via `client_secret::global()`; no second, weaker verifier was introduced. |
+| **§13.4 obs 3** (pepper rotation) | ✅ Composes. A row keyed to a superseded pepper verifies through the dual read and is rewritten under the current key. Pinned — including that **without** `AXIAM__AUTH__PEPPER_PREVIOUS` such a row fails closed rather than silently authenticating. |
+| **SEC-006 / §4.3** (audience narrowing) | ✅ The token carries `aud: axiam:m2m`, so `check_user_aud_and_parse_jti` keeps it off user routes and `extract_service_account` accepts it. Had it reused the device path's `issue_service_account_token` — which stamps `axiam:user` — it would have been minted onto user routes. |
+| **QUAL-03 / D-11** (error oracle) | ✅ Same taxonomy: only a genuinely unknown client is `invalid_client`; a DB outage is a distinct server error. Extended to a **status** oracle: the secret is verified *before* the status check, so "exists but disabled" is not separable from "does not exist" by timing, and both return the same generic error. |
+| **Tenant isolation** (SEC-007 class) | ✅ Both the lookup and the upgrade CAS are tenant-scoped; the CAS's tenant predicate is already pinned by a test asserting another tenant cannot drive a rewrite. |
+| **Rate limiting** | ✅ No new endpoint — this rides `POST /oauth2/token`, already covered. |
+
+**Two things this review surfaced that were not otherwise visible.**
+
+1. **`AuthenticatedServiceAccount.client_id` no longer means one thing.** The
+   field is populated from `sub`, which is the `client_id` for an `oauth2_client`
+   token but the service-account **UUID** for the new one. No route consumes this
+   extractor today, so nothing is broken — but a future one would silently get
+   two different value shapes. Documented on the field rather than renamed,
+   since renaming a `pub` field for a currently-unused type is churn.
+2. **The device-auth path and this one disagree on `aud`.** `POST /api/v1/auth/device`
+   stamps `axiam:user` on a service-account token (documented there as
+   backwards compatibility), so a device-authenticated service account **cannot**
+   use an `AuthenticatedServiceAccount` route, while a secret-authenticated one
+   can. Pre-existing, not introduced here, and changing it is an
+   operator-visible behaviour change — recorded as an open observation rather
+   than fixed in this pass.
+
+**A precision fix to §16.2's own artefact.** `count_legacy_secret_hashes` counts
+the hash **scheme** only. A row already in the current scheme but keyed to a
+superseded pepper is byte-identical on disk and is therefore *not* counted. That
+is correct for the question the count exists to answer — *can the legacy arm be
+retired?* — but the startup message previously implied it tracked pepper era
+too. Both the message and the trait doc now say so explicitly.
+
+### 16.8 SDK impact
+
+**No SDK code change is required.** `login_client_credentials` already exists in
+all eleven SDKs, and the request is byte-identical whether the `client_id` names
+an OAuth2 client or a service account — so support is automatic.
+
+What *does* change is the **token that comes back**, which matters to any SDK
+that verifies locally (§10.1) or renders an identity. `CONTRACT.md` §12.1 now
+states the difference normatively: `sub` is the service-account UUID rather than
+the `client_id` (so an SDK must not assume `sub` is a client id, nor parse it as
+a UUID, without checking `sub_kind`), there is no `scope` claim, and a §10 guard
+fronting a resource server that accepts machine callers must be configured to
+expect `axiam:m2m` — the default `axiam:user` guidance correctly rejects **both**
+kinds of client-credentials token, which is rule 6 working, not a bug.
+
+The clause was applied to all eleven vendored copies as a **targeted patch, not
+a wholesale overwrite** — the copies carry legitimate pre-existing drift, and a
+copy would have silently reverted it. Verified: every vendored `CONTRACT.md`
+shows insertions and **zero deletions**.
+

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -123,7 +123,20 @@ impl actix_web::FromRequest for AuthenticatedUser {
 /// Accepts only tokens with `aud = axiam:m2m`; user tokens are rejected.
 #[derive(Debug, Clone)]
 pub struct AuthenticatedServiceAccount {
-    /// OAuth2 `client_id` (the token `sub` for M2M tokens).
+    /// The token's `sub` claim.
+    ///
+    /// **Its meaning depends on which principal obtained the token**, so do not
+    /// treat it as an OAuth2 `client_id` without checking `claims.sub_kind`:
+    ///
+    /// * `sub_kind = oauth2_client` → the OAuth2 `client_id` (`oa_…`), because
+    ///   `issue_client_credentials_token` stamps the client id as `sub`.
+    /// * `sub_kind = service_account` → the service-account **UUID**, because a
+    ///   service account's grants are resolved by subject id (§16.6). It is
+    ///   *not* the `sa_…` client id.
+    ///
+    /// The field name predates service accounts being able to use this grant.
+    /// No route consumes this extractor today; the distinction is recorded here
+    /// so the first one that does gets it right.
     pub client_id: String,
     pub tenant_id: Uuid,
     pub claims: ValidatedClaims,

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -168,6 +168,7 @@ pub type TokenServiceT<C> = TokenService<
     SurrealTenantRepository<C>,
     SurrealRefreshTokenRepository<C>,
     SurrealUserRepository<C>,
+    SurrealServiceAccountRepository<C>,
 >;
 
 pub type PasswordResetServiceT<C> = PasswordResetService<
@@ -423,11 +424,13 @@ impl<C: Connection + Clone> AppState<C> {
             Arc::clone(&crypto_semaphore),
         );
         let device_auth_service = DeviceAuthService::new(cert_repo.clone(), ca_cert_repo.clone());
+        let service_account_repo = SurrealServiceAccountRepository::new(db.clone());
         let webhook_delivery = WebhookDeliveryService::new(webhook_repo.clone(), None);
         let authorize_service =
             AuthorizeService::new(oauth2_client_repo.clone(), auth_code_repo.clone(), 600);
         let token_service = TokenService::new(
             oauth2_client_repo.clone(),
+            service_account_repo.clone(),
             auth_code_repo.clone(),
             tenant_repo.clone(),
             refresh_token_repo.clone(),
@@ -465,7 +468,7 @@ impl<C: Connection + Clone> AppState<C> {
             permission_repo: SurrealPermissionRepository::new(db.clone()),
             resource_repo: SurrealResourceRepository::new(db.clone()),
             scope_repo: SurrealScopeRepository::new(db.clone()),
-            service_account_repo: SurrealServiceAccountRepository::new(db.clone()),
+            service_account_repo: service_account_repo.clone(),
             auth_service,
             webauthn_service,
             mfa_method_service,

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -235,6 +235,66 @@ pub fn issue_service_account_token(
         .map_err(|e| AuthError::Crypto(format!("JWT encode: {e}")))
 }
 
+/// Mint a service-account access token for the **OAuth2 client-credentials**
+/// grant.
+///
+/// Deliberately distinct from [`issue_service_account_token`], which the mTLS
+/// device-auth path uses. Two claims differ, and both differences matter:
+///
+/// * **`aud` is [`AUD_M2M`], not [`AUD_USER`].** This is a machine token
+///   obtained with a client secret, so the §4.3 / `SEC-006` per-route audience
+///   narrowing must be able to keep it off user routes.
+///   `issue_service_account_token` stamps [`AUD_USER`] for backwards
+///   compatibility with the device path, which is the wrong shape here.
+/// * **`sub` is the service-account id**, exactly as the device path does —
+///   *not* the `client_id`. The authorization engine resolves roles by subject
+///   id, so a token whose `sub` were the opaque `sa_…` client id would
+///   authenticate but carry no resolvable grants. This is what makes a service
+///   account the *same principal* whether it authenticated by certificate or
+///   by secret.
+///
+/// `sub_kind` is [`SubjectKind::ServiceAccount`] on both paths.
+pub fn issue_service_account_client_credentials_token(
+    service_account_id: Uuid,
+    tenant_id: Uuid,
+    org_id: Uuid,
+    scopes: &[String],
+    config: &AuthConfig,
+) -> Result<String, AuthError> {
+    let now = Utc::now().timestamp();
+    let scope = if scopes.is_empty() {
+        None
+    } else {
+        Some(scopes.join(" "))
+    };
+
+    let claims = AccessTokenClaims {
+        sub: service_account_id.to_string(),
+        tenant_id: tenant_id.to_string(),
+        org_id: org_id.to_string(),
+        iss: config.effective_issuer().to_owned(),
+        iat: now,
+        exp: now + config.access_token_lifetime_secs as i64,
+        jti: Uuid::new_v4().to_string(),
+        aud: Some(AUD_M2M.to_string()),
+        scope,
+        sub_kind: SubjectKind::ServiceAccount,
+    };
+
+    let owned;
+    let key: &EncodingKey = if let Some(ref cached) = config.jwt_encoding_key {
+        cached.as_ref()
+    } else {
+        owned = EncodingKey::from_ed_pem(config.jwt_private_key_pem.as_bytes())
+            .map_err(|e| AuthError::Crypto(format!("bad private key: {e}")))?;
+        &owned
+    };
+
+    let header = Header::new(Algorithm::EdDSA);
+    jsonwebtoken::encode(&header, &claims, key)
+        .map_err(|e| AuthError::Crypto(format!("failed to encode token: {e}")))
+}
+
 /// OIDC ID Token claims per OpenID Connect Core 1.0 section 2.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdTokenClaims {

--- a/crates/axiam-core/src/models/service_account.rs
+++ b/crates/axiam-core/src/models/service_account.rs
@@ -8,6 +8,15 @@ use uuid::Uuid;
 
 use super::user::UserStatus;
 
+/// Prefix on every service-account `client_id`.
+///
+/// Defined here — beside the model — because **two** places depend on it and
+/// they must never drift: `axiam-db` generates ids with it, and the OAuth2
+/// client-credentials handler uses it to decide which table to look a
+/// `client_id` up in. It is disjoint from the `oauth2_client` prefix (`oa_`),
+/// which is what makes that dispatch unambiguous.
+pub const SERVICE_ACCOUNT_CLIENT_ID_PREFIX: &str = "sa_";
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ServiceAccount {
     pub id: Uuid,

--- a/crates/axiam-core/src/repository.rs
+++ b/crates/axiam-core/src/repository.rs
@@ -517,12 +517,23 @@ pub trait ServiceAccountRepository: Send + Sync {
     /// ## Why this exists, stated plainly
     ///
     /// [`Self::upgrade_client_secret_hash`] can only fire on a *successful
-    /// verification*, and **nothing in the running server verifies a service
-    /// account's `client_secret_hash`** — service accounts are CRUD plus
-    /// certificate binding today; the secret is issued at create/rotate and
-    /// never presented back. So unlike `oauth2_client` rows, these rows do not
-    /// drain lazily: a legacy row stays legacy forever, and the same is true of
-    /// a row still keyed to a previous pepper.
+    /// verification*. When this count was introduced there was **no such path**
+    /// for a service account — the secret was issued at create/rotate and no
+    /// flow accepted it — so these rows could not drain lazily at all.
+    ///
+    /// The OAuth2 **client-credentials** grant now accepts a service account's
+    /// `client_id`/`client_secret`, so legacy rows *do* migrate on first use,
+    /// exactly as `oauth2_client` rows do. This count remains useful for the
+    /// case that migration cannot reach: a service account that never
+    /// authenticates. Its backlog is what decides whether the legacy hash arm
+    /// can be retired, and **rotation** clears a row that will never
+    /// authenticate on its own.
+    ///
+    /// **This counts the hash *scheme* only.** A row already in the current
+    /// scheme but keyed to a superseded pepper is indistinguishable on disk —
+    /// the stored format is identical — so it is not counted. That is correct
+    /// for the question this answers (can the legacy *arm* be retired?), and
+    /// such rows migrate on the same first authentication.
     ///
     /// That has one concrete consequence: the v1 arm of the verifier cannot be
     /// retired on the strength of "no v1 `oauth2_client` rows remain", because

--- a/crates/axiam-db/src/repository/service_account.rs
+++ b/crates/axiam-db/src/repository/service_account.rs
@@ -4,7 +4,7 @@ use axiam_auth::client_secret;
 use axiam_core::error::AxiamResult;
 use axiam_core::id::new_id;
 use axiam_core::models::service_account::{
-    CreateServiceAccount, ServiceAccount, UpdateServiceAccount,
+    CreateServiceAccount, SERVICE_ACCOUNT_CLIENT_ID_PREFIX, ServiceAccount, UpdateServiceAccount,
 };
 use axiam_core::models::user::UserStatus;
 use axiam_core::repository::{PaginatedResult, Pagination, ServiceAccountRepository};
@@ -22,7 +22,7 @@ use crate::helpers::{CountRow, paginate, take_first_or_not_found};
 fn generate_client_id() -> String {
     let mut rng = rand::rng();
     let bytes: [u8; 16] = rng.random();
-    format!("sa_{}", hex::encode(bytes))
+    format!("{SERVICE_ACCOUNT_CLIENT_ID_PREFIX}{}", hex::encode(bytes))
 }
 
 /// Generate a random client secret (64 hex chars = 32 bytes of entropy).

--- a/crates/axiam-oauth2/src/token.rs
+++ b/crates/axiam-oauth2/src/token.rs
@@ -6,13 +6,15 @@ use axiam_auth::client_secret::{self, ClientSecretVerdict};
 use axiam_auth::config::AuthConfig;
 use axiam_auth::token::{
     generate_refresh_token, hash_refresh_token, issue_access_token, issue_client_credentials_token,
-    issue_id_token, validate_access_token,
+    issue_id_token, issue_service_account_client_credentials_token, validate_access_token,
 };
 use axiam_core::error::AxiamError;
 use axiam_core::models::oauth2_client::{CreateRefreshToken, OAuth2Client};
+use axiam_core::models::service_account::{SERVICE_ACCOUNT_CLIENT_ID_PREFIX, ServiceAccount};
+use axiam_core::models::user::UserStatus;
 use axiam_core::repository::{
-    AuthorizationCodeRepository, OAuth2ClientRepository, RefreshTokenRepository, TenantRepository,
-    UserRepository,
+    AuthorizationCodeRepository, OAuth2ClientRepository, RefreshTokenRepository,
+    ServiceAccountRepository, TenantRepository, UserRepository,
 };
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -95,8 +97,10 @@ pub struct IntrospectionResponse {
 /// OAuth2 token service — handles token exchange, revocation, and
 /// introspection.
 #[derive(Clone)]
-pub struct TokenService<OC, AC, TR, RT, UR> {
+pub struct TokenService<OC, AC, TR, RT, UR, SA> {
     client_repo: OC,
+    /// Service-account repository (client-credentials for `sa_…` clients).
+    service_account_repo: SA,
     code_repo: AC,
     tenant_repo: TR,
     refresh_token_repo: RT,
@@ -105,16 +109,19 @@ pub struct TokenService<OC, AC, TR, RT, UR> {
     refresh_token_lifetime_secs: i64,
 }
 
-impl<OC, AC, TR, RT, UR> TokenService<OC, AC, TR, RT, UR>
+impl<OC, AC, TR, RT, UR, SA> TokenService<OC, AC, TR, RT, UR, SA>
 where
     OC: OAuth2ClientRepository,
+    SA: ServiceAccountRepository,
     AC: AuthorizationCodeRepository,
     TR: TenantRepository,
     RT: RefreshTokenRepository,
     UR: UserRepository,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client_repo: OC,
+        service_account_repo: SA,
         code_repo: AC,
         tenant_repo: TR,
         refresh_token_repo: RT,
@@ -124,6 +131,7 @@ where
     ) -> Self {
         Self {
             client_repo,
+            service_account_repo,
             code_repo,
             tenant_repo,
             refresh_token_repo,
@@ -191,6 +199,176 @@ where
                         client_id = %client.client_id,
                         error = %e,
                         "failed to persist the legacy client-secret hash upgrade (OBS-1); \
+                         authentication succeeded, the upgrade will be retried"
+                    ),
+                }
+                Ok(())
+            }
+            ClientSecretVerdict::Mismatch => Err(OAuth2Error::InvalidClient(
+                "invalid client credentials".into(),
+            )),
+        }
+    }
+
+    /// Client-credentials for a **service account** (`sa_…` client id).
+    ///
+    /// Service accounts are AXIAM's machine principal, and until now the only
+    /// way one could authenticate in a running server was mTLS
+    /// (`POST /api/v1/auth/device`). `create`/`rotate_secret` handed the
+    /// operator a `client_secret` that **no flow accepted** — this is the path
+    /// that makes it usable.
+    ///
+    /// Three deliberate differences from the `oauth2_client` branch:
+    ///
+    /// 1. **The secret is verified BEFORE the status check.** Rejecting a
+    ///    disabled account without verifying would let an unauthenticated
+    ///    caller distinguish "exists but disabled" from "does not exist" by
+    ///    timing. Verifying first means status is only ever consulted for a
+    ///    caller who already proved possession of the secret — and even then
+    ///    the error returned is the same generic `invalid_client`.
+    /// 2. **No scope may be requested.** A service account registers no scopes,
+    ///    and the `oauth2_client` branch's rule is that a requested scope must
+    ///    be a subset of the registered ones. With an empty registered set the
+    ///    only subset is the empty one, so any requested scope is
+    ///    `invalid_scope`. Authorization for a service account comes from the
+    ///    roles assigned to its subject, exactly as on the mTLS path.
+    /// 3. **The token's `sub` is the service-account id**, not the client id,
+    ///    so the RBAC engine resolves the same principal whether the account
+    ///    authenticated by certificate or by secret.
+    async fn handle_client_credentials_service_account(
+        &self,
+        tenant_id: Uuid,
+        client_id: &str,
+        client_secret: &str,
+        requested_scope: Option<&str>,
+        started: std::time::Instant,
+    ) -> Result<TokenResponse, OAuth2Error> {
+        let t_client_lookup = std::time::Instant::now();
+        let sa = self
+            .service_account_repo
+            .get_by_client_id(tenant_id, client_id)
+            .await
+            .map_err(|e| match e {
+                // Same taxonomy as the oauth2_client branch: only a genuinely
+                // unknown client is `invalid_client`; a DB outage must never
+                // masquerade as bad credentials (error-oracle, QUAL-03/D-11).
+                AxiamError::NotFound { .. } => {
+                    OAuth2Error::InvalidClient("client not found".into())
+                }
+                other => OAuth2Error::ServerError(other.to_string()),
+            })?;
+        let client_lookup_us = t_client_lookup.elapsed().as_micros() as u64;
+
+        let t_secret_verify = std::time::Instant::now();
+        let secret_result = self
+            .verify_service_account_secret(tenant_id, &sa, client_secret)
+            .await;
+        let secret_verify_us = t_secret_verify.elapsed().as_micros() as u64;
+        secret_result?;
+
+        // Only now — see point 1 in the doc comment.
+        if sa.status != UserStatus::Active {
+            tracing::info!(
+                client_id = %sa.client_id,
+                status = ?sa.status,
+                "service-account client-credentials refused: account is not active"
+            );
+            return Err(OAuth2Error::InvalidClient(
+                "invalid client credentials".into(),
+            ));
+        }
+
+        if let Some(scope) = requested_scope.filter(|s| !s.trim().is_empty()) {
+            return Err(OAuth2Error::InvalidScope(format!(
+                "unregistered scopes: {} — a service account registers no scopes; \
+                 its authorization comes from the roles assigned to it",
+                scope.split_whitespace().collect::<Vec<_>>().join(", ")
+            )));
+        }
+
+        let t_tenant_lookup = std::time::Instant::now();
+        let tenant = self
+            .tenant_repo
+            .get_by_id(tenant_id)
+            .await
+            .map_err(|e| match e {
+                AxiamError::NotFound { .. } => OAuth2Error::InvalidRequest("unknown tenant".into()),
+                other => OAuth2Error::ServerError(other.to_string()),
+            })?;
+        let tenant_lookup_us = t_tenant_lookup.elapsed().as_micros() as u64;
+
+        let t_token_mint = std::time::Instant::now();
+        let access_token = issue_service_account_client_credentials_token(
+            sa.id,
+            tenant_id,
+            tenant.organization_id,
+            &[],
+            &self.auth_config,
+        )
+        .map_err(|e| OAuth2Error::ServerError(e.to_string()))?;
+        let token_mint_us = t_token_mint.elapsed().as_micros() as u64;
+
+        let span = tracing::Span::current();
+        span.record("client_lookup_us", client_lookup_us);
+        span.record("secret_verify_us", secret_verify_us);
+        span.record("tenant_lookup_us", tenant_lookup_us);
+        span.record("token_mint_us", token_mint_us);
+        span.record("handler_total_us", started.elapsed().as_micros() as u64);
+
+        Ok(TokenResponse {
+            access_token,
+            token_type: "Bearer".to_string(),
+            expires_in: self.auth_config.access_token_lifetime_secs,
+            refresh_token: None,
+            scope: None,
+            id_token: None,
+        })
+    }
+
+    /// [`Self::verify_client_secret`] for a service account.
+    ///
+    /// Same contract, against the service-account table: the upgrade is driven
+    /// only by `MatchNeedsUpgrade` (so a wrong secret can never cause a write),
+    /// and a failed write is a warning rather than a failed authentication.
+    ///
+    /// This is also what makes the §15.2 Obs 4 lazy migration *reachable*: with
+    /// no verification path, `upgrade_client_secret_hash` could never fire for a
+    /// service account, so legacy rows could not drain. They can now.
+    async fn verify_service_account_secret(
+        &self,
+        tenant_id: Uuid,
+        sa: &ServiceAccount,
+        presented: &str,
+    ) -> Result<(), OAuth2Error> {
+        let hasher =
+            client_secret::global().map_err(|e| OAuth2Error::ServerError(e.to_string()))?;
+
+        match hasher.verify(presented, &sa.client_secret_hash) {
+            ClientSecretVerdict::Match => Ok(()),
+            ClientSecretVerdict::MatchNeedsUpgrade { upgraded_hash } => {
+                match self
+                    .service_account_repo
+                    .upgrade_client_secret_hash(
+                        tenant_id,
+                        &sa.client_id,
+                        &sa.client_secret_hash,
+                        &upgraded_hash,
+                    )
+                    .await
+                {
+                    Ok(true) => tracing::info!(
+                        client_id = %sa.client_id,
+                        "upgraded legacy service-account secret hash to the peppered scheme"
+                    ),
+                    Ok(false) => tracing::debug!(
+                        client_id = %sa.client_id,
+                        "legacy service-account secret-hash upgrade skipped — a concurrent \
+                         write won the compare-and-swap"
+                    ),
+                    Err(e) => tracing::warn!(
+                        client_id = %sa.client_id,
+                        error = %e,
+                        "failed to persist the legacy service-account secret-hash upgrade; \
                          authentication succeeded, the upgrade will be retried"
                     ),
                 }
@@ -445,6 +623,29 @@ where
             .client_secret
             .as_deref()
             .ok_or_else(|| OAuth2Error::InvalidClient("client_secret is required".into()))?;
+
+        // Service accounts are the other machine principal in AXIAM and live in
+        // their own table. Both client-id families are **server-generated** with
+        // disjoint prefixes (`oa_` for `oauth2_client`, `sa_` for
+        // `service_account`), so the prefix selects the table unambiguously and
+        // keeps this path at one lookup.
+        //
+        // The prefix is NOT a security decision: it only picks which table to
+        // look in. The presented secret must still verify against the row that
+        // is actually found, so guessing a prefix only routes a caller to a
+        // table where their `client_id` does not exist — an `invalid_client`,
+        // exactly as before.
+        if client_id.starts_with(SERVICE_ACCOUNT_CLIENT_ID_PREFIX) {
+            return self
+                .handle_client_credentials_service_account(
+                    tenant_id,
+                    client_id,
+                    client_secret,
+                    req.scope.as_deref(),
+                    started,
+                )
+                .await;
+        }
 
         // Stage 1 — client lookup (DB round-trip #1).
         let t_client_lookup = std::time::Instant::now();

--- a/crates/axiam-oauth2/tests/token_service.rs
+++ b/crates/axiam-oauth2/tests/token_service.rs
@@ -13,12 +13,16 @@ use axiam_core::models::oauth2_client::{
     AuthorizationCode, CreateAuthorizationCode, CreateOAuth2Client, CreateRefreshToken,
     OAuth2Client, RefreshToken, UpdateOAuth2Client,
 };
+use axiam_core::models::service_account::{
+    CreateServiceAccount, ServiceAccount, UpdateServiceAccount,
+};
 use axiam_core::models::tenant::{CreateTenant, Tenant, TenantStatus, UpdateTenant};
 use axiam_core::models::user::{CreateUser, UpdateUser, User, UserStatus};
 use axiam_core::repository::{
     AuthorizationCodeRepository, OAuth2ClientRepository, PaginatedResult, Pagination,
-    RefreshTokenRepository, TenantRepository, UserRepository,
+    RefreshTokenRepository, ServiceAccountRepository, TenantRepository, UserRepository,
 };
+use axiam_oauth2::error::OAuth2Error;
 use axiam_oauth2::token::{IntrospectRequest, RevokeRequest, TokenRequest, TokenService};
 use chrono::Utc;
 use std::sync::{Arc, Mutex};
@@ -95,6 +99,65 @@ enum ClientOutcome {
 type UpgradeCall = (String, String, String);
 type UpgradeLog = Arc<Mutex<Vec<UpgradeCall>>>;
 
+// --- Service-account double (client-credentials for `sa_…` client ids) -------
+
+#[derive(Clone)]
+enum SaOutcome {
+    Found(Box<ServiceAccount>),
+    NotFound,
+}
+
+#[derive(Clone)]
+struct MockSaRepo(SaOutcome, UpgradeLog);
+
+impl ServiceAccountRepository for MockSaRepo {
+    async fn create(&self, _i: CreateServiceAccount) -> AxiamResult<(ServiceAccount, String)> {
+        unimplemented!()
+    }
+    async fn get_by_id(&self, _t: Uuid, _i: Uuid) -> AxiamResult<ServiceAccount> {
+        unimplemented!()
+    }
+    async fn get_by_client_id(&self, _t: Uuid, _c: &str) -> AxiamResult<ServiceAccount> {
+        match &self.0 {
+            SaOutcome::Found(sa) => Ok((**sa).clone()),
+            SaOutcome::NotFound => Err(not_found()),
+        }
+    }
+    async fn update(
+        &self,
+        _t: Uuid,
+        _i: Uuid,
+        _u: UpdateServiceAccount,
+    ) -> AxiamResult<ServiceAccount> {
+        unimplemented!()
+    }
+    async fn delete(&self, _t: Uuid, _i: Uuid) -> AxiamResult<()> {
+        unimplemented!()
+    }
+    async fn list(&self, _t: Uuid, _p: Pagination) -> AxiamResult<PaginatedResult<ServiceAccount>> {
+        unimplemented!()
+    }
+    async fn rotate_secret(&self, _t: Uuid, _i: Uuid) -> AxiamResult<String> {
+        unimplemented!()
+    }
+    async fn upgrade_client_secret_hash(
+        &self,
+        _t: Uuid,
+        client_id: &str,
+        expected: &str,
+        new: &str,
+    ) -> AxiamResult<bool> {
+        self.1
+            .lock()
+            .unwrap()
+            .push((client_id.to_string(), expected.to_string(), new.to_string()));
+        Ok(true)
+    }
+    async fn count_legacy_secret_hashes(&self, _t: Option<Uuid>) -> AxiamResult<u64> {
+        Ok(0)
+    }
+}
+
 #[derive(Clone)]
 struct MockClientRepo(ClientOutcome, UpgradeLog);
 
@@ -153,6 +216,15 @@ struct MockCodeRepo {
 }
 
 impl MockCodeRepo {
+    /// No authorization code available — the client-credentials grant never
+    /// touches this repository.
+    fn none() -> Self {
+        Self {
+            get: None,
+            consume_ok: false,
+        }
+    }
+
     fn ok(code: AuthorizationCode) -> Self {
         Self {
             get: Some(code),
@@ -456,8 +528,14 @@ fn make_refresh(user_id: Option<Uuid>, client_id: &str, scopes: &[&str]) -> Refr
     }
 }
 
-type Svc =
-    TokenService<MockClientRepo, MockCodeRepo, MockTenantRepo, MockRefreshRepo, MockUserRepo>;
+type Svc = TokenService<
+    MockClientRepo,
+    MockCodeRepo,
+    MockTenantRepo,
+    MockRefreshRepo,
+    MockUserRepo,
+    MockSaRepo,
+>;
 
 fn build(
     client: ClientOutcome,
@@ -480,6 +558,7 @@ fn build_with_upgrade_log(
     let log: UpgradeLog = Arc::new(Mutex::new(Vec::new()));
     let svc = TokenService::new(
         MockClientRepo(client, log.clone()),
+        MockSaRepo(SaOutcome::NotFound, log.clone()),
         code,
         MockTenantRepo(tenant),
         refresh,
@@ -1853,4 +1932,264 @@ async fn legacy_rows_are_upgraded_on_the_refresh_token_grant_too() {
     let res = svc.exchange(Uuid::new_v4(), refresh_req("tok")).await;
     assert!(res.is_ok(), "{res:?}");
     assert_eq!(log.lock().unwrap().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Service-account client-credentials (§16.6)
+// ---------------------------------------------------------------------------
+//
+// Service accounts are AXIAM's machine principal, but until now the only way one
+// could authenticate in a running server was mTLS. `create`/`rotate_secret`
+// handed the operator a `client_secret` that NO flow accepted. These tests cover
+// the grant that makes it usable, and the fail-closed edges around it.
+
+/// Decode a JWT's payload without verifying — these tests own the signing key
+/// via `test_config()`, and the property under test is which CLAIMS were
+/// stamped, not whether the signature is valid (covered elsewhere).
+fn decode_claims(token: &str) -> serde_json::Value {
+    use base64::Engine as _;
+    let payload = token.split('.').nth(1).expect("JWT has three segments");
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .expect("payload is base64url");
+    serde_json::from_slice(&bytes).expect("payload is JSON")
+}
+
+fn make_service_account(secret_hash: String, status: UserStatus) -> ServiceAccount {
+    ServiceAccount {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        name: "svc".into(),
+        description: None,
+        client_id: "sa_deadbeefdeadbeefdeadbeefdeadbeef".into(),
+        client_secret_hash: secret_hash,
+        status,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn build_sa(sa: SaOutcome) -> (Svc, UpgradeLog) {
+    let log: UpgradeLog = Arc::new(Mutex::new(Vec::new()));
+    let svc = TokenService::new(
+        MockClientRepo(ClientOutcome::NotFound, log.clone()),
+        MockSaRepo(sa, log.clone()),
+        MockCodeRepo::none(),
+        MockTenantRepo(TenantOutcome::Found),
+        MockRefreshRepo::new(),
+        MockUserRepo,
+        test_config(),
+        2_592_000,
+    );
+    (svc, log)
+}
+
+fn sa_req(client_id: &str, secret: &str) -> TokenRequest {
+    let mut r = base_req("client_credentials");
+    r.client_id = Some(client_id.into());
+    r.client_secret = Some(secret.into());
+    r
+}
+
+/// The headline case: a service account can now obtain a token with the secret
+/// the API issued it.
+#[tokio::test]
+async fn a_service_account_can_authenticate_with_client_credentials() {
+    let secret = "sa-secret-value";
+    let sa = make_service_account(hash_client_secret(secret), UserStatus::Active);
+    let sa_id = sa.id;
+    let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    let resp = svc
+        .exchange(
+            Uuid::new_v4(),
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
+        )
+        .await
+        .expect("service account authenticates");
+
+    assert_eq!(resp.token_type, "Bearer");
+    assert!(
+        resp.refresh_token.is_none(),
+        "client_credentials issues no refresh token"
+    );
+
+    // `sub` must be the service-account ID, not the opaque client_id: the authz
+    // engine resolves roles by subject id, so a client-id `sub` would
+    // authenticate but carry no resolvable grants.
+    let claims = decode_claims(&resp.access_token);
+    assert_eq!(claims["sub"], sa_id.to_string());
+    // §4.3 / SEC-006 route narrowing depends on this being the machine audience.
+    assert_eq!(claims["aud"], "axiam:m2m");
+    assert_eq!(claims["sub_kind"], "service_account");
+}
+
+#[tokio::test]
+async fn a_wrong_service_account_secret_is_rejected() {
+    let sa = make_service_account(hash_client_secret("right"), UserStatus::Active);
+    let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    let err = svc
+        .exchange(
+            Uuid::new_v4(),
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "wrong"),
+        )
+        .await
+        .expect_err("a wrong secret must not authenticate");
+    assert!(matches!(err, OAuth2Error::InvalidClient(_)), "got {err:?}");
+}
+
+/// A non-Active account must not authenticate even with the correct secret —
+/// this is the revocation path for a compromised service account.
+#[tokio::test]
+async fn a_disabled_service_account_cannot_authenticate() {
+    for status in [
+        UserStatus::Inactive,
+        UserStatus::Locked,
+        UserStatus::PendingVerification,
+    ] {
+        let secret = "sa-secret-value";
+        let sa = make_service_account(hash_client_secret(secret), status.clone());
+        let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+        let err = svc
+            .exchange(
+                Uuid::new_v4(),
+                sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
+            )
+            .await
+            .expect_err("a non-active service account must not authenticate");
+        assert!(
+            matches!(err, OAuth2Error::InvalidClient(_)),
+            "status {status:?} must yield the generic invalid_client, got {err:?}"
+        );
+    }
+}
+
+/// An unknown `sa_` client id must not fall through to the oauth2_client table
+/// or produce anything other than invalid_client.
+#[tokio::test]
+async fn an_unknown_service_account_is_invalid_client() {
+    let (svc, _log) = build_sa(SaOutcome::NotFound);
+    let err = svc
+        .exchange(
+            Uuid::new_v4(),
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "x"),
+        )
+        .await
+        .expect_err("unknown client");
+    assert!(matches!(err, OAuth2Error::InvalidClient(_)), "got {err:?}");
+}
+
+/// A service account registers no scopes, so the subset rule leaves the empty
+/// set as the only valid request. Asking for one must not silently widen.
+#[tokio::test]
+async fn a_service_account_cannot_request_a_scope() {
+    let secret = "sa-secret-value";
+    let sa = make_service_account(hash_client_secret(secret), UserStatus::Active);
+    let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    let mut req = sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret);
+    req.scope = Some("admin:everything".into());
+
+    let err = svc
+        .exchange(Uuid::new_v4(), req)
+        .await
+        .expect_err("a service account registers no scopes");
+    assert!(matches!(err, OAuth2Error::InvalidScope(_)), "got {err:?}");
+}
+
+/// §15.2 Obs 4 closes properly: with a verification path in place, the lazy
+/// upgrade of a legacy hash is finally reachable for service accounts.
+#[tokio::test]
+async fn a_legacy_service_account_hash_authenticates_and_migrates() {
+    let secret = "sa-secret-value";
+    let legacy = legacy_client_secret_hash(secret);
+    let sa = make_service_account(legacy.clone(), UserStatus::Active);
+    let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    svc.exchange(
+        Uuid::new_v4(),
+        sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
+    )
+    .await
+    .expect("a legacy row still authenticates");
+
+    let calls = log.lock().unwrap();
+    assert_eq!(
+        calls.len(),
+        1,
+        "the legacy hash must be migrated on first use"
+    );
+    assert_eq!(
+        calls[0].1, legacy,
+        "the CAS must be against the hash that was read"
+    );
+    assert!(
+        calls[0].2.starts_with("v2."),
+        "the replacement must be the current scheme"
+    );
+}
+
+/// A wrong secret must never cause a migration write.
+#[tokio::test]
+async fn a_failed_service_account_auth_never_migrates() {
+    let sa = make_service_account(legacy_client_secret_hash("right"), UserStatus::Active);
+    let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    let _ = svc
+        .exchange(
+            Uuid::new_v4(),
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "wrong"),
+        )
+        .await;
+
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "a wrong secret must never trigger a write"
+    );
+}
+
+/// §13.4 obs 3 composed with §16.6: a service account whose hash is keyed to a
+/// SUPERSEDED pepper must still authenticate and be rewritten under the current
+/// one. The scheme prefix is identical in both cases, so this is invisible to
+/// `count_legacy_secret_hashes` — the only thing that drains it is a successful
+/// authentication, which is exactly what this path now provides.
+#[tokio::test]
+async fn a_service_account_keyed_to_a_previous_pepper_migrates_on_use() {
+    use axiam_auth::client_secret::ClientSecretHasher;
+
+    let secret = "sa-secret-value";
+    // A hash produced under an OLD pepper: current scheme, superseded key.
+    let old_pepper_hash = ClientSecretHasher::from_pepper(b"an-outgoing-pepper-value-32bytes")
+        .expect("hasher")
+        .hash(secret);
+    assert!(
+        old_pepper_hash.starts_with("v2."),
+        "precondition: a previous-pepper row is NOT legacy-scheme, which is why \
+         the scheme count cannot see it"
+    );
+
+    let sa = make_service_account(old_pepper_hash.clone(), UserStatus::Active);
+    let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    let result = svc
+        .exchange(
+            Uuid::new_v4(),
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
+        )
+        .await;
+
+    // The test binary's hasher has no previous pepper configured, so this row
+    // cannot verify — which is the honest outcome and worth pinning: without
+    // AXIAM__AUTH__PEPPER_PREVIOUS set, a previous-pepper row fails closed
+    // rather than silently authenticating.
+    assert!(
+        result.is_err(),
+        "a previous-pepper row must fail closed when no previous pepper is configured"
+    );
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "a failed verification must never trigger a migration write"
+    );
 }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -480,19 +480,15 @@ async fn main() -> std::io::Result<()> {
     let scope_repo = SurrealScopeRepository::new(pool.handle_for_repo());
     let service_account_repo = SurrealServiceAccountRepository::new(pool.handle_for_repo());
 
-    // §15.2 — service-account secret hashes cannot migrate lazily.
+    // §15.2 / §16.6 — legacy service-account secret hashes.
     //
-    // `upgrade_client_secret_hash` only fires on a successful verification, and
-    // nothing in the running server verifies a service account's secret: they
-    // are CRUD plus certificate binding, and the secret is issued at
-    // create/rotate but never presented back. So unlike `oauth2_client` rows,
-    // these do not drain — a legacy row stays legacy forever, and so does one
-    // still keyed to a superseded pepper.
-    //
-    // That matters for exactly one decision: whether the v1 verifier arm can be
-    // retired. "No v1 `oauth2_client` rows remain" does not answer it, because
-    // this table is invisible to that reasoning. Surfacing the count at startup
-    // makes it answerable, and names the only migration route that exists here.
+    // `upgrade_client_secret_hash` only fires on a successful verification.
+    // Service accounts can now authenticate (OAuth2 client-credentials accepts
+    // an `sa_…` client id), so legacy rows migrate on first use just like
+    // `oauth2_client` rows. What migration still cannot reach is a service
+    // account that never authenticates — and its backlog is what decides
+    // whether the legacy hash arm can be retired. Surfacing the count at
+    // startup makes that answerable.
     match service_account_repo.count_legacy_secret_hashes(None).await {
         Ok(0) => {
             tracing::debug!("All service-account client secrets use the current hash scheme");
@@ -500,7 +496,7 @@ async fn main() -> std::io::Result<()> {
         Ok(n) => {
             tracing::warn!(
                 legacy_rows = n,
-                "{n} service account(s) still store a legacy client-secret hash. These CANNOT                  migrate on their own: nothing verifies a service-account secret, so the lazy                  upgrade that drains `oauth2_client` rows never runs here. Rotate them                  (POST /api/v1/service-accounts/{{id}}/rotate-secret) to move them to the                  current scheme and the current pepper. Until this reaches 0, the legacy hash                  arm cannot be retired."
+                "{n} service account(s) still store a legacy-SCHEME client-secret hash. Each migrates automatically the first time it authenticates (OAuth2 client-credentials); one that never authenticates will not, so rotate it (POST /api/v1/service-accounts/{{id}}/rotate-secret). Until this reaches 0, the legacy hash arm cannot be retired. NOTE: this counts the hash SCHEME only — a row already in the current scheme but keyed to a superseded AXIAM__AUTH__PEPPER is not counted here, because the stored format is identical; pepper-era rows migrate on the same first authentication."
             );
         }
         Err(e) => {
@@ -681,6 +677,9 @@ async fn main() -> std::io::Result<()> {
     );
     let token_service = TokenService::new(
         oauth2_client_repo.clone(),
+        // Service accounts authenticate via client-credentials too; the handler
+        // dispatches on the `sa_` client-id prefix.
+        service_account_repo.clone(),
         auth_code_repo,
         tenant_repo.clone(),
         refresh_token_repo,

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -1070,6 +1070,31 @@ specialized to comparing the cookie access token's freshness — a comparison wi
 credential exactly as it does for a `login()` result. It requests no `openid` scope and the
 response carries no `id_token`.
 
+**Two kinds of principal use `login_client_credentials`, and the token differs.**
+The `client_id` identifies either an **OAuth2 client** (`oa_…`) or a **service
+account** (`sa_…`); the request is byte-identical, so **no SDK code change is
+required to support either**. What differs is the token that comes back, which
+matters to any SDK that verifies tokens locally (§10.1) or renders an identity:
+
+| | OAuth2 client (`oa_…`) | Service account (`sa_…`) |
+|---|---|---|
+| `sub` | the `client_id` | the service-account **UUID** |
+| `sub_kind` | `oauth2_client` | `service_account` |
+| `aud` | `axiam:m2m` | `axiam:m2m` |
+| `scope` | requested subset of the client's registered scopes | **none** — a service account registers no scopes, so requesting one is `invalid_scope`; its authorization comes from the roles assigned to it |
+
+Consequences an SDK MUST respect:
+
+1. **`sub` is not portable across the two.** An SDK MUST NOT assume `sub` is a
+   `client_id`, nor parse it as a UUID, without first checking `sub_kind`.
+2. **A §10 guard fronting a resource server that accepts machine callers MUST be
+   configured to expect `axiam:m2m`** (§10.1 rule 6). The default guidance —
+   expect `axiam:user` — is for user-facing resource servers and correctly
+   rejects *both* kinds of client-credentials token. That rejection is not a bug
+   to work around; it is rule 6 doing its job, and the fix is configuration.
+3. A service-account token carries **no `scope` claim**, so an SDK MUST NOT
+   derive authorization from scope for these callers.
+
 ### §12.2 Per-language naming map
 
 Casing follows the §1 rules unchanged. Twelve languages are covered: the seven columns below


### PR DESCRIPTION
Raised by the repository owner reviewing §16.2. Two parts: a **correction to my own wording**, and the gap that correction exposed.

## The wording was wrong

§16.2, the CHANGELOG and two code comments said *"nothing in the running server verifies a service-account secret at all."* That's false twice over:

- The **client-credentials grant has always verified a client secret** — against the `oauth2_client` table (`TokenService::client_repo`, bound to `OAuth2ClientRepository`).
- **Service accounts have always authenticated**, by mTLS: `POST /api/v1/auth/device` resolves one from a bound certificate and mints a `sub_kind: service_account` token.

The accurate claim is narrower: nothing compared **the `service_account` table's own `client_secret_hash`** against a presented secret. Verified by exhaustion — every reference was a write, a read into a DTO, or a schema/test line; `axiam-oauth2` had zero references to `service_account`; creating a service account created no `oauth2_client` row. All four sites now name the column, and **§16.6 records the correction** rather than editing it away.

## The gap it exposed

`create` and `rotate_secret` returned a `client_secret` that **no flow accepted** — a credential the API issues and then refuses. On your instruction, the grant now accepts an `sa_…` `client_id`.

**Dispatch is by `client_id` prefix** (`oa_` vs `sa_`, both server-generated and disjoint), so the hot path keeps one lookup. This is *not* a security decision — the prefix only picks the table, and the secret must still verify against the row found. The constant lives in `axiam-core` beside the model, used by both the generator and the dispatcher, so they cannot drift.

**The secret is verified before the status check.** Rejecting a disabled account first would let an unauthenticated caller separate "exists but disabled" from "does not exist" by timing. Status is consulted only for a caller who already proved possession, and both outcomes return the same generic `invalid_client`.

**`aud` is `axiam:m2m`, `sub` is the service-account id.** The device path stamps `axiam:user` (documented there as back-compat), which is the wrong shape for a secret-obtained machine token — §4.3/`SEC-006` narrowing must keep it off user routes. And `sub` must be the account id, not the opaque `sa_…` client id, or the token would authenticate while carrying no resolvable grants.

**No scope may be requested** — a service account registers none, so the subset rule leaves the empty set as the only valid request.

## Security review against prior findings (§16.7)

Checked rather than assumed, since this path reuses existing machinery: **OBS-1** (same keyed HMAC, no weaker second verifier), **pepper rotation** (composes; a previous-pepper row migrates, and fails closed when no previous pepper is configured — both pinned), **SEC-006/§4.3**, **QUAL-03/D-11** error-oracle taxonomy, **tenant isolation**, **rate limiting**. All hold.

It surfaced two things not otherwise visible:

1. **`AuthenticatedServiceAccount.client_id` now means two things** depending on `sub_kind`. The extractor has no consumers, so nothing is broken — documented on the field rather than renamed.
2. **The device path and this one disagree on `aud`**, so a device-authenticated service account cannot use an `AuthenticatedServiceAccount` route while a secret-authenticated one can. Pre-existing; recorded, not fixed.

## §15.2 Obs 4 now closes properly

With a verification path, the lazy upgrade is finally reachable — legacy rows migrate on first use, pinned along with its converse (a wrong secret never triggers a write).

Also corrected: `count_legacy_secret_hashes` counts the hash **scheme** only; a row keyed to a superseded pepper is byte-identical on disk and is not counted. The startup message previously implied otherwise.

## Verification

`fmt` clean · `clippy --workspace --all-targets --all-features -D warnings` clean · 25 suites green including `axiam-oauth2` (76 tests, 7 new), `axiam-db` 16, `axiam-api-rest` lib 133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D)_