### PR TITLE
security: close SEC-086 and the §17 residuals, narrow the device audience

### DIFF
--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -1174,3 +1174,201 @@ This is new authentication surface and was reviewed as such rather than as a dif
 - **Open findings: SEC-086 (LOW)** — the only one, and a one-line fix.
 - **Highest-value follow-up that is not a finding**: move the mTLS service-account token to `axiam:m2m` (residual 1). Everything else above is an observation or an accepted trade-off.
 - **On the new feature**: this is the first *feature* reviewed in this series rather than a fix, and it landed with correct audience separation, server-derived tenant/org, status checks and scope handling on the first pass — the classes that previous rounds had to find the hard way (NEW-1 org derivation, SEC-006 audience confusion, SEC-007 tenant scoping) were all handled up front. The residuals it does carry are mostly inherited parity with the older client-credentials branch, not new mistakes.
+
+## 18. Remediation of §17 (2026-08-04)
+
+- **Base**: server `ca323e7b` (the §17 record) on `main`, itself on top of `5509c2c1` (the new grant).
+- **Scope**: the one open finding (SEC-086), the one partial in §17.1, and the §17.2 residuals.
+- **Result**: SEC-086 closed; the §17.1 partial closed; residuals 1, 2, 3, 6 and 7 actioned — including the audience change §17.4 named as the highest-value follow-up. Residuals 4 and 5 remain accepted trade-offs. No new findings.
+
+### 18.1 SEC-086 — the client-existence oracle
+
+Every token-endpoint client-authentication failure now returns the same
+`error_description` through a single constant, `CLIENT_AUTH_FAILED`
+(`oauth2/token.rs`). Five sites previously said `"client not found"` for an
+unknown client and `"invalid client credentials"` for a bad secret; all five
+now say the latter. The `NotFound`-versus-other-error distinction the
+QUAL-03/D-11 comments protect is untouched — it stays internal, still mapping
+to `invalid_client` versus `server_error` — so a DB outage still cannot read as
+bad credentials. Only the caller-visible wording collapsed.
+
+`authorize.rs:74` was deliberately **left alone**. At the authorization
+endpoint `client_id` is public by construction (it travels in the URL), RFC
+6749 §4.1.2.1 requires informing the resource owner directly rather than
+redirecting, and no credential is presented — so "invalid client credentials"
+there would be actively misleading, and there is no secret for it to protect.
+
+Pinned by `an_unknown_client_is_indistinguishable_from_a_wrong_secret`, which
+asserts the two failures are equal as `(code, description)` pairs and then pins
+the literal wording, so a future edit cannot reintroduce the oracle by changing
+both arms to something that still names the cause.
+
+**On the timing asymmetry the finding also named** — the unknown-client branch
+returns before any HMAC is computed — this was assessed and deliberately not
+"fixed" with a dummy HMAC. The skipped work is a single HMAC-SHA256 over a
+short string: sub-microsecond, and dominated by the DB round-trip that differs
+between the two branches anyway (a miss and a row read are not equal-cost, and
+cannot be made so without a dummy query). Adding a compensating HMAC would
+close the smaller channel while leaving the larger one, which is theatre rather
+than remediation. The honest statement is that the *description* oracle is
+closed and a timing channel bounded by DB variance remains — against 128-bit
+CSPRNG client ids, which is why SEC-086 was LOW to begin with.
+
+### 18.2 The §17.1 partial — compare-before-clear
+
+The cache-invalidation publisher's failure path cleared its channel slot only
+if the slot still held "the same channel", tested with `Channel::id()`. §17.1
+was right that this is the AMQP channel **number** (`u16`), recycled by the
+broker after a close, so it identifies a slot on the connection and not a
+handle. `Arc::ptr_eq` is unavailable — lapin does not expose the inner `Arc` —
+so the slot is now `Option<(u64, Channel)>` stamped from a monotonic
+`AtomicU64` bumped on every fill. Generations are never reused, so `==` means
+"still the very handle that failed" exactly, and the comparison no longer rests
+on an invariant the library does not guarantee.
+
+**Test gap, stated plainly:** this cannot be exercised here. Constructing two
+real `lapin::Channel`s needs a live broker, which this crate's tests do not
+have — the same limitation the existing publisher test already records in its
+own comment. The change is verified by construction, not by a test.
+
+### 18.3 Residual 1 — the mTLS device path now mints `axiam:m2m`
+
+§17.4 called this "the most valuable follow-up", and it was, but §17 did not
+state the fact that determines how to land it: **every guarded REST handler
+takes `AuthenticatedUser`, which requires `aud = axiam:user`, and
+`AuthenticatedServiceAccount` is consumed by no route.** So `axiam:m2m` reached
+*zero* REST endpoints. Flipping the device path on its own would not have
+narrowed a too-wide grant; it would have replaced it with no grant at all —
+an outage for every deployed IoT device, with no migration path.
+
+So the flip landed together with the surface it needs:
+
+1. `issue_service_account_token` stamps `AUD_M2M` (`auth/token.rs`). Both ways
+   a service account can authenticate — mTLS and client-credentials — now yield
+   a machine-audience token. The audience describes the principal, not the
+   issuing endpoint.
+2. A new `AuthenticatedPrincipal` extractor accepts **either** audience and
+   yields `(subject_id, tenant_id, org_id, is_machine)`.
+3. It is used on the authorization-check endpoints **only** — `POST
+   /api/v1/authz/check` and the batch form — which are the machine-facing
+   read-only surface. Every other route keeps `AuthenticatedUser` and still
+   rejects machine tokens outright.
+
+Three properties worth recording because they are what make the widening safe:
+
+- **User tokens are not weakened.** A `axiam:user` token taken through the
+  wider extractor still gets the same session-revocation check (REQ-7 / D-15).
+  That check is skipped only for machines, which have no session row to check.
+  The absent-`aud` back-compat window is still decided by the *same*
+  `check_user_aud_and_parse_jti` the narrow extractor uses, so the two cannot
+  drift, and an absent `aud` is never silently treated as a machine.
+- **Authorization is not widened.** `RequirePermission::check_subject` applies
+  RBAC identically to both kinds of principal — deliberately with no
+  `is_machine` parameter to branch on — so a device still needs
+  `authz:check_as` to query another subject. Pinned by
+  `a_machine_principal_still_needs_check_as_to_query_another_subject`.
+- **The audit trail stays truthful.** `append_check_as_audit` previously
+  hardcoded `ActorType::User`; it now takes the principal's actor type, so a
+  device's cross-subject query is recorded as a `ServiceAccount`. `authz.check_as`
+  is legally significant, so attributing it to a user would have been a false
+  record.
+
+**This is a breaking change**, and the third in this series after the two in
+§9.3. A device can no longer call user-facing routes. That access was implicit
+rather than designed — nothing pinned it, which is precisely why the flip was
+initially invisible to the device-auth suite: it never asserted `aud` at all.
+It does now, and it also asserts the narrowing bites by driving the device
+token at a user route and requiring a 401.
+
+### 18.4 Residual 2 — the gRPC audience check
+
+The real gap was narrower and worse than "no audience check": `decode_access_token`
+accepts both audiences and **skips the audience check entirely when the claim is
+absent** (the D-20 pre-Phase-4 window), so a token with no `aud` reached the
+authorization service with nothing applied and nothing recorded. REST gates that
+case on `allow_missing_aud_as_user` and warns on every use; this transport did
+neither.
+
+The interceptor now states the policy: both audiences accepted (deliberately —
+this is the service-mesh check surface, so machine callers are the norm while
+user tokens reach it through SDK callers), an unknown audience rejected, and an
+absent one gated on the same `allow_missing_aud_as_user` flag with the same
+per-request warning. gRPC was **not** narrowed to m2m-only: that would break
+user-token callers, and nothing in the review suggests it should.
+
+### 18.5 Residuals 3, 6, 7
+
+- **3 — a failed client auth accrued nothing.** The token endpoint now writes
+  an `oauth2.client_auth_failed` audit entry on every `invalid_client`, with
+  the attempted `client_id`, the grant type and the client IP; never the
+  secret. Fire-and-forget, so an audit-sink outage cannot turn a 401 into a
+  500 (T-15-04). Recorded with `actor_id = Uuid::nil()` and `ActorType::System`
+  because the caller is by definition unauthenticated — the presented
+  `client_id` must be evidence in the metadata, not promoted to identity.
+  **Lockout was deliberately not added**: secrets are 256-bit CSPRNG values so
+  online guessing is not the threat, and a lockout keyed on a caller-supplied
+  `client_id` would hand any unauthenticated party a DoS against a known
+  client. This closes the detection half, which is the half that was missing.
+- **6 — the cross-tenant boundary.** The handler now asserts
+  `sa.tenant_id == tenant_id` before the secret is verified, so a foreign row
+  can neither act as a verification oracle nor trigger a hash-upgrade write
+  against another tenant's record. §17.2 noted no test could prove this because
+  the mock ignores `tenant_id`; that indifference is exactly what makes the
+  test possible — it models a repository whose tenant predicate has been
+  dropped. `a_service_account_from_another_tenant_is_refused` fails without the
+  assertion, and before it that exchange **succeeded**. The seven pre-existing
+  service-account tests were handing the fixture a random tenant and exchanging
+  under a different one; they now bind both to the same tenant, so each
+  exercises the behaviour it names rather than the new refusal.
+- **7 — the misleading field name.** `AuthenticatedServiceAccount.client_id`
+  is now `subject`. No route consumes the extractor, so the rename is free —
+  which is why it happened now rather than after something depended on it.
+
+### 18.6 Deliberately not actioned
+
+1. **Residual 4 — disabling a service account does not revoke issued tokens.**
+   Unchanged: m2m tokens have no session row and introspection re-validates the
+   JWT without re-reading the account, so a disabled account's token reports
+   `active: true` until expiry (default 900 s). Identical in shape to the
+   existing OAuth2-client path and the same accepted `T-39` trade-off. Closing
+   it means giving machine tokens a server-side revocation record, which is a
+   design change, not a patch.
+2. **Residual 5 — `ServiceAccount` has no expiry field.** A schema and
+   lifecycle change; rotation remains the control. Not a defect to smuggle into
+   a security remediation.
+3. **§16.3a's remaining SDK work — the rule-8 guardrail tests.** Still landed
+   only in TypeScript and Python; still outstanding in the other nine. Carried
+   again, and it should be said plainly that this is now the third round it has
+   been carried. It is a mechanical but genuinely multi-language lift (two
+   tests each across eight languages) and deserves its own PR series rather
+   than being appended to a round whose subject is a breaking authentication
+   change. §15.1's hand-verification that all eleven guards reject correctly
+   today still stands, so this remains a regression-guard gap, not a defect.
+4. Everything §16.4 listed as deliberately not actioned, unchanged.
+
+### 18.7 What a verifier should look at hardest
+
+1. **The `AuthenticatedPrincipal` widening.** It is the one place a machine
+   token can now enter the REST surface. Confirm it is used on the two authz-check
+   handlers and nowhere else; that the session-revocation check really does still
+   run for user tokens taken through it; and that an absent `aud` cannot reach the
+   machine branch.
+2. **The device audience flip's blast radius.** The claim is that the
+   authorization-check endpoints are the only REST surface a device needs.
+   That is an assertion about deployments, not about code — worth challenging
+   against how fleets actually use the device token.
+3. **The tenant assertion's placement.** It is before secret verification on
+   purpose. Confirm no reordering puts a foreign row through the hasher.
+4. **The audit event's metadata.** Confirm the presented `client_id` is the
+   only caller-controlled value recorded and that no secret can reach it.
+
+### 18.8 SDK impact
+
+`CONTRACT.md` §12.1 gains the device-token breaking change, and §10.1 rule 6
+now states the machine-facing case explicitly: `axiam:m2m` is what *every*
+service-account token carries, by either authentication path. No SDK code
+change is required — the device-auth call and response shape are unchanged,
+only the `aud` value differs — but a §10 guard fronting a resource server that
+accepts device callers must be configured to expect `axiam:m2m`, and any SDK
+device flow that called a non-authz endpoint with the device token must
+migrate that call deliberately.

