### PR TITLE
feat(website): link the Coveralls coverage reports; fix footer alignment

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -11,9 +11,10 @@ which is the authenticated admin SPA.
 
 - **Home** — hero, feature grid, architecture, the vibe-coding story, SDK
   overview and compliance.
-- **SDKs** — the seven official client SDKs, each with a detail page linking to
-  its package-registry entry and package documentation (docs.rs, tsdocs.dev,
-  Read the Docs, javadoc.io, fuget.org, pkg.go.dev).
+- **SDKs** — the eleven official client SDKs, each with a detail page linking to
+  its package-registry entry, package documentation (docs.rs, tsdocs.dev,
+  Read the Docs, javadoc.io, fuget.org, pkg.go.dev, DocC, Doxygen), repository,
+  examples and Coveralls coverage report.
 - **Docs** — a small documentation site: quickstart plus platform and operate
   guides, with a functional sidebar and per-page table of contents.
 - **Security** — the public threat-modeling and security write-up, including an

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import type { Page } from "../types";
-import { GITHUB_URL } from "../data";
-import { GithubIcon } from "./icons";
+import { GITHUB_URL, COVERALLS_URL } from "../data";
+import { CoverallsIcon, GithubIcon } from "./icons";
 import { logoMark } from "../assets";
 
 interface HeaderProps {
@@ -66,6 +66,23 @@ export default function Header({ page, go }: HeaderProps) {
         >
           <GithubIcon />
           Star
+        </a>
+        <a
+          className="ax-navlink"
+          href={COVERALLS_URL}
+          target="_blank"
+          rel="noreferrer"
+          title="Test coverage on Coveralls"
+          aria-label="AXIAM test coverage on Coveralls"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 7,
+            color: "#cbd5e1",
+          }}
+        >
+          <CoverallsIcon />
+          Coverage
         </a>
         <button className="ax-cta btn-primary" onClick={() => go("docs")}>
           Get started

--- a/website/src/components/icons.tsx
+++ b/website/src/components/icons.tsx
@@ -8,6 +8,18 @@ export function GithubIcon({ size = 17 }: { size?: number }) {
   );
 }
 
