### PR TITLE
docs(website): update benchmarks page to run 5, add SDK and §10 sections

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -20,8 +20,12 @@ which is the authenticated admin SPA.
 - **Security** — the public threat-modeling and security write-up, including an
   interactive browser for all nine OWASP Threat Dragon diagrams and the 149
   STRIDE threats behind them.
-- **Benchmarks** — currently a **draft** with placeholder figures; real,
-  measured results will be published here after the benchmark runs.
+- **Benchmarks** — the measured head-to-head against Keycloak and Zitadel,
+  transcribed from [`benchmarks/PUBLIC_BENCH_ANALYSIS.md`](../benchmarks/PUBLIC_BENCH_ANALYSIS.md)
+  (currently run 5): throughput, efficiency and resource charts, the TLS/mTLS
+  cost table, the eleven-SDK client benchmarks, the labelled investigation
+  passes, the honest caveats and the report's §10 "why build AXIAM at all?"
+  excerpt.
 - **Roadmap** — the 19-phase, 64-task delivery plan.
 - **News** — project milestones and engineering notes.
 

--- a/website/src/data.ts
+++ b/website/src/data.ts
@@ -5,6 +5,8 @@ import type {
   BenchScenario,
   BenchEfficiencyRow,
   BenchResourceRow,
+  BenchSdkRow,
+  BenchSdkFootprintRow,
 } from "./types";
 
 /**
@@ -772,12 +774,13 @@ export const PHASES: Phase[] = [
 
 /**
  * Benchmark scenarios, transcribed from
- * `benchmarks/PUBLIC_BENCH_ANALYSIS.md` (fifth draft, run 4 of 2026-08-01/02,
- * AXIAM post-fix build vs Keycloak 26.7.0 vs Zitadel v4.15.2) — the first
- * matrix measured after the shared rate-limit write-behind fix. All figures
- * are the p0-plaintext profile from the capped matrix (§1/§8), **median of 3
- * runs** (per-cell throughput spread ±0.2–2.8% on AXIAM cells). Only valid
- * cells are charted; comparability labels are carried onto the chart.
+ * `benchmarks/PUBLIC_BENCH_ANALYSIS.md` (sixth draft, run 5 of 2026-08-05/06,
+ * AXIAM 1.0.0-alpha24 — the published, digest-pinned release image — vs
+ * Keycloak 26.7.0 vs Zitadel v4.16.2). All figures are the p0-plaintext
+ * profile from the capped matrix (§1/§8), **median of 3 runs** (per-cell
+ * throughput spread ±0.3–2.1% on AXIAM cells, ±12–17% on the batch cells).
+ * Only valid cells are charted; comparability labels are carried onto the
+ * chart.
  */
 export const BENCH_SCENARIOS: BenchScenario[] = [
   {
@@ -785,59 +788,59 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
     title: "Machine-to-machine token issuance",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 2727, display: "2,727", axiam: true },
-      { target: "Zitadel", value: 425, display: "425" },
+      { target: "AXIAM", value: 2804, display: "2,804", axiam: true },
+      { target: "Zitadel", value: 431, display: "431" },
       { target: "Keycloak", value: 354, display: "354" },
     ],
     takeaway:
-      "AXIAM issues 7.7× more tokens/s than Keycloak and 6.4× more than Zitadel — up from 5.2×/4.3× in run 3, entirely from removing the synchronous rate-limit write (+50% on this endpoint). Reproduced within ±0.4% across three runs.",
+      "AXIAM issues 7.9× more tokens/s than Keycloak and 6.5× more than Zitadel — and, new this run, roughly 8× under TLS 1.3 and mutual TLS too. The previous draft's one glaring asterisk, a −57% drop on this endpoint under TLS, is gone: the cause was Nagle's algorithm interacting with delayed ACKs, and with TCP_NODELAY shipped as the default the TLS penalty is now −2.0%.",
   },
   {
     id: "introspection",
     title: "Token introspection (RFC 7662)",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 4387, display: "4,387", axiam: true },
-      { target: "Keycloak", value: 1860, display: "1,860" },
-      { target: "Zitadel", value: 932, display: "932" },
+      { target: "AXIAM", value: 4504, display: "4,504", axiam: true },
+      { target: "Keycloak", value: 1888, display: "1,888" },
+      { target: "Zitadel", value: 941, display: "941" },
     ],
     takeaway:
-      "Run 3's closest head-to-head is no longer close: +97% post-fix puts AXIAM at 2.4× Keycloak and 4.7× Zitadel, with a 1.7× better p95 (48 vs 82 ms) and a near-zero TLS penalty (−1.6%).",
+      "2.4× Keycloak and 4.8× Zitadel, with a ~1.8× better p95 (48 vs 82 ms) and a near-zero TLS/mTLS penalty (−2.5% / −2.8%). Held within ±0.5% across three runs on the released image.",
   },
   {
     id: "jwks",
     title: "JWKS fetch (RFC 7517)",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 26371, display: "26,371", axiam: true },
-      { target: "Keycloak", value: 4565, display: "4,565" },
-      { target: "Zitadel", value: 2096, display: "2,096" },
+      { target: "AXIAM", value: 26680, display: "26,680", axiam: true },
+      { target: "Keycloak", value: 4573, display: "4,573" },
+      { target: "Zitadel", value: 2091, display: "2,091" },
     ],
     takeaway:
-      "A 5.8–12.6× gap — and still limited by the load generator rather than by AXIAM: k6 itself burned ~5 CPU cores while the AXIAM server sat at 1.6 of its 2, so the true ceiling is higher.",
+      "A 5.8–12.8× gap — and still limited by the load generator rather than by AXIAM: k6 itself burned ~5 CPU cores while the AXIAM server sat below 1.7 of its 2, so the true ceiling is higher. This cell measures latency, not capacity.",
   },
   {
     id: "userinfo",
     title: "OIDC userinfo — REST",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 4547, display: "4,547", axiam: true },
-      { target: "Keycloak", value: 3783, display: "3,783" },
-      { target: "Zitadel", value: 1000, display: "1,000" },
+      { target: "AXIAM", value: 4752, display: "4,752", axiam: true },
+      { target: "Keycloak", value: 3721, display: "3,721" },
+      { target: "Zitadel", value: 995, display: "995" },
     ],
     takeaway:
-      "AXIAM leads 1.2× Keycloak and 4.5× Zitadel while its database is pegged — uncapped to 4 DB cores the same cell reaches 7,215 req/s. On whole-stack req/s-per-core Keycloak wins this cell; on server-only CPU per request AXIAM is 2.1× cheaper. Both are published.",
+      "AXIAM leads 1.3× Keycloak and 4.8× Zitadel while its database is pegged. On whole-stack req/s-per-core Keycloak again wins this cell; on server-only CPU per request AXIAM is 2.1× cheaper (0.25 vs 0.53 cpu·ms). Both are published, as in every draft.",
   },
   {
     id: "userinfo_grpc",
     title: "OIDC userinfo — gRPC",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 12665, display: "12,665", axiam: true },
-      { target: "Zitadel", value: 180, display: "180" },
+      { target: "AXIAM", value: 12307, display: "12,307", axiam: true },
+      { target: "Zitadel", value: 191, display: "191" },
     ],
     takeaway:
-      "The biggest single change in this run: 12,665 identity reads/s at a 6 ms p95 — 2.8× AXIAM's own REST path and 3.3× Keycloak's best number — where run 3 measured 3,294/s (every gRPC call used to pay the rate-limit write). Zitadel's own gRPC userinfo measured 180–185/s on the same harness, 82% below its REST cell; Keycloak exposes no gRPC equivalent.",
+      "12,307 identity reads/s at a 6 ms p95 — 2.6× AXIAM's own REST path and 3.3× Keycloak's best userinfo number. Zitadel's own gRPC userinfo measured 191–201/s on the same harness, 80% below its REST cell: its gRPC surface is a management API, which is fair, and is exactly why treating gRPC as a first-class data plane is a differentiator. Keycloak exposes no gRPC equivalent.",
   },
   {
     id: "password_login",
@@ -845,11 +848,11 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
       { target: "AXIAM", value: 69, display: "69", axiam: true },
-      { target: "Keycloak", value: 44, display: "(44)" },
+      { target: "Keycloak", value: 47, display: "(47)" },
       { target: "Zitadel", value: 2.0, display: "(2)" },
     ],
     takeaway:
