### PR TITLE
security: fix the §22.3 residuals

### DIFF
--- a/claude_dev/security-analysis-2026-08-02.md
+++ b/claude_dev/security-analysis-2026-08-02.md
@@ -1740,3 +1740,111 @@ Recording it because of where it came from: rule 8 was written to describe a con
 - **Open findings: none.** SEC-071 … SEC-087 are all closed and independently verified, as are `T-145`, OBS-1 … OBS-4 and every §10.4 residual.
 - **Open items are all observations or accepted trade-offs**: §22.3 items 1–4, the SEC-086 timing channel, and the long-standing design decisions recorded in the threat model (`T-16`/`T-87` no deny-override, `T-39` token revocation lag, `T-110`/`T-118` append-only audit versus erasure).
 - **Closing assessment.** Seven verification passes, each of which found something the preceding remediation's self-report had missed — SEC-080, SEC-079, SEC-085, two partials, SEC-086, SEC-087. The trend is the point: the severity fell from HIGH (a cross-tenant authentication bypass) to LOW (an error-string oracle), and this round's residuals are second-order consequences of fixes rather than defects in the original design. The practices that produced that curve are worth keeping past this document: remediation and verification stay separate; a remediation names its own weakest points; evidence must resolve on the default branch; and a control that eleven implementations must satisfy gets written down once, normatively, rather than inferred eleven times.
+
+## 23. Remediation of §22.3 (2026-08-04)
+
+- **Base**: server `54b39a62` (the §22 record) on `main`.
+- **Scope**: the four residuals in §22.3. There were no open findings to close — §22.4 confirmed that — so this round is entirely second-order cleanup, two items of which §20's own fix created.
+- **Result**: residuals 1, 2 and 3 fixed; residual 4's documentation half fixed; the gRPC parity gap carried deliberately, with the reasoning stated. No new findings.
+
+### 23.1 Residual 1 — the tenant-existence timing differential
+
+§22.3 is right, and right about the cause being mine. The SEC-087 fix awaited a
+tenant read before returning the error, and only performed the insert when the
+tenant existed — so a failed client authentication returned measurably faster
+for a nonexistent tenant than a real one, on an endpoint requiring no
+credential.
+
+Fixed by **detaching the audit operation from the response path entirely**
+(`actix_web::rt::spawn`), rather than by trying to balance the two branches.
+Balancing is the weaker answer: it leaves the differential in place and bets on
+the padding tracking future edits to the branch. Detaching removes the
+dependency, so no ordering of tenant read and insert can be observed from
+outside at all.
+
+It also makes the function honest. Its doc comment has said *"fire-and-forget"*
+since §18, and until now it was awaited — the comment described an intent the
+code did not implement.
+
+**Not falsifiable by a test**, and worth saying rather than implying otherwise:
+a timing assertion at this resolution would be flaky in CI. The property is
+structural — the response is constructed without awaiting the audit future —
+and is verified by reading the call site. What the tests *do* pin is the
+consequence: they poll for the row instead of expecting it synchronously, which
+would fail if anyone re-attached the write.
+
+### 23.2 Residual 2 — the audit row no longer fails open
+
+Also correct, and the sharpest of the four: a non-`NotFound` error from the
+tenant read dropped the row silently. The rationale was sound (a DB fault must
+not turn a 401 into a 500, T-15-04) but the effect was that a database fault
+cost exactly the telemetry the row exists to provide — and a database fault is
+plausibly correlated with an incident.
+
+A row that cannot be attributed to a real tenant now goes to the **system
+partition** (`tenant_id = nil`, which `AuditLogRepository::list_system` already
+exists to serve), carrying `unattributed_reason` (`unknown_tenant` or
+`tenant_lookup_failed`) and the caller-named tenant under
+`claimed_tenant_id_untrusted`.
+
+This preserves SEC-087's actual guarantee while dropping the collateral damage.
+The guarantee was never "no row is written" — it was **"a caller cannot choose
+which real tenant's append-only log a row lands in"**, and nil is a single fixed
+partition nobody can steer toward. So the unknown-tenant case is no longer
+discarded either: a caller probing random tenant ids is itself a signal, and it
+is now visible in one place rather than only in a log line.
+
+### 23.3 Residual 3 — the cap was in the wrong unit
+
+`chars().take(128)` bounds code points, not bytes, so a multibyte `client_id`
+stored up to 512. Replaced with a byte-bounded truncation that walks back to a
+character boundary, keeping the stored value valid UTF-8.
+
+§22.3 also noted the *test* asserted a byte length that passed only because its
+payload was ASCII — the more useful half of the observation, since it explains
+why the defect was invisible. A second test now uses `'é'` (two bytes), and
+falsification confirms the numbers: against the old code it records **253 bytes
+for 128 chars**, while the ASCII test continues to pass. The pre-existing
+char-vs-byte looseness in `client_ip`/`user_agent` is left alone — bounded there
+by much smaller limits, and changing them is unrelated churn.
+
+### 23.4 Residual 4 — the `client_ip` docstring
+
+It claimed the forwarding headers are honoured *"as trusted by the Actix-Web
+server configuration"*. §22.3 is right that this is false: Actix-Web has **no
+trusted-proxy list** and reads `X-Forwarded-For` whenever present.
+
+Corrected explicitly rather than softened, including a note that the previous
+wording was wrong, and pointing at `peer_ip` for unauthenticated paths. A
+docstring that overstates a security property is worth more than a cosmetic fix:
+it is the thing a future reader would rely on when deciding whether the value
+needs treating as untrusted, which is exactly the decision SEC-087 turned on.
+
+### 23.5 Deliberately not actioned
+
+**The gRPC m2m/user parity gap**, carried since §19.5. The interceptor rejects
+an unknown audience and fails closed on an absent one, but accepts both
+`axiam:user` and `axiam:m2m` on all four services — so a device token can reach
+`UserService` over gRPC while being refused the equivalent REST route.
+
+Still not actioned, and the reason has not changed: narrowing it is a
+**deployment-visible decision**, not a defect fix. gRPC is the service-mesh
+surface where machine callers are the norm, and splitting the audiences there
+would break user-token callers that route through the mesh today. §19.5 called
+it defensible and it remains so. It is now stated in the CHANGELOG (§20.3), so
+an operator meets it as documented behaviour rather than discovering it.
+
+If it is ever narrowed it should be per-service and opt-in, which is a design
+change deserving its own round.
+
+### 23.6 What a verifier should look at hardest
+
+1. **The spawned audit task.** Confirm nothing in it can outlive or panic the
+   worker, and that the response path truly no longer awaits it. This is the
+   change most likely to have a second-order effect I have not seen.
+2. **Whether nil-tenant rows are actually reachable to operators.**
+   `list_system` exists, but a partition nobody queries is telemetry only in
+   principle. Worth checking the admin surface exposes it.
+3. **That routing to nil did not re-open SEC-087.** The property is that a
+   caller cannot steer a row into a *chosen* tenant. Confirm no path lets the
+   claimed tenant id become the written one without the existence check.

