### PR TITLE
security: close SEC-086 fully and SEC-087, fix the CHANGELOG inversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,18 @@ jobs:
       #   RUSTSEC-2023-0089 — atomic-polyfill unmaintained; transitive via surrealdb, no CVE.
       #   RUSTSEC-2026-0194 — quick-xml DoS; transitive via samael (SAML), which pins ^0.37 (no >=0.41 path); SAML off by default.
       #   RUSTSEC-2026-0195 — quick-xml DoS; transitive via samael (SAML), which pins ^0.37 (no >=0.41 path); SAML off by default.
+      #   RUSTSEC-2026-0235 — rkyv OOB read. NOT COMPILED INTO ANY AXIAM ARTIFACT: rkyv is an
+      #     `optional = true` dependency of rust_decimal behind its `rkyv` feature, and nothing in
+      #     our graph enables it. `cargo tree -i rkyv --target all --all-features` prints "nothing
+      #     to print", and rkyv appears zero times in the fully-resolved tree. cargo-audit reads
+      #     Cargo.lock, which records optional dependencies whether or not a feature ever pulls
+      #     them in, so this is a lockfile artifact rather than a reachable vulnerability — unlike
+      #     the entries above, which are real dependencies with a reachability argument.
+      #     Re-verify with the command above if rust_decimal's feature defaults ever change.
       - name: cargo audit
         uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24  # v1
         with:
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2025-0141,RUSTSEC-2023-0089,RUSTSEC-2026-0194,RUSTSEC-2026-0195
+          ignore: RUSTSEC-2023-0071,RUSTSEC-2025-0141,RUSTSEC-2023-0089,RUSTSEC-2026-0194,RUSTSEC-2026-0195,RUSTSEC-2026-0235
 
       # --- cargo deny (advisories + licenses + bans + sources) ---
       - name: cargo deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **⚠ BREAKING — a certificate-authenticated device now receives a machine
+  token (`aud: axiam:m2m`), not a user token.** `POST /api/v1/auth/device`
+  stamped `aud: axiam:user`, so any device that authenticated by mTLS passed
+  **every** user-facing route guard. It now stamps `axiam:m2m`, matching the
+  client-credentials grant: a service account is the same principal however it
+  authenticated, and §4.3/`SEC-006` route narrowing finally applies to both.
+
+  **What breaks.** A device token is no longer accepted on user-facing REST
+  routes. It *is* accepted on the authorization-check endpoints — `POST
+  /api/v1/authz/check` and `/api/v1/authz/check/batch` — which are the
+  machine-facing surface and were widened in the same change so that no
+  required device call started failing. Any other endpoint a fleet calls with a
+  device token must be migrated deliberately; that access was implicit rather
+  than designed.
+
+  **Before upgrading**, check whether your devices call anything beyond the
+  authz-check endpoints. SDK guards fronting a resource server that accepts
+  device callers must be configured to expect `axiam:m2m` (`CONTRACT.md` §10.1
+  rule 6, §12.1) — a guard set to `axiam:user` will now reject device tokens,
+  which is the narrowing working as intended.
+
+  gRPC is unchanged: its interceptor accepts both audiences on all services, so
+  the m2m/user split is REST-only.
+
 ### Security
+
+- **A client-existence oracle survived on the `authorization_code` grant
+  (SEC-086, second pass).** The first pass unified every token-endpoint
+  `error_description` behind one constant, but only two of the three grants
+  ordered their checks safely. On `authorization_code` the client lookup ran
+  *before* the secret-presence check and the grant-type check ran *before*
+  secret verification, so an unauthenticated caller could still separate "no
+  such client" from "client exists" — with no secret at all, and again with any
+  dummy secret. Both checks now follow verification, matching
+  `client_credentials` and `refresh_token`. `unauthorized_client` is now
+  reachable only by a caller who has already proven possession of the secret.
+
+- **The failed-client-auth audit row could be written into any tenant
+  (SEC-087).** `/oauth2/token` is unauthenticated and takes `tenant_id` from a
+  query parameter, so the audit row added in the previous change let an
+  anonymous caller append rows to an arbitrary — or nonexistent — tenant's
+  append-only log. The tenant is now resolved before the write; the
+  caller-supplied `client_id` is truncated; and the recorded IP is the
+  transport peer address, with the forgeable `X-Forwarded-For` value kept in
+  metadata under a name marking it untrusted.
 
 - **Neither half of the decision-cache staleness bound is operator-removable any
   more (§15.2).** Two gaps compounded: `decision_cache_ttl_secs` was an
@@ -55,9 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the subset rule leaves the empty set as the only valid request; its
     authorization comes from the roles assigned to it, as on the mTLS path.
   - **The token's `sub` is the service-account id**, not the client id, and its
-    `aud` is `axiam:m2m` (not the `axiam:user` the device path stamps for
-    backwards compatibility) so §4.3/`SEC-006` route narrowing keeps it off user
-    routes. A service account is now the same principal however it authenticated.
+    `aud` is `axiam:m2m`, so §4.3/`SEC-006` route narrowing keeps it off user
+    routes. A service account is now the same principal however it authenticated
+    — see the breaking device-audience change below, which makes the mTLS path
+    stamp `axiam:m2m` as well.
 
 - **Legacy client-secret hashes in `service_account` are now countable
   (§15.2).** `count_legacy_secret_hashes(tenant)` plus a startup warning.

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -1577,3 +1577,42 @@ such a modelling change would have to start.
    introduced by the previous round's fixes; SEC-087 was mine. This round adds
    a tenant lookup and a new helper to an unauthenticated path — the same shape
    of change that produced SEC-087.
+
+### 20.7 RUSTSEC-2026-0235 — suppressed as a verified false positive
+
+Not a §19 finding; it surfaced as a red `Security Scan` while this round was in
+review, and it was failing on `main` as well — `a4cd23a2`, a docs-only commit
+touching one markdown file, fails the identical check. The RUSTSEC database
+refreshed between the 09:24 and 09:48 runs.
+
+The visible errors (`Path does not exist: *.sarif`) are downstream noise: the
+`cargo-audit` step exits 1, which aborts the job before any scanner writes its
+SARIF file.
+
+The advisory is **rkyv 0.7.46** — out-of-bounds reads in archives containing
+`Rc`/`Arc`, fixed in 0.8.17. Suppressed after verifying it cannot affect any
+AXIAM artifact:
+
+- rkyv is `optional = true` in `rust_decimal`, gated behind that crate's `rkyv`
+  feature, and **nothing in our graph enables it**.
+- `cargo tree -i rkyv --target all --all-features` reports *"nothing to print"*,
+  and rkyv occurs **zero** times in the fully-resolved tree.
+- `cargo-deny`, which resolves features rather than reading the lockfile,
+  independently reports `advisory-not-detected — no crate matched advisory
+  criteria` for this id. Two tools disagreeing in exactly the way the
+  explanation predicts is the strongest evidence available here.
+
+The cause is that `cargo-audit` scans `Cargo.lock`, which records optional
+dependencies whether or not any feature ever pulls them in. So this is a
+lockfile artifact, not a vulnerability in shipped code.
+
+This makes it **different in kind from the five existing ignores**, and the
+entries say so. Those are real dependencies carrying a reachability argument —
+a claim about how the code is used, which can be wrong. This one is a claim
+that the code is never compiled, which is mechanically checkable, and the
+comment records the exact command to re-check it. Both `ci.yml` and `deny.toml`
+were updated, since the former's comment requires them to stay in sync.
+
+`rust_decimal` 1.42.1 is current and still pins rkyv 0.7.x, so there is no
+upgrade path either — but that is incidental: the fix here is not "we accept
+the risk", it is "there is no risk to accept in this build".