-      "AXIAM is the only target valid at both profiles — 69 req/s at a 774 ms p95, on ≤ 140 MiB of server memory. Parenthesized numbers failed our own validity gate and are shown only for transparency: Keycloak completed 1 of 3 runs cleanly even at the raised 2 GiB cap (it wants ~3.5–4 GiB under sustained hashing; next run gives it exactly that, labeled), and Zitadel's default bcrypt cost puts it at ~22 s p50.",
+      "AXIAM is the only target valid at every profile — 69 req/s at a 761 ms p95, on ~119 MiB of average server memory. Parenthesized numbers failed our own validity gate: Keycloak completed 1 of 3 runs cleanly at p0 (it did produce its first valid login cell of the series at p2 — 51 req/s), and Zitadel's default bcrypt cost puts it at ~22 s p50. The promised 4 GiB Keycloak attempt ran, and did not rescue it: ~21 req/s at a ~2.5 s p95, slower than its 2 GiB survivor runs.",
     note: "2 of 3 targets excluded by the validity gate",
   },
   {
@@ -857,17 +860,17 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
     title: "Session / token refresh",
     unit: "throughput · requests/s · plaintext · median of 3",
     bars: [
-      { target: "AXIAM", value: 839, display: "839", axiam: true },
+      { target: "AXIAM", value: 545, display: "545", axiam: true },
       { target: "Keycloak", value: 377, display: "377" },
     ],
     takeaway:
-      "Informational, not a like-for-like race: AXIAM has no ROPC/password grant by design, so its cell measures session-cookie refresh (CSRF double-submit, single-use rotation) while Keycloak's measures the OAuth2 refresh-token grant. Both are real, both rotate; new this run is that AXIAM's cell is a full median-of-3 (run 3 had a single confirm run). Zitadel needs an offline_access flow the harness doesn't implement.",
-    note: "protocol-variant — two different protocols doing a related job",
+      "Informational, not a like-for-like race: AXIAM has no ROPC/password grant by design, so its cell measures session-cookie refresh (CSRF double-submit, single-use rotation) while Keycloak's measures the OAuth2 refresh-token grant. Honesty first — AXIAM's refresh regressed 35% since the previous draft (839 → 545 req/s, p50 47.5 → 88.8 ms), with no harness change on that path; the suspects are our own post-run-4 security hardening and/or database version drift, and the bisection is open. Zitadel needs an offline_access flow the harness doesn't implement.",
+    note: "protocol-variant — and a −35% regression we introduced ourselves",
   },
 ];
 
 /**
- * Whole-stack efficiency, head-to-head (p0-plaintext, median-of-3, run 4).
+ * Whole-stack efficiency, head-to-head (p0-plaintext, median-of-3, run 5).
  * `req/s per core` is higher-is-better; `cpu·ms/req` is lower-is-better.
  * AXIAM's figures still carry its audit broker and, on some cells, a
  * saturated database inside them — which is why Keycloak edges it on the
@@ -875,10 +878,10 @@ export const BENCH_SCENARIOS: BenchScenario[] = [
  * there; both breakdowns are published in the raw report).
  */
 export const BENCH_EFFICIENCY: BenchEfficiencyRow[] = [
-  { scenario: "Client credentials", perCore: ["835", "171", "122"], cpuMs: ["1.20", "5.84", "8.20"] },
-  { scenario: "Token introspection", perCore: ["1,288", "786", "250"], cpuMs: ["0.78", "1.27", "4.00"] },
-  { scenario: "JWKS fetch", perCore: ["16,184", "2,278", "703"], cpuMs: ["0.06", "0.44", "1.42"] },
-  { scenario: "OIDC userinfo", perCore: ["1,376", "1,891", "348"], cpuMs: ["0.73", "0.53", "2.88"] },
+  { scenario: "Client credentials", perCore: ["816", "171", "122"], cpuMs: ["1.23", "5.85", "8.21"] },
+  { scenario: "Token introspection", perCore: ["1,269", "799", "252"], cpuMs: ["0.79", "1.25", "3.98"] },
+  { scenario: "JWKS fetch", perCore: ["15,855", "2,288", "701"], cpuMs: ["0.06", "0.44", "1.43"] },
+  { scenario: "OIDC userinfo", perCore: ["1,437", "1,863", "346"], cpuMs: ["0.70", "0.54", "2.89"] },
 ];
 
 /**
@@ -890,37 +893,41 @@ export const BENCH_EFFICIENCY: BenchEfficiencyRow[] = [
 export const BENCH_AUTHZ: BenchScenario = {
   id: "authz",
   title: "Authorization decisions (AXIAM-only)",
-  unit: "throughput · requests/s · plaintext",
+  unit: "decisions/s · plaintext · median of 3 · decision cache OFF unless labelled",
   bars: [
-    { target: "REST · single", value: 753, display: "753", axiam: true },
-    { target: "gRPC · single", value: 887, display: "887", axiam: true },
-    { target: "REST · cache ON", value: 791, display: "791", axiam: true },
-    { target: "gRPC · cache ON", value: 11598, display: "11,598", axiam: true },
+    { target: "REST · single", value: 1032, display: "1,032", axiam: true },
+    { target: "gRPC · single", value: 1268, display: "1,268", axiam: true },
+    { target: "REST · batch", value: 5130, display: "5,130", axiam: true },
+    { target: "gRPC · batch", value: 4640, display: "4,640", axiam: true },
+    { target: "REST · caches ON", value: 11647, display: "11,647", axiam: true },
+    { target: "gRPC · cache ON", value: 11172, display: "11,172", axiam: true },
   ],
   takeaway:
-    "gRPC now leads REST by 18% at half the p50 — run 3 had gRPC 18% behind, and that whole deficit was the rate-limit write. Both single-check paths are database-saturated at the 2-core DB cap and scale to 1,434 / 1,678 req/s with 4 DB cores. The optional decision cache is charted at its best case: 13.1× on gRPC at a favorable keyspace, but only +5% on REST, where per-request session-cookie validation (a database read the cache deliberately doesn't cover) becomes the limiter. It stays off by default; the realistic-keyspace measurement is +32%. Batch: the shipped `coalesced` default measured 744 batch ops/s = 3,721 checks/s (4.98× singles) — carried from run 3, because this run's batch cells accidentally exercised the non-default `concurrent` strategy.",
+    "Single checks are up +37% (REST) and +43% (gRPC) on the released image, the direct result of removing two full-table scans found with EXPLAIN after run 4 — a fix now guarded by CI tests that fail if any hot authorization query regresses to a table scan. The batch cells finally measure the strategy the product actually ships (`coalesced`), and the settled claim reproduces at matrix scale: 1,026 REST batch ops/s = 5,130 checks/s = 4.97× singles. The two cache rows are a labelled best-case pass, not the default: with both the decision cache and the session-validation cache on (5 s TTL), REST reaches parity with gRPC — confirming that REST's deficit was one extra database round-trip, its per-request session-revocation read. Caches stay OFF by default, and revocation through the API was measured to take effect 262 ms after the call even with them on.",
+  note: "AXIAM-only — no competitor exposes an equivalent decision endpoint",
 };
 
 /**
- * Resource usage during the tests (run 4 §5) — p0-plaintext, median-of-3,
+ * Resource usage during the tests (run 5 §5) — p0-plaintext, median-of-3,
  * every server container capped identically at 2 CPUs / 2,048 MiB.
  * Values are `[AXIAM, Keycloak, Zitadel]`.
  */
 