+/**
+ * Coveralls' mark — the five-pointed star from their favicon, drawn in
+ * `currentColor` so it sits alongside the GitHub icon in the header.
+ */
+export function CoverallsIcon({ size = 17 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 1.6l2.94 7.24 7.8.54-5.99 5.02 1.9 7.58L12 17.9l-6.65 4.08 1.9-7.58-5.99-5.02 7.8-.54L12 1.6z" />
+    </svg>
+  );
+}
+
 const strokeProps = {
   width: 24,
   height: 24,

--- a/website/src/data.ts
+++ b/website/src/data.ts
@@ -24,6 +24,7 @@ export const SDKS: Sdk[] = [
     docsUrl: "https://docs.rs/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-rust-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-rust-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-rust-sdk?branch=main",
     pkg: "axiam-sdk",
     install: "cargo add axiam-sdk",
     blurb: "Native async client with the full REST, gRPC and AMQP surface.",
@@ -62,6 +63,7 @@ async fn get_doc(path: web::Path<String>) -> impl Responder {
     docsUrl: "https://tsdocs.dev/docs/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-typescript-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-typescript-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-typescript-sdk?branch=main",
     pkg: "axiam-sdk",
     install: "npm install axiam-sdk",
     blurb:
@@ -104,6 +106,7 @@ export class DocsController {
     docsUrl: "https://axiam-sdk.readthedocs.io/",
     repoUrl: "https://github.com/ilpanich/axiam-python-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-python-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-python-sdk?branch=main",
     pkg: "axiam-sdk",
     install: "pip install axiam-sdk",
     blurb:
@@ -143,6 +146,7 @@ def read_doc(doc_id: str,
     docsUrl: "https://javadoc.io/doc/io.github.ilpanich/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-java-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-java-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-java-sdk?branch=main",
     pkg: "io.github.ilpanich:axiam-sdk",
     install: 'implementation("io.github.ilpanich:axiam-sdk:1.0.0")',
     blurb:
@@ -183,6 +187,7 @@ class DocController {
     docsUrl: "https://www.fuget.org/packages/Axiam.Sdk",
     repoUrl: "https://github.com/ilpanich/axiam-csharp-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-csharp-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-csharp-sdk?branch=main",
     pkg: "Axiam.Sdk",
     install: "dotnet add package Axiam.Sdk",
     blurb:
@@ -219,6 +224,7 @@ public class DocsController : ControllerBase
     registryUrl: "https://packagist.org/packages/axiam/axiam-sdk",
     repoUrl: "https://github.com/ilpanich/axiam-php-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-php-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-php-sdk?branch=main",
     pkg: "axiam/axiam-sdk",
     install: "composer require axiam/axiam-sdk",
     blurb: "PSR-friendly client with middleware for Laravel and Symfony apps.",
@@ -260,6 +266,7 @@ class DocController
     docsUrl: "https://pkg.go.dev/github.com/ilpanich/axiam-go-sdk#section-documentation",
     repoUrl: "https://github.com/ilpanich/axiam-go-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-go-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-go-sdk?branch=main",
     pkg: "github.com/ilpanich/axiam-go-sdk",
     install: "go get github.com/ilpanich/axiam-go-sdk",
     blurb:
@@ -296,6 +303,7 @@ mux.Handle("GET /docs/{id}",
     docsUrl: "https://javadoc.io/doc/io.github.ilpanich/axiam-sdk-kotlin",
     repoUrl: "https://github.com/ilpanich/axiam-kotlin-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-kotlin-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-kotlin-sdk?branch=main",
     pkg: "io.github.ilpanich:axiam-sdk-kotlin",
     install: 'implementation("io.github.ilpanich:axiam-sdk-kotlin:1.0.0-alpha15")',
     blurb:
@@ -343,6 +351,7 @@ routing {
     docsUrl: "https://ilpanich.github.io/axiam-swift-sdk/",
     repoUrl: "https://github.com/ilpanich/axiam-swift-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-swift-sdk/tree/main/Examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-swift-sdk?branch=main",
     pkg: "AxiamSDK",
     install:
       '.package(url: "https://github.com/ilpanich/axiam-swift-sdk.git", from: "1.0.0-alpha15")',
@@ -389,6 +398,7 @@ let user = try await requireRead(ctx)`,
     docsUrl: "https://ilpanich.github.io/axiam-c-sdk/",
     repoUrl: "https://github.com/ilpanich/axiam-c-sdk",
     examplesUrl: "https://github.com/ilpanich/axiam-c-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-c-sdk?branch=main",
     pkg: "axiam-c-sdk",
     install: "vcpkg install axiam-c-sdk --overlay-ports=./ports",
     blurb:
@@ -437,6 +447,7 @@ if (st != AXIAM_GUARD_ALLOW)
     repoUrl: "https://github.com/ilpanich/axiam-cplusplus-sdk",
     examplesUrl:
       "https://github.com/ilpanich/axiam-cplusplus-sdk/tree/main/examples",
+    coverageUrl: "https://coveralls.io/github/ilpanich/axiam-cplusplus-sdk?branch=main",
     pkg: "axiam-cpp-sdk",
     install: "vcpkg install axiam-cpp-sdk --overlay-ports=./ports",
     blurb:
@@ -940,3 +951,12 @@ export const BENCH_RPS_PER_GIB: BenchResourceRow[] = [
 ];
 
 export const GITHUB_URL = "https://github.com/ilpanich/axiam";
+
+/**
+ * Line coverage for the server workspace and the admin frontend, reported to
+ * Coveralls by `.github/workflows/coverage.yml` on every push to main. Each
+ * SDK repository reports its own coverage the same way — see `coverageUrl` on
+ * the entries in `SDKS`.
+ */
+export const COVERALLS_URL =
+  "https://coveralls.io/github/ilpanich/axiam?branch=main";

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -354,6 +354,11 @@ code {
 .ax-footer-col {
   display: flex;
   flex-direction: column;
+  /* Shrink-wrap each link to its text. Without this the items stretch to the
+     full column width, and a <button>'s UA `text-align: center` then floats
+     its label away from the column heading while the <a> items stay flush
+     left — the two kinds of link in a column no longer line up. */
+  align-items: flex-start;
   gap: 10px;
   font-size: 14px;
 }

--- a/website/src/pages/SdkDetail.tsx
+++ b/website/src/pages/SdkDetail.tsx
@@ -1,4 +1,5 @@
 import type { Page, Sdk } from "../types";
+import { CoverallsIcon } from "../components/icons";
 
 interface SdkDetailProps {
   sdk: Sdk;
@@ -170,6 +171,17 @@ export default function SdkDetail({ sdk, go }: SdkDetailProps) {
           rel="noreferrer"
         >
           Examples ↗
+        </a>
+        <a
+          className="ax-ghost"
+          href={sdk.coverageUrl}
+          target="_blank"
+          rel="noreferrer"
+          title={`${sdk.name} SDK test coverage on Coveralls`}
+          style={{ display: "inline-flex", alignItems: "center", gap: 8 }}
+        >
+          <CoverallsIcon size={15} />
+          Coverage ↗
         </a>
       </div>
 

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -25,6 +25,12 @@ export interface Sdk {
   repoUrl: string;
   /** Link to the runnable examples folder inside the SDK repository. */
   examplesUrl: string;
+  /**
+   * The SDK's Coveralls page. Every SDK repository reports line coverage to
+   * Coveralls on each push to its main branch, the same way the server
+   * workspace does.
+   */
+  coverageUrl: string;
   pkg: string;
   install: string;
   blurb: string;


### PR DESCRIPTION
## Summary

Coverage reports existed but had no route from the website. This adds two entry points, plus a footer alignment fix noticed while reviewing the result.

- **Header** — a Coveralls icon and "Coverage" link beside the GitHub "Star" link, pointing at the server workspace report (`coveralls.io/github/ilpanich/axiam?branch=main`).
- **SDK detail pages** — a "Coverage ↗" link on all eleven SDKs, alongside the existing registry, docs, repository and examples links, pointing at that SDK's own Coveralls page.

## Details

`Sdk` gains a `coverageUrl` field, populated for all eleven SDKs; `COVERALLS_URL` in `data.ts` holds the server-workspace report and documents where the numbers come from.

`CoverallsIcon` is Coveralls' five-pointed star mark, drawn as inline SVG in `currentColor` so it matches the GitHub icon's treatment and keeps the site free of external asset requests.

Before linking anything I checked all twelve targets against the Coveralls API — the main repo and each of the eleven SDK repositories return live report data on `main`, so no link points at an untracked repository.

Also corrects the website README, which still described "the seven official client SDKs" and listed only six documentation hosts.

## Footer alignment

The footer link columns were misaligned on wide screens. The items stretched to the full column width, and a `<button>`'s user-agent `text-align: center` then floated its label away from the column heading, while the `<a>` items ("GitHub", the licence link) stayed flush left — so the two kinds of link in one column did not line up.

Fixed with `align-items: flex-start` on `.ax-footer-col`, which shrink-wraps each item. Every label now starts at the column's left edge, and each link's hit area no longer spans the empty rest of the column. Verified by measuring the rendered geometry at 1600px, and re-checked at the 860px and 390px breakpoints.

## Verification

- `npx tsc -b`, `npx oxlint`, `npm run build` clean.
- Rendered and checked in a browser: header link resolves to the right URL at 1440px and 390px with no overflow; the Rust SDK detail page shows all five links with correct hrefs, and the coverage href is the per-SDK Coveralls page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ghCgqe6HRGsA9jS86B3Uw