--- a/crates/axiam-api-rest/src/extractors/client_info.rs
+++ b/crates/axiam-api-rest/src/extractors/client_info.rs
@@ -11,10 +11,23 @@ pub const MAX_IP_LEN: usize = 45;
 /// Maximum length for a User-Agent string.
 pub const MAX_UA_LEN: usize = 512;
 
-/// Extract the real client IP from [`ConnectionInfo`], capped to [`MAX_IP_LEN`].
+/// Extract the client IP as *asserted by the request*, capped to [`MAX_IP_LEN`].
 ///
-/// Uses `realip_remote_addr` which respects the `X-Forwarded-For` / `X-Real-IP`
-/// headers as trusted by the Actix-Web server configuration.
+/// Uses `realip_remote_addr`, which returns the first entry of `X-Forwarded-For`
+/// (else `X-Real-IP`, else the peer address).
+///
+/// # This value is not validated by Actix-Web
+///
+/// An earlier version of this doc said the headers are honoured "as trusted by
+/// the Actix-Web server configuration". That is wrong, and worth correcting
+/// rather than softening: Actix-Web has **no trusted-proxy list**. It reads the
+/// forwarding headers whenever they are present, so behind no proxy — or behind
+/// one that does not overwrite them — this value is whatever the caller typed.
+///
+/// It is still the right choice on an **authenticated** path behind a proxy
+/// that does overwrite `X-Forwarded-For`, which is the deployment this is for.
+/// On an **unauthenticated** path use [`peer_ip`] instead, or record this one
+/// under a name that marks it untrusted (SEC-087, §22.3).
 pub fn client_ip(req: &HttpRequest) -> Option<String> {
     req.connection_info()
         .realip_remote_addr()

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -31,6 +31,24 @@ use crate::state::AppState;
 /// bounding what an anonymous caller can push into the log.
 const MAX_CLIENT_ID_LEN: usize = 128;
 
+/// Truncate to at most [`MAX_CLIENT_ID_LEN`] **bytes**, cutting on a character
+/// boundary so the result is still valid UTF-8.
+///
+/// §22.3 residual 3: the previous `chars().take(N)` capped code points, not
+/// bytes, so a multibyte id could still store 4× the intended size. The cap
+/// exists to bound what an anonymous caller can push into an append-only log,
+/// and a bound expressed in the wrong unit is not the bound that was intended.
+fn truncate_bytes_on_char_boundary(s: &str) -> String {
+    if s.len() <= MAX_CLIENT_ID_LEN {
+        return s.to_owned();
+    }
+    let mut end = MAX_CLIENT_ID_LEN;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_owned()
+}
+
 // ---------------------------------------------------------------------------
 // DTOs
 // ---------------------------------------------------------------------------
@@ -224,16 +242,33 @@ pub async fn token<C: Connection + Clone>(
         }
         Err(e) => {
             if matches!(e, OAuth2Error::InvalidClient(_)) {
-                append_client_auth_failure_audit(
-                    &state.tenant_repo,
-                    &state.audit_repo,
-                    tenant_id,
-                    attempted_client_id.as_deref(),
-                    &grant_type,
-                    peer_ip(&req),
-                    client_ip(&req),
-                )
-                .await;
+                // §22.3 residual 1: this used to be awaited, which put a tenant
+                // read (and, when it succeeded, an insert) on the response path
+                // — so a failed client auth returned measurably faster for a
+                // NONEXISTENT tenant than a real one, on an unauthenticated
+                // endpoint. Detaching it removes the differential at its source
+                // rather than trying to balance the two branches, and makes the
+                // "fire-and-forget" this function has always claimed actually
+                // true. The response below no longer waits on the audit sink at
+                // all.
+                let tenant_repo = state.tenant_repo.clone();
+                let audit_repo = state.audit_repo.clone();
+                let attempted = attempted_client_id.clone();
+                let grant = grant_type.clone();
+                let peer = peer_ip(&req);
+                let forwarded = client_ip(&req);
+                actix_web::rt::spawn(async move {
+                    append_client_auth_failure_audit(
+                        &tenant_repo,
+                        &audit_repo,
+                        tenant_id,
+                        attempted.as_deref(),
+                        &grant,
+                        peer,
+                        forwarded,
+                    )
+                    .await;
+                });
             }
             build_oauth2_error_response(&e)
         }
@@ -271,18 +306,31 @@ pub async fn token<C: Connection + Clone>(
 /// tenant's append-only log — or into a tenant id that never existed — at
 /// request rate. Three separate controls apply here as a result:
 ///
-/// 1. **The tenant is resolved before the write.** An unknown tenant is
-///    dropped with a rate-limited warning instead of minting log rows under an
-///    id no operator will ever read. This bounds the set of writable partitions
-///    to tenants that actually exist. It does *not* stop a caller from
-///    generating failures against a real tenant they do not belong to — and it
-///    deliberately doesn't try to, because that event is **true**: a failed
-///    client authentication did occur against that tenant, and suppressing it
-///    would blind the operator to a real attack. The volumetric control for
-///    that is the endpoint's rate limit, not the audit layer.
-/// 2. **The client id is truncated.** It is caller-supplied and otherwise
-///    unbounded, unlike the `client_ip`/`user_agent` helpers which have always
-///    capped their inputs.
+/// 1. **The tenant is resolved before the write**, and a row that cannot be
+///    attributed to a real tenant goes to the **system partition**
+///    (`tenant_id = nil`, the one [`AuditLogRepository::list_system`] serves)
+///    rather than to a caller-chosen id. This bounds what an anonymous caller
+///    can steer: they may cause a row, but never choose which real tenant's
+///    append-only log it lands in. It does *not* stop a caller from generating
+///    failures against a real tenant they do not belong to — and deliberately
+///    doesn't try to, because that event is **true**: a failed client
+///    authentication did occur against that tenant, and suppressing it would
+///    blind the operator to a real attack. The volumetric control is the
+///    endpoint's rate limit, not the audit layer.
+///
+///    §22.3 residual 2: an earlier version *dropped* the row whenever the
+///    tenant read failed for any reason other than `NotFound`. The reasoning
+///    (a DB outage must not turn a 401 into a 500) was right, but the effect
+///    was that a database fault cost exactly the telemetry this row exists to
+///    provide — and a database fault is plausibly correlated with an incident.
+///    Routing to the system partition keeps the signal in precisely the case
+///    where losing it hurts most, while still refusing to guess a tenant.
+/// 2. **The client id is truncated on a character boundary, by bytes.**
+///    §22.3 residual 3: the cap was applied with `chars().take(N)`, so a
+///    multibyte id still stored up to 4N bytes. It is caller-supplied and
+///    otherwise unbounded, unlike the `client_ip`/`user_agent` helpers which
+///    have always capped their inputs (and which share the same char-vs-byte
+///    looseness, bounded there by much smaller limits).
 /// 3. **The IP is recorded at two trust levels.** `ip_address` carries the
 ///    transport peer address, which a caller cannot forge. The
 ///    `X-Forwarded-For`-derived value goes to metadata under a name that says
@@ -299,36 +347,43 @@ async fn append_client_auth_failure_audit<C: Connection + Clone>(
     peer_ip: Option<String>,
     forwarded_ip_untrusted: Option<String>,
 ) {
-    // Control 1 — never write into a tenant that does not exist.
-    match tenant_repo.get_by_id(tenant_id).await {
-        Ok(_) => {}
+    // Control 1 — attribute the row to the request's tenant only when that
+    // tenant demonstrably exists; otherwise fall back to the system partition.
+    // `attributed_tenant` is nil in both the unknown and the indeterminate
+    // case, so a caller can never place a row in a real tenant's log by naming
+    // one.
+    let (attributed_tenant, tenant_note) = match tenant_repo.get_by_id(tenant_id).await {
+        Ok(_) => (tenant_id, None),
         Err(AxiamError::NotFound { .. }) => {
             tracing::warn!(
-                %tenant_id,
+                claimed_tenant_id = %tenant_id,
                 %grant_type,
-                "oauth2: dropping client-auth-failure audit for unknown tenant (SEC-087)"
+                "oauth2: client-auth-failure audit routed to the system partition — unknown tenant (SEC-087)"
             );
-            return;
+            (Uuid::nil(), Some("unknown_tenant"))
         }
         Err(e) => {
-            // Same fire-and-forget posture as the append below: a tenant-lookup
-            // outage must not turn a 401 into a 500 (T-15-04). Drop the row.
+            // A DB fault must not turn a 401 into a 500 (T-15-04), and must not
+            // cost the telemetry either (§22.3 residual 2). Record it as
+            // unattributed rather than dropping it.
             tracing::error!(
                 error = %e,
-                %tenant_id,
-                "oauth2: tenant lookup failed for client-auth-failure audit"
+                claimed_tenant_id = %tenant_id,
+                "oauth2: tenant lookup failed for client-auth-failure audit; \
+                 routing to the system partition"
             );
-            return;
+            (Uuid::nil(), Some("tenant_lookup_failed"))
         }
-    }
+    };
 
-    // Control 2 — bound the one remaining caller-controlled string.
+    // Control 2 — bound the one remaining caller-controlled string, by BYTES,
+    // truncating on a character boundary so the stored value stays valid UTF-8.
     let attempted_client_id: Option<String> =
-        attempted_client_id.map(|s| s.chars().take(MAX_CLIENT_ID_LEN).collect::<String>());
+        attempted_client_id.map(truncate_bytes_on_char_boundary);
 
     if let Err(e) = audit_repo
         .append(CreateAuditLogEntry {
-            tenant_id,
+            tenant_id: attributed_tenant,
             actor_id: Uuid::nil(),
             actor_type: ActorType::System,
             action: "oauth2.client_auth_failed".into(),
@@ -341,6 +396,10 @@ async fn append_client_auth_failure_audit<C: Connection + Clone>(
                 "grant_type": grant_type,
                 // Named so nobody downstream mistakes it for verified input.
                 "forwarded_for_untrusted": forwarded_ip_untrusted,
+                // Present only on a system-partition row: the tenant the caller
+                // named, and why it could not be attributed. Also caller-supplied.
+                "claimed_tenant_id_untrusted": tenant_note.map(|_| tenant_id.to_string()),
+                "unattributed_reason": tenant_note,
             })),
         })
         .await
@@ -349,7 +408,7 @@ async fn append_client_auth_failure_audit<C: Connection + Clone>(
         // the audit sink is unavailable (T-15-04).
         tracing::error!(
             error = %e,
-            %tenant_id,
+            tenant_id = %attributed_tenant,
             %grant_type,
             "oauth2: failed to write oauth2.client_auth_failed audit log"
         );

--- a/crates/axiam-api-rest/tests/oauth2_flow_test.rs
+++ b/crates/axiam-api-rest/tests/oauth2_flow_test.rs
@@ -1561,11 +1561,50 @@ async fn client_auth_failure_rows(
         .items
 }
 
+/// Rows in the **system partition** (`tenant_id = nil`) — where a failure that
+/// cannot be attributed to a real tenant is recorded (§22.3 residual 2).
+async fn client_auth_failure_system_rows(
+    db: &Surreal<TestDb>,
+) -> Vec<axiam_core::models::audit::AuditLogEntry> {
+    use axiam_core::repository::{AuditLogFilter, AuditLogRepository};
+    axiam_db::SurrealAuditLogRepository::new(db.clone())
+        .list_system(
+            AuditLogFilter {
+                action: Some("oauth2.client_auth_failed".into()),
+                ..Default::default()
+            },
+            axiam_core::repository::Pagination::default(),
+        )
+        .await
+        .unwrap()
+        .items
+}
+
+/// The audit write is deliberately **off the response path** (§22.3 residual 1),
+/// so a row appears shortly after the 401 rather than before it. Poll instead of
+/// sleeping a fixed amount: a fixed sleep is either flaky or slow, and this also
+/// documents that the detachment is the intended behaviour rather than a race.
+async fn eventually<F, Fut, T>(mut f: F) -> Vec<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Vec<T>>,
+{
+    for _ in 0..100 {
+        let rows = f().await;
+        if !rows.is_empty() {
+            return rows;
+        }
+        actix_web::rt::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    Vec::new()
+}
+
 #[actix_rt::test]
 async fn a_failed_client_auth_is_audited_against_a_real_tenant() {
     // The control case. Detection is the whole point of this row (§17.2
     // residual 3), so the SEC-087 hardening must not silence the true event:
-    // a failed authentication against a tenant that exists is still recorded.
+    // a failed authentication against a tenant that exists is still recorded,
+    // and against that tenant, not the system partition.
     let (db, _org_id, tenant_id) = setup_db().await;
     let auth = test_auth_config();
     let app = test_app!(db, auth);
@@ -1573,20 +1612,24 @@ async fn a_failed_client_auth_is_audited_against_a_real_tenant() {
     let resp = failing_token_post(&app, tenant_id, "oa_nosuchclient", None).await;
     assert_eq!(resp.status().as_u16(), 401);
 
-    let rows = client_auth_failure_rows(&db, tenant_id).await;
+    let rows = eventually(|| client_auth_failure_rows(&db, tenant_id)).await;
     assert_eq!(rows.len(), 1, "the real event must still be recorded");
+    assert!(
+        rows[0].metadata["unattributed_reason"].is_null(),
+        "a row for a real tenant must not be marked unattributed"
+    );
 }
 
 #[actix_rt::test]
 async fn an_anonymous_caller_cannot_write_audit_rows_into_an_unknown_tenant() {
     // SEC-087. `/oauth2/token` needs no credential and takes `tenant_id`
     // straight from the query string, so before the fix any anonymous caller
-    // could append rows to an append-only log under *any* uuid — including one
-    // belonging to no tenant at all — at request rate.
+    // could append rows to an append-only log under *any* uuid.
     //
-    // Rows under a nonexistent tenant are pure garbage: no operator will ever
-    // read that partition, and the uuid space is unbounded, so this is the arm
-    // worth refusing outright.
+    // §22.3 residual 2 changed what happens to the refused row rather than
+    // whether it is refused: it is no longer dropped, it is routed to the
+    // system partition. The property that matters is unchanged and asserted
+    // here — the caller still cannot place a row under an id of their choosing.
     let (db, _org_id, _tenant_id) = setup_db().await;
     let auth = test_auth_config();
     let app = test_app!(db, auth);
@@ -1594,17 +1637,35 @@ async fn an_anonymous_caller_cannot_write_audit_rows_into_an_unknown_tenant() {
     let victim = Uuid::new_v4(); // never created
     let resp = failing_token_post(&app, victim, "oa_nosuchclient", None).await;
 
-    // The caller must not be able to tell the write was refused.
+    // The caller must not be able to tell where the row went.
     assert_eq!(
         resp.status().as_u16(),
         401,
-        "dropping the audit row must not change the response"
+        "routing the audit row must not change the response"
     );
 
+    // The signal is preserved...
+    let system = eventually(|| client_auth_failure_system_rows(&db)).await;
+    assert_eq!(
+        system.len(),
+        1,
+        "the failure must still be recorded somewhere"
+    );
+    assert_eq!(
+        system[0].metadata["unattributed_reason"].as_str(),
+        Some("unknown_tenant")
+    );
+    assert_eq!(
+        system[0].metadata["claimed_tenant_id_untrusted"].as_str(),
+        Some(victim.to_string().as_str()),
+        "the caller-named tenant is kept as evidence, marked untrusted"
+    );
+
+    // ...but not under the id the caller named.
     let rows = client_auth_failure_rows(&db, victim).await;
     assert!(
         rows.is_empty(),
-        "no audit row may be written into a tenant that does not exist"
+        "no audit row may be written into a tenant the caller merely named"
     );
 }
 
@@ -1623,14 +1684,14 @@ async fn the_audited_client_id_is_truncated_and_the_forwarded_ip_is_untrusted() 
     let resp = failing_token_post(&app, tenant_id, &huge, Some("203.0.113.9")).await;
     assert_eq!(resp.status().as_u16(), 401);
 
-    let rows = client_auth_failure_rows(&db, tenant_id).await;
+    let rows = eventually(|| client_auth_failure_rows(&db, tenant_id)).await;
     assert_eq!(rows.len(), 1);
     let meta = &rows[0].metadata;
 
     let recorded = meta["client_id"].as_str().expect("client_id recorded");
     assert!(
         recorded.len() <= 128,
-        "client_id must be truncated, got {} chars",
+        "client_id must be truncated, got {} bytes",
         recorded.len()
     );
 
@@ -1647,5 +1708,72 @@ async fn the_audited_client_id_is_truncated_and_the_forwarded_ip_is_untrusted() 
         meta["forwarded_for_untrusted"].as_str(),
         Some("203.0.113.9"),
         "the forgeable value is kept, but only under a name that says so"
+    );
+}
+
+#[actix_rt::test]
+async fn a_multibyte_client_id_is_capped_in_bytes_not_code_points() {
+    // §22.3 residual 3. The cap used `chars().take(128)`, so a multibyte id
+    // stored up to 512 bytes — and the previous test could not see it, because
+    // its payload was ASCII and so byte length and code-point count agreed.
+    // 'é' is two bytes in UTF-8, so 5000 of them is 10 000 bytes and would have
+    // stored 256.
+    let (db, _org_id, tenant_id) = setup_db().await;
+    let auth = test_auth_config();
+    let app = test_app!(db, auth);
+
+    let multibyte = format!("oa_{}", "é".repeat(5000));
+    let resp = failing_token_post(&app, tenant_id, &multibyte, None).await;
+    assert_eq!(resp.status().as_u16(), 401);
+
+    let rows = eventually(|| client_auth_failure_rows(&db, tenant_id)).await;
+    assert_eq!(rows.len(), 1);
+    let recorded = rows[0].metadata["client_id"]
+        .as_str()
+        .expect("client_id recorded");
+
+    assert!(
+        recorded.len() <= 128,
+        "the cap is a BYTE bound: got {} bytes ({} chars)",
+        recorded.len(),
+        recorded.chars().count()
+    );
+    // And the stored value must still be valid UTF-8 — truncating mid-character
+    // would either panic or corrupt the record.
+    assert!(
+        std::str::from_utf8(recorded.as_bytes()).is_ok(),
+        "truncation must land on a character boundary"
+    );
+}
+
+#[actix_rt::test]
+async fn an_audit_sink_problem_does_not_cost_the_failure_signal() {
+    // §22.3 residual 2: a tenant read that fails for any reason other than
+    // NotFound used to drop the row entirely, so a database fault cost exactly
+    // the telemetry this row exists to provide — and a database fault is
+    // plausibly correlated with an incident.
+    //
+    // The indeterminate branch cannot be provoked through the HTTP surface
+    // without tearing down the DB mid-request, so this asserts the reachable
+    // half of the same property: every failed client authentication lands
+    // SOMEWHERE queryable, whatever the tenant turns out to be.
+    let (db, _org_id, tenant_id) = setup_db().await;
+    let auth = test_auth_config();
+    let app = test_app!(db, auth);
+
+    // A real tenant → its own partition.
+    let r1 = failing_token_post(&app, tenant_id, "oa_a", None).await;
+    assert_eq!(r1.status().as_u16(), 401);
+    let real = eventually(|| client_auth_failure_rows(&db, tenant_id)).await;
+    assert_eq!(real.len(), 1);
+
+    // An unknown tenant → the system partition, never lost.
+    let r2 = failing_token_post(&app, Uuid::new_v4(), "oa_b", None).await;
+    assert_eq!(r2.status().as_u16(), 401);
+    let system = eventually(|| client_auth_failure_system_rows(&db)).await;
+    assert_eq!(
+        system.len(),
+        1,
+        "an unattributable failure must be recorded, not dropped"
     );
 }


### PR DESCRIPTION
§22.4 confirmed **no open findings**, so this round is entirely second-order cleanup of the four residuals in §22.3 — **two of which my own §20 SEC-087 fix introduced.** Recorded as §23.

## Residual 1 — the tenant-existence timing differential *(mine)*

The SEC-087 fix awaited a tenant read before returning the error, and only inserted when the tenant existed — so a failed client auth returned measurably faster for a nonexistent tenant, on an endpoint needing no credential.

Fixed by **detaching the audit operation from the response path** (`rt::spawn`) rather than balancing the branches. Balancing is weaker: it leaves the differential in place and bets on the padding tracking future edits. Detaching removes the dependency, so no ordering of read and insert is observable from outside.

It also makes the function honest — its doc has said *"fire-and-forget"* since §18 while being awaited.

**Not falsifiable by a test**, and I'd rather say so than imply otherwise: a timing assertion at this resolution would be flaky. The property is structural and verified by reading the call site. What the tests *do* pin is the consequence — they poll for the row rather than expecting it synchronously, which fails if anyone re-attaches the write.

## Residual 2 — the audit row no longer fails open *(mine)*

The sharpest of the four. A non-`NotFound` tenant read error dropped the row silently, so a database fault cost exactly the telemetry the row exists for — and DB faults correlate with incidents.

Unattributable rows now go to the **system partition** (`tenant_id = nil`, which `list_system` already serves), carrying `unattributed_reason` and the caller-named tenant as `claimed_tenant_id_untrusted`.

This keeps SEC-087's actual guarantee. That guarantee was never *"no row is written"* — it was **"a caller cannot choose which real tenant's append-only log a row lands in"**, and nil is a fixed partition nobody can steer toward. So the unknown-tenant case is kept too: probing random tenant ids is itself a signal, now visible in one place rather than only a log line.

## Residual 3 — the cap was in the wrong unit

`chars().take(128)` bounds code points, so a multibyte `client_id` stored up to 512 bytes. Now byte-bounded, truncating on a character boundary.

§22.3's more useful observation was that the *test* asserted a byte length passing only because its payload was ASCII. A new test uses `'é'`; falsification records **253 bytes for 128 chars** against the old code while the ASCII test keeps passing — exactly why this was invisible.

## Residual 4 — the `client_ip` docstring

It claimed the forwarding headers are honoured *"as trusted by the Actix-Web server configuration"*. False: Actix-Web has **no trusted-proxy list**. Corrected explicitly, including that the old wording was wrong, with a pointer to `peer_ip` for unauthenticated paths — this is the docstring a future reader relies on when deciding whether the value is untrusted, which is the decision SEC-087 turned on.

## Deliberately not actioned

**The gRPC m2m/user parity gap**, carried since §19.5. Narrowing it is a deployment-visible decision, not a defect fix: gRPC is the mesh surface where machine callers are the norm, and splitting audiences there breaks user-token callers routing through it today. It is now documented in the CHANGELOG, so operators meet it as stated behaviour. If narrowed, it should be per-service and opt-in — its own round.

## Verification

`fmt --all` and `clippy --all-targets --all-features -D warnings` clean. Green: `api-rest --lib` (136), `oauth2_flow` (36), `oauth2_conformance`, `audit`, `qual03`, `rate_limit_client_identity`. Residuals 2 and 3 falsified against the pre-fix code; residual 1 is structural, as stated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkTHvZQMV47t3UwkEtmB1D)_