--- a/crates/axiam-amqp/src/cache_invalidation.rs
+++ b/crates/axiam-amqp/src/cache_invalidation.rs
@@ -147,6 +147,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use axiam_authz::decision_cache::DecisionCache;
@@ -798,7 +799,21 @@ pub struct CacheInvalidationPublisher {
     ///
     /// `tokio::sync::Mutex`, not `std::sync::Mutex`: the guard is held across
     /// the `.await` on the broker's confirm.
-    channel: TokioMutex<Option<Channel>>,
+    ///
+    /// Paired with a **generation counter**, bumped every time the slot is
+    /// filled. §17.1 recorded that the compare-before-clear below originally
+    /// tested `Channel::id()`, which in lapin is the AMQP channel *number*
+    /// (`u16`) — the broker recycles it after a close, so it identifies a slot
+    /// on the connection rather than a particular handle. Two channels that
+    /// are genuinely different could therefore compare equal (a reopen that
+    /// happened to be assigned the same number), and the clear would discard a
+    /// healthy replacement. The generation is monotonic and process-local, so
+    /// the comparison is exact and does not rest on a lapin invariant.
+    channel: TokioMutex<Option<(u64, Channel)>>,
+    /// Source of the generation stamps above. Every increment happens while
+    /// the `channel` lock is held, which supplies all the ordering that
+    /// matters; the counter is atomic purely so the slot's type stays simple.
+    next_generation: AtomicU64,
     master_key: Vec<u8>,
     origin_id: Uuid,
 }