--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -1376,12 +1376,12 @@ migrate that call deliberately.
 
 ---
 
-## 18. Verification of the SEC-086 / §17 remediation (2026-08-03)
+## 19. Verification of the SEC-086 / §17 remediation (2026-08-04)
 
 - **Commit**: server `d15878a2` (PR #268); all eleven SDKs carry the matching CONTRACT doc sync, no code change.
 - **Headline**: the §17.2 recommendation I ranked above the finding — **narrow the device audience** — was actioned, and actioned well. But the SEC-086 fix is **PARTIAL**, and the audit-event residual was closed in a way that opens a small new surface. New findings continue at **SEC-087**.
 
-### 18.1 Device audience narrowing — ✅ CONFIRMED, and correctly sequenced
+### 19.1 Device audience narrowing — ✅ CONFIRMED, and correctly sequenced
 
 The mTLS device path now stamps `AUD_M2M` instead of `AUD_USER` (`auth/token.rs:236-237`), so a certificate-authenticated service account no longer passes user-route guards. There is no third `axiam:device` audience — devices were folded into the existing machine audience, which is the simpler choice and matches the stated model ("the same principal however it authenticated").
 
@@ -1389,7 +1389,7 @@ The mTLS device path now stamps `AUD_M2M` instead of `AUD_USER` (`auth/token.rs:
 
 Two observations, neither a defect: a cert-bound device token and a secret-bearer service-account token are now byte-identical in both `aud` and `sub_kind`, so possession-of-a-certificate is no longer distinguishable downstream from possession-of-a-secret — the accepted price of not minting a distinct device audience. And the m2m branch of `AuthenticatedPrincipal` parses `sub` as a UUID, so an *OAuth2-client* m2m token 401s there; fail-closed, but an undocumented asymmetry between the two machine principal kinds.
 
-### 18.2 SEC-086 — 🔶 PARTIAL, not closed
+### 19.2 SEC-086 — 🔶 PARTIAL, not closed
 
 A single `CLIENT_AUTH_FAILED` constant was introduced and applied to nine sites, and `"client not found"` no longer appears in the file. The internal `NotFound`-vs-other taxonomy is correctly preserved in `tracing` while kept out of the response. Both halves of that work are sound.
 
@@ -1407,7 +1407,7 @@ Client existence is therefore still decidable — on a grant the fix did not wal
 
 **Recommended fix**: move the secret-presence check before the client lookup on the `authorization_code` path, matching the other two grants. Then the description half is genuinely closed everywhere.
 
-### 18.3 New finding
+### 19.3 New finding
 
 #### SEC-087 [LOW] ❌ — unauthenticated, tenant-unvalidated audit writes at the token endpoint
 
@@ -1417,13 +1417,13 @@ Client existence is therefore still decidable — on a grant the fix did not wal
 - **Two smaller defects in the same code**: `attempted_client_id` is written to metadata **untruncated**, unlike the sibling `client_ip`/`user_agent` helpers which cap length; and `client_ip` uses `realip_remote_addr()`, so spoofable forwarding headers now land in audit rows on an unauthenticated path.
 - **Fix**: resolve and validate the tenant before writing (or write the row under a system/unknown-tenant sentinel), truncate the client id to a bounded length, and either use `peer_addr()` here or record the IP as explicitly untrusted.
 
-### 18.4 Documentation defect on a breaking change
+### 19.4 Documentation defect on a breaking change
 
 `CHANGELOG.md:57-59` still states that the service-account `aud` is `axiam:m2m` *"(not the `axiam:user` the device path stamps for backwards compatibility)"*. **That parenthetical is now the exact inverse of reality** — the device path stamps `axiam:m2m` as of this commit. The change is labelled BREAKING, is documented properly in the code (`auth/token.rs:200-217`) and in `CONTRACT.md:1098-1120`, but the CHANGELOG — the one file an operator reads before upgrading — was not touched and now asserts the opposite of what shipped. A stale doc comment at `auth/token.rs:263-267` repeats the same inverted claim two lines away from the code that contradicts it.
 
 This is not a vulnerability, but on a breaking authentication change it is the highest-consequence documentation defect in the set: an operator who reads the CHANGELOG will conclude their device tokens still work on user routes.
 
-### 18.5 Verified sound
+### 19.5 Verified sound
 
 - **gRPC audience check** (§17.2 residual 2) — the interceptor now validates `aud`, accepting both audiences and **failing closed on an unknown one**, with absent-`aud` gated on the same back-compat flag as REST. Note it accepts `axiam:m2m` on all four services, so a device token can call `UserService`/`TokenService` over gRPC while being refused the equivalent REST routes: the interceptor fixed the fail-closed gap, not the parity gap. Defensible for a mesh transport, but the m2m/user *split* remains REST-only.
 - **Tenant assertion in the handler** (§17.2 residual 6) — `if sa.tenant_id != tenant_id { … }` now runs **before** secret verification, so a foreign row is never used as a verification oracle and cannot trigger a hash-upgrade write against another tenant's record. Pinned by a test that also asserts the verification log stays empty.
@@ -1431,9 +1431,149 @@ This is not a vulnerability, but on a breaking authentication change it is the h
 - **The §16.5 publisher-lock residual is closed properly**: the compare-before-clear now uses a monotonic generation counter rather than the recyclable `Channel::id()`, which is exactly the fix §17.1 suggested.
 - **Regression scan clean** — no tenant predicate dropped (one added), no limit loosened, no secret in a log, and the only new unauthenticated write surface is SEC-087 above.
 
-### 18.6 Standing status
+### 19.6 Standing status
 
 - **Open findings**: **SEC-086 (LOW, PARTIAL — `authorization_code` existence oracle + accepted timing channel)** and **SEC-087 (LOW, new)**. Both are small and both have concrete one-place fixes.
 - **Highest-consequence non-finding**: the CHANGELOG inversion on a breaking change (§18.4). Fix before anyone upgrades.
 - **Still open from earlier sections**: the gRPC m2m/user parity gap, the rule-8 regression test in ten SDKs, the slug-vs-UUID diagnostic being log-only with PHP undiagnosed.
 - **Assessment**: the device-audience narrowing is the strongest single change in this series — it closed a real authority gap, shipped its compensating grant in the same commit so nothing broke, and got the audit-actor detail right without being asked. The pattern worth naming from this round is the opposite one: **two of the three problems found here were introduced by the fixes themselves** (the audit-write surface, the CHANGELOG inversion), and the third is a fix that stopped one grant short. Remediation continues to be the most productive place to look for new findings.
+
+## 20. Remediation of §19 (2026-08-04)
+
+- **Base**: server `a4cd23a2` (the §19 record) on `main`.
+- **Scope**: both open findings — SEC-086 (partial) and SEC-087 (new) — plus the §19.4 documentation defect and the §19.1 undocumented asymmetry.
+- **Result**: SEC-086 fully closed in its description half; SEC-087 closed; the CHANGELOG defect fixed and found to be larger than reported; the asymmetry documented. **One correction to §19**, in §20.1.
+
+### 20.1 SEC-086 — closed, and the recommended fix was not sufficient
+
+§19.2 is right that the oracle survived on `authorization_code`, and right about
+the cause: that grant ran its checks in a different order from the two safe
+ones. **Its recommended fix does not close the finding**, and the difference
+matters enough to state precisely.
+
+The recommendation was to move the secret-presence check ahead of the client
+lookup. That closes the *no-secret* probe §19.2 tabulates. But the grant-type
+check also sat **before** secret verification on this path, and both safe grants
+put it after. So a second probe survives the recommended fix — costing the
+attacker one throwaway secret:
+
+| Probe | Case | Before | After §19's fix alone | After this change |
+|---|---|---|---|---|
+| no secret | unknown client | `invalid_client` | `invalid_client`/"secret required" | `invalid_client`/"secret required" |
+| no secret | exists, lacks grant | `unauthorized_client` | `invalid_client`/"secret required" | `invalid_client`/"secret required" |
+| no secret | exists, has grant | `invalid_client`/"secret required" | `invalid_client`/"secret required" | `invalid_client`/"secret required" |
+| **dummy secret** | unknown client | `invalid_client` | `invalid_client` | `invalid_client` |
+| **dummy secret** | **exists, lacks grant** | `unauthorized_client` | **`unauthorized_client`** ⟵ still leaks | `invalid_client` |
+
+Both orderings are therefore corrected: presence → lookup → **verify** →
+grant-type, exactly matching `client_credentials` and `refresh_token`.
+`unauthorized_client` is now reachable only by a caller who has already proven
+possession of the secret, which is the property that actually makes it safe to
+return a specific error at all.
+
+`authorization_code_does_not_reveal_whether_a_client_exists` asserts both
+probes. It was falsified twice: once against the original ordering (probe 1
+fails) and once against §19's recommended fix applied alone (probe 1 passes,
+**probe 2 fails**) — which is the evidence for the correction above.
+
+**The timing channel remains open and remains accepted**, on the reasoning
+§18.1 gave and §19.2 explicitly declined to dispute. SEC-086's *description*
+half is now genuinely closed on all three grants.
+
+### 20.2 SEC-087 — closed
+
+§19.3 is correct in full: the audit row added for §17.2 residual 3 was written
+from an unauthenticated endpoint whose `tenant_id` is a query parameter, so an
+anonymous caller could append to any tenant's append-only log, or to a uuid
+belonging to no tenant. Three controls, matching the three defects reported:
+
+1. **The tenant is resolved before the write.** An unknown tenant is dropped
+   with a warning. Deliberately, this does **not** try to stop failures against
+   a tenant the caller doesn't belong to: that event is *true* — a failed
+   client authentication did occur against that tenant — and suppressing it
+   would blind an operator to a real attack, which is the opposite of what the
+   row exists for. Rows under a *nonexistent* tenant are different in kind:
+   nobody will ever read that partition and the uuid space is unbounded, so
+   that arm is refused outright. The volumetric control for the real-tenant
+   case stays the endpoint's rate limit.
+2. **The client id is truncated** to 128 chars.
+3. **The IP is recorded at two trust levels**: `ip_address` now carries the
+   transport peer address, which cannot be forged, and the `X-Forwarded-For`
+   value moves to metadata as `forwarded_for_untrusted`. A new `peer_ip`
+   helper sits beside `client_ip`; `client_ip` is unchanged and remains correct
+   on authenticated paths behind a trusted proxy.
+
+Note the failure posture is unchanged: a tenant-lookup outage drops the row
+rather than turning a 401 into a 500 (T-15-04), same as the append itself.
+
+Three tests, each falsified against its own control independently — the
+truncation assertion fires before the IP assertion in the shared test, so the
+IP control was falsified in a separate run rather than assumed. A fourth test,
+`a_failed_client_auth_is_audited_against_a_real_tenant`, pins the control case:
+the hardening must not silence the true event, which is the way this fix could
+most plausibly go wrong later.
+
+### 20.3 §19.4 — the CHANGELOG defect was larger than reported
+
+§19.4 called this the highest-consequence non-finding, and it was right. On
+inspection it was worse than an inverted parenthetical: **the breaking change
+had no CHANGELOG entry at all.** The only mention of the device audience
+anywhere in the file was the stale aside inside the service-account entry. An
+operator reading it would have concluded both that device tokens still work on
+user routes *and* that nothing breaking had shipped.
+
+Fixed by adding a `### Changed` entry that leads with the breaking change,
+states what stops working, points at the compensating grant, tells the reader
+what to check before upgrading, and notes that gRPC is unaffected so the
+m2m/user split is REST-only. The inverted parenthetical is corrected, and
+SEC-086/SEC-087 are recorded under `### Security`.
+
+The stale doc comment at `auth/token.rs` is also fixed — and it was inverted in
+a second way §19 did not mention. It claimed the two issuing functions were
+"deliberately distinct" with "two claims differ", naming `aud` as one of them.
+Since the residual-1 flip they agree on `aud`, `sub` *and* `sub_kind`; what
+actually still differs is `jti` (generated here, caller-supplied there) and
+`scope` (requestable here, absent there). The comment now says that.
+
+### 20.4 §19.1 — the OAuth2-client asymmetry, documented not "fixed"
+
+§19.1 observed that the m2m branch of `AuthenticatedPrincipal` parses `sub` as
+a UUID, so an OAuth2-client m2m token 401s there while a service-account one
+passes — fail-closed, but undocumented.
+
+Documented rather than changed, because the 401 is correct. Role assignments
+are keyed on a subject UUID and an OAuth2 client has no row in that graph, so
+admitting one would produce a principal the engine can only ever evaluate to
+"no grants": a caller that authenticates and then fails every check. That is
+strictly worse than a clean rejection, and it invites a later "fix" that
+invents a subject mapping. The comment says so, and marks that parse as where
+such a modelling change would have to start.
+
+### 20.5 Carried, unchanged
+
+- **The SEC-086 timing channel** — accepted, reasoning in §18.1, undisputed in §19.2.
+- **The gRPC m2m/user parity gap** (§19.5) — the interceptor accepts `axiam:m2m`
+  on all four services, so a device token can reach `UserService` over gRPC
+  while being refused the equivalent REST route. §19.5 calls this defensible for
+  a mesh transport and it is, but the split being REST-only is now stated in the
+  CHANGELOG so it is at least not a surprise.
+- **Residuals 4 and 5** (§18.6) — design changes, not patches.
+- **The rule-8 guardrail tests in nine SDKs** — carried a fourth time. Still a
+  two-tests-across-eight-languages lift that wants its own PR series; §15.1's
+  hand-verification that all eleven guards reject correctly still stands.
+
+### 20.6 What a verifier should look at hardest
+
+1. **The reordered `authorization_code` path.** Confirm nothing between the
+   presence check and secret verification can return a distinguishable error,
+   and that the PKCE/code handling below it is unaffected by the move.
+2. **The tenant gate on the audit write.** Confirm it cannot be turned into a
+   tenant-existence oracle of its own — it is fire-and-forget and changes no
+   response, but that is the obvious way this fix could backfire.
+3. **`peer_ip` adoption.** It is used only on this unauthenticated path.
+   Confirm no authenticated path was switched to it by accident, which would
+   silently degrade audit quality behind a proxy.
+4. **The pattern §19.6 named.** Two of the three problems it found were
+   introduced by the previous round's fixes; SEC-087 was mine. This round adds
+   a tenant lookup and a new helper to an unauthenticated path — the same shape
+   of change that produced SEC-087.

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -426,6 +426,23 @@ fn extract_principal(req: &HttpRequest) -> Result<AuthenticatedPrincipal, AxiamA
         check_user_aud_and_parse_jti(&validated, config)?;
     }
 
+    // `sub` must be a UUID, which quietly makes this extractor reject one of
+    // the two machine principal kinds — an asymmetry worth stating rather than
+    // leaving to be rediscovered.
+    //
+    // A *service account*'s `sub` is its UUID, so it parses. An *OAuth2
+    // client*'s `sub` is its `oa_…` client id, so it does not, and such a
+    // caller gets 401 here even though its token carries `axiam:m2m` and is
+    // accepted elsewhere.
+    //
+    // That is the correct outcome, not a gap to close: role assignments are
+    // keyed on a subject UUID, and an OAuth2 client has no row in that graph.
+    // Admitting one would produce a principal the authorization engine can
+    // only ever evaluate to "no grants" — a caller that authenticates and then
+    // fails every check, which is a worse experience than a clean 401 and
+    // invites someone to "fix" it later by inventing a subject mapping. If
+    // OAuth2 clients ever need to be RBAC subjects, that is a deliberate
+    // modelling change, and this parse is where it would start.
     let subject_id =
         Uuid::parse_str(&validated.0.sub).map_err(|_| AxiamError::AuthenticationFailed {
             reason: "invalid sub claim".into(),

--- a/crates/axiam-api-rest/src/extractors/client_info.rs
+++ b/crates/axiam-api-rest/src/extractors/client_info.rs
@@ -21,6 +21,24 @@ pub fn client_ip(req: &HttpRequest) -> Option<String> {
         .map(|s| s.chars().take(MAX_IP_LEN).collect())
 }
 
+/// Extract the **transport peer address**, capped to [`MAX_IP_LEN`].
+///
+/// Unlike [`client_ip`], this ignores `X-Forwarded-For` / `X-Real-IP` entirely
+/// and reports the address the connection actually came from. Behind a trusted
+/// reverse proxy that is the proxy's own address, which is why [`client_ip`]
+/// remains the right choice on authenticated paths.
+///
+/// Use this on **unauthenticated** endpoints, where the forwarding headers are
+/// caller-supplied and therefore forgeable (SEC-087): an attacker who can pick
+/// the IP written to an audit row can make an operator act against an innocent
+/// host. Callers that want both should record this as the trusted value and
+/// keep [`client_ip`] alongside it, explicitly labelled untrusted.
+pub fn peer_ip(req: &HttpRequest) -> Option<String> {
+    req.connection_info()
+        .peer_addr()
+        .map(|s| s.chars().take(MAX_IP_LEN).collect())
+}
+
 /// Extract the `User-Agent` header value, capped to [`MAX_UA_LEN`].
 pub fn user_agent(req: &HttpRequest) -> Option<String> {
     req.headers()

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -16,13 +16,20 @@ use serde::{Deserialize, Serialize};
 use surrealdb::Connection;
 use uuid::Uuid;
 
+use axiam_core::error::AxiamError;
 use axiam_core::models::audit::{ActorType, AuditOutcome, CreateAuditLogEntry};
-use axiam_core::repository::AuditLogRepository;
-use axiam_db::SurrealAuditLogRepository;
+use axiam_core::repository::{AuditLogRepository, TenantRepository};
+use axiam_db::{SurrealAuditLogRepository, SurrealTenantRepository};
 
 use crate::extractors::auth::AuthenticatedUser;
-use crate::extractors::client_info::client_ip;
+use crate::extractors::client_info::{client_ip, peer_ip};
 use crate::state::AppState;
+
+/// Cap for the caller-supplied `client_id` recorded in a failed-client-auth
+/// audit row (SEC-087). Server-generated ids are `oa_`/`sa_` + a 32-char
+/// encoding, so this leaves generous headroom for a legitimate value while
+/// bounding what an anonymous caller can push into the log.
+const MAX_CLIENT_ID_LEN: usize = 128;
 
 // ---------------------------------------------------------------------------
 // DTOs
@@ -218,10 +225,12 @@ pub async fn token<C: Connection + Clone>(
         Err(e) => {
             if matches!(e, OAuth2Error::InvalidClient(_)) {
                 append_client_auth_failure_audit(
+                    &state.tenant_repo,
                     &state.audit_repo,
                     tenant_id,
                     attempted_client_id.as_deref(),
                     &grant_type,
+                    peer_ip(&req),
                     client_ip(&req),
                 )
                 .await;
@@ -253,13 +262,70 @@ pub async fn token<C: Connection + Clone>(
 /// metadata instead, where it is evidence rather than identity.
 ///
 /// The secret is never recorded, in any form.
+///
+/// # SEC-087 — this endpoint is unauthenticated, so nothing here may be trusted
+///
+/// `/oauth2/token` takes its `tenant_id` from a **query parameter** and requires
+/// no credential to reach. The first version of this function wrote the row
+/// unconditionally, which let any anonymous caller append rows into an arbitrary
+/// tenant's append-only log — or into a tenant id that never existed — at
+/// request rate. Three separate controls apply here as a result:
+///
+/// 1. **The tenant is resolved before the write.** An unknown tenant is
+///    dropped with a rate-limited warning instead of minting log rows under an
+///    id no operator will ever read. This bounds the set of writable partitions
+///    to tenants that actually exist. It does *not* stop a caller from
+///    generating failures against a real tenant they do not belong to — and it
+///    deliberately doesn't try to, because that event is **true**: a failed
+///    client authentication did occur against that tenant, and suppressing it
+///    would blind the operator to a real attack. The volumetric control for
+///    that is the endpoint's rate limit, not the audit layer.
+/// 2. **The client id is truncated.** It is caller-supplied and otherwise
+///    unbounded, unlike the `client_ip`/`user_agent` helpers which have always
+///    capped their inputs.
+/// 3. **The IP is recorded at two trust levels.** `ip_address` carries the
+///    transport peer address, which a caller cannot forge. The
+///    `X-Forwarded-For`-derived value goes to metadata under a name that says
+///    it is untrusted: on an authenticated path behind a trusted proxy the
+///    forwarded value is the useful one, but here anyone can assert it, and an
+///    operator who blocks a forged IP has been made to act against the wrong
+///    host.
 async fn append_client_auth_failure_audit<C: Connection + Clone>(
+    tenant_repo: &SurrealTenantRepository<C>,
     audit_repo: &SurrealAuditLogRepository<C>,
     tenant_id: Uuid,
     attempted_client_id: Option<&str>,
     grant_type: &str,
-    ip_address: Option<String>,
+    peer_ip: Option<String>,
+    forwarded_ip_untrusted: Option<String>,
 ) {
+    // Control 1 — never write into a tenant that does not exist.
+    match tenant_repo.get_by_id(tenant_id).await {
+        Ok(_) => {}
+        Err(AxiamError::NotFound { .. }) => {
+            tracing::warn!(
+                %tenant_id,
+                %grant_type,
+                "oauth2: dropping client-auth-failure audit for unknown tenant (SEC-087)"
+            );
+            return;
+        }
+        Err(e) => {
+            // Same fire-and-forget posture as the append below: a tenant-lookup
+            // outage must not turn a 401 into a 500 (T-15-04). Drop the row.
+            tracing::error!(
+                error = %e,
+                %tenant_id,
+                "oauth2: tenant lookup failed for client-auth-failure audit"
+            );
+            return;
+        }
+    }
+
+    // Control 2 — bound the one remaining caller-controlled string.
+    let attempted_client_id: Option<String> =
+        attempted_client_id.map(|s| s.chars().take(MAX_CLIENT_ID_LEN).collect::<String>());
+
     if let Err(e) = audit_repo
         .append(CreateAuditLogEntry {
             tenant_id,
@@ -268,10 +334,13 @@ async fn append_client_auth_failure_audit<C: Connection + Clone>(
             action: "oauth2.client_auth_failed".into(),
             resource_id: None,
             outcome: AuditOutcome::Failure,
-            ip_address,
+            // Control 3 — the unforgeable half.
+            ip_address: peer_ip,
             metadata: Some(serde_json::json!({
                 "client_id": attempted_client_id,
                 "grant_type": grant_type,
+                // Named so nobody downstream mistakes it for verified input.
+                "forwarded_for_untrusted": forwarded_ip_untrusted,
             })),
         })
         .await

--- a/crates/axiam-api-rest/tests/oauth2_flow_test.rs
+++ b/crates/axiam-api-rest/tests/oauth2_flow_test.rs
@@ -1512,3 +1512,140 @@ async fn oidc_no_id_token_without_openid_scope() {
         "id_token must not be present without openid scope"
     );
 }
+
+// ---------------------------------------------------------------------------
+// SEC-087 — the failed-client-auth audit row is written on an UNAUTHENTICATED
+// endpoint, so every input to it is attacker-controlled.
+// ---------------------------------------------------------------------------
+
+/// POST a deliberately-failing client authentication, with full control over
+/// the tenant, client id and forwarding header.
+async fn failing_token_post(
+    app: &impl actix_web::dev::Service<
+        actix_http::Request,
+        Response = actix_web::dev::ServiceResponse,
+        Error = actix_web::Error,
+    >,
+    tenant_id: Uuid,
+    client_id: &str,
+    forwarded_for: Option<&str>,
+) -> actix_web::dev::ServiceResponse {
+    let form =
+        format!("grant_type=client_credentials&client_id={client_id}&client_secret=wrong-secret");
+    let mut r = test::TestRequest::post()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/oauth2/token?tenant_id={tenant_id}"))
+        .insert_header(("Content-Type", "application/x-www-form-urlencoded"));
+    if let Some(f) = forwarded_for {
+        r = r.insert_header(("X-Forwarded-For", f));
+    }
+    test::call_service(app, r.set_payload(form).to_request()).await
+}
+
+async fn client_auth_failure_rows(
+    db: &Surreal<TestDb>,
+    tenant_id: Uuid,
+) -> Vec<axiam_core::models::audit::AuditLogEntry> {
+    use axiam_core::repository::{AuditLogFilter, AuditLogRepository};
+    axiam_db::SurrealAuditLogRepository::new(db.clone())
+        .list(
+            tenant_id,
+            AuditLogFilter {
+                action: Some("oauth2.client_auth_failed".into()),
+                ..Default::default()
+            },
+            axiam_core::repository::Pagination::default(),
+        )
+        .await
+        .unwrap()
+        .items
+}
+
+#[actix_rt::test]
+async fn a_failed_client_auth_is_audited_against_a_real_tenant() {
+    // The control case. Detection is the whole point of this row (§17.2
+    // residual 3), so the SEC-087 hardening must not silence the true event:
+    // a failed authentication against a tenant that exists is still recorded.
+    let (db, _org_id, tenant_id) = setup_db().await;
+    let auth = test_auth_config();
+    let app = test_app!(db, auth);
+
+    let resp = failing_token_post(&app, tenant_id, "oa_nosuchclient", None).await;
+    assert_eq!(resp.status().as_u16(), 401);
+
+    let rows = client_auth_failure_rows(&db, tenant_id).await;
+    assert_eq!(rows.len(), 1, "the real event must still be recorded");
+}
+
+#[actix_rt::test]
+async fn an_anonymous_caller_cannot_write_audit_rows_into_an_unknown_tenant() {
+    // SEC-087. `/oauth2/token` needs no credential and takes `tenant_id`
+    // straight from the query string, so before the fix any anonymous caller
+    // could append rows to an append-only log under *any* uuid — including one
+    // belonging to no tenant at all — at request rate.
+    //
+    // Rows under a nonexistent tenant are pure garbage: no operator will ever
+    // read that partition, and the uuid space is unbounded, so this is the arm
+    // worth refusing outright.
+    let (db, _org_id, _tenant_id) = setup_db().await;
+    let auth = test_auth_config();
+    let app = test_app!(db, auth);
+
+    let victim = Uuid::new_v4(); // never created
+    let resp = failing_token_post(&app, victim, "oa_nosuchclient", None).await;
+
+    // The caller must not be able to tell the write was refused.
+    assert_eq!(
+        resp.status().as_u16(),
+        401,
+        "dropping the audit row must not change the response"
+    );
+
+    let rows = client_auth_failure_rows(&db, victim).await;
+    assert!(
+        rows.is_empty(),
+        "no audit row may be written into a tenant that does not exist"
+    );
+}
+
+#[actix_rt::test]
+async fn the_audited_client_id_is_truncated_and_the_forwarded_ip_is_untrusted() {
+    // Two smaller SEC-087 defects in the same row, both stemming from the same
+    // cause — this endpoint is unauthenticated, so both values are supplied by
+    // whoever is attacking it.
+    let (db, _org_id, tenant_id) = setup_db().await;
+    let auth = test_auth_config();
+    let app = test_app!(db, auth);
+
+    // `client_id` was recorded verbatim, unlike the sibling ip/user-agent
+    // helpers which have always capped their inputs.
+    let huge = format!("oa_{}", "A".repeat(5000));
+    let resp = failing_token_post(&app, tenant_id, &huge, Some("203.0.113.9")).await;
+    assert_eq!(resp.status().as_u16(), 401);
+
+    let rows = client_auth_failure_rows(&db, tenant_id).await;
+    assert_eq!(rows.len(), 1);
+    let meta = &rows[0].metadata;
+
+    let recorded = meta["client_id"].as_str().expect("client_id recorded");
+    assert!(
+        recorded.len() <= 128,
+        "client_id must be truncated, got {} chars",
+        recorded.len()
+    );
+
+    // The IP an operator would act on must be the transport peer, which a
+    // caller cannot forge — not the X-Forwarded-For value, which anyone can
+    // assert on an unauthenticated endpoint. Blocking a forged IP means acting
+    // against an innocent host.
+    let ip = rows[0].ip_address.as_deref().expect("ip recorded");
+    assert!(
+        ip.starts_with("127.0.0.1"),
+        "ip_address must be the unforgeable peer address, got {ip}"
+    );
+    assert_eq!(
+        meta["forwarded_for_untrusted"].as_str(),
+        Some("203.0.113.9"),
+        "the forgeable value is kept, but only under a name that says so"
+    );
+}

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -257,22 +257,29 @@ pub fn issue_service_account_token(
 /// Mint a service-account access token for the **OAuth2 client-credentials**
 /// grant.
 ///
-/// Deliberately distinct from [`issue_service_account_token`], which the mTLS
-/// device-auth path uses. Two claims differ, and both differences matter:
+/// The sibling of [`issue_service_account_token`], which the mTLS device-auth
+/// path uses. The two now agree on **`aud`, `sub` and `sub_kind`** — this is a
+/// service account either way, and since the residual-1 narrowing both paths
+/// stamp [`AUD_M2M`], so §4.3 / `SEC-006` route narrowing keeps both off user
+/// routes.
 ///
-/// * **`aud` is [`AUD_M2M`], not [`AUD_USER`].** This is a machine token
-///   obtained with a client secret, so the §4.3 / `SEC-006` per-route audience
-///   narrowing must be able to keep it off user routes.
-///   `issue_service_account_token` stamps [`AUD_USER`] for backwards
-///   compatibility with the device path, which is the wrong shape here.
-/// * **`sub` is the service-account id**, exactly as the device path does —
-///   *not* the `client_id`. The authorization engine resolves roles by subject
-///   id, so a token whose `sub` were the opaque `sa_…` client id would
-///   authenticate but carry no resolvable grants. This is what makes a service
-///   account the *same principal* whether it authenticated by certificate or
-///   by secret.
+/// *(This comment previously said the device path stamps [`AUD_USER`] for
+/// backwards compatibility and that the two were "deliberately distinct" in
+/// audience. That has been the inverse of the code since the residual-1 flip.)*
 ///
-/// `sub_kind` is [`SubjectKind::ServiceAccount`] on both paths.
+/// **`sub` is the service-account id**, not the `client_id`, on both paths. The
+/// authorization engine resolves roles by subject id, so a token whose `sub`
+/// were the opaque `sa_…` client id would authenticate but carry no resolvable
+/// grants. This is what makes a service account the *same principal* whether it
+/// authenticated by certificate or by secret.
+///
+/// Two claims still differ, both because of how each path is reached:
+///
+/// * **`jti` is generated here**, whereas the mTLS path takes it from the
+///   caller. Neither path has a session row to derive one from.
+/// * **`scope` may be populated here.** The device path has no way to request
+///   scopes; this grant does, though a service account registers none, so in
+///   practice `scopes` is empty and this collapses to `None` (§12.1).
 pub fn issue_service_account_client_credentials_token(
     service_account_id: Uuid,
     tenant_id: Uuid,

--- a/crates/axiam-oauth2/src/token.rs
+++ b/crates/axiam-oauth2/src/token.rs
@@ -458,6 +458,23 @@ where
             .as_deref()
             .ok_or_else(|| OAuth2Error::InvalidRequest("client_id is required".into()))?;
 
+        // Require client_secret — all clients are confidential (no
+        // public-client distinction exists yet).
+        //
+        // SEC-086 (second pass): this check MUST precede the client lookup.
+        // When it ran after, a caller posting no `client_secret` at all got
+        // three distinguishable answers — `invalid_client`/generic for an
+        // unknown client, `unauthorized_client` for a client lacking the
+        // grant, and `invalid_client`/"client_secret is required" for a
+        // client that had it — so client existence stayed decidable on this
+        // grant even after the description was unified everywhere else.
+        // `client_credentials` and `refresh_token` already ordered it this
+        // way; only this grant did not.
+        let client_secret = req
+            .client_secret
+            .as_deref()
+            .ok_or_else(|| OAuth2Error::InvalidClient("client_secret is required".into()))?;
+
         // Authenticate client
         let client = self
             .client_repo
@@ -477,21 +494,22 @@ where
                 other => OAuth2Error::ServerError(other.to_string()),
             })?;
 
+        // Secret verification must also precede the grant-type check, and for
+        // the same reason: `unauthorized_client` is only reachable by a caller
+        // who has *already proven possession of the secret*. Ordered the other
+        // way, supplying any dummy secret still separated "client exists but
+        // lacks this grant" from "no such client" — a second oracle on the
+        // same grant, which moving the presence check alone does not close.
+        // Both safe grants verify first; this now matches them exactly.
+        self.verify_client_secret(tenant_id, &client, client_secret)
+            .await?;
+
         // Verify client is authorized for authorization_code grant
         if !client.grant_types.iter().any(|s| s == "authorization_code") {
             return Err(OAuth2Error::UnauthorizedClient(
                 "client not authorized for authorization_code grant".into(),
             ));
         }
-
-        // Require client_secret — all clients are confidential
-        // (no public-client distinction exists yet).
-        let client_secret = req
-            .client_secret
-            .as_deref()
-            .ok_or_else(|| OAuth2Error::InvalidClient("client_secret is required".into()))?;
-        self.verify_client_secret(tenant_id, &client, client_secret)
-            .await?;
 
         // Look up the authorization code without consuming it so we
         // can verify PKCE *before* marking it as used.  This prevents

--- a/crates/axiam-oauth2/tests/token_service.rs
+++ b/crates/axiam-oauth2/tests/token_service.rs
@@ -2322,3 +2322,92 @@ async fn an_unknown_client_is_indistinguishable_from_a_wrong_secret() {
         "invalid client credentials"
     );
 }
+
+/// SEC-086 (second pass): the `authorization_code` grant must not reveal
+/// whether a `client_id` exists — under **either** probe.
+///
+/// The first pass unified every `error_description` behind one constant but
+/// left this grant's *ordering* alone, and ordering is what leaked here. Two
+/// distinct probes existed, and the two safe grants
+/// (`client_credentials`, `refresh_token`) were immune to both only because
+/// they happen to check in the right order:
+///
+/// 1. **No `client_secret` at all.** With the lookup running first, an unknown
+///    client answered `invalid_client`, a client lacking the grant answered
+///    `unauthorized_client`, and a client that had it answered
+///    `invalid_client`/"client_secret is required" — three outcomes, so
+///    existence was decidable without presenting any credential.
+/// 2. **Any dummy `client_secret`.** Fixing (1) alone does not close this:
+///    with the grant-type check still ahead of secret verification, a client
+///    that exists but lacks the grant answers `unauthorized_client` while an
+///    unknown client answers `invalid_client`. The probe just costs one
+///    throwaway secret.
+///
+/// Both arms are asserted because the fix for (1) is the one an auditor would
+/// naturally reach for, and it is insufficient on its own.
+#[tokio::test]
+async fn authorization_code_does_not_reveal_whether_a_client_exists() {
+    fn shape(e: &OAuth2Error) -> (String, String) {
+        (e.error_code().to_string(), e.error_description())
+    }
+
+    async fn probe(client: ClientOutcome, secret: Option<&str>) -> OAuth2Error {
+        let svc = build(
+            client,
+            dummy_code_repo(),
+            TenantOutcome::Found,
+            MockRefreshRepo::new(),
+        );
+        let mut req = auth_code_req(None);
+        req.client_secret = secret.map(String::from);
+        svc.exchange(Uuid::new_v4(), req)
+            .await
+            .expect_err("must not succeed")
+    }
+
+    // A client that exists but is not registered for this grant — the row an
+    // attacker is trying to confirm the existence of.
+    let other_grant = || ClientOutcome::Found(make_client(&["client_credentials"], &[]));
+    // A client that exists and does have the grant, so only the secret is wrong.
+    let right_grant = || ClientOutcome::Found(make_client(&["authorization_code"], &[]));
+
+    // --- Probe 1: no secret presented at all ---
+    let unknown = probe(ClientOutcome::NotFound, None).await;
+    let exists_other_grant = probe(other_grant(), None).await;
+    let exists_right_grant = probe(right_grant(), None).await;
+
+    assert_eq!(
+        shape(&unknown),
+        shape(&exists_other_grant),
+        "probe 1: a client that exists but lacks the grant must be \
+         indistinguishable from one that does not exist"
+    );
+    assert_eq!(
+        shape(&unknown),
+        shape(&exists_right_grant),
+        "probe 1: a client that exists and has the grant must be \
+         indistinguishable from one that does not exist"
+    );
+
+    // --- Probe 2: a dummy secret, which defeats a presence-check-only fix ---
+    let unknown = probe(ClientOutcome::NotFound, Some("wrong")).await;
+    let exists_other_grant = probe(other_grant(), Some("wrong")).await;
+    let exists_right_grant = probe(right_grant(), Some("wrong")).await;
+
+    assert_eq!(
+        shape(&unknown),
+        shape(&exists_other_grant),
+        "probe 2: `unauthorized_client` must be unreachable without first \
+         proving possession of the secret"
+    );
+    assert_eq!(
+        shape(&unknown),
+        shape(&exists_right_grant),
+        "probe 2: a wrong secret must look the same as an unknown client"
+    );
+
+    // Pin the wording, so a future edit cannot re-open the oracle by making
+    // every arm say something that still names the cause.
+    assert_eq!(unknown.error_code(), "invalid_client");
+    assert_eq!(unknown.error_description(), "invalid client credentials");
+}

--- a/deny.toml
+++ b/deny.toml
@@ -32,6 +32,20 @@ ignore = [
     # Review date: 2026-07-03. Re-evaluate when samael upstream bumps quick-xml to >=0.41.0.
     { id = "RUSTSEC-2026-0194", reason = "Transitive via samael (quick-xml ^0.37, no >=0.41 path); SAML opt-in/off by default; DoS-only. Review: 2026-07-03" },
     { id = "RUSTSEC-2026-0195", reason = "Transitive via samael (quick-xml ^0.37, no >=0.41 path); SAML opt-in/off by default; DoS-only. Review: 2026-07-03" },
+    # RUSTSEC-2026-0235: rkyv 0.7.46 — insufficient archive validation, out-of-bounds reads in
+    # archives containing Rc/Arc. Solution: upgrade to >=0.8.17.
+    # This one differs in kind from every entry above: the others are real dependencies carrying a
+    # reachability argument, whereas rkyv is NEVER COMPILED. It is an `optional = true` dependency
+    # of rust_decimal, gated behind that crate's `rkyv` feature, and nothing in the AXIAM graph
+    # enables it. Verified: `cargo tree -i rkyv --target all --all-features` reports "nothing to
+    # print", and rkyv occurs zero times in the fully-resolved tree. cargo-audit and cargo-deny
+    # both read Cargo.lock, which records optional dependencies regardless of whether any feature
+    # activates them, so the finding is a lockfile artifact and not a vulnerability in a shipped
+    # artifact. (rust_decimal 1.42.1 is current and still pins rkyv 0.7.x, so there is also no
+    # upgrade path — but that is beside the point here, since the code is not built.)
+    # Review date: 2026-08-04. Re-verify with the command above if rust_decimal's feature defaults
+    # change, or drop this entry if rust_decimal moves to rkyv >=0.8.17.
+    { id = "RUSTSEC-2026-0235", reason = "rkyv is optional in rust_decimal and no feature enables it — zero occurrences in the resolved tree, never compiled; Cargo.lock artifact only. Review: 2026-08-04" },
 ]
 
 [licenses]


### PR DESCRIPTION
Remediates both open findings from §19 of `claude_dev/security-analysis-2026-08-02.md`, plus the documentation defect it flagged. Recorded as **§20** (§19's section was renumbered — it had collided with §18).

## SEC-086 — closed, and §19's recommended fix was not sufficient

§19.2 correctly identified that the oracle survived on `authorization_code` and correctly diagnosed the cause as check ordering. But its recommended fix — move the secret-presence check ahead of the client lookup — **does not close the finding**.

The grant-type check *also* sat before secret verification on that path, and both safe grants put it after. So a second probe survives, costing the attacker one throwaway secret:

| Probe | Case | Before | After §19's fix alone | After this PR |
|---|---|---|---|---|
| no secret | unknown client | `invalid_client` | `invalid_client`/"secret required" | `invalid_client`/"secret required" |
| no secret | exists, lacks grant | `unauthorized_client` | `invalid_client`/"secret required" | `invalid_client`/"secret required" |
| no secret | exists, has grant | `invalid_client`/"secret required" | `invalid_client`/"secret required" | `invalid_client`/"secret required" |
| **dummy secret** | unknown client | `invalid_client` | `invalid_client` | `invalid_client` |
| **dummy secret** | **exists, lacks grant** | `unauthorized_client` | **`unauthorized_client`** ⟵ still leaks | `invalid_client` |

Both orderings are corrected to match `client_credentials` and `refresh_token` exactly: **presence → lookup → verify → grant-type**. `unauthorized_client` is now reachable only by a caller who has already proven possession of the secret, which is what makes returning a specific error there safe at all.

`authorization_code_does_not_reveal_whether_a_client_exists` asserts both probes and was **falsified twice** — against the original ordering (probe 1 fails), and against §19's recommended fix applied alone (probe 1 passes, **probe 2 fails**). That second run is the evidence for the correction.

The timing channel remains open and remains accepted, on the reasoning §18.1 gave and §19.2 explicitly declined to dispute.

## SEC-087 — closed (this one was mine)

§19.3 is correct in full. The audit row I added last round for §17.2 residual 3 is written from an unauthenticated endpoint whose `tenant_id` is a query parameter, so any anonymous caller could append to an arbitrary tenant's append-only log — or one belonging to no tenant — at request rate. Three controls:

1. **The tenant is resolved before the write.** Deliberately this does *not* suppress failures against a tenant the caller doesn't belong to: that event is **true**, and hiding it would blind an operator to a real attack, which is the opposite of why the row exists. Rows under a *nonexistent* tenant are different in kind — nobody reads that partition, the uuid space is unbounded — so only that arm is refused. Rate limiting stays the volumetric control.
2. **The client id is truncated** to 128 chars.
3. **The IP is recorded at two trust levels** — `ip_address` is now the unforgeable transport peer; the `X-Forwarded-For` value moves to metadata as `forwarded_for_untrusted`. New `peer_ip` helper beside `client_ip`, which is unchanged and still correct on authenticated paths behind a proxy.

Failure posture unchanged: a tenant-lookup outage drops the row rather than turning a 401 into a 500 (T-15-04).

Each control was falsified independently — the truncation assert fires before the IP assert in the shared test, so the IP control got its own run rather than being assumed. A fourth test pins the control case: the hardening must not silence the true event, which is how this fix could most plausibly go wrong later.

## §19.4 — the CHANGELOG defect was larger than reported

§19.4 called this the highest-consequence non-finding. On inspection it was worse than an inverted parenthetical: **the breaking change had no CHANGELOG entry at all.** An operator would have concluded both that device tokens still work on user routes *and* that nothing breaking shipped.

Adds a `### Changed` entry leading with the breaking change: what stops working, the compensating grant, what to check before upgrading, and that gRPC is unaffected so the m2m/user split is REST-only.

The stale `auth/token.rs` comment was inverted in a **second** way §19 didn't note: it claimed the two issuing functions are "deliberately distinct" in `aud`. They now agree on `aud`, `sub` *and* `sub_kind`; what actually differs is `jti` and `scope`.

## §19.1 — documented, not "fixed"

The `AuthenticatedPrincipal` m2m branch rejects an OAuth2-client token because `sub` isn't a UUID. That 401 is correct: role assignments are keyed on a subject UUID and an OAuth2 client has no row in that graph, so admitting one yields a principal that authenticates and then fails every check — worse than a clean rejection, and an invitation for someone to later invent a subject mapping. The comment says so and marks that parse as where such a change would start.

## Verification

`fmt --all` and `clippy --all-targets --all-features -D warnings` clean. Green: `oauth2` (119 + 79 + …), `auth` (33), `api-rest --lib` (136), and the `oauth2_flow` (34), `oauth2_conformance`, `oauth2_client`, `device_auth`, `service_account`, `audit` and `qual03` integration suites. Full workspace `Test` runs in CI — the complete `api-rest` integration build exhausts the sandbox disk.

## SDK impact: none

Deliberately no SDK PRs this round. The set of OAuth2 error *codes* is unchanged — only which one a specific probe receives — and the audit metadata shape isn't part of `CONTRACT.md`. Nothing downstream needs re-syncing.

## Carried

The SEC-086 timing channel (accepted), the gRPC m2m/user parity gap (§19.5 — now at least stated in the CHANGELOG), residuals 4 and 5, and the rule-8 guardrail tests in nine SDKs, carried a fourth time and still wanting their own PR series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D)_