-/** Per-server peak RSS in MiB, by scenario. */
-export const BENCH_MEMORY_PEAK: BenchResourceRow[] = [
-  { scenario: "JWKS fetch", values: [98, 973, 163] },
-  { scenario: "Client credentials", values: [106, 979, 147] },
-  { scenario: "Token introspection", values: [104, 795, 161] },
-  { scenario: "Token refresh", values: [106, 804, null] },
-  { scenario: "OIDC userinfo", values: [105, 806, 162] },
-  { scenario: "Password login", values: [140, 796, 131], marker: "*" },
+/** Average RSS of the *server* container in MiB, by scenario. */
+export const BENCH_MEMORY_AVG: BenchResourceRow[] = [
+  { scenario: "JWKS fetch", values: [88, 836, 154] },
+  { scenario: "Client credentials", values: [90, 710, 138] },
+  { scenario: "Token introspection", values: [95, 752, 153] },
+  { scenario: "Token refresh", values: [95, 755, null] },
+  { scenario: "OIDC userinfo", values: [94, 756, 153] },
+  { scenario: "Password login", values: [119, 853, 154], marker: "*" },
+  { scenario: "Authorization check / batch", values: [94, null, null], marker: "†" },
 ];
 
-/** Worst-case server RSS observed anywhere in the run, in MiB. */
+/** The highest per-scenario server average observed anywhere in the run, in MiB. */
 export const BENCH_MEMORY_WORST: BenchResourceRow = {
-  scenario: "Worst case, whole run",
-  values: [172, 1070, 216],
+  scenario: "Highest scenario average, whole run",
+  values: [119, 853, 154],
 };
 
 /** The identical per-server container memory cap, in MiB. */
@@ -928,26 +935,82 @@ export const BENCH_MEMORY_CAP = 2048;
 
 /** Whole-stack memory range (server + database + broker), in MiB. */
 export const BENCH_STACK_MEMORY: [string, string, string][] = [
-  ["AXIAM", "415–590 MiB", "server + SurrealDB + RabbitMQ"],
-  ["Keycloak", "814–1,129 MiB", "server + PostgreSQL"],
-  ["Zitadel", "293–443 MiB", "server + PostgreSQL"],
+  ["AXIAM", "375–533 MiB", "server + SurrealDB + RabbitMQ"],
+  ["Keycloak", "816–973 MiB", "server + PostgreSQL"],
+  ["Zitadel", "281–457 MiB", "server + PostgreSQL"],
 ];
 
 /** CPU-milliseconds per request, whole stack unless noted (lower is better). */
 export const BENCH_CPU_PER_REQ: BenchResourceRow[] = [
-  { scenario: "Client credentials", values: [1.2, 5.84, 8.2] },
-  { scenario: "Token introspection", values: [0.78, 1.27, 4.0] },
-  { scenario: "JWKS fetch", values: [0.06, 0.44, 1.42] },
-  { scenario: "OIDC userinfo", values: [0.73, 0.53, 2.88] },
+  { scenario: "Client credentials", values: [1.23, 5.85, 8.21] },
+  { scenario: "Token introspection", values: [0.79, 1.25, 3.98] },
+  { scenario: "JWKS fetch", values: [0.06, 0.44, 1.43] },
+  { scenario: "OIDC userinfo", values: [0.7, 0.54, 2.89] },
   { scenario: "OIDC userinfo (server only)", values: [0.25, 0.53, 0.86] },
 ];
 
 /** Requests per second per GiB of whole-stack RAM (higher is better). */
 export const BENCH_RPS_PER_GIB: BenchResourceRow[] = [
-  { scenario: "Client credentials", values: [5988, 338, 1218] },
-  { scenario: "Token introspection", values: [8709, 1939, 2199] },
-  { scenario: "OIDC userinfo", values: [8948, 3999, 2312] },
-  { scenario: "JWKS fetch", values: [60723, 5741, 7330] },
+  { scenario: "Client credentials", values: [6528, 416, 1239] },
+  { scenario: "Token introspection", values: [9312, 2134, 2228] },
+  { scenario: "OIDC userinfo", values: [11522, 4319, 2319] },
+  { scenario: "JWKS fetch", values: [66270, 5022, 7351] },
+];
+
+/**
+ * Security cost of TLS 1.3 (p2) and native, in-process mutual TLS (p3),
+ * as a throughput delta against the plaintext (p0) cell of the same
+ * scenario — run 5 §4, median-of-3, valid cells only. Negative is a cost.
+ */
+export const BENCH_TLS_COST: { scenario: string; tls: string; mtls: string }[] = [
+  { scenario: "Client credentials", tls: "−2.0%", mtls: "−3.8%" },
+  { scenario: "Token introspection", tls: "−2.5%", mtls: "−2.8%" },
+  { scenario: "OIDC userinfo — REST / gRPC", tls: "−3.5% / −2.9%", mtls: "−6.6% / −3.0%" },
+  { scenario: "Authz check — REST / gRPC", tls: "−0.8% / −0.2%", mtls: "−1.5% / −0.7%" },
+  { scenario: "Authz batch — REST / gRPC", tls: "−1.1% / −1.2%", mtls: "−2.2% / −0.3%" },
+  { scenario: "Session refresh", tls: "−0.9%", mtls: "−0.5%" },
+  { scenario: "Password login", tls: "+0.3%", mtls: "−2.1%" },
+  { scenario: "JWKS fetch", tls: "−9.7%", mtls: "−10.2%" },
+];
+
+/**
+ * SDK client benchmarks — run 5 §9. All eleven official SDKs ran the same
+ * four operations against the same seeded AXIAM at plaintext, **three passes
+ * each, medianed**, with a matched-concurrency k6 wire baseline measured on
+ * the same host first — which is what makes the overhead column meaningful
+ * for the first time in this series.
+ */
+export const BENCH_SDK_LATENCY: BenchSdkRow[] = [
+  { sdk: "Rust", login: "257.5", refresh: "17.3", checkP50: "10.0", checkP95: "59.8", thr: "869", overhead: "+2.7", best: true },
+  { sdk: "Go", login: "253.8", refresh: "17.3", checkP50: "10.1", checkP95: "60.0", thr: "840", overhead: "+2.9" },
+  { sdk: "Java", login: "254.7", refresh: "17.3", checkP50: "10.3", checkP95: "60.1", thr: "835", overhead: "+3.0" },
+  { sdk: "C#", login: "234.6", refresh: "17.2", checkP50: "10.3", checkP95: "60.8", thr: "821", overhead: "+3.7", flag: "merged 2 of 3 passes" },
+  { sdk: "TypeScript", login: "255.7", refresh: "16.7", checkP50: "18.1", checkP95: "34.2", thr: "805", overhead: "(−22.9)", flag: "baseline comparability under audit" },
+  { sdk: "Kotlin", login: "233.4", refresh: "17.2", checkP50: "11.0", checkP95: "61.7", thr: "773", overhead: "+4.6" },
+  { sdk: "Swift", login: "231.7", refresh: "17.3", checkP50: "11.3", checkP95: "61.4", thr: "747", overhead: "+4.3" },
+  { sdk: "Python", login: "238.9", refresh: "17.3", checkP50: "40.2", checkP95: "116.8", thr: "311", overhead: "+59.7", flag: "slow outlier — being profiled" },
+  { sdk: "C++", login: "242.2", refresh: "17.2", checkP50: "3.2", checkP95: "280.2", thr: "313", overhead: "+223.1", flag: "reconnect-shaped p95 tail, under investigation" },
+  { sdk: "C", login: "—", refresh: "—", checkP50: "3.0", checkP95: "3.8", thr: "318", overhead: "—", serial: true },
+  { sdk: "PHP", login: "—", refresh: "—", checkP50: "3.6", checkP95: "4.3", thr: "272", overhead: "—", serial: true },
+];
+
+/**
+ * Each SDK's own client-side process cost over its whole bench — new in run 5,
+ * and half the story for IoT and sidecar deployments where the client, not the
+ * server, is the constrained side.
+ */
+export const BENCH_SDK_FOOTPRINT: BenchSdkFootprintRow[] = [
+  { sdk: "Go", runtime: "go 1.26", cpu: 3.3, rss: 36 },
+  { sdk: "PHP", runtime: "php 8.5", cpu: 5.6, rss: 59, serial: true },
+  { sdk: "C#", runtime: ".NET 8", cpu: 10.3, rss: 105 },
+  { sdk: "TypeScript", runtime: "node 22", cpu: 13.1, rss: 125 },
+  { sdk: "Swift", runtime: "swift 6.3", cpu: 13.3, rss: 48 },
+  { sdk: "C", runtime: "gcc 16, C11", cpu: 13.9, rss: 13, serial: true },
+  { sdk: "Kotlin", runtime: "JVM 21", cpu: 17.1, rss: 458 },
+  { sdk: "C++", runtime: "g++ 16", cpu: 17.6, rss: 39 },
+  { sdk: "Java", runtime: "JVM 21", cpu: 21.1, rss: 306 },
+  { sdk: "Rust", runtime: "cargo", cpu: 23.4, rss: 23 },
+  { sdk: "Python", runtime: "python 3.14", cpu: 40.0, rss: 88 },
 ];
 
 export const GITHUB_URL = "https://github.com/ilpanich/axiam";

--- a/website/src/pages/Benchmarks.tsx
+++ b/website/src/pages/Benchmarks.tsx
@@ -4,12 +4,15 @@ import {
   BENCH_SCENARIOS,
   BENCH_AUTHZ,
   BENCH_EFFICIENCY,
-  BENCH_MEMORY_PEAK,
+  BENCH_MEMORY_AVG,
   BENCH_MEMORY_WORST,
   BENCH_MEMORY_CAP,
   BENCH_STACK_MEMORY,
   BENCH_CPU_PER_REQ,
   BENCH_RPS_PER_GIB,
+  BENCH_TLS_COST,
+  BENCH_SDK_LATENCY,
+  BENCH_SDK_FOOTPRINT,
 } from "../data";
 
 /* ---- shared bits ------------------------------------------------------- */
@@ -343,16 +346,17 @@ function ResourceChart({
   );
 }
 
-/** Peak server memory drawn against the identical 2,048 MiB container cap. */
+/** Server memory drawn against the identical 2,048 MiB container cap. */
 function MemoryCapChart() {
   return (
     <div className="glass-card" style={{ padding: 26 }}>
       <h3 style={{ margin: 0, fontSize: 17, fontWeight: 700 }}>
-        Peak server memory vs the container cap
+        Server memory vs the container cap
       </h3>
       <div style={{ fontSize: 12.5, color: "#64748b", margin: "4px 0 22px" }}>
-        worst case over the whole run · MiB · the full track is the identical{" "}
-        {BENCH_MEMORY_CAP.toLocaleString("en-US")} MiB cap every server got
+        highest per-scenario average over the whole run · MiB · the full track is
+        the identical {BENCH_MEMORY_CAP.toLocaleString("en-US")} MiB cap every
+        server got
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
         {TARGET_SERIES.map((s, i) => {
@@ -421,11 +425,13 @@ function MemoryCapChart() {
           paddingTop: 16,
         }}
       >
-        The cap was <em>raised</em> from 1 GiB to 2 GiB for this run — for all
-        three targets equally — because Keycloak could not reliably survive
-        sustained password-login load at 1 GiB, and peaked at 1,070 MiB here.
-        AXIAM peaked at 172 MiB, 8% of the same allowance, while delivering the
-        throughput numbers above.
+        The cap is 2 GiB for every target — raised from 1 GiB two runs ago,
+        equally for all three, because Keycloak could not reliably survive
+        sustained password-login load below it. Across this entire matrix
+        AXIAM's server averaged 86–120 MiB, under 6% of the same allowance,
+        while delivering the throughput numbers above; Keycloak's heaviest
+        scenario averaged 853 MiB, and raising its cap to 4 GiB for a labelled
+        login attempt made it slower rather than faster.
       </p>
     </div>
   );
@@ -436,86 +442,120 @@ function MemoryCapChart() {
 const HEADLINES = [
   {
     label: "Token issuance",
-    value: "6.4–7.7×",
-    sub: "more tokens/s than Zitadel / Keycloak — median of 3 runs, ±0.4%",
+    value: "6.5–7.9×",
+    sub: "more tokens/s than Zitadel / Keycloak — and now the same ~8× under TLS 1.3 and mutual TLS",
   },
   {
     label: "Identity reads over gRPC",
-    value: "12,665",
-    sub: "req/s at a 6 ms p95 — 3.3× Keycloak's best userinfo number",
+    value: "12,307",
+    sub: "req/s at a 6 ms p95 — 3.3× Keycloak's best userinfo number; Zitadel's gRPC measures 191/s",
   },
   {
-    label: "Peak server memory",
-    value: "172 MiB",
-    sub: "8% of the 2 GiB the same envelope gave every target — Keycloak peaked at 1,070 MiB",
+    label: "Native mutual TLS",
+    value: "≈1%",
+    sub: "cost over plain TLS 1.3, in-process, no sidecar — in the run of record at median-of-3",
   },
 ];
 
 /* ---- environment facts ------------------------------------------------- */
 
 const TARGETS = [
-  ["AXIAM", "axiam-server, post-fix build (Rust, build_ref recorded per cell)", "SurrealDB v3 + RabbitMQ 4"],
+  [
+    "AXIAM",
+    "AXIAM 1.0.0-alpha24 — the published release image, pinned by digest",
+    "SurrealDB v3 (digest-pinned) + RabbitMQ 4",
+  ],
   ["Keycloak", "Keycloak 26.7.0 (JVM)", "PostgreSQL 16 (uniformly tuned)"],
-  ["Zitadel", "Zitadel v4.15.2 (Go)", "PostgreSQL 16 (uniformly tuned)"],
+  ["Zitadel", "Zitadel v4.16.2 (Go)", "PostgreSQL 16 (uniformly tuned)"],
 ];
 
 /* ---- sensitivity highlights -------------------------------------------- */
 
 const SENSITIVITY = [
   {
-    title: "The defect we published, then fixed, then re-measured",
-    body: "The previous draft's most important finding was a bug in our own product: six hot endpoints paid one synchronous datastore write — the shared rate-limit counter — before the handler even ran, and on the gRPC listener every single call paid it. The fix (a write-behind counter: decisions in memory, one coalesced write per bucket per interval) shipped, and this run is the end-to-end re-measurement: token issuance +50%, introspection +97%, gRPC authz checks +47%, gRPC userinfo +284%, and no regression anywhere else. The trade is stated plainly: cross-replica rate-limit enforcement is now eventual rather than synchronous, with a bounded overshoot that is zero on a single replica.",
+    title: "Mystery 1 closed — the TLS plateau was Nagle's algorithm",
+    body: "The previous draft published a −57% TLS drop on token issuance as an open question with a named suspect: actix-web never set TCP_NODELAY, so Nagle's algorithm held the second TLS record of each HTTP/2 response until the peer's 40 ms delayed-ACK timer fired. The controlled A/B settles it — 1,172 req/s with the old behaviour (a flat 42.8 / 44.1 ms plateau, reproduced exactly), 2,642 req/s with TCP_NODELAY, against a 2,757 req/s plaintext control. The wire-level photograph confirms the mechanism: an `ss -ti` snapshot inside the server's network namespace caught 18 of 20 connections frozen with bytes in the send queue behind a single unacked segment, versus zero in the control. TCP_NODELAY now ships on by default, and the TLS penalty is −2.0%.",
   },
   {
-    title: "Native mTLS is still free",
-    body: "The p3 profile terminates client-certificate TLS 1.3 inside the server process — no proxy in front, the verified peer certificate is the identity source — and again lands at parity with plain TLS 1.3 on every scenario. For IoT and service-mesh fleets, certificate verification costs nothing measurable on top of TLS. It remains, as far as we can measure, unique in this field.",
+    title: "Mystery 2 closed — REST's authz deficit was one database read",
+    body: "With the decision cache on, gRPC checks used to reach 13× while REST barely moved. A 2×2 (decision cache × session-validation cache) confirms the cause: REST validates session revocation on every request, gRPC validates the JWT and stops. Turning both caches on lifts REST from 5,597 to 11,647 checks/s — parity with gRPC's 11,172 — while the session cache does nothing at all for gRPC, which never did the read. Both caches remain OFF by default: these are hot-key ceilings, not expectations. The flip side is stated with the same candour — part of gRPC's speed is that it does not re-check revocation per call, so token expiry (15 min max) is its revocation bound, a documented posture choice with a strict mode on the roadmap.",
   },
   {
-    title: "Give the database cores first",
-    body: "Uncapping only the database from 2 to 4 CPUs (servers untouched) moves authz checks +90% / +89% (REST/gRPC), client credentials +64%, introspection +42% and userinfo +59%, while JWKS, login and gRPC userinfo don't move at all. Post-fix, database CPU is the product's main ceiling — so if your workload is authz- or identity-read heavy, that is where the next core belongs.",
+    title: "Caching and revocation, measured rather than assumed",
+    body: "The obvious objection to any decision cache is that it delays revocation, so this run measured it twice over with caching on at a 5 s TTL. Revoke a role through the API and the invalidation hook fires end to end: a deny is served 262 ms after the revocation call. Delete the grant behind the server's back — directly in the database, suppressing every hook — and stale allows persist to 5.2 s, inside the promised TTL-plus-slack bound. Revocation through the API is immediate even with caches on; only out-of-band database surgery waits out the TTL, which is exactly the documented contract.",
   },
   {
-    title: "The decision cache, at its best case and its worst",
-    body: "With the optional decision cache on (5 s TTL, opt-in), gRPC checks reach 11,598 req/s — 13.1× — at the bench's favourable keyspace, and batch reaches 26,000–45,000 checks/s. REST checks gain only 5%: their per-request session-cookie validation is a database read the decision cache deliberately does not cover, and it becomes the new limiter. Read 13× as a ceiling at ~100% hit rate, not an expectation; the realistic-keyspace measurement is +32%. The default stays off, the server logs its live hit rate, and the REST session cost is now a tracked optimisation target.",
+    title: "Mystery 3 closed — per-query waste removed, concurrency remains",
+    body: "EXPLAIN on the live schema found two full-table scans on the hot authorization read path. Removing them (no schema change needed) took cache-off capped checks from 753 to 1,010–1,032 req/s, past the pre-registered 1,000 bar, and CI tests now fail if any hot authorization query ever regresses to a table scan. The capped→uncapped delta (2→4 database cores) narrowed from ~+90% to +75–79%, which reframes the ceiling: per-query cost is no longer the dominant waste, database concurrency is. Read-scaling now outranks further per-query tuning on the roadmap, and \"give the database cores first\" remains the operative sizing guidance for authz-heavy workloads.",
   },
   {
-    title: "Shipped rate limits, measured — and a second bug found",
-    body: "One pass ran AXIAM with its production per-IP limits active: a 50-user single-IP flood is throttled to the configured trickle on every limited endpoint while unlimited paths run at full speed beside it, so the 429 path is cheap and the defaults do their abuse-stopping job. The same pass caught a real bug — the gRPC limiter admits about 1/60th of its configured rate, a per-second limit enforced against a per-minute window — found here, root-caused in code, fix tracked. Until it ships, treat the gRPC authz limit as per-minute, or limit at the mesh/gateway layer instead.",
+    title: "Native mTLS is still free — now in the run of record",
+    body: "The p3 profile terminates client-certificate TLS 1.3 inside the server process — no proxy in front, the verified peer certificate is the identity source. This run promotes it from a sensitivity pass to a full matrix profile at median-of-3, and it holds: mutual TLS costs about 1% over plain TLS 1.3 on every scenario. For an IoT or zero-trust fleet that needs client certificates on every connection, AXIAM is the only one of the three offering this in-process, and it is effectively free — where Keycloak pays −17% on its hottest read under mTLS and could not produce a valid login cell under it at all.",
   },
 ];
 
 const CAVEATS = [
   {
-    title: "The TLS client-credentials drop (−57%) is still unexplained",
-    body: "Client-credentials throughput falls 56.7% at p2, while introspection loses 1.6%, userinfo 2.4% and authz checks nothing at all under identical TLS — so this is not a crypto cost. New post-fix evidence narrows it: under TLS the endpoint shows a flat ~43 ms per request with nothing saturated, which is a serialization plateau, and the old prime suspect (the rate-limit write) is now gone. A dedicated VU-sweep is the next round's task. Even with the penalty, AXIAM's TLS token issuance leads the field 2.8–3.4×.",
+    title: "Session/token refresh regressed 35% — and it is our own doing",
+    body: "AXIAM's refresh cell fell from 839 to 545 req/s (p50 47.5 → 88.8 ms) between the two runs, on tight medians, with no harness change anywhere on that path. The suspects are our own post-run-4 security-hardening commits and/or database version drift, and a stage-timed bisection is queued. The cross-vendor position is unchanged — AXIAM still leads Keycloak on this cell, under its protocol-variant label — but we would rather flag our own regression than let a favourable ratio hide it.",
   },
   {
-    title: "This run's batch cells measured the wrong strategy",
-    body: "A benchmark compose file still pinned the pre-decision default, so the batch cells accidentally exercised the non-default `concurrent` strategy (199 batch ops/s = 995 checks/s, ~1.3× singles). The shipped default is `coalesced`, whose settled measurement remains the previous draft's verdict — 744 batch ops/s = 3,721 checks/s = 4.98× singles over REST, ~4,330 checks/s over gRPC. The harness pin is fixed; run 5 re-measures the default at full matrix scale.",
+    title: "The rate limiter fails our own enforcement assertions — in both directions",
+    body: "This run added an automated check comparing configured limits against admitted rates under a single-IP flood, with a ±10% bar. Login passes exactly (11/min admitted against 10 configured). The REST machine endpoints over-admit — +12% on token, +48% on introspect, +50% on authz check — as token-bucket burst bleeds into the sustained window. The gRPC families under-admit by ×20–33 (181/min admitted against 6,000 configured on authz): the ×60 units bug of the previous draft is genuinely fixed, but two cooperating limiter layers with mismatched windows appear to compound under overload, which is a real availability bug under attack. Three limiter families (revoke, gRPC admin, gRPC infra) still have no test scenario. Compliant clients under the limit are unaffected by any of this — but until it is fixed and re-measured we do not advertise gRPC throughput under the abuse posture, and we publish the failing table rather than the passing subset.",
   },
   {
-    title: "Keycloak's login cells are excluded — by memory, not by function",
-    body: "Even at the raised 2 GiB cap, Keycloak completed only 1 of 3 password-login runs cleanly per profile, so our own validity gate excludes those cells (the single clean run is published in parentheses, not charted). Prior diagnostics show it wants ~3.5–4 GiB under sustained hashing load; the next run gives its login cells exactly that, clearly labeled. Zitadel's login exclusion is its default bcrypt cost — expected, and tunable — and its refresh exclusion is a flow our harness doesn't implement yet.",
+    title: "Keycloak's login story is genuinely hard to measure fairly",
+    body: "We raised Keycloak's cap to 4 GiB as promised, and it got slower: ~21 req/s at a ~2.5 s p95, still failing the validity gate and below its 2 GiB survivor runs. Its login behaviour looks memory-sensitive rather than simply memory-starved, so we will say that rather than keep raising its cap. Credit where it is due — it produced its first valid login cell of this series at p2 (51 req/s), and that is charted. Zitadel's login exclusion remains its default bcrypt cost, which is expected and tunable, and its refresh exclusion is a flow our harness still doesn't implement.",
   },
   {
-    title: "Median-of-3, fully labeled — but still a laptop",
-    body: "42 of 48 matrix cells are valid and every invalid cell is listed with its reason; every cell is the median of three runs (spread ±0.2–2.8% on AXIAM cells, so deltas above ~5% are signal). The hardware is still a consumer laptop (Dell XPS 15, i7-8750H): package temperatures hit 96–100 °C on hot cells and the clock varied 3.2–3.9 GHz. The thermal envelope was identical for all targets, so cross-target fairness holds and absolute numbers are, if anything, conservative — but a server-class re-run remains the standing caveat.",
+    title: "Median-of-3 on a release image — but still a laptop",
+    body: "64 of 72 matrix cells are valid and every invalid cell is listed with its reason; every cell is the median of three runs (spread ≤ ±2% on AXIAM cells, ±13–17% on the batch cells, where coalescing is phase-sensitive). The hardware is still a consumer laptop (Dell XPS 15, i7-8750H): package temperatures hit 95–100 °C on hot cells and the clock varied 3.1–3.9 GHz. The thermal envelope was identical for all targets, so cross-target fairness holds and absolute numbers are, if anything, conservative — but the server-class re-run remains the standing caveat, and the biggest single upgrade this series can still make.",
   },
   {
-    title: "The SDK pass is a first pass",
-    body: "All eleven SDKs ran the same four operations at all three profiles with zero errors in 132 op-cells — but it is a single pass, not a median-of-3, and no matched-concurrency wire baseline was captured, so we are not publishing an 'SDK overhead vs raw HTTP' number yet. The C and PHP harnesses run serially, so their rows aren't comparable with the concurrency-16 ones; the C# refresh row measures its auth helper's (correct) token cache rather than the wire; and one C++ tail anomaly is under investigation.",
+    title: "Not a like-for-like re-run of the previous draft",
+    body: "Between the two runs, two authorization table scans were removed, Nagle was disabled on the REST listener, the gRPC rate-limiter units bug was fixed, the shipped rate-limit defaults were revised, and the batch default the harness measures finally matches the batch default the product ships. Treat this run as the new baseline; where a controlled comparison was wanted, a one-variable A/B was run and is reported as such. The investigation passes are single labelled runs by design — only the matrix cells are median-of-3.",
   },
 ];
 
 const NEXT = [
-  "Re-measure the batch default (`coalesced`) at full matrix scale",
-  "Fix the ×60 gRPC rate-limiter units bug, then re-run the posture pass",
-  "A 4 GiB, clearly-labeled Keycloak password-login cell",
-  "The VU-sweep that explains the TLS client-credentials plateau",
-  "SDK median-of-3 repeats plus the missing wire baseline",
-  "Cut the REST session-validation database read the decision cache can't cover",
+  "The refresh-regression bisection, stage-timed",
+  "Fix the gRPC limiter starvation and the REST over-admission, re-verified by the same assertion script that failed them here",
+  "Scenario coverage for the three untested limiter families",
+  "The TypeScript wire-baseline audit before any TS overhead claim is published",
+  "Profile the Python SDK gap that survived the async-driver fix",
+  "Chase the C++ reconnect tail into server-side idle-timeout suspects",
   "A server-class re-run to replace the laptop numbers",
 ];
+
+/* ---- §10 excerpt: why build AXIAM at all? ------------------------------ */
+
+/**
+ * Excerpted from §10 of `benchmarks/PUBLIC_BENCH_ANALYSIS.md`. The report
+ * answers the fair question the field invites — Keycloak is mature and
+ * ubiquitous, Zitadel is modern and well-engineered — from the measurements
+ * rather than from ambition, and it answers it with the cons attached. Both
+ * halves are reproduced here.
+ */
+const WHY_AXIAM = [
+  {
+    n: "1",
+    title: "The efficiency gap is real, large, and it is the product",
+    body: "These are not micro-optimizations: on identical hardware, identical caps and identical scenarios, AXIAM issues ~8× the tokens, introspects ~2.4–4.8× the tokens, and serves ~6–13× the JWKS reads of the incumbents — in 86–120 MiB of server RSS, under 8% of what Keycloak uses for less throughput. IAM is infrastructure that runs 24/7 in front of everything; its cost floor and its p95 are a tax every request in the system pays. Rust with no GC pauses, no JVM warm-up, and CPU-shaped-per-request economics moves that floor by close to an order of magnitude — that is a capability difference, not a benchmark trophy.",
+  },
+  {
+    n: "2",
+    title: "Nobody else treats the machine/IoT edge as the main stage",
+    body: "Authorization decisions as a first-class, benchmarked hot path (5,100+ hierarchy-aware RBAC checks/s on 2+2 cores, batch API at the shipped default); a gRPC data plane that does 12,000+ identity reads/s at a 6 ms p95 (the competitors' gRPC surfaces are management APIs, and it shows — Zitadel's measures 200/s); and in-process mutual TLS at ~1% cost, no sidecar — which makes per-device client certificates the cheap option for IoT fleets rather than an architecture project. If your workload is humans logging into web apps, Keycloak serves you well today. If it is services and devices asking “may I?” tens of thousands of times a second, that workload is what AXIAM is shaped around.",
+  },
+  {
+    n: "3",
+    title: "Security posture as measured defaults, not documentation",
+    body: "AXIAM is the only target here that ships abuse rate-limits on by default — sized from these measurements, with human endpoints locked strictly regardless of posture (and login enforcement measured exact under flood; the machine-endpoint enforcement gaps above are published, tracked bugs, not fine print). Argon2id, EdDSA short-lived tokens, single-use rotating refresh tokens, append-only audit and encrypted-at-rest secrets are defaults, not options. And the process is part of the posture: this benchmark series has now found, published and fixed a synchronous rate-limit write, a ×60 limiter units bug, a Nagle-induced TLS latency cliff and two authorization table scans — and currently carries an open refresh regression and a gRPC flood-behaviour bug in public view. We think an IAM vendor that measures itself adversarially and publishes the misses is itself a security feature.",
+  },
+];
+
+const WHY_AXIAM_CONS =
+  "AXIAM is alpha: it has a fraction of Keycloak's protocol surface, extension ecosystem, hosting options and community; Zitadel's resting stack is smaller than ours (SurrealDB + RabbitMQ ride along in every AXIAM deployment); Keycloak wins one whole-stack efficiency cell outright; our RBAC engine is additive-only in v1.0-beta (no deny-override); SurrealDB is a younger storage engine than Postgres by a decade; and every number in this document comes from one consumer laptop until the server-class re-run lands. Choosing AXIAM today means choosing a young system whose performance-per-watt, machine-first design and measurement culture you value over incumbent breadth. That trade is exactly the niche the incumbents leave open — and the measurements above are why we believe the niche is worth serving.";
 
 /* ---- page -------------------------------------------------------------- */
 
@@ -538,9 +578,11 @@ export default function Benchmarks() {
       <p style={{ margin: "0 0 24px", fontSize: 17, color: "#94a3b8", maxWidth: 720 }}>
         A vendor-neutral harness drives the identical logical workload through a
         per-target adapter, comparing AXIAM against Keycloak and Zitadel across
-        OAuth2/OIDC flows. Below are the run-4 results — the first complete
-        matrix measured on a build with no known measurement-distorting defect
-        in it, and the first with a resource-usage profile to match.
+        OAuth2/OIDC flows. Below are the run-5 results — the first measured
+        against a <strong style={{ color: "#e2e8f0" }}>published release image</strong>{" "}
+        rather than a working tree, pulled by digest exactly as any reader would
+        pull it, and the first with the full three-profile matrix (plaintext,
+        TLS&nbsp;1.3, native mutual TLS) in the run of record.
       </p>
 
       {/* ---- Preliminary banner ---- */}
@@ -563,21 +605,23 @@ export default function Benchmarks() {
           <div
             style={{ fontSize: 15, fontWeight: 700, color: "#ffd98a", marginBottom: 4 }}
           >
-            Temporary results — the benchmark is still being improved
+            Preliminary results — the benchmark is still being improved
           </div>
           <p style={{ margin: 0, fontSize: 14, lineHeight: 1.65, color: "#e2e8f0" }}>
-            These numbers come from run 4 (2026-08-01/02) — a full{" "}
-            <strong>median-of-3</strong> matrix, three targets, two TLS
-            profiles, 42 of 48 cells valid with every invalid cell listed and
-            explained. It is the re-measurement on the build that fixes the
-            rate-limit defect the previous run found in AXIAM itself, so the
-            gains on the six affected endpoints (+47% to +284%) are the story of
-            this draft. They are still temporary: this run's batch cells
-            measured the wrong strategy through a harness slip, Keycloak's login
-            cells need a larger labeled memory envelope to be fair, and
-            everything still runs on a consumer laptop rather than server-class
-            hardware. Treat them as a strong, reproducible signal, not a final
-            verdict; this page is updated as each improved run lands.
+            These numbers come from run 5 (2026-08-05/06) — a full{" "}
+            <strong>median-of-3</strong> matrix, three targets, three profiles
+            (plaintext, TLS 1.3, native mTLS), 64 of 72 cells valid with every
+            invalid cell listed and explained, measured against the released,
+            digest-pinned <code>1.0.0-alpha24</code> image. The story of this
+            draft is that all three of the previous draft's open mysteries were
+            closed with controlled experiments — the TLS plateau, the REST/gRPC
+            authorization asymmetry and the database ceiling. It also found two
+            new problems, published here with the same candour: a refresh
+            regression we introduced ourselves, and a rate limiter that fails
+            our own enforcement assertions. Everything still runs on a consumer
+            laptop rather than server-class hardware. Treat these as a strong,
+            reproducible signal, not a final verdict; this page is updated as
+            each improved run lands.
           </p>
         </div>
       </div>
@@ -685,8 +729,8 @@ export default function Benchmarks() {
         <div className="ax-grid-2" style={{ marginTop: 20, gap: 14 }}>
           {[
             ["Load model", "Closed-loop, 50 virtual users. 30 s warm-up + 120 s measured window per scenario — repeated 3×, median reported."],
-            ["Profiles", "p0-plaintext and p2-tls13 (TLS 1.3, terminated in-process by all three targets, gRPC included) — plus a labeled p3-mTLS pass for AXIAM."],
-            ["Validity gates", "A cell counts only if error rate ≤ 1% and p95 < 2000 ms. Failing cells are labelled, never charted as a head-to-head — 42 of 48 cells passed this run."],
+            ["Profiles", "Three, all median-of-3 in the run of record: p0-plaintext, p2-tls13 (TLS 1.3 terminated in-process by all three targets, gRPC included) and p3-mtls (in-process mutual TLS), now a full matrix profile rather than a sensitivity pass."],
+            ["Validity gates", "A cell counts only if error rate ≤ 1% and p95 < 2000 ms. Failing cells are labelled, never charted as a head-to-head — 64 of 72 cells passed this run, and the settle gate cleared first-probe on every session."],
             ["Container caps", "IAM server 2 CPU / 2 GiB · database 2 CPU / 1 GiB · RabbitMQ (AXIAM only) 1 CPU / 512 MiB. The server cap was raised from 1 GiB — for every target equally — because Keycloak could not reliably survive login load below it."],
           ].map(([t, b]) => (
             <div key={t} className="glass-card" style={{ padding: 20 }}>
@@ -714,11 +758,12 @@ export default function Benchmarks() {
           </li>
           <li style={{ marginBottom: 8 }}>
             <strong>Provenance recorded.</strong> Every container in every cell
-            records its image digest, and every AXIAM cell records the build ref
-            it ran — so improvements between runs are attributable to a known
-            binary. This run used a post-fix build rather than a published
-            release image; run 5 returns to a release image whose build ref is a
-            commit on <code>main</code>.
+            records its image digest, and this run benchmarks a{" "}
+            <em>published</em> artifact —{" "}
+            <code>ghcr.io/ilpanich/axiam/server:1.0.0-alpha24</code>, pinned by
+            digest and pulled exactly as any reader would pull it — so the
+            numbers describe a release anyone can fetch rather than a working
+            tree only we can build.
           </li>
           <li style={{ marginBottom: 8 }}>
             <strong>Competitors tuned, not hobbled.</strong> PostgreSQL is
@@ -837,11 +882,11 @@ export default function Benchmarks() {
       <section style={{ marginBottom: 52 }}>
         <SectionTitle kicker="Resource usage" title="What it costs to run" />
         <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760 }}>
-          New in this run: memory and CPU were sampled per container, every
-          second, throughout every cell — so the throughput numbers above come
-          with the bill for producing them. Same load, same 2-CPU /
-          2&nbsp;GiB envelope for every server. All figures are the p0-plaintext
-          profile, median of three runs.
+          Memory and CPU are sampled per container, every second, throughout
+          every cell — so the throughput numbers above come with the bill for
+          producing them. Same load, same 2-CPU / 2&nbsp;GiB envelope for every
+          server. All figures are the p0-plaintext profile, median of three
+          runs.
         </p>
 
         <div style={{ display: "flex", flexDirection: "column", gap: 20, marginTop: 22 }}>
@@ -849,10 +894,10 @@ export default function Benchmarks() {
 
           <ResourceChart
             title="Server memory by scenario"
-            unit="peak resident memory · MiB · lower is better"
-            rows={BENCH_MEMORY_PEAK}
+            unit="average resident memory of the server container · MiB · lower is better"
+            rows={BENCH_MEMORY_AVG}
             format={(n) => `${n.toLocaleString("en-US")} MiB`}
-            footnote="* On the partially valid password-login cells the peak medians and average medians diverge across runs, so the worst-case-over-the-whole-run figures in the chart above are the honest summary for that scenario. Zitadel has no refresh cell — its flow is excluded from this run."
+            footnote="* Keycloak's login cells are only partially valid, and its 4 GiB labelled attempt is excluded from this chart entirely — it is reported in the caveats instead. † Authorization checks and batches have no competitor equivalent; AXIAM's server ran them in 86–94 MiB. Zitadel has no refresh cell — its flow is excluded from this run."
           />
 
           <ResourceChart
@@ -929,12 +974,13 @@ export default function Benchmarks() {
           }}
         >
           Read plainly: <strong style={{ color: "#e2e8f0" }}>Zitadel's stack is the
-          smallest of the three</strong> — its Go server is respectably compact and its
+          smallest at rest</strong> — its Go server is respectably compact and its
           costs surface as CPU per request instead. AXIAM's stack is not the
           smallest, but it does the most work per byte and per core, by 1.6× to
-          17× on every cell except one. And where Keycloak needed its memory cap
-          doubled just to run the login scenario, AXIAM's server never exceeded
-          172 MiB of the same 2 GiB allowance.
+          24× on every cell except one. And where Keycloak needed its memory cap
+          doubled just to run the login scenario — then got slower when we
+          doubled it again — AXIAM's server averaged 86–120 MiB across the
+          entire matrix, of the same 2 GiB allowance.
         </p>
       </section>
 
@@ -944,22 +990,323 @@ export default function Benchmarks() {
         <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 22 }}>
           No head-to-head here — Keycloak and Zitadel expose no equivalent decision
           endpoint. Each check is a full RBAC evaluation (tenant-scoped roles,
-          resource hierarchy, scopes) against live data, over REST and gRPC. The
-          cache-ON rows are a labeled best-case sensitivity pass, not the default
-          configuration; the batch figure quoted below is carried over from the
-          previous run, because this run's batch cells measured the wrong
-          strategy (see the honesty section).
+          resource hierarchy, scopes) against live data, over REST and gRPC,
+          with the decision cache off. Batch bars are checks/s at the shipped{" "}
+          <code style={{ color: "#67e8f9" }}>coalesced</code> default — measured
+          at full matrix scale this time, after the previous run's harness pin
+          accidentally exercised a non-default strategy. The two cache-ON bars
+          are a labelled best-case sensitivity pass, not the default
+          configuration.
         </p>
         <BarChart scenario={BENCH_AUTHZ} />
       </section>
 
+      {/* ---- TLS / mTLS cost ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="Security cost" title="What TLS 1.3 and mutual TLS cost" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760, marginBottom: 20 }}>
+          Throughput delta against the plaintext cell of the same scenario, from
+          the run of record at median-of-3. Both encrypted profiles terminate
+          in-process — no proxy, no sidecar — and on p3 the verified client
+          certificate is the identity source. Most REST rows measure TLS{" "}
+          <em>plus</em> an HTTP/1.1→2 protocol change together, and are labelled
+          as such in the raw report.
+        </p>
+        <div className="glass-card" style={{ padding: 4, overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5, minWidth: 480 }}>
+            <thead>
+              <tr>
+                {["Scenario", "TLS 1.3 (p2)", "Mutual TLS (p3)"].map((h) => (
+                  <th
+                    key={h}
+                    style={{
+                      textAlign: "left",
+                      padding: "12px 16px",
+                      borderBottom: "1px solid rgba(0,212,255,.18)",
+                      color: "#67e8f9",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {BENCH_TLS_COST.map((row) => (
+                <tr key={row.scenario}>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#e2e8f0",
+                      fontWeight: 600,
+                    }}
+                  >
+                    {row.scenario}
+                  </td>
+                  {[row.tls, row.mtls].map((cell, ci) => (
+                    <td
+                      key={ci}
+                      style={{
+                        padding: "11px 16px",
+                        borderBottom: "1px solid rgba(255,255,255,.06)",
+                        color: "#cbd5e1",
+                        fontFamily: "ui-monospace,Menlo,monospace",
+                      }}
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p style={{ margin: "16px 4px 0", fontSize: 13.5, color: "#94a3b8", lineHeight: 1.7, maxWidth: 760 }}>
+          The headline stands its third and strongest re-measurement:{" "}
+          <strong style={{ color: "#e2e8f0" }}>
+            native mutual TLS costs AXIAM about 1% over plain TLS 1.3 on every
+            scenario
+          </strong>
+          . For comparison, Keycloak pays up to −17.2% under mTLS on its hottest
+          read and could not produce a valid login cell under it; Zitadel's
+          valid cells sit between −1.7% and −3.9%.
+        </p>
+      </section>
+
+      {/* ---- SDK benchmarks ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="SDKs" title="What the client libraries cost" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760 }}>
+          All eleven official SDKs run the same four operations against the same
+          seeded AXIAM at plaintext — <strong>three passes each, medianed</strong>{" "}
+          — with a matched-concurrency k6 wire baseline measured on the same host
+          first. That baseline is what makes the last column meaningful: it is
+          the authorization-check p95 an SDK adds over raw HTTP at the same
+          concurrency, and this is the first run of this series that can publish
+          it honestly.
+        </p>
+
+        <div className="glass-card" style={{ padding: 4, marginTop: 22, overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13, minWidth: 720 }}>
+            <thead>
+              <tr>
+                {[
+                  "SDK",
+                  "login p50",
+                  "refresh p50",
+                  "check p50",
+                  "check p95",
+                  "check thr",
+                  "p95 overhead vs wire",
+                ].map((h, i) => (
+                  <th
+                    key={h}
+                    style={{
+                      textAlign: i === 0 ? "left" : "right",
+                      padding: "12px 14px",
+                      borderBottom: "1px solid rgba(0,212,255,.18)",
+                      color: "#67e8f9",
+                      fontWeight: 700,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {BENCH_SDK_LATENCY.map((row) => (
+                <tr key={row.sdk}>
+                  <td
+                    style={{
+                      padding: "11px 14px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#e2e8f0",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {row.sdk}
+                    {row.serial && (
+                      <span style={{ color: "#64748b", fontWeight: 500 }}> · serial</span>
+                    )}
+                    {row.flag && (
+                      <div style={{ fontSize: 11.5, color: "#ffd98a", fontWeight: 500, marginTop: 2 }}>
+                        ⚠ {row.flag}
+                      </div>
+                    )}
+                  </td>
+                  {[row.login, row.refresh, row.checkP50, row.checkP95, row.thr, row.overhead].map(
+                    (cell, ci) => (
+                      <td
+                        key={ci}
+                        style={{
+                          padding: "11px 14px",
+                          borderBottom: "1px solid rgba(255,255,255,.06)",
+                          textAlign: "right",
+                          whiteSpace: "nowrap",
+                          fontFamily: "ui-monospace,Menlo,monospace",
+                          color:
+                            ci === 5 && row.best
+                              ? "#67e8f9"
+                              : cell === "—"
+                                ? "#64748b"
+                                : "#cbd5e1",
+                          fontWeight: ci === 5 && row.best ? 700 : 400,
+                        }}
+                      >
+                        {cell}
+                      </td>
+                    ),
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p style={{ margin: "12px 4px 0", fontSize: 12.5, color: "#64748b", lineHeight: 1.6 }}>
+          Milliseconds unless noted; throughput in requests/s; concurrency 16.
+          The two <em>serial</em> harnesses (C and PHP) drive a single worker by
+          their own design, so their throughput is not comparable with the
+          others and they run no login/refresh op-cell.
+        </p>
+
+        <ul style={{ margin: "20px 0 0", paddingLeft: 22, color: "#cbd5e1", lineHeight: 1.75, maxWidth: 760 }}>
+          <li style={{ marginBottom: 8 }}>
+            <strong>The server, not the SDKs, sets the floor.</strong> Ten SDKs
+            measure refresh at 16.7–17.3 ms p50 and login at 232–257 ms —
+            server-side Argon2id dominates identically from every language.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>Hot-path overhead is single-digit milliseconds</strong> at
+            p95 for seven of the nine concurrent SDKs (+2.7 to +4.6 ms over raw
+            k6 at the same concurrency) — the headline the wire baseline was
+            built to establish.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>Python is still the outlier</strong> after moving to a
+            genuinely async driver (p50 40 ms, +60 ms p95 overhead). The previous
+            draft blamed the harness; the harness is now clean, so the remaining
+            gap belongs to the SDK/runtime and is being profiled.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>C++ keeps its reconnect-shaped tail</strong> (p50 3.2 ms,
+            p95 280 ms) despite the connection-age fix — the investigation has
+            moved to server-side idle-timeout suspects.
+          </li>
+          <li style={{ marginBottom: 8 }}>
+            <strong>TypeScript's negative “overhead” is flagged, not
+            celebrated.</strong> A client should not beat the wire baseline on
+            the same box, so its baseline comparability is under audit before we
+            publish any TS overhead claim.
+          </li>
+        </ul>
+
+        <h3 style={{ margin: "34px 0 6px", fontSize: 17, fontWeight: 700 }}>
+          Client-side footprint
+        </h3>
+        <p style={{ fontSize: 14, color: "#94a3b8", lineHeight: 1.7, maxWidth: 760, margin: "0 0 18px" }}>
+          New this run: each SDK's own process CPU over the whole bench and its
+          peak resident memory — half the story for IoT and sidecar deployments,
+          where the client is the constrained side. First pass of this telemetry.
+        </p>
+        <div className="glass-card" style={{ padding: 4, overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5, minWidth: 480 }}>
+            <thead>
+              <tr>
+                {["SDK", "Runtime", "Client CPU (s)", "Peak RSS (MiB)"].map((h, i) => (
+                  <th
+                    key={h}
+                    style={{
+                      textAlign: i > 1 ? "right" : "left",
+                      padding: "12px 16px",
+                      borderBottom: "1px solid rgba(0,212,255,.18)",
+                      color: "#67e8f9",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {BENCH_SDK_FOOTPRINT.map((row) => (
+                <tr key={row.sdk}>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#e2e8f0",
+                      fontWeight: 700,
+                    }}
+                  >
+                    {row.sdk}
+                    {row.serial && (
+                      <span style={{ color: "#64748b", fontWeight: 500 }}> · serial</span>
+                    )}
+                  </td>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      color: "#94a3b8",
+                    }}
+                  >
+                    {row.runtime}
+                  </td>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      textAlign: "right",
+                      fontFamily: "ui-monospace,Menlo,monospace",
+                      color: row.cpu <= 3.3 ? "#67e8f9" : "#cbd5e1",
+                      fontWeight: row.cpu <= 3.3 ? 700 : 400,
+                    }}
+                  >
+                    {row.cpu.toFixed(1)}
+                  </td>
+                  <td
+                    style={{
+                      padding: "11px 16px",
+                      borderBottom: "1px solid rgba(255,255,255,.06)",
+                      textAlign: "right",
+                      fontFamily: "ui-monospace,Menlo,monospace",
+                      color: row.rss <= 23 ? "#67e8f9" : "#cbd5e1",
+                      fontWeight: row.rss <= 23 ? 700 : 400,
+                    }}
+                  >
+                    {row.rss}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p style={{ margin: "16px 4px 0", fontSize: 13.5, color: "#94a3b8", lineHeight: 1.7, maxWidth: 760 }}>
+          Go is by far the cheapest concurrent client on CPU; C and Rust are the
+          smallest on memory (13 and 23 MiB — the embedded/IoT lane); the JVM
+          SDKs pay the expected 300–460 MiB runtime tax at equal wire
+          performance; Python is the most expensive on CPU <em>and</em> the
+          slowest, a consistent picture. One number we flag rather than explain:
+          Rust's client CPU reads high relative to its excellent latency
+          profile, and since this is the first run of this telemetry, that figure
+          gets a second look before we draw conclusions from it.
+        </p>
+      </section>
+
       {/* ---- Sensitivity ---- */}
       <section style={{ marginBottom: 52 }}>
-        <SectionTitle kicker="Sensitivity" title="What the labeled passes showed" />
+        <SectionTitle kicker="Investigation" title="Three mysteries, closed" />
         <p style={{ fontSize: 14, color: "#64748b", lineHeight: 1.6, maxWidth: 760, marginBottom: 20 }}>
-          Beyond the head-to-head matrix, run 4 ran five labeled single-variable
-          passes — never mixed into the comparison tables — to verify the fix,
-          find each system's walls, and size AXIAM's tuning levers.
+          The previous draft published three unexplained results as open
+          questions with named hypotheses. Run 5 tested all three with labeled
+          single-variable passes — never mixed into the comparison tables — and
+          closed all three with data. This is why we benchmark in the open: the
+          benchmark is also a debugger.
         </p>
         <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
           {SENSITIVITY.map((s) => (
@@ -994,6 +1341,65 @@ export default function Benchmarks() {
               </p>
             </div>
           ))}
+        </div>
+      </section>
+
+      {/* ---- §10 excerpt: why build AXIAM at all? ---- */}
+      <section style={{ marginBottom: 52 }}>
+        <SectionTitle kicker="From the report · §10" title="Why build AXIAM at all?" />
+        <p style={{ fontSize: 15, color: "#cbd5e1", lineHeight: 1.7, maxWidth: 760, marginBottom: 20 }}>
+          A fair question given this field: Keycloak is mature and ubiquitous,
+          Zitadel is modern and well-engineered, Auth0 and Okta are excellent
+          managed products. Five drafts of measurements into this project, the
+          answer has sharpened rather than softened. Excerpted from §10 of the
+          analysis:
+        </p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {WHY_AXIAM.map((w) => (
+            <div key={w.n} className="glass-card" style={{ padding: 22, display: "flex", gap: 16 }}>
+              <div
+                aria-hidden="true"
+                style={{
+                  flex: "none",
+                  width: 30,
+                  height: 30,
+                  borderRadius: 8,
+                  display: "grid",
+                  placeItems: "center",
+                  background: "rgba(0,212,255,.08)",
+                  border: "1px solid rgba(0,212,255,.25)",
+                  color: "#67e8f9",
+                  fontWeight: 800,
+                  fontSize: 14,
+                }}
+              >
+                {w.n}
+              </div>
+              <div>
+                <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 6, color: "#67e8f9" }}>
+                  {w.title}
+                </div>
+                <p style={{ margin: 0, fontSize: 13.5, color: "#94a3b8", lineHeight: 1.65 }}>
+                  {w.body}
+                </p>
+              </div>
+            </div>
+          ))}
+          <div
+            className="glass-card"
+            style={{
+              padding: 22,
+              borderColor: "rgba(255,189,46,.35)",
+              background: "rgba(255,189,46,.06)",
+            }}
+          >
+            <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 6, color: "#ffd98a" }}>
+              And the honest cons, in the same breath
+            </div>
+            <p style={{ margin: 0, fontSize: 13.5, color: "#e2e8f0", lineHeight: 1.7 }}>
+              {WHY_AXIAM_CONS}
+            </p>
+          </div>
         </div>
       </section>
 
@@ -1037,11 +1443,19 @@ export default function Benchmarks() {
             <code style={{ color: "#67e8f9", fontFamily: "ui-monospace,Menlo,monospace" }}>
               benchmarks/docs/methodology.md
             </code>
-            . Sources: benchmark run 4 of 2026-08-01/02 (median-of-3 capped
-            matrix × two TLS profiles × three targets; labeled sensitivity
-            passes for DB-uncapped, decision-cache, native mTLS, production
-            rate-limit posture and batch strategy; an 11-language SDK pass;
-            per-cell k6 summaries with 1-second container and host telemetry).
+            . Sources: benchmark run 5 of 2026-08-05/06 (median-of-3 capped
+            matrix × three profiles × three targets, against the digest-pinned{" "}
+            <code style={{ color: "#67e8f9", fontFamily: "ui-monospace,Menlo,monospace" }}>
+              1.0.0-alpha24
+            </code>{" "}
+            release image; labeled investigation passes for the TCP_NODELAY A/B
+            with VU sweep and in-namespace socket captures, the session/decision
+            cache 2×2, the cache-on revocation cell, DB capped/uncapped, the
+            4 GiB Keycloak login attempt and the production rate-limit posture;
+            an 11-language SDK median-of-3 pass with a matched-VU wire baseline
+            and client CPU/RSS telemetry; per-cell k6 summaries with 1-second
+            container and host telemetry). Target versions: AXIAM 1.0.0-alpha24,
+            Keycloak 26.7.0, Zitadel v4.16.2, SurrealDB v3, PostgreSQL 16.
           </p>
         </div>
       </section>

--- a/website/src/types.ts
+++ b/website/src/types.ts
@@ -129,3 +129,43 @@ export interface BenchResourceRow {
   /** Optional footnote marker appended to the scenario label. */
   marker?: string;
 }
+
+/**
+ * One SDK's row in the client-side benchmark table. Latencies are
+ * pre-formatted milliseconds; `overhead` is the authorization-check p95
+ * measured against a matched-concurrency raw-wire baseline on the same host.
+ */
+export interface BenchSdkRow {
+  sdk: string;
+  /** Password-login p50, ms — server-side Argon2id dominates it. */
+  login: string;
+  /** Session-refresh p50, ms. */
+  refresh: string;
+  /** Authorization-check p50 / p95, ms. */
+  checkP50: string;
+  checkP95: string;
+  /** Authorization-check throughput, requests/s. */
+  thr: string;
+  /** Check p95 overhead over the wire baseline, ms. */
+  overhead: string;
+  /**
+   * Serial harnesses run a single worker by their own design, so their
+   * throughput is not comparable with the concurrency-16 SDKs.
+   */
+  serial?: boolean;
+  /** A caveat carried onto the row rather than buried in a footnote. */
+  flag?: string;
+  /** Fastest concurrent SDK — highlighted, never sorted differently. */
+  best?: boolean;
+}
+
+/** One SDK's own client-process cost over the whole benchmark. */
+export interface BenchSdkFootprintRow {
+  sdk: string;
+  runtime: string;
+  /** Total client CPU seconds consumed by the SDK's own process. */
+  cpu: number;
+  /** Peak client resident memory, MiB. */
+  rss: number;
+  serial?: boolean;
+}


### PR DESCRIPTION
Transcribe the sixth draft of benchmarks/PUBLIC_BENCH_ANALYSIS.md (run 5 of
2026-08-05/06, the first measured against the published, digest-pinned
1.0.0-alpha24 release image) onto the public Benchmarks page.

Data (website/src/data.ts):
- All head-to-head scenarios refreshed to the run-5 p0 medians, including
  the token-refresh cell's self-reported −35% regression and Keycloak's
  first valid login cell.
- Authorization chart now carries batch cells at the shipped `coalesced`
  default (4.97× singles) and the labelled both-caches-on REST/gRPC parity
  rows.
- Efficiency, whole-stack memory, cpu·ms/req and req/s-per-GiB tables
  updated; server memory rows re-based from peak to the average RSS the
  new report publishes (BENCH_MEMORY_PEAK → BENCH_MEMORY_AVG).
- New BENCH_TLS_COST (§4), BENCH_SDK_LATENCY and BENCH_SDK_FOOTPRINT (§9)
  with their BenchSdkRow / BenchSdkFootprintRow types.

Page (website/src/pages/Benchmarks.tsx):
- Banner, intro, setup facts, target versions and provenance bullet
  rewritten for the release-image, three-profile, 64-of-72-cell run.
- Sensitivity section becomes "three mysteries, closed" (Nagle/TCP_NODELAY
  A/B, the session-revocation read behind REST's authz deficit, the
  database ceiling), plus the cache-on revocation measurement.
- Caveats replaced with run 5's: the refresh regression, the rate limiter
  failing our own enforcement assertions in both directions, Keycloak's
  unrescuable login cells, and the not-like-for-like comparability warning.
- New TLS 1.3 / mutual TLS cost table.
- New SDK section: eleven-SDK median-of-3 latency table with a real wire
  baseline, the client CPU/RSS footprint table and the flagged outliers.
- New "Why build AXIAM at all?" section excerpting report §10, cons included.
- Next-steps chips and the sources footer point at run 5.

Also refresh the website README, which still described the Benchmarks page
as a draft with placeholder figures.