@@ -819,6 +834,7 @@ impl CacheInvalidationPublisher {
         Self {
             channels,
             channel: TokioMutex::new(None),
+            next_generation: AtomicU64::new(0),
             master_key,
             origin_id,
         }
@@ -878,19 +894,22 @@ impl CacheInvalidationPublisher {
     /// reopen logic single-threaded while letting publishes proceed
     /// concurrently — which is what the AMQP channel already supports.
     async fn publish_payload(&self, payload: &[u8]) -> Result<(), AmqpError> {
-        let channel = {
+        let (generation, channel) = {
             let mut slot = self.channel.lock().await;
 
             // Drop a channel the broker has already closed, so the next block
             // opens a fresh one instead of publishing into a dead handle.
-            if slot.as_ref().is_some_and(|c| !c.status().connected()) {
+            if slot.as_ref().is_some_and(|(_, c)| !c.status().connected()) {
                 warn!("Cache-invalidation publisher channel is closed — reopening");
                 *slot = None;
             }
             if slot.is_none() {
-                *slot = Some(self.channels.open().await?);
+                let opened = self.channels.open().await?;
+                let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+                *slot = Some((generation, opened));
             }
-            slot.as_ref().expect("channel opened above").clone()
+            let (generation, channel) = slot.as_ref().expect("channel opened above");
+            (*generation, channel.clone())
             // Guard dropped here — the confirm below is awaited unlocked.
         };
 
@@ -909,8 +928,16 @@ impl CacheInvalidationPublisher {
                 // replaced the slot with a healthy channel. Clearing
                 // unconditionally would discard that one too, and a burst of
                 // failures could then thrash the slot indefinitely.
+                //
+                // The comparison is on the generation stamp, not on
+                // `Channel::id()`: the latter is the broker's channel *number*
+                // and is recycled after a close, so a reopened channel could
+                // wear the same id as the dead one this call was holding and
+                // be cleared in its place (§17.1). Generations are monotonic
+                // and never reused, so `==` here means "still the very handle
+                // that failed" and nothing else.
                 let mut slot = self.channel.lock().await;
-                if slot.as_ref().is_some_and(|c| c.id() == channel.id()) {
+                if slot.as_ref().is_some_and(|(g, _)| *g == generation) {
                     *slot = None;
                 }
                 Err(e)

--- a/crates/axiam-api-grpc/src/middleware/auth.rs
+++ b/crates/axiam-api-grpc/src/middleware/auth.rs
@@ -9,7 +9,7 @@
 //! than trusting the request body.
 
 use axiam_auth::config::AuthConfig;
-use axiam_auth::token::validate_access_token;
+use axiam_auth::token::{AUD_M2M, AUD_USER, validate_access_token};
 use tonic::service::Interceptor;
 use tonic::{Request, Status};
 
@@ -41,6 +41,34 @@ impl Interceptor for AuthInterceptor {
 
         let claims = validate_access_token(token, &self.auth_config)
             .map_err(|_| Status::unauthenticated("invalid or expired token"))?;
+
+        // §17.2 residual 2: the audience policy on this transport used to be
+        // entirely implicit. `decode_access_token` accepts both audiences, and
+        // deliberately **skips** the audience check altogether when the claim
+        // is absent (the D-20 pre-Phase-4 back-compat window) — so a token
+        // with no `aud` reached the authorization service with no narrowing
+        // applied and nothing recorded about it. The REST extractors gate that
+        // same case on `allow_missing_aud_as_user` and warn on every use; this
+        // transport did neither.
+        //
+        // gRPC accepts **both** audiences on purpose, and that is now stated
+        // rather than inherited: this is the low-latency check surface for a
+        // service mesh, so machine callers are the norm, while user tokens
+        // reach it through SDK callers doing the same checks. What is fixed
+        // here is the *unstated* third case.
+        match claims.0.aud.as_deref() {
+            Some(AUD_USER) | Some(AUD_M2M) => {}
+            None => {
+                if !self.auth_config.allow_missing_aud_as_user {
+                    return Err(Status::unauthenticated("aud required"));
+                }
+                tracing::warn!(
+                    token_jti = %claims.0.jti,
+                    "grpc: accepted access token without aud — backward-compat window active"
+                );
+            }
+            Some(_) => return Err(Status::unauthenticated("unknown audience")),
+        }
 
         req.extensions_mut().insert(claims);
         Ok(req)

--- a/crates/axiam-api-rest/src/authz.rs
+++ b/crates/axiam-api-rest/src/authz.rs
@@ -186,9 +186,27 @@ impl RequirePermission {
         user: &AuthenticatedUser,
         authz: &dyn AuthzChecker,
     ) -> Result<(), AxiamApiError> {
+        self.check_subject(user.tenant_id, user.user_id, authz)
+            .await
+    }
+
+    /// Same check, against an explicit `(tenant, subject)` pair.
+    ///
+    /// Exists so the authorization-check endpoints can guard a caller that may
+    /// be a machine rather than a user (§17.2 residual 1) without every one of
+    /// the ~100 [`check`](Self::check) call sites having to change. RBAC is
+    /// applied **identically** to both kinds of principal — a service account's
+    /// grants come from the roles assigned to it, exactly as a user's do — so
+    /// there is deliberately no `is_machine` parameter here to branch on.
+    pub async fn check_subject(
+        &self,
+        tenant_id: Uuid,
+        subject_id: Uuid,
+        authz: &dyn AuthzChecker,
+    ) -> Result<(), AxiamApiError> {
         let request = AccessRequest {
-            tenant_id: user.tenant_id,
-            subject_id: user.user_id,
+            tenant_id,
+            subject_id,
             action: self.action.clone(),
             resource_id: self.resource_id,
             scope: self.scope.clone(),

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -123,7 +123,7 @@ impl actix_web::FromRequest for AuthenticatedUser {
 /// Accepts only tokens with `aud = axiam:m2m`; user tokens are rejected.
 #[derive(Debug, Clone)]
 pub struct AuthenticatedServiceAccount {
-    /// The token's `sub` claim.
+    /// The token's `sub` claim — the **subject** of the machine token.
     ///
     /// **Its meaning depends on which principal obtained the token**, so do not
     /// treat it as an OAuth2 `client_id` without checking `claims.sub_kind`:
@@ -134,10 +134,12 @@ pub struct AuthenticatedServiceAccount {
     ///   service account's grants are resolved by subject id (§16.6). It is
     ///   *not* the `sa_…` client id.
     ///
-    /// The field name predates service accounts being able to use this grant.
-    /// No route consumes this extractor today; the distinction is recorded here
-    /// so the first one that does gets it right.
-    pub client_id: String,
+    /// Named `subject` rather than `client_id` for exactly that reason
+    /// (§17.2 residual 7): the old name was accurate for only one of the two
+    /// principals and invited the first consumer to treat a UUID as a client
+    /// id. No route consumes this extractor today, so the rename is free —
+    /// which is why it happens now rather than after something depends on it.
+    pub subject: String,
     pub tenant_id: Uuid,
     pub claims: ValidatedClaims,
 }
@@ -344,10 +346,148 @@ fn extract_service_account(
         })?;
 
     Ok(AuthenticatedServiceAccount {
-        client_id: validated.0.sub.clone(),
+        subject: validated.0.sub.clone(),
         tenant_id,
         claims: validated,
     })
+}
+
+// ---------------------------------------------------------------------------
+// AuthenticatedPrincipal extractor — accepts either audience
+// ---------------------------------------------------------------------------
+
+/// An authenticated caller that may be **either** a human user
+/// (`aud = axiam:user`) or a machine (`aud = axiam:m2m`).
+///
+/// This exists so the mTLS device path can carry the machine audience
+/// (§17.2 residual 1) without losing the endpoints a device legitimately
+/// needs. Before it, `axiam:m2m` reached **no** REST route at all — every
+/// guarded handler takes [`AuthenticatedUser`], which rejects that audience —
+/// so moving device tokens to `axiam:m2m` on its own would have replaced a
+/// too-wide grant with no grant, which is an outage rather than a narrowing.
+///
+/// **What this deliberately is not:** a general-purpose relaxation. It is used
+/// only on the authorization-check endpoints, which are the machine-facing
+/// read-only surface. Every other route keeps [`AuthenticatedUser`] and so
+/// keeps rejecting machine tokens outright. Widening its use is a security
+/// decision, not a convenience one.
+///
+/// Two properties worth stating because they are easy to lose:
+///
+/// * **User tokens are not weakened.** A `axiam:user` token extracted this way
+///   still goes through the same session-revocation check
+///   [`AuthenticatedUser`] applies, so a revoked session cannot reach these
+///   endpoints through the wider extractor. That check is skipped only for
+///   machine tokens, which have no session row to check by construction.
+/// * **`aud` must be present.** The `allow_missing_aud_as_user` back-compat
+///   window is honoured for the user branch only, exactly as on the narrow
+///   extractor — an absent `aud` is never silently treated as a machine.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedPrincipal {
+    /// The subject the authorization engine should evaluate: the user id for a
+    /// user token, the service-account id for a machine token. Both are the
+    /// token's `sub`, and both are what role assignments are keyed on.
+    pub subject_id: Uuid,
+    pub tenant_id: Uuid,
+    pub org_id: Uuid,
+    /// `true` when the caller authenticated as a machine (`aud = axiam:m2m`).
+    /// Handlers use this for audit attribution, not for authorization — RBAC
+    /// is applied identically to both kinds.
+    pub is_machine: bool,
+    pub claims: ValidatedClaims,
+}
+
+impl AuthenticatedPrincipal {
+    /// Audit actor type matching how this principal authenticated.
+    pub fn actor_type(&self) -> axiam_core::models::audit::ActorType {
+        if self.is_machine {
+            axiam_core::models::audit::ActorType::ServiceAccount
+        } else {
+            axiam_core::models::audit::ActorType::User
+        }
+    }
+}
+
+fn extract_principal(req: &HttpRequest) -> Result<AuthenticatedPrincipal, AxiamApiError> {
+    let config = req
+        .app_data::<web::Data<AuthConfig>>()
+        .ok_or(AxiamError::Internal("missing auth config".into()))?;
+
+    let validated = match req.extensions().get::<Arc<CachedUserIdentity>>() {
+        Some(cached) => cached.claims.clone(),
+        None => parse_validated_claims(req)?,
+    };
+
+    // Machine tokens take the m2m branch; everything else (including the
+    // absent-`aud` back-compat window) is decided by the *same* function the
+    // narrow user extractor uses, so the two cannot drift apart.
+    let is_machine = validated.0.aud.as_deref() == Some(AUD_M2M);
+    if !is_machine {
+        check_user_aud_and_parse_jti(&validated, config)?;
+    }
+
+    let subject_id =
+        Uuid::parse_str(&validated.0.sub).map_err(|_| AxiamError::AuthenticationFailed {
+            reason: "invalid sub claim".into(),
+        })?;
+    let tenant_id =
+        Uuid::parse_str(&validated.0.tenant_id).map_err(|_| AxiamError::AuthenticationFailed {
+            reason: "invalid tenant_id claim".into(),
+        })?;
+    let org_id =
+        Uuid::parse_str(&validated.0.org_id).map_err(|_| AxiamError::AuthenticationFailed {
+            reason: "invalid org_id claim".into(),
+        })?;
+
+    Ok(AuthenticatedPrincipal {
+        subject_id,
+        tenant_id,
+        org_id,
+        is_machine,
+        claims: validated,
+    })
+}
+
+impl actix_web::FromRequest for AuthenticatedPrincipal {
+    type Error = AxiamApiError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self, Self::Error>>>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        let principal_result = extract_principal(req);
+        let validator = req
+            .app_data::<web::Data<Arc<dyn SessionValidator>>>()
+            .map(|d| d.get_ref().clone());
+
+        Box::pin(async move {
+            let principal = principal_result?;
+
+            // A user token reaching these endpoints must satisfy exactly the
+            // same session-revocation rule it would on any other route
+            // (REQ-7 / D-15). Skipping it for machines is not a relaxation:
+            // a machine token has no session row, so there is nothing to
+            // revoke — revocation for machines is disabling the account,
+            // which the token-issuing path checks.
+            if !principal.is_machine
+                && let Some(validator) = validator
+            {
+                let session_id = Uuid::parse_str(&principal.claims.0.jti).map_err(|_| {
+                    AxiamError::AuthenticationFailed {
+                        reason: "invalid jti".into(),
+                    }
+                })?;
+                if !validator
+                    .is_session_active(principal.tenant_id, session_id)
+                    .await
+                {
+                    return Err(AxiamError::AuthenticationFailed {
+                        reason: "session revoked or expired".into(),
+                    }
+                    .into());
+                }
+            }
+            Ok(principal)
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/axiam-api-rest/src/handlers/authz_check.rs
+++ b/crates/axiam-api-rest/src/handlers/authz_check.rs
@@ -6,7 +6,7 @@
 //!
 //! Both endpoints delegate to the **same** `AuthzChecker::check_access`
 //! path as the gRPC `AuthorizationService` (D-08). Identity is derived
-//! exclusively from the verified JWT (`user.tenant_id`, `user.user_id`);
+//! exclusively from the verified JWT (`user.tenant_id`, `user.subject_id`);
 //! no identity field is accepted from the request body.
 //!
 //! The `subject_id` field in the body enables cross-subject ("check-as")
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::authz::{AuthzChecker, AuthzData, RequirePermission};
 use crate::error::AxiamApiError;
-use crate::extractors::auth::AuthenticatedUser;
+use crate::extractors::auth::AuthenticatedPrincipal;
 use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
@@ -98,6 +98,7 @@ async fn append_check_as_audit<C: Connection + Clone>(
     audit_repo: &SurrealAuditLogRepository<C>,
     tenant_id: Uuid,
     actor_id: Uuid,
+    actor_type: ActorType,
     queried_subject: Uuid,
     resource_id: Uuid,
 ) {
@@ -105,7 +106,11 @@ async fn append_check_as_audit<C: Connection + Clone>(
         .append(CreateAuditLogEntry {
             tenant_id,
             actor_id,
-            actor_type: ActorType::User,
+            // §17.2 residual 1: these endpoints now also serve machine
+            // callers, so the actor type follows the principal rather than
+            // being hardcoded — a device must not be recorded as a User in a
+            // legally significant trail.
+            actor_type,
             action: "authz.check_as".into(),
             resource_id: Some(resource_id),
             outcome: AuditOutcome::Success,
@@ -149,7 +154,7 @@ async fn append_check_as_audit<C: Connection + Clone>(
     security(("bearer" = []))
 )]
 pub async fn check_access<C: Connection + Clone>(
-    user: AuthenticatedUser,
+    user: AuthenticatedPrincipal,
     authz: AuthzData,
     state: web::Data<AppState<C>>,
     body: web::Json<CheckAccessBody>,
@@ -161,20 +166,21 @@ pub async fn check_access<C: Connection + Clone>(
     // is always user.tenant_id (never from body).
     let effective_subject = if let Some(sid) = body.subject_id {
         RequirePermission::new("authz:check_as", user.tenant_id)
-            .check(&user, authz.get_ref().as_ref())
+            .check_subject(user.tenant_id, user.subject_id, authz.get_ref().as_ref())
             .await?;
         // T-15-04: audit every cross-subject query before returning.
         append_check_as_audit(
             &state.audit_repo,
             user.tenant_id,
-            user.user_id,
+            user.subject_id,
+            user.actor_type(),
             sid,
             resource_id,
         )
         .await;
         sid
     } else {
-        user.user_id
+        user.subject_id
     };
 
     let access_req = AccessRequest {
@@ -213,7 +219,7 @@ pub async fn check_access<C: Connection + Clone>(
     security(("bearer" = []))
 )]
 pub async fn batch_check_access<C: Connection + Clone>(
-    user: AuthenticatedUser,
+    user: AuthenticatedPrincipal,
     authz: AuthzData,
     state: web::Data<AppState<C>>,
     body: web::Json<BatchCheckAccessBody>,
@@ -226,7 +232,7 @@ pub async fn batch_check_access<C: Connection + Clone>(
     let has_override = body.checks.iter().any(|c| c.subject_id.is_some());
     if has_override {
         RequirePermission::new("authz:check_as", user.tenant_id)
-            .check(&user, authz.get_ref().as_ref())
+            .check_subject(user.tenant_id, user.subject_id, authz.get_ref().as_ref())
             .await?;
     }
 
@@ -238,14 +244,23 @@ pub async fn batch_check_access<C: Connection + Clone>(
     let checker: &dyn AuthzChecker = authz.get_ref().as_ref();
     let audit_repo_ref: &SurrealAuditLogRepository<C> = &state.audit_repo;
     let tenant_id = user.tenant_id;
-    let actor_id = user.user_id;
+    let actor_id = user.subject_id;
+    let actor_kind = user.actor_type();
 
     let mut access_requests = Vec::with_capacity(body.checks.len());
     for check in body.checks {
         let resource_id = check.resource_id;
         let effective_subject = if let Some(sid) = check.subject_id {
             // T-15-04: audit each cross-subject item individually.
-            append_check_as_audit(audit_repo_ref, tenant_id, actor_id, sid, resource_id).await;
+            append_check_as_audit(
+                audit_repo_ref,
+                tenant_id,
+                actor_id,
+                actor_kind.clone(),
+                sid,
+                resource_id,
+            )
+            .await;
             sid
         } else {
             actor_id

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -16,7 +16,12 @@ use serde::{Deserialize, Serialize};
 use surrealdb::Connection;
 use uuid::Uuid;
 
+use axiam_core::models::audit::{ActorType, AuditOutcome, CreateAuditLogEntry};
+use axiam_core::repository::AuditLogRepository;
+use axiam_db::SurrealAuditLogRepository;
+
 use crate::extractors::auth::AuthenticatedUser;
+use crate::extractors::client_info::client_ip;
 use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
@@ -153,6 +158,7 @@ pub async fn authorize<C: Connection + Clone>(
     ),
 )]
 pub async fn token<C: Connection + Clone>(
+    req: HttpRequest,
     tenant_query: web::Query<TenantQuery>,
     form: web::Form<TokenRequest>,
     state: web::Data<AppState<C>>,
@@ -163,6 +169,10 @@ pub async fn token<C: Connection + Clone>(
     // I5: keep the grant type for the stage-timing event below. The token
     // service moves `form`, so copy the (short) discriminator first.
     let grant_type = form.grant_type.clone();
+    // §17.2 residual 3: same reason, for the failed-client-auth audit event
+    // below. Never the secret — only the client id, which is the caller's own
+    // input and is what an operator needs to correlate an attack.
+    let attempted_client_id = form.client_id.clone();
     let started = std::time::Instant::now();
 
     match state.token_service.exchange(tenant_id, form).await {
@@ -205,7 +215,75 @@ pub async fn token<C: Connection + Clone>(
                 .content_type("application/json")
                 .body(body)
         }
-        Err(e) => build_oauth2_error_response(&e),
+        Err(e) => {
+            if matches!(e, OAuth2Error::InvalidClient(_)) {
+                append_client_auth_failure_audit(
+                    &state.audit_repo,
+                    tenant_id,
+                    attempted_client_id.as_deref(),
+                    &grant_type,
+                    client_ip(&req),
+                )
+                .await;
+            }
+            build_oauth2_error_response(&e)
+        }
+    }
+}
+
+/// Append an `oauth2.client_auth_failed` audit entry, fire-and-forget.
+///
+/// §17.2 residual 3: a failed client authentication at the token endpoint used
+/// to accrue **nothing** — no counter, no lockout, no audit row, no metric —
+/// and `/oauth2` is not covered by the audit middleware, so nothing else
+/// filled the gap either. Contrast the interactive login path, which records
+/// every failure and applies exponential backoff.
+///
+/// This closes the **detection** half only, which is the half that was
+/// genuinely missing. Lockout is deliberately *not* added here: client
+/// credentials are 256-bit CSPRNG values, so online guessing is not the threat
+/// — and a lockout keyed on a caller-supplied `client_id` would hand any
+/// unauthenticated party a denial-of-service against a known client. The
+/// endpoint's existing rate limit remains the volumetric control.
+///
+/// Recorded with `actor_id = Uuid::nil()` and [`ActorType::System`] because
+/// the caller is by definition unauthenticated: the presented `client_id`
+/// either does not exist or did not prove possession of its secret, so it must
+/// not be promoted into the actor field as though it had. It goes in the
+/// metadata instead, where it is evidence rather than identity.
+///
+/// The secret is never recorded, in any form.
+async fn append_client_auth_failure_audit<C: Connection + Clone>(
+    audit_repo: &SurrealAuditLogRepository<C>,
+    tenant_id: Uuid,
+    attempted_client_id: Option<&str>,
+    grant_type: &str,
+    ip_address: Option<String>,
+) {
+    if let Err(e) = audit_repo
+        .append(CreateAuditLogEntry {
+            tenant_id,
+            actor_id: Uuid::nil(),
+            actor_type: ActorType::System,
+            action: "oauth2.client_auth_failed".into(),
+            resource_id: None,
+            outcome: AuditOutcome::Failure,
+            ip_address,
+            metadata: Some(serde_json::json!({
+                "client_id": attempted_client_id,
+                "grant_type": grant_type,
+            })),
+        })
+        .await
+    {
+        // Never propagated: a token-endpoint 401 must not become a 500 because
+        // the audit sink is unavailable (T-15-04).
+        tracing::error!(
+            error = %e,
+            %tenant_id,
+            %grant_type,
+            "oauth2: failed to write oauth2.client_auth_failed audit log"
+        );
     }
 }
 

--- a/crates/axiam-api-rest/src/tests/authz_check_test.rs
+++ b/crates/axiam-api-rest/src/tests/authz_check_test.rs
@@ -25,7 +25,7 @@ use uuid::Uuid;
 
 use crate::authz::{AllowAllAuthzChecker, AuthzChecker, AuthzData, DenyAllAuthzChecker};
 use crate::error::AxiamApiError;
-use crate::extractors::auth::AuthenticatedUser;
+use crate::extractors::auth::AuthenticatedPrincipal;
 use crate::handlers::authz_check::{
     BatchCheckAccessBody, CheckAccessBody, batch_check_access, check_access,
 };
@@ -49,7 +49,14 @@ async fn setup_db() -> Surreal<surrealdb::engine::local::Db> {
     db
 }
 
-fn make_user(tenant_id: Uuid, user_id: Uuid) -> AuthenticatedUser {
+/// A human principal (`aud = axiam:user`) for these handlers.
+///
+/// The authorization-check endpoints take [`AuthenticatedPrincipal`] since
+/// §17.2 residual 1, because they are the one REST surface a machine token is
+/// allowed to reach. `is_machine: false` here keeps every pre-existing test
+/// asserting exactly what it did before; `make_machine` below covers the new
+/// branch.
+fn make_user(tenant_id: Uuid, user_id: Uuid) -> AuthenticatedPrincipal {
     let session_id = Uuid::new_v4();
     let claims = ValidatedClaims(AccessTokenClaims {
         sub: user_id.to_string(),
@@ -63,11 +70,36 @@ fn make_user(tenant_id: Uuid, user_id: Uuid) -> AuthenticatedUser {
         scope: None,
         sub_kind: SubjectKind::User,
     });
-    AuthenticatedUser {
-        user_id,
+    AuthenticatedPrincipal {
+        subject_id: user_id,
         tenant_id,
         org_id: Uuid::nil(),
-        session_id,
+        is_machine: false,
+        claims,
+    }
+}
+
+/// A machine principal (`aud = axiam:m2m`) — a certificate-authenticated
+/// device or a service account holding a client-credentials token.
+fn make_machine(tenant_id: Uuid, service_account_id: Uuid) -> AuthenticatedPrincipal {
+    let claims = ValidatedClaims(AccessTokenClaims {
+        sub: service_account_id.to_string(),
+        tenant_id: tenant_id.to_string(),
+        org_id: Uuid::nil().to_string(),
+        iss: "test".into(),
+        iat: 0,
+        exp: i64::MAX,
+        jti: Uuid::new_v4().to_string(),
+        aud: Some("axiam:m2m".into()),
+        scope: None,
+        sub_kind: axiam_auth::token::SubjectKind::ServiceAccount,
+    });
+
+    AuthenticatedPrincipal {
+        subject_id: service_account_id,
+        tenant_id,
+        org_id: Uuid::nil(),
+        is_machine: true,
         claims,
     }
 }
@@ -424,4 +456,93 @@ async fn batch_check_access_matches_sequential_per_item_check_access() {
             "result[{i}] mismatch between concurrent batch and sequential per-item check_access"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// §17.2 residual 1 — a machine principal reaches the authz-check endpoints
+// ---------------------------------------------------------------------------
+
+/// A certificate-authenticated device (now `aud = axiam:m2m`) can still run an
+/// authorization check.
+///
+/// This is the test that makes the audience flip safe to ship. `aud` moved
+/// from `axiam:user` to `axiam:m2m` so a device stops passing *user*-facing
+/// route guards — but the check endpoints are the surface a device actually
+/// needs, so they must keep working. Without the `AuthenticatedPrincipal`
+/// widening this request would 401, and the narrowing would have been an
+/// outage rather than a fix.
+#[tokio::test]
+async fn a_machine_principal_can_run_an_authz_check() {
+    let tenant_id = Uuid::new_v4();
+    let service_account_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+
+    let db = setup_db().await;
+    let state = make_state(db);
+    let authz = make_authz(AllowAllAuthzChecker);
+    let machine = make_machine(tenant_id, service_account_id);
+
+    let body = web::Json(CheckAccessBody {
+        action: "devices:report".into(),
+        resource_id,
+        scope: None,
+        subject_id: None,
+    });
+
+    let result = check_access(machine, authz, state, body).await;
+    assert_eq!(
+        status_code(&result),
+        200,
+        "a machine token must be accepted on the authz-check endpoint"
+    );
+    let json = read_body_json(result.unwrap()).await;
+    assert_eq!(json["allowed"], true);
+}
+
+/// The `authz:check_as` gate applies to machines exactly as it does to users.
+///
+/// Widening the accepted audience must not widen *authorization*: a device
+/// asking about another subject is subject to the same permission check, and
+/// the deny-all checker means it does not have it.
+#[tokio::test]
+async fn a_machine_principal_still_needs_check_as_to_query_another_subject() {
+    let tenant_id = Uuid::new_v4();
+    let service_account_id = Uuid::new_v4();
+    let other_subject = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+
+    let db = setup_db().await;
+    let state = make_state(db);
+    let authz = make_authz(DenyAllAuthzChecker);
+    let machine = make_machine(tenant_id, service_account_id);
+
+    let body = web::Json(CheckAccessBody {
+        action: "users:get".into(),
+        resource_id,
+        scope: None,
+        subject_id: Some(other_subject),
+    });
+
+    let result = check_access(machine, authz, state, body).await;
+    assert_eq!(
+        status_code(&result),
+        403,
+        "a machine without authz:check_as must not query another subject"
+    );
+}
+
+/// The audit trail must record a device as a service account, not as a user.
+///
+/// `authz.check_as` is legally significant, so attributing a machine's
+/// cross-subject query to `ActorType::User` would be a false record. Before
+/// the principal widening the actor type was hardcoded.
+#[test]
+fn a_machine_principal_audits_as_a_service_account() {
+    use axiam_core::models::audit::ActorType;
+
+    let machine = make_machine(Uuid::new_v4(), Uuid::new_v4());
+    let human = make_user(Uuid::new_v4(), Uuid::new_v4());
+
+    assert!(matches!(machine.actor_type(), ActorType::ServiceAccount));
+    assert!(matches!(human.actor_type(), ActorType::User));
 }

--- a/crates/axiam-api-rest/tests/device_auth_test.rs
+++ b/crates/axiam-api-rest/tests/device_auth_test.rs
@@ -334,6 +334,33 @@ async fn device_auth_mints_service_account_sub_kind() {
 
     let claims = decode_access_token(access_token, &auth).unwrap();
     assert_eq!(claims.sub_kind, SubjectKind::ServiceAccount);
+
+    // §17.2 residual 1: the device path now mints the MACHINE audience. It
+    // used to stamp `axiam:user`, which meant a certificate-authenticated
+    // device passed every user-facing route guard — the same principal got a
+    // user token by certificate and a machine token by secret, leaving the
+    // SEC-006 / §4.3 narrowing half applied.
+    //
+    // Nothing pinned the audience on this path before, which is why the flip
+    // was invisible to this suite.
+    assert_eq!(
+        claims.aud.as_deref(),
+        Some(axiam_auth::token::AUD_M2M),
+        "a device token must carry the machine audience"
+    );
+
+    // And the narrowing must actually bite: the same token is refused by a
+    // user-facing route. Without this the assertion above only pins a string.
+    let req = test::TestRequest::get()
+        .uri("/api/v1/users")
+        .insert_header(("Authorization", format!("Bearer {access_token}")))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "a device token must not be accepted on a user-facing route"
+    );
 }
 
 #[actix_rt::test]

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -194,10 +194,28 @@ pub fn issue_client_credentials_token(
 /// The `sub` claim is the service account's `user_id` (mirrors the shape
 /// the device-auth handler previously passed to [`issue_access_token`]).
 /// `jti` is caller-supplied — service-account/device auth has no session
-/// row, so callers pass a random UUID. `aud` and `scope` mirror the values
-/// the device-auth call previously passed to `issue_access_token`
-/// ([`AUD_USER`], no scopes) — only `sub_kind` differs (D-09). This claim
-/// is informational only (D-10): validation and authz are unaffected.
+/// row, so callers pass a random UUID. `scope` is empty: a device's
+/// authorization comes from the roles assigned to its service account.
+///
+/// # ⚠ Breaking change — `aud` is now [`AUD_M2M`]
+///
+/// This function used to stamp [`AUD_USER`], so a certificate-authenticated
+/// device received a **user**-audience token and passed every user-facing
+/// route guard. That was a documented back-compat decision, but it meant the
+/// same principal got a user token by certificate and a machine token by
+/// secret, leaving the SEC-006 / §4.3 audience narrowing only half applied
+/// (§17.2 residual 1).
+///
+/// Both service-account authentication paths — mTLS here, and
+/// [`issue_service_account_client_credentials_token`] — now mint
+/// [`AUD_M2M`]. The audience finally describes *what kind of principal
+/// holds the token* rather than which endpoint happened to issue it.
+///
+/// **Operator impact:** a device can no longer call user-facing routes. The
+/// authorization-check endpoints accept machine tokens via
+/// `AuthenticatedPrincipal`; any other route a fleet depends on must be
+/// migrated deliberately, which is the point — those grants were previously
+/// implicit.
 pub fn issue_service_account_token(
     user_id: Uuid,
     tenant_id: Uuid,
@@ -215,7 +233,8 @@ pub fn issue_service_account_token(
         iat: now,
         exp: now + config.access_token_lifetime_secs as i64,
         jti,
-        aud: Some(AUD_USER.to_string()),
+        // §17.2 residual 1: was AUD_USER. See the breaking-change note above.
+        aud: Some(AUD_M2M.to_string()),
         scope: None,
         sub_kind: SubjectKind::ServiceAccount,
     };

--- a/crates/axiam-oauth2/src/token.rs
+++ b/crates/axiam-oauth2/src/token.rs
@@ -23,6 +23,28 @@ use uuid::Uuid;
 use crate::error::OAuth2Error;
 use crate::pkce;
 
+/// The single `error_description` every token-endpoint client-authentication
+/// failure returns, whatever actually went wrong (SEC-086).
+///
+/// The `invalid_client` error *code* was already uniform across "no such
+/// client" and "wrong secret". The *description* was not: an unknown client
+/// said `"client not found"`, which let an unauthenticated caller probe
+/// whether a given `client_id` — including an `sa_…` service-account id —
+/// exists. The masquerade the QUAL-03/D-11 comments describe was applied to
+/// the code and not to the message; this constant applies it to both.
+///
+/// The `NotFound`-versus-other-error distinction those comments protect is
+/// unaffected: it stays internal, mapping to `invalid_client` versus
+/// `server_error`, so a DB outage still never reads as bad credentials. Only
+/// the caller-visible wording is collapsed.
+///
+/// Deliberately **not** used at the authorization endpoint
+/// (`authorize.rs`): there `client_id` is public by construction, RFC 6749
+/// §4.1.2.1 requires informing the resource owner directly rather than
+/// redirecting, and no credential is presented — so "invalid client
+/// credentials" would be actively misleading there.
+const CLIENT_AUTH_FAILED: &str = "invalid client credentials";
+
 // ---------------------------------------------------------------------------
 // DTOs
 // ---------------------------------------------------------------------------
@@ -204,9 +226,9 @@ where
                 }
                 Ok(())
             }
-            ClientSecretVerdict::Mismatch => Err(OAuth2Error::InvalidClient(
-                "invalid client credentials".into(),
-            )),
+            ClientSecretVerdict::Mismatch => {
+                Err(OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into()))
+            }
         }
     }
 
@@ -252,12 +274,37 @@ where
                 // Same taxonomy as the oauth2_client branch: only a genuinely
                 // unknown client is `invalid_client`; a DB outage must never
                 // masquerade as bad credentials (error-oracle, QUAL-03/D-11).
+                // The description is CLIENT_AUTH_FAILED here too, so an
+                // unauthenticated caller cannot learn whether an `sa_…`
+                // client id exists (SEC-086).
                 AxiamError::NotFound { .. } => {
-                    OAuth2Error::InvalidClient("client not found".into())
+                    OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into())
                 }
                 other => OAuth2Error::ServerError(other.to_string()),
             })?;
         let client_lookup_us = t_client_lookup.elapsed().as_micros() as u64;
+
+        // Defence in depth (§17.2 residual 6). The lookup above is already
+        // tenant-scoped in SQL, so this can only fire if that predicate is
+        // ever dropped or a repository implementation ignores `tenant_id` —
+        // exactly the regression the assertion exists to catch. Without it the
+        // cross-tenant property of this grant lives entirely in a `WHERE`
+        // clause two crates away, and no test in this crate can prove it
+        // because the mocks do not filter by tenant.
+        //
+        // Deliberately checked *before* the secret is verified: a row from the
+        // wrong tenant must not have its secret compared at all, and the
+        // presented client id is the caller's own input, so refusing early
+        // leaks nothing it did not already know.
+        if sa.tenant_id != tenant_id {
+            tracing::error!(
+                requested_tenant = %tenant_id,
+                account_tenant = %sa.tenant_id,
+                "service-account lookup returned a row from another tenant — refusing; \
+                 this indicates a dropped tenant predicate in the repository layer"
+            );
+            return Err(OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into()));
+        }
 
         let t_secret_verify = std::time::Instant::now();
         let secret_result = self
@@ -273,9 +320,7 @@ where
                 status = ?sa.status,
                 "service-account client-credentials refused: account is not active"
             );
-            return Err(OAuth2Error::InvalidClient(
-                "invalid client credentials".into(),
-            ));
+            return Err(OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into()));
         }
 
         if let Some(scope) = requested_scope.filter(|s| !s.trim().is_empty()) {
@@ -374,9 +419,9 @@ where
                 }
                 Ok(())
             }
-            ClientSecretVerdict::Mismatch => Err(OAuth2Error::InvalidClient(
-                "invalid client credentials".into(),
-            )),
+            ClientSecretVerdict::Mismatch => {
+                Err(OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into()))
+            }
         }
     }
 
@@ -422,9 +467,12 @@ where
                 // QUAL-03/D-11: only a genuinely-unknown client maps to
                 // invalid_client. Any other error (e.g. a DB outage) must
                 // surface as a distinct server error, never masquerade as
-                // bad client credentials (error-oracle).
+                // bad client credentials (error-oracle). The distinction is
+                // internal only — the caller-visible description is
+                // CLIENT_AUTH_FAILED either way, so it cannot be used to
+                // probe which client ids exist (SEC-086).
                 AxiamError::NotFound { .. } => {
-                    OAuth2Error::InvalidClient("client not found".into())
+                    OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into())
                 }
                 other => OAuth2Error::ServerError(other.to_string()),
             })?;
@@ -657,9 +705,12 @@ where
                 // QUAL-03/D-11: only a genuinely-unknown client maps to
                 // invalid_client. Any other error (e.g. a DB outage) must
                 // surface as a distinct server error, never masquerade as
-                // bad client credentials (error-oracle).
+                // bad client credentials (error-oracle). The distinction is
+                // internal only — the caller-visible description is
+                // CLIENT_AUTH_FAILED either way, so it cannot be used to
+                // probe which client ids exist (SEC-086).
                 AxiamError::NotFound { .. } => {
-                    OAuth2Error::InvalidClient("client not found".into())
+                    OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into())
                 }
                 other => OAuth2Error::ServerError(other.to_string()),
             })?;
@@ -802,9 +853,12 @@ where
                 // QUAL-03/D-11: only a genuinely-unknown client maps to
                 // invalid_client. Any other error (e.g. a DB outage) must
                 // surface as a distinct server error, never masquerade as
-                // bad client credentials (error-oracle).
+                // bad client credentials (error-oracle). The distinction is
+                // internal only — the caller-visible description is
+                // CLIENT_AUTH_FAILED either way, so it cannot be used to
+                // probe which client ids exist (SEC-086).
                 AxiamError::NotFound { .. } => {
-                    OAuth2Error::InvalidClient("client not found".into())
+                    OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into())
                 }
                 other => OAuth2Error::ServerError(other.to_string()),
             })?;
@@ -1094,9 +1148,12 @@ where
                 // QUAL-03/D-11: only a genuinely-unknown client maps to
                 // invalid_client. Any other error (e.g. a DB outage) must
                 // surface as a distinct server error, never masquerade as
-                // bad client credentials (error-oracle).
+                // bad client credentials (error-oracle). The distinction is
+                // internal only — the caller-visible description is
+                // CLIENT_AUTH_FAILED either way, so it cannot be used to
+                // probe which client ids exist (SEC-086).
                 AxiamError::NotFound { .. } => {
-                    OAuth2Error::InvalidClient("client not found".into())
+                    OAuth2Error::InvalidClient(CLIENT_AUTH_FAILED.into())
                 }
                 other => OAuth2Error::ServerError(other.to_string()),
             })?;

--- a/crates/axiam-oauth2/tests/token_service.rs
+++ b/crates/axiam-oauth2/tests/token_service.rs
@@ -1955,10 +1955,24 @@ fn decode_claims(token: &str) -> serde_json::Value {
     serde_json::from_slice(&bytes).expect("payload is JSON")
 }
 
-fn make_service_account(secret_hash: String, status: UserStatus) -> ServiceAccount {
+/// A service account belonging to `tenant_id`.
+///
+/// The tenant is a parameter rather than a fresh UUID because the grant now
+/// asserts that the row the repository returned really belongs to the tenant
+/// the request was made under (§17.2 residual 6). The mock repository ignores
+/// its `tenant_id` argument — that is deliberate, and it is what lets
+/// `a_service_account_from_another_tenant_is_refused` below drive the
+/// assertion — so every *other* test has to hand the fixture the same tenant
+/// it exchanges under, or it would be exercising the cross-tenant refusal
+/// instead of the behaviour it names.
+fn make_service_account(
+    tenant_id: Uuid,
+    secret_hash: String,
+    status: UserStatus,
+) -> ServiceAccount {
     ServiceAccount {
         id: Uuid::new_v4(),
-        tenant_id: Uuid::new_v4(),
+        tenant_id,
         name: "svc".into(),
         description: None,
         client_id: "sa_deadbeefdeadbeefdeadbeefdeadbeef".into(),
@@ -1996,13 +2010,14 @@ fn sa_req(client_id: &str, secret: &str) -> TokenRequest {
 #[tokio::test]
 async fn a_service_account_can_authenticate_with_client_credentials() {
     let secret = "sa-secret-value";
-    let sa = make_service_account(hash_client_secret(secret), UserStatus::Active);
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(tenant, hash_client_secret(secret), UserStatus::Active);
     let sa_id = sa.id;
     let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
     let resp = svc
         .exchange(
-            Uuid::new_v4(),
+            tenant,
             sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
         )
         .await
@@ -2026,12 +2041,13 @@ async fn a_service_account_can_authenticate_with_client_credentials() {
 
 #[tokio::test]
 async fn a_wrong_service_account_secret_is_rejected() {
-    let sa = make_service_account(hash_client_secret("right"), UserStatus::Active);
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(tenant, hash_client_secret("right"), UserStatus::Active);
     let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
     let err = svc
         .exchange(
-            Uuid::new_v4(),
+            tenant,
             sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "wrong"),
         )
         .await
@@ -2049,12 +2065,13 @@ async fn a_disabled_service_account_cannot_authenticate() {
         UserStatus::PendingVerification,
     ] {
         let secret = "sa-secret-value";
-        let sa = make_service_account(hash_client_secret(secret), status.clone());
+        let tenant = Uuid::new_v4();
+        let sa = make_service_account(tenant, hash_client_secret(secret), status.clone());
         let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
         let err = svc
             .exchange(
-                Uuid::new_v4(),
+                tenant,
                 sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
             )
             .await
@@ -2086,14 +2103,15 @@ async fn an_unknown_service_account_is_invalid_client() {
 #[tokio::test]
 async fn a_service_account_cannot_request_a_scope() {
     let secret = "sa-secret-value";
-    let sa = make_service_account(hash_client_secret(secret), UserStatus::Active);
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(tenant, hash_client_secret(secret), UserStatus::Active);
     let (svc, _log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
     let mut req = sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret);
     req.scope = Some("admin:everything".into());
 
     let err = svc
-        .exchange(Uuid::new_v4(), req)
+        .exchange(tenant, req)
         .await
         .expect_err("a service account registers no scopes");
     assert!(matches!(err, OAuth2Error::InvalidScope(_)), "got {err:?}");
@@ -2105,11 +2123,12 @@ async fn a_service_account_cannot_request_a_scope() {
 async fn a_legacy_service_account_hash_authenticates_and_migrates() {
     let secret = "sa-secret-value";
     let legacy = legacy_client_secret_hash(secret);
-    let sa = make_service_account(legacy.clone(), UserStatus::Active);
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(tenant, legacy.clone(), UserStatus::Active);
     let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
     svc.exchange(
-        Uuid::new_v4(),
+        tenant,
         sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
     )
     .await
@@ -2134,12 +2153,17 @@ async fn a_legacy_service_account_hash_authenticates_and_migrates() {
 /// A wrong secret must never cause a migration write.
 #[tokio::test]
 async fn a_failed_service_account_auth_never_migrates() {
-    let sa = make_service_account(legacy_client_secret_hash("right"), UserStatus::Active);
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(
+        tenant,
+        legacy_client_secret_hash("right"),
+        UserStatus::Active,
+    );
     let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
     let _ = svc
         .exchange(
-            Uuid::new_v4(),
+            tenant,
             sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "wrong"),
         )
         .await;
@@ -2170,12 +2194,13 @@ async fn a_service_account_keyed_to_a_previous_pepper_migrates_on_use() {
          the scheme count cannot see it"
     );
 
-    let sa = make_service_account(old_pepper_hash.clone(), UserStatus::Active);
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(tenant, old_pepper_hash.clone(), UserStatus::Active);
     let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
 
     let result = svc
         .exchange(
-            Uuid::new_v4(),
+            tenant,
             sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
         )
         .await;
@@ -2191,5 +2216,109 @@ async fn a_service_account_keyed_to_a_previous_pepper_migrates_on_use() {
     assert!(
         log.lock().unwrap().is_empty(),
         "a failed verification must never trigger a migration write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// §17.2 residual 6 — the cross-tenant boundary is asserted in the auth path
+// ---------------------------------------------------------------------------
+
+/// The grant must refuse a row that belongs to a different tenant than the one
+/// the request was made under.
+///
+/// This is the test §17.2 residual 6 said could not exist: "the mock in the
+/// test suite ignores `tenant_id`, so no test currently proves it; only the
+/// real SQL does." That is precisely why the check belongs in the handler as
+/// well as in the query — the mock's indifference to `tenant_id` models a
+/// repository whose tenant predicate has been dropped, which is the regression
+/// worth catching. Before the assertion this exchange **succeeded** and minted
+/// a token for another tenant's service account.
+#[tokio::test]
+async fn a_service_account_from_another_tenant_is_refused() {
+    let secret = "sa-secret-value";
+    let account_tenant = Uuid::new_v4();
+    let requested_tenant = Uuid::new_v4();
+    assert_ne!(account_tenant, requested_tenant, "precondition");
+
+    let sa = make_service_account(
+        account_tenant,
+        hash_client_secret(secret),
+        UserStatus::Active,
+    );
+    let (svc, log) = build_sa(SaOutcome::Found(Box::new(sa)));
+
+    let err = svc
+        .exchange(
+            requested_tenant,
+            // The correct secret — so the refusal is attributable to the tenant
+            // mismatch alone and not to a credential failure.
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", secret),
+        )
+        .await
+        .expect_err("a service account must not authenticate outside its tenant");
+
+    assert!(
+        matches!(err, OAuth2Error::InvalidClient(_)),
+        "must be the generic invalid_client, got {err:?}"
+    );
+
+    // The refusal happens before the secret is ever compared, so a foreign row
+    // cannot be used as a verification oracle and cannot trigger a hash upgrade
+    // write against another tenant's record.
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "a cross-tenant row must never reach the secret-verification path"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SEC-086 — the token endpoint must not reveal which client ids exist
+// ---------------------------------------------------------------------------
+
+/// An unknown client and a wrong secret must be **indistinguishable** to the
+/// caller — same error code *and* same `error_description`.
+///
+/// Before SEC-086 the codes matched but the descriptions did not ("client not
+/// found" versus "invalid client credentials"), and the description is
+/// serialized verbatim into the 401 body, so an unauthenticated caller could
+/// probe whether any given `sa_…` or `oa_…` client id existed.
+#[tokio::test]
+async fn an_unknown_client_is_indistinguishable_from_a_wrong_secret() {
+    fn shape(e: &OAuth2Error) -> (String, String) {
+        (e.error_code().to_string(), e.error_description())
+    }
+
+    // --- service-account branch (`sa_…`) ---
+    let tenant = Uuid::new_v4();
+    let sa = make_service_account(tenant, hash_client_secret("right"), UserStatus::Active);
+    let (svc_found, _) = build_sa(SaOutcome::Found(Box::new(sa)));
+    let (svc_missing, _) = build_sa(SaOutcome::NotFound);
+
+    let wrong_secret = svc_found
+        .exchange(
+            tenant,
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "wrong"),
+        )
+        .await
+        .expect_err("wrong secret");
+    let unknown_client = svc_missing
+        .exchange(
+            tenant,
+            sa_req("sa_deadbeefdeadbeefdeadbeefdeadbeef", "wrong"),
+        )
+        .await
+        .expect_err("unknown client");
+
+    assert_eq!(
+        shape(&wrong_secret),
+        shape(&unknown_client),
+        "an unknown service-account client id must be indistinguishable from a bad secret"
+    );
+
+    // Pin the actual wording too, so a future edit cannot reintroduce the
+    // oracle by changing both arms to something that still names the cause.
+    assert_eq!(
+        unknown_client.error_description(),
+        "invalid client credentials"
     );
 }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -845,7 +845,17 @@ async fn main() -> std::io::Result<()> {
     let decision_cache = config.authz.build_decision_cache();
     if let Some(cache) = decision_cache.as_ref() {
         tracing::info!(
-            ttl_secs = config.authz.decision_cache_ttl_secs,
+            // §17.1: the accessor, not the raw field. This was the workspace's
+            // sole non-test raw read, and it logged the operator's *requested*
+            // TTL while the cache ran on the clamped one — so an operator who
+            // set 86400 saw "86400" here and reasonably concluded the clamp
+            // had not applied. `configured_ttl_secs` is emitted only when the
+            // two differ, which is exactly when the discrepancy needs
+            // explaining.
+            ttl_secs = config.authz.decision_cache_ttl_secs(),
+            configured_ttl_secs = (config.authz.decision_cache_ttl_secs
+                != config.authz.decision_cache_ttl_secs())
+            .then_some(config.authz.decision_cache_ttl_secs),
             max_entries = config.authz.decision_cache_max_entries,
             // Multi-replica posture stated at the point of enablement, not
             // only in the docs. Without the §4.2 broadcast channel,

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -749,7 +749,7 @@ would never have honoured.
 | 3 | `nbf` | **Honoured when present.** A token whose `nbf` is in the future MUST be rejected. Absent `nbf` is valid. |
 | 4 | `tenant_id` | **REQUIRED and asserted.** MUST equal the client's configured tenant. Absent claim, or no configured tenant to compare against, MUST fail closed. The JWKS trust anchor is **organization-wide**, so signature validity alone does not bound a token to a tenant. |
 | 5 | `iss` | **Checked when the SDK is configured with an expected issuer**; absent configuration means no check. When configured, a mismatch MUST be rejected. |
-| 6 | `aud` | **Checked when the SDK is configured with an expected audience.** When configured, a token whose `aud` does not contain it MUST be rejected. SDKs guarding a user-facing resource server SHOULD expect `axiam:user`. |
+| 6 | `aud` | **Checked when the SDK is configured with an expected audience.** When configured, a token whose `aud` does not contain it MUST be rejected. SDKs guarding a user-facing resource server SHOULD expect `axiam:user`; one guarding a **machine-facing** resource server SHOULD expect `axiam:m2m`, which is what *every* service-account token now carries — both the client-credentials grant and the mTLS device path (§12.1). |
 | 7 | clock skew | Rules 2 and 3 MAY allow a **small, named, documented** leeway (RECOMMENDED 60 s). It MUST be a named constant, not an inline literal, and MUST NOT be operator-configurable to an unbounded value. |
 | 8 | subject of the decision | The guard MUST decide on **the caller's credential and no other**. When that credential fails any rule above, the guard MUST reject. It MUST NOT retry, refresh, or fall back to a *different* credential — in particular not the SDK client's own session — and MUST NOT admit the request under any identity other than the one the caller presented. |
 
@@ -1094,6 +1094,30 @@ Consequences an SDK MUST respect:
    to work around; it is rule 6 doing its job, and the fix is configuration.
 3. A service-account token carries **no `scope` claim**, so an SDK MUST NOT
    derive authorization from scope for these callers.
+
+**⚠ Breaking change — a device (mTLS) token is now `axiam:m2m` too.**
+`POST /api/v1/auth/device` (§6.1) used to return a token stamped
+`aud: axiam:user`, so a certificate-authenticated device passed every
+user-facing route guard. It now returns `aud: axiam:m2m`, matching the
+client-credentials path above: **both** ways a service account can
+authenticate now yield a machine-audience token. The audience finally
+describes *what kind of principal holds the token* rather than which endpoint
+issued it.
+
+What this means for an SDK:
+
+- **No SDK code change is required.** The device-auth call and its response
+  shape are unchanged; only the `aud` claim value differs.
+- **A §10 guard fronting a resource server that accepts device callers MUST
+  expect `axiam:m2m`** — the same rule-6 consequence as point 2 above, now
+  reaching a second class of caller. A guard configured for `axiam:user` will
+  reject device tokens, correctly.
+- **Server-side, a device token no longer reaches user-facing REST routes.**
+  It is accepted on the authorization-check endpoints (`POST
+  /api/v1/authz/check` and the batch form), which are the machine-facing
+  surface. An SDK whose device flow called any other endpoint with the
+  device token must migrate that call deliberately — the previous access was
+  implicit, not designed.
 
 ### §12.2 Per-language naming map
 


### PR DESCRIPTION
Remediates §17 of `claude_dev/security-analysis-2026-08-02.md` — the one open finding, the one partial, and the residuals. Recorded in a new **§18**.

## SEC-086 (LOW) — client-existence oracle at the token endpoint

Both failure modes returned `invalid_client`, but with *different descriptions* — `"client not found"` vs `"invalid client credentials"` — and the description is serialized verbatim into the 401 body, so an unauthenticated caller could probe whether any `sa_…` or `oa_…` client id existed. All five `token.rs` sites now return one `CLIENT_AUTH_FAILED` constant.

The `NotFound`-vs-other-error distinction the QUAL-03/D-11 comments protect is untouched — it stays internal (`invalid_client` vs `server_error`), so a DB outage still cannot read as bad credentials.

`authorize.rs` is **deliberately excluded**: there `client_id` is public by construction, RFC 6749 §4.1.2.1 requires a direct error, and no credential is presented — "invalid client credentials" would be actively misleading.

**On the timing asymmetry the finding also named:** assessed and deliberately not papered over with a dummy HMAC. The skipped work is one HMAC-SHA256 — sub-microsecond, and dominated by the DB round-trip that differs between the branches anyway and can't be equalized without a dummy query. A compensating HMAC would close the smaller channel while leaving the larger one. §18.1 states this rather than claiming a clean close.

## §17.1 partial — compare-before-clear

The publisher tested `Channel::id()`, which §17.1 correctly identified as the AMQP channel **number** (`u16`), recycled by the broker after a close. `Arc::ptr_eq` is unavailable (lapin doesn't expose the inner `Arc`), so the slot now carries a monotonic generation stamp. Exact, and no longer resting on an unguaranteed library invariant.

*Test gap stated plainly:* two real `lapin::Channel`s need a live broker, which this crate's tests don't have — the same limit the existing publisher test already records. Verified by construction.

## ⚠ Residual 1 — the mTLS device path now mints `axiam:m2m` (BREAKING)

§17.4 called this the highest-value follow-up. §17 didn't state the fact that decides *how* to land it: **every guarded REST handler takes `AuthenticatedUser` (requires `axiam:user`), and `AuthenticatedServiceAccount` is consumed by no route** — so `axiam:m2m` reached zero REST endpoints. Flipping the device path alone wouldn't have narrowed a too-wide grant, it would have replaced it with *no* grant: an outage for every deployed device.

So the flip lands with the surface it needs:

1. `issue_service_account_token` stamps `AUD_M2M` — both service-account auth paths now yield a machine token. The audience describes the principal, not the issuing endpoint.
2. New `AuthenticatedPrincipal` extractor accepts either audience.
3. Used on the **authz-check endpoints only**. Every other route keeps `AuthenticatedUser` and still rejects machine tokens.

What makes the widening safe:

- **User tokens aren't weakened** — still get the session-revocation check (REQ-7/D-15); skipped only for machines, which have no session row. Absent-`aud` is decided by the *same* function the narrow extractor uses, so the two can't drift, and is never treated as a machine.
- **Authorization isn't widened** — `check_subject` applies RBAC identically, with no `is_machine` to branch on. A device still needs `authz:check_as` to query another subject.
- **The audit trail stays truthful** — `append_check_as_audit` hardcoded `ActorType::User`; it now follows the principal. `authz.check_as` is legally significant.

This is the third deliberate breaking change in the series (after the two in §9.3). The device-auth suite never asserted `aud` at all, which is why the flip was initially invisible to it.

## Residual 2 — gRPC audience

The gap was worse than "no check": `decode_access_token` **skips** audience validation entirely when the claim is absent, so a no-`aud` token reached the authorization service with nothing applied and nothing logged. The interceptor now rejects an unknown audience and gates an absent one on `allow_missing_aud_as_user`, matching REST. Both audiences stay accepted there by design — narrowing to m2m-only would break user-token callers.

## Residuals 3, 6, 7

- **3** — token endpoint now writes `oauth2.client_auth_failed` (client_id, grant_type, IP; **never** the secret), fire-and-forget so an audit outage can't turn a 401 into a 500. `actor_id = nil` / `ActorType::System`: the caller is unauthenticated, so the presented client id is evidence, not identity. **Lockout deliberately omitted** — secrets are 256-bit CSPRNG, and a lockout keyed on a caller-supplied `client_id` is a DoS against any known client.
- **6** — asserts `sa.tenant_id == tenant_id` *before* the secret is verified, so a foreign row is neither a verification oracle nor a cross-tenant write trigger.
- **7** — `AuthenticatedServiceAccount.client_id` → `subject`.

Plus: the decision-cache TTL log emitted the *unclamped* operator value while the cache used the clamped one (§17.1 cosmetic).

## Tests

Both new oauth2 tests were **falsified** — reverted the fix, confirmed only they fail:

- `a_service_account_from_another_tenant_is_refused` — §17.2 said no test could prove this since the mock ignores `tenant_id`; that indifference is exactly what makes it testable. Before the assertion this exchange **succeeded**.
- `an_unknown_client_is_indistinguishable_from_a_wrong_secret`
- machine-principal acceptance, its `check_as` gate, actor-type attribution
- device token's audience **and** its 401 on a user route (falsified against the flip)

Seven pre-existing SA tests were handing the fixture a random tenant and exchanging under a different one; they now bind both, so each exercises what it names.

Green: `fmt --all`, `clippy --all-targets --all-features -D warnings` across the workspace, `oauth2` (78), `api-rest --lib` (136), `amqp`, `auth`, `grpc`, `authz`, and the device/oauth2/rbac/auth integration suites.

## Not actioned (recorded in §18.6)

Residual 4 (disabled SA's tokens live until expiry — same accepted T-39 trade-off as the client path) and residual 5 (no expiry field) are design changes, not patches. §16.3a's rule-8 SDK guardrail tests are carried a third time — a two-tests-across-eight-languages lift that deserves its own PR series rather than riding along with a breaking auth change; §15.1's hand-verification that all eleven guards reject correctly still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D)_