### PR TITLE
Track E (benchmark harness) + the D-track harness audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,12 @@ jobs:
       - name: bench-pack manifest self-test
         working-directory: benchmarks
         run: bash runner/pack-selftest.sh
+      # J8: the SDK median-of-N merger must name a pass that produced no
+      # record and fail, rather than silently reporting "median of 2" against
+      # repeat=3. Stdlib python only — no SDK toolchains needed.
+      - name: SDK median-of-N provenance self-test
+        working-directory: benchmarks
+        run: bash sdk/test-median-provenance.sh
       # Shell syntax gate for the runner scripts. `bash -n` is not a linter,
       # but the runner is 1 000+ lines of bash that only ever executes inside a
       # multi-hour matrix run — a syntax error there is otherwise discovered at

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,27 @@ jobs:
         working-directory: frontend
         run: npm run test:a11y
 
+  bench-harness:
+    name: Bench Harness Self-Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      # J13/E2: the bench-pack manifest guard. Hermetic — it builds a fixture
+      # results tree and runs runner/pack-filelist.sh over it, so no docker, no
+      # k6, no seeded stack. Run 5 shipped a shareable archive that silently
+      # dropped every investigation artifact; this is the regression that
+      # catches the next such drop in seconds rather than after a matrix.
+      - name: bench-pack manifest self-test
+        working-directory: benchmarks
+        run: bash runner/pack-selftest.sh
+      # Shell syntax gate for the runner scripts. `bash -n` is not a linter,
+      # but the runner is 1 000+ lines of bash that only ever executes inside a
+      # multi-hour matrix run — a syntax error there is otherwise discovered at
+      # the worst possible moment.
+      - name: Runner scripts parse
+        working-directory: benchmarks
+        run: for f in runner/*.sh; do bash -n "$f"; done
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -268,6 +268,47 @@ serves everything at ~45 req/s with the datastore pinned at ~1 core, which
 silently corrupted every cell that ran first after a seed — see
 [`PRIVATE_BENCH_ANALYSIS.md`](PRIVATE_BENCH_ANALYSIS.md) §1.
 
+### Seed-size sensitivity (`bench-bulk-seed`)
+
+Every published AXIAM number so far was measured against a fixture of one
+tenant, two users, one resource and the ~100 built-in registry permissions. The
+obvious reader question — *does the check path hold at 100 000 users and a
+four-deep resource tree?* — had no answer in the archive (J12). It does now:
+
+```bash
+just target=axiam profile=p2-tls13 bench-up
+just target=axiam bench-seed          # the functional fixture, via the REST API
+just scale=10 bench-bulk-seed         # 10 000 users, 2 000 resources, depth 4
+just target=axiam profile=p2-tls13 bench-run
+```
+
+`runner/bulk-seed.sh` writes SurrealQL directly into the datastore in batched
+transactions (`--batch`, default 1 000 statements per `BEGIN`/`COMMIT`) —
+provisioning 100 000 users through the REST API would mean 100 000 Argon2id
+hashes and is not a thing anyone waits for. Three properties make the resulting
+cell comparable:
+
+- **The functional fixture is untouched.** `benchuser`, `bench-resource` and
+  `bench-reader` keep their ids, so the scenario runs the *same logical query*
+  against a bigger index. That is the only comparison worth making.
+- **The tree is deep, not just wide.** `--depth` (default 4) and `--fanout`
+  (6) build a balanced hierarchy, because a flat 10 000-resource fixture
+  exercises the ancestor-walk code exactly as hard as a 1-resource one.
+- **Some grants are denies.** `--deny-ratio` (default 0.05) writes a fraction
+  of grants as `effect: deny`, so the cell measures B1's deny-override path
+  rather than only its no-denies short-circuit. Set `0` to measure the cheap
+  path exclusively.
+
+Bulk users **cannot authenticate by construction** — their `password_hash` is a
+sentinel string that is not an Argon2id encoded hash at all, so verification
+fails to parse. The fixture adds volume; it does not add usable credentials.
+
+The resulting scale is recorded in `.seed/axiam.bulk.env` and lands in every
+cell's `meta.json` as `seed_scale` / `seed_fixture`, so a 10× measurement can
+never be mistaken for a base-fixture one. Absent file means scale 1.
+
+`just bench-bulk-verify` prints the row counts without writing anything.
+
 ## Out of scope (v1.0-beta)
 
 **AMQP async-authz benchmarking** (server `axiam-amqp` + the Go/Python/TypeScript

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -192,6 +192,44 @@ cell — see [§8 "Multiple runs — median-of-N"](docs/methodology.md#8-multipl
 just repeat=3 targets="axiam keycloak" profiles="p0-plaintext p2-tls13" bench-matrix
 ```
 
+### Sharing a run (`bench-pack`) — what the archive contains
+
+`just bench-pack` writes `results-<date>.tar.xz`. Its manifest is produced by
+[`runner/pack-filelist.sh`](runner/pack-filelist.sh) — one script, so the
+archive and its regression test can never disagree:
+
+| Included (by extension, anywhere under `results/`) | Why |
+|---|---|
+| `*.json` | k6 summaries (`*.k6.json`) and per-cell run metadata (`*.meta.json`) |
+| `*.csv` / `*.tsv` | container resource samples (`*.res.csv`) and host telemetry (`*.host.csv`) |
+| `*.md` | the generated `report.md`, plus every investigation verdict — `rl-prod-summary.md`, `sdk-report.md`, targeted-run write-ups |
+| `*.log` / `*.txt` | investigation captures — `nsenter.log` socket snapshots, `h5-revocation.log`, docker-log excerpts |
+
+Excluded by construction (pruned, not filtered afterwards):
+
+- `results/dry-run/**` — a dry run writes real-*looking* artifacts for
+  five-second unsettled windows. They are diagnostics, never measurements.
+- anything matching `*seed*` — client secrets and the bench user's password.
+  These normally live in `.seed/` (outside `results/` entirely); the prune also
+  covers the legacy `results/<target>.seed.env` path `run-benchmark.sh` still
+  honours.
+
+The include list is by extension on purpose. Run 5 shipped an archive that
+dropped every investigation artifact because the list named five exact
+filenames and could not anticipate the sixth (J13). Matching extensions means
+the *next* investigation's artifact is packed by default rather than found
+missing after the fact.
+
+```bash
+just bench-pack-selftest   # hermetic; no docker, no k6. Asserts both directions.
+```
+
+The self-test builds a fixture tree carrying one of every run-5 artifact shape,
+runs the real selection script over it, and fails if an investigation artifact
+is missing *or* if a dry-run/seed path survives. After packing, `bench-pack`
+additionally re-scans the finished archive for `SECRET`/`PASSWORD` content
+(ignoring the `"<redacted>"` key names `axiam_env` legitimately records).
+
 ## Status of components
 
 | Component                         | State                                                        |

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -179,6 +179,17 @@ bench-up:
         export BENCH_AXIAM_COOKIE_SECURE="${BENCH_AXIAM_COOKIE_SECURE:-false}"
         echo "[bench-up] p0-plaintext: AXIAM__AUTH__COOKIE_SECURE=${BENCH_AXIAM_COOKIE_SECURE} (k6's jar cannot replay Secure cookies over http://)"
       fi
+      # J9/E1: RUST_LOG is what decides whether the server emits the
+      # `axiam::perf` stage-timing events an investigation pass reads. It is
+      # already wired through targets/axiam/docker-compose.yml, but run 5's I5
+      # pass still produced empty logs because the variable was exported for
+      # `bench-run` — long after `bench-up` had baked the container's
+      # environment (PRIVATE_BENCH_ANALYSIS.md §2.6). Setting it here, loudly,
+      # makes the value that actually lands in the container part of the
+      # bring-up record; run-benchmark.sh's BENCH_REQUIRE_ENV preflight then
+      # verifies it off `docker inspect` before spending any k6 time.
+      export RUST_LOG="${RUST_LOG:-axiam=warn}"
+      echo "[bench-up] RUST_LOG=$RUST_LOG (stage timings need axiam=debug — set it HERE, on bench-up, not on bench-run)"
       # Default the prebuilt image tag to the workspace version so it tracks
       # releases automatically (override with BENCH_AXIAM_IMAGE).
       if [ -z "${BENCH_AXIAM_IMAGE:-}" ]; then
@@ -752,26 +763,22 @@ sdk-bench-test *languages:
 bench-clean:
     find results -type f ! -name '.gitkeep' -delete || true
 
-# Package shareable results into results-<date>.tar.xz. Only k6 summaries,
-# resource/host CSVs, run metadata, and the generated report are included —
-# NOT .seed/ (client secrets, bench user password), which report.py and this
+# Package shareable results into results-<date>.tar.xz. k6 summaries,
+# resource/host CSVs, run metadata, the generated report AND every
+# investigation artifact (*.md / *.log / *.tsv / *.txt) are included — NOT
+# .seed/ (client secrets, bench user password), which report.py and this
 # recipe never read from and which `git` never sees (see .gitignore / A7 in
-# claude_dev/benchmark-improvement-plan.md). Verifies the archive is clean
-# before leaving it on disk.
+# claude_dev/benchmark-improvement-plan.md). The selection lives in
+# runner/pack-filelist.sh so `bench-pack-selftest` can exercise exactly this
+# logic rather than a re-implementation of it (J13/E2). Verifies the archive
+# is clean before leaving it on disk.
 bench-pack:
     #!/usr/bin/env bash
     set -euo pipefail
     OUT="results-$(date +%Y-%m-%d).tar.xz"
     FILELIST="$(mktemp)"
     trap 'rm -f "$FILELIST"' EXIT
-    # -path results/dry-run -prune: a dry run writes real-looking artifacts
-    # (k6 summaries, res/host CSVs, meta.json) for 5-second unsettled windows.
-    # They are diagnostics, never measurements, so they must not reach a shared
-    # archive — meta.json carries "dry_run": true, but pruning the whole subtree
-    # is the guarantee that does not depend on anyone reading that field.
-    find results -path results/dry-run -prune -o \
-      \( -name '*.k6.json' -o -name '*.res.csv' -o -name '*.host.csv' \
-      -o -name '*.meta.json' -o -name 'report.md' \) -type f -print > "$FILELIST"
+    bash runner/pack-filelist.sh results > "$FILELIST"
     if [ ! -s "$FILELIST" ]; then
       echo "[bench-pack] nothing to pack — run a benchmark + 'just bench-report' first" >&2
       exit 1
@@ -797,3 +804,10 @@ bench-pack:
       exit 1
     fi
     echo "[bench-pack] OK — $OUT contains no secret material."
+
+# J13/E2 regression guard for the bench-pack manifest: builds a fixture
+# results tree carrying one of every artifact shape run 5 produced, runs the
+# REAL selection logic over it, and asserts both directions. Hermetic (no
+# docker, no k6) — CI runs the same script on every PR.
+bench-pack-selftest:
+    bash runner/pack-selftest.sh

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -766,9 +766,26 @@ sdk-bench-all:
         BENCH_RESULTS_DIR="$PASS_DIR" bash sdk/run-all.sh
         PASS_DIRS+=("$PASS_DIR")
       done
-      python3 sdk/median.py --runs "${PASS_DIRS[@]}" --out "$RESULTS_ROOT"
+      # J8: median.py exits non-zero when any language merged fewer than
+      # $REPEAT passes — run 5 shipped a C# "median of 2" against repeat=3 and
+      # nobody noticed until analysis. The merged records and the report are
+      # still written (the exit code is the LAST thing it does), so collect.py
+      # below still runs and the operator still gets the numbers; what changes
+      # is that the shell's exit status, and the SDK_BENCH_MEDIAN_INCOMPLETE
+      # banner, make the gap impossible to scroll past. Set
+      # SDK_BENCH_ALLOW_PARTIAL=1 to accept it deliberately.
+      MEDIAN_RC=0
+      if [ "${SDK_BENCH_ALLOW_PARTIAL:-0}" = "1" ]; then
+        python3 sdk/median.py --runs "${PASS_DIRS[@]}" --out "$RESULTS_ROOT" --allow-partial
+      else
+        python3 sdk/median.py --runs "${PASS_DIRS[@]}" --out "$RESULTS_ROOT" || MEDIAN_RC=$?
+      fi
     fi
     python3 sdk/collect.py --results "$RESULTS_ROOT"
+    if [ "${MEDIAN_RC:-0}" != "0" ]; then
+      echo "[sdk-bench-all] SDK_BENCH_MEDIAN_INCOMPLETE: at least one language merged fewer passes than repeat={{repeat}} — see the [median] lines above and each record's passes_missing. The report above is still valid data; it is just built on fewer passes than requested." >&2
+      exit "$MEDIAN_RC"
+    fi
 
 # Verify every language bench presents its p3-mtls client certificate
 # (CONTRACT.md §6.1) — no AXIAM stack, no seed, no containers required: the

--- a/benchmarks/justfile
+++ b/benchmarks/justfile
@@ -68,6 +68,8 @@ repeat := "3"
 # the whole target x profile matrix. See runner/run-benchmark.sh's `--dry-run`
 # block for the exact knobs (BENCH_DRY_VUS / BENCH_DRY_DURATION / ...).
 dry := "0"
+# E3: fixture-size multiplier for `bench-bulk-seed` (see that recipe).
+scale := "10"
 
 # Generate throwaway TLS/mTLS certs for the security profiles (idempotent).
 bench-certs:
@@ -414,6 +416,28 @@ bench-seed:
     else
       bash runner/seed.sh {{target}}
     fi
+
+# E3/J12: inflate the seeded AXIAM fixture to N x scale for the seed-size
+# sensitivity cell. Requires the stack up and `bench-seed` done. Writes rows
+# straight into SurrealDB in batched transactions (the REST path is fine for
+# the functional fixture and hopeless for 100 000 users), leaves the seeded
+# benchuser/bench-resource/bench-reader objects untouched so before/after
+# numbers compare the same logical query against a bigger index, and records
+# the resulting scale in .seed/axiam.bulk.env → every cell's meta.json.
+#
+#   just scale=10 bench-bulk-seed          # 10 000 users, 2 000 resources
+#   just scale=100 bench-bulk-seed         # the 100x cell
+#   just bench-bulk-verify                 # row counts only, no writes
+#
+# Knobs (env): BENCH_SEED_USERS/RESOURCES/ROLES (per-tenant bases before the
+# multiplier), BENCH_SEED_TENANTS (extra tenants), BENCH_SEED_DEPTH,
+# BENCH_SEED_DENY_RATIO, BENCH_SEED_BATCH.
+bench-bulk-seed:
+    bash runner/bulk-seed.sh --scale {{scale}}
+
+# Row counts for the tables the bulk seed touches — no writes.
+bench-bulk-verify:
+    bash runner/bulk-seed.sh --verify-only
 
 # Run the scenario suite (load + resource sampling) for a target/profile.
 # G2/H1: run-benchmark.sh gates its first cell behind a post-seed settle check

--- a/benchmarks/runner/bulk-seed.py
+++ b/benchmarks/runner/bulk-seed.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Emit SurrealQL that inflates an already-seeded AXIAM bench fixture to N x scale.
+
+Why this exists (E3 / J12)
+--------------------------
+The run-5 matrix measured a fixture of ~1 tenant, ~2 users, 1 resource and ~100
+registry permissions. Every authz number in the report is therefore a number for
+a *tiny* dataset, and the honest question a reader asks -- "does the 12 k/s
+check path hold when the tenant has 100 000 users and a four-deep resource
+tree?" -- has no answer in the archive. The seed-size sensitivity cell needs a
+10x (or 100x) fixture, and it needs it in minutes, not hours.
+
+`runner/seed.sh` provisions through the REST API, which is correct for the
+*functional* fixture (it exercises the same handlers a real operator would) and
+hopeless for volume: one HTTP round trip, one Argon2id hash and several indexed
+writes per user, times 100 000.
+
+So this generator writes SurrealQL directly, in transactions of
+`--batch` statements, to be piped into the datastore. It is a *load-test data
+generator*, not a provisioning tool, and the difference is deliberate:
+
+  * **Bulk users cannot authenticate, by construction.** Their `password_hash`
+    is the literal sentinel below -- not an Argon2id encoded hash at all, so
+    verification fails to parse and the login is denied. Generating real hashes
+    would mean either 100 000 Argon2id runs (defeating the point) or one shared
+    hash for a known password (a fixture that ships a usable credential for
+    every synthetic account, which is not a thing to leave lying in a
+    datastore). Volume is the goal; authentication is not.
+  * **The functional fixture is never touched.** `runner/seed.sh`'s
+    `benchuser` / `bench-resource` / `bench-reader` objects keep their ids, so
+    an authz cell run against a 10x fixture measures the SAME logical query
+    against a bigger index -- which is the only way the before/after comparison
+    means anything.
+  * **Deterministic ids.** Every generated record's UUID is derived from
+    (entity kind, index), so re-running is an UPSERT no-op rather than a second
+    100 000 records, and a scenario can address the bulk set without reading it
+    back.
+
+Usage:
+    bulk-seed.py --tenant-id <uuid> [--scale 10] [...] > bulk.surql
+
+The companion `bulk-seed.sh` pipes this into the running SurrealDB container
+and reports timings and row counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+# Not an Argon2id encoded hash: `$argon2id$...` is the only shape the verifier
+# accepts, so this fails to parse and every login against a bulk user is denied
+# before any password comparison happens. Written in full words so that anyone
+# who greps a datastore dump and finds it knows immediately what it is.
+NON_AUTHENTICATABLE = "!axiam-bulk-seed-fixture-not-authenticatable!"
+
+# UUID namespaces per entity kind. Each is a syntactically valid UUIDv4
+# (version nibble 4, variant nibble 8) whose last 12 hex digits are the record
+# index, so ids are stable across runs and trivially recognisable in a dump as
+# generated rather than organic.
+NS = {
+    "tenant": "be000001",
+    "user": "be000002",
+    "role": "be000003",
+    "resource": "be000004",
+    "permission": "be000005",
+    "group": "be000006",
+    # Edge tables get namespaces too. `RELATE` always creates a NEW edge, so a
+    # re-run would either duplicate `child_of` or violate the UNIQUE(in,out)
+    # indexes on `has_role`/`grants` and abort the transaction. Addressing each
+    # edge by a deterministic id and UPSERTing it makes the whole load
+    # re-runnable, which matters because a bulk seed is exactly the thing an
+    # operator interrupts halfway and restarts.
+    "e_has_tenant": "bf000001",
+    "e_child_of": "bf000002",
+    "e_grants": "bf000003",
+    "e_has_role": "bf000004",
+}
+
+
+def rid(kind: str, index: int) -> str:
+    """Deterministic, valid UUID for the index-th record of `kind`."""
+    return f"{NS[kind]}-0000-4000-8000-{index:012x}"
+
+
+def esc(s: str) -> str:
+    """Escape a Python string for a single-quoted SurrealQL string literal."""
+    return s.replace("\\", "\\\\").replace("'", "\\'")
+
+
+class Batcher:
+    """Emits statements wrapped in BEGIN/COMMIT transactions of `size`.
+
+    One transaction per 1 000 records (the default) is the point of the whole
+    exercise: SurrealDB commits each bare statement individually otherwise, and
+    the fsync-per-statement cost is what makes a naive bulk load take hours.
+    Batching too aggressively is the opposite failure -- a single 100 000
+    statement transaction holds locks for its whole duration and can exhaust
+    memory -- so the size stays a knob with a sane default.
+    """
+
+    def __init__(self, out, size: int) -> None:
+        self.out = out
+        self.size = size
+        self.n = 0
+        self.open = False
+        self.total = 0
+
+    def add(self, stmt: str) -> None:
+        if not self.open:
+            self.out.write("BEGIN TRANSACTION;\n")
+            self.open = True
+            self.n = 0
+        self.out.write(stmt + "\n")
+        self.n += 1
+        self.total += 1
+        if self.n >= self.size:
+            self.flush()
+
+    def flush(self) -> None:
+        if self.open:
+            self.out.write("COMMIT TRANSACTION;\n")
+            self.open = False
+            self.n = 0
+
+
+def emit_tenants(b: Batcher, org_id: str, base_tenant: str, count: int) -> list[str]:
+    """Extra tenants alongside the seeded one. Returns every tenant id in play.
+
+    Multi-tenancy is the dimension a single-tenant fixture cannot measure at
+    all: every hot authz query filters on `tenant_id`, so an index holding one
+    tenant's rows and an index holding fifty tenants' rows are different
+    physical objects even at the same total row count.
+    """
+    ids = [base_tenant]
+    for i in range(count):
+        tid = rid("tenant", i)
+        ids.append(tid)
+        b.add(
+            f"UPSERT tenant:`{tid}` SET "
+            f"organization_id = '{esc(org_id)}', "
+            f"name = 'Bulk Tenant {i}', "
+            f"slug = 'bulk-t{i}', "
+            f"status = 'Active', "
+            f"settings = {{}};"
+        )
+        eid = rid("e_has_tenant", i)
+        b.add(
+            f"UPSERT has_tenant:`{eid}` SET "
+            f"in = organization:`{esc(org_id)}`, out = tenant:`{tid}`;"
+        )
+    return ids
+
+
+def emit_users(b: Batcher, tenant_id: str, offset: int, count: int) -> None:
+    for i in range(count):
+        idx = offset + i
+        uid = rid("user", idx)
+        b.add(
+            f"UPSERT user:`{uid}` SET "
+            f"tenant_id = '{esc(tenant_id)}', "
+            f"username = 'bulk-u{idx}', "
+            f"email = 'bulk-u{idx}@bulk.invalid', "
+            f"password_hash = '{esc(NON_AUTHENTICATABLE)}', "
+            f"status = 'Active', "
+            f"mfa_enabled = false, "
+            f"failed_login_attempts = 0, "
+            f"metadata = {{ bulk_seed: true }};"
+        )
+
+
+def emit_resource_tree(
+    b: Batcher, tenant_id: str, offset: int, count: int, depth: int, fanout: int
+) -> list[str]:
+    """A `depth`-deep tree of `count` resources. Returns the generated ids.
+
+    Depth matters more than count for the authz engine: a check against a leaf
+    walks its ancestor chain, so a flat 10 000-resource fixture exercises the
+    hierarchy code exactly as hard as a 1-resource one (i.e. not at all). Both
+    `parent_id` and the `child_of` edge are written because the repository
+    layer maintains both and different queries read different ones -- a fixture
+    that set only one would make some queries fast for the wrong reason.
+    """
+    ids: list[str] = []
+    # Size the root level so that growing by `fanout` for `depth` levels lands
+    # on roughly `count` nodes: count / (1 + f + f^2 + ... + f^(depth-1)).
+    # Getting this wrong in the obvious direction (too many roots) produces a
+    # wide, shallow tree that looks like the requested size and exercises none
+    # of the ancestor-walk code the cell exists to stress.
+    widths = [fanout ** level for level in range(depth)]
+    roots = max(1, count // max(1, sum(widths)))
+    prev_level: list[str] = []
+    made = 0
+    for level in range(depth):
+        if made >= count:
+            break
+        want = roots if level == 0 else len(prev_level) * fanout
+        want = max(1, min(want, count - made))
+        this_level: list[str] = []
+        for i in range(want):
+            idx = offset + made + i
+            rrid = rid("resource", idx)
+            this_level.append(rrid)
+            ids.append(rrid)
+            if level == 0:
+                b.add(
+                    f"UPSERT resource:`{rrid}` SET "
+                    f"tenant_id = '{esc(tenant_id)}', "
+                    f"name = 'bulk-res-{idx}', "
+                    f"resource_type = 'bulk', "
+                    f"parent_id = NONE, "
+                    f"metadata = {{ bulk_seed: true, depth: {level} }};"
+                )
+            else:
+                parent = prev_level[i % len(prev_level)]
+                b.add(
+                    f"UPSERT resource:`{rrid}` SET "
+                    f"tenant_id = '{esc(tenant_id)}', "
+                    f"name = 'bulk-res-{idx}', "
+                    f"resource_type = 'bulk', "
+                    f"parent_id = '{parent}', "
+                    f"metadata = {{ bulk_seed: true, depth: {level} }};"
+                )
+                eid = rid("e_child_of", idx)
+                b.add(
+                    f"UPSERT child_of:`{eid}` SET "
+                    f"in = resource:`{rrid}`, out = resource:`{parent}`;"
+                )
+        made += want
+        prev_level = this_level
+    # The geometric sizing leaves a remainder when count is not a clean
+    # multiple; hang it off the deepest level so the requested count is met
+    # exactly rather than approximately.
+    while made < count and prev_level:
+        idx = offset + made
+        rrid = rid("resource", idx)
+        parent = prev_level[made % len(prev_level)]
+        ids.append(rrid)
+        b.add(
+            f"UPSERT resource:`{rrid}` SET "
+            f"tenant_id = '{esc(tenant_id)}', "
+            f"name = 'bulk-res-{idx}', "
+            f"resource_type = 'bulk', "
+            f"parent_id = '{parent}', "
+            f"metadata = {{ bulk_seed: true, depth: {depth} }};"
+        )
+        b.add(
+            f"UPSERT child_of:`{rid('e_child_of', idx)}` SET "
+            f"in = resource:`{rrid}`, out = resource:`{parent}`;"
+        )
+        made += 1
+    return ids
+
+
+def emit_roles_and_grants(
+    b: Batcher,
+    tenant_id: str,
+    offset: int,
+    count: int,
+    resources: list[str],
+    users_offset: int,
+    users_count: int,
+    deny_ratio: float,
+) -> None:
+    """Roles, their permission grants, and role assignments onto the tree.
+
+    `deny_ratio` writes a proportion of the grants as `effect = 'deny'`. This
+    is not decoration: B1's deny-override path only runs its second indexed
+    query for tenants that actually hold deny rules, so a fixture with zero
+    denies measures the cheap path exclusively and would let a deny-path
+    regression ship unmeasured.
+    """
+    if not resources:
+        return
+    for i in range(count):
+        idx = offset + i
+        role_id = rid("role", idx)
+        perm_id = rid("permission", idx)
+        b.add(
+            f"UPSERT role:`{role_id}` SET "
+            f"tenant_id = '{esc(tenant_id)}', "
+            f"name = 'bulk-role-{idx}', "
+            f"description = 'Bulk seed role', "
+            f"is_global = false;"
+        )
+        b.add(
+            f"UPSERT permission:`{perm_id}` SET "
+            f"tenant_id = '{esc(tenant_id)}', "
+            f"action = 'bulk:act{idx}', "
+            f"description = 'Bulk seed permission';"
+        )
+        effect = "deny" if (deny_ratio > 0 and (i % max(1, int(1 / deny_ratio))) == 0) else "allow"
+        b.add(
+            f"UPSERT grants:`{rid('e_grants', idx)}` SET "
+            f"in = role:`{role_id}`, out = permission:`{perm_id}`, "
+            f"scope_ids = NONE, effect = '{effect}';"
+        )
+        # Assign the role to a user, scoped to a resource in the tree. Spread
+        # across the tree rather than all on one node so ancestor walks differ
+        # in length between checks, as they do in a real deployment.
+        if users_count > 0:
+            uid = rid("user", users_offset + (i % users_count))
+            res = resources[i % len(resources)]
+            b.add(
+                f"UPSERT has_role:`{rid('e_has_role', idx)}` SET "
+                f"in = user:`{uid}`, out = role:`{role_id}`, "
+                f"resource_id = '{res}';"
+            )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--tenant-id", required=True,
+                   help="the seeded tenant (BENCH_TENANT_ID) the bulk rows join")
+    p.add_argument("--org-id", default="",
+                   help="the seeded organization (BENCH_ORG_ID); required when --tenants > 0")
+    p.add_argument("--scale", type=int, default=10,
+                   help="multiplier applied to every base count (default 10)")
+    p.add_argument("--users", type=int, default=1000,
+                   help="base users per tenant, before --scale (default 1000)")
+    p.add_argument("--resources", type=int, default=200,
+                   help="base resources per tenant, before --scale (default 200)")
+    p.add_argument("--roles", type=int, default=50,
+                   help="base roles per tenant, before --scale (default 50)")
+    p.add_argument("--tenants", type=int, default=0,
+                   help="EXTRA tenants beyond the seeded one (default 0; not scaled)")
+    p.add_argument("--depth", type=int, default=4,
+                   help="resource-tree depth (default 4)")
+    p.add_argument("--fanout", type=int, default=6,
+                   help="children per resource node (default 6)")
+    p.add_argument("--deny-ratio", type=float, default=0.05,
+                   help="fraction of grants written as effect='deny' (default 0.05); "
+                        "0 disables, which measures ONLY B1's cheap no-denies path")
+    p.add_argument("--batch", type=int, default=1000,
+                   help="statements per BEGIN/COMMIT transaction (default 1000)")
+    args = p.parse_args()
+
+    if args.tenants > 0 and not args.org_id:
+        print("bulk-seed: --org-id is required when --tenants > 0", file=sys.stderr)
+        return 2
+    if args.scale < 1:
+        print("bulk-seed: --scale must be >= 1", file=sys.stderr)
+        return 2
+
+    users = args.users * args.scale
+    resources = args.resources * args.scale
+    roles = args.roles * args.scale
+
+    b = Batcher(sys.stdout, args.batch)
+    tenants = emit_tenants(b, args.org_id, args.tenant_id, args.tenants)
+
+    # Offsets keep every tenant's records in a disjoint id range, so a re-run
+    # with a different --tenants count does not renumber (and thus duplicate)
+    # an existing tenant's rows.
+    for t_index, tid in enumerate(tenants):
+        u_off = t_index * users
+        r_off = t_index * resources
+        ro_off = t_index * roles
+        emit_users(b, tid, u_off, users)
+        res_ids = emit_resource_tree(b, tid, r_off, resources, args.depth, args.fanout)
+        emit_roles_and_grants(b, tid, ro_off, roles, res_ids, u_off, users, args.deny_ratio)
+
+    b.flush()
+
+    print(
+        f"-- bulk-seed: {b.total} statements across {len(tenants)} tenant(s): "
+        f"{users} users, {resources} resources (depth {args.depth}, fanout {args.fanout}), "
+        f"{roles} roles/permissions/grants each; deny_ratio={args.deny_ratio}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/runner/bulk-seed.sh
+++ b/benchmarks/runner/bulk-seed.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# bulk-seed.sh — inflate the seeded AXIAM bench fixture to N x scale (E3 / J12).
+#
+# Prerequisites: the axiam stack is up (`just target=axiam ... bench-up`) and
+# `just target=axiam bench-seed` has completed, so .seed/axiam.seed.env carries
+# the tenant/org the bulk rows attach to.
+#
+# The generated SurrealQL goes straight into the datastore's own CLI inside the
+# container. SurrealDB is deliberately NOT port-published by the bench compose
+# file (targets/axiam/docker-compose.yml), so `docker exec` is the access path
+# — and using the container's `/surreal` client rather than an HTTP POST means
+# the load speaks the same protocol version as the server it is loading.
+#
+# Usage:
+#   runner/bulk-seed.sh [--scale N] [--verify-only] [-- <bulk-seed.py args>]
+#
+# Env knobs (all optional):
+#   BENCH_SEED_SCALE     multiplier, default 10
+#   BENCH_SEED_USERS     base users per tenant, default 1000
+#   BENCH_SEED_RESOURCES base resources per tenant, default 200
+#   BENCH_SEED_ROLES     base roles per tenant, default 50
+#   BENCH_SEED_TENANTS   extra tenants, default 0
+#   BENCH_SEED_DEPTH     resource-tree depth, default 4
+#   BENCH_SEED_DENY_RATIO fraction of grants written as deny, default 0.05
+#   BENCH_SEED_BATCH     statements per transaction, default 1000
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BENCH="$(cd "$HERE/.." && pwd)"
+SEED_DIR="${BENCH_SEED_DIR:-$BENCH/.seed}"
+SEED_ENV="$SEED_DIR/axiam.seed.env"
+RESULTS="${BENCH_RESULTS_DIR:-$BENCH/results}"
+DB_CONTAINER="${BENCH_DB_CONTAINER:-bench-axiam-surrealdb}"
+
+VERIFY_ONLY=0
+EXTRA=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --scale) BENCH_SEED_SCALE="$2"; shift 2 ;;
+    --verify-only) VERIFY_ONLY=1; shift ;;
+    --) shift; EXTRA=("$@"); break ;;
+    *) echo "[bulk-seed] unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+SCALE="${BENCH_SEED_SCALE:-10}"
+USERS="${BENCH_SEED_USERS:-1000}"
+RESOURCES="${BENCH_SEED_RESOURCES:-200}"
+ROLES="${BENCH_SEED_ROLES:-50}"
+TENANTS="${BENCH_SEED_TENANTS:-0}"
+DEPTH="${BENCH_SEED_DEPTH:-4}"
+DENY_RATIO="${BENCH_SEED_DENY_RATIO:-0.05}"
+BATCH="${BENCH_SEED_BATCH:-1000}"
+
+[ -f "$SEED_ENV" ] || {
+  echo "[bulk-seed] $SEED_ENV not found — run 'just target=axiam bench-seed' first." >&2
+  exit 1
+}
+# shellcheck disable=SC1090
+source "$SEED_ENV"
+[ -n "${BENCH_TENANT_ID:-}" ] || { echo "[bulk-seed] BENCH_TENANT_ID is empty in $SEED_ENV" >&2; exit 1; }
+
+docker inspect "$DB_CONTAINER" >/dev/null 2>&1 || {
+  echo "[bulk-seed] container $DB_CONTAINER is not running — bring the stack up first." >&2
+  exit 1
+}
+
+# The datastore credentials the compose file gave the container. Read them back
+# off `docker inspect` rather than trusting this shell, for the same reason
+# run-benchmark.sh does: what ACTUALLY ran is the only reliable source.
+db_env() { docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$DB_CONTAINER" 2>/dev/null | sed -n "s/^$1=//p" | head -1; }
+DB_USER="${AXIAM__DB__USERNAME:-$(db_env SURREAL_USER)}"
+DB_PASS="${AXIAM__DB__PASSWORD:-$(db_env SURREAL_PASS)}"
+DB_NS="${AXIAM__DB__NAMESPACE:-axiam}"
+DB_DB="${AXIAM__DB__DATABASE:-axiam}"
+if [ -z "$DB_USER" ] || [ -z "$DB_PASS" ]; then
+  # The bench compose passes them on the command line, not the environment.
+  CMDLINE="$(docker inspect -f '{{json .Config.Cmd}}' "$DB_CONTAINER" 2>/dev/null || echo '[]')"
+  DB_USER="${DB_USER:-$(printf '%s' "$CMDLINE" | python3 -c 'import json,sys; a=json.load(sys.stdin); print(a[a.index("--user")+1] if "--user" in a else "")')}"
+  DB_PASS="${DB_PASS:-$(printf '%s' "$CMDLINE" | python3 -c 'import json,sys; a=json.load(sys.stdin); print(a[a.index("--pass")+1] if "--pass" in a else "")')}"
+fi
+[ -n "$DB_USER" ] && [ -n "$DB_PASS" ] || {
+  echo "[bulk-seed] could not determine datastore credentials — export AXIAM__DB__USERNAME/PASSWORD." >&2
+  exit 1
+}
+
+# One `surreal sql` invocation, reading SurrealQL on stdin.
+sql() {
+  docker exec -i "$DB_CONTAINER" /surreal sql \
+    --endpoint http://localhost:8000 \
+    --username "$DB_USER" --password "$DB_PASS" \
+    --namespace "$DB_NS" --database "$DB_DB" \
+    --hide-welcome "$@"
+}
+
+# Row counts for the tables the load touches. Printed before and after so the
+# operator sees the delta rather than a claim about it — the same "publish the
+# receipts" rule the benchmark docs apply to throughput numbers.
+counts() {
+  printf 'SELECT count() FROM user GROUP ALL;
+SELECT count() FROM resource GROUP ALL;
+SELECT count() FROM role GROUP ALL;
+SELECT count() FROM permission GROUP ALL;
+SELECT count() FROM grants GROUP ALL;
+SELECT count() FROM has_role GROUP ALL;
+SELECT count() FROM tenant GROUP ALL;
+' | sql 2>/dev/null | tr -d '\n' | sed 's/}\]\[/}] [/g'
+}
+
+echo "[bulk-seed] target tenant $BENCH_TENANT_ID in $DB_CONTAINER ($DB_NS/$DB_DB)"
+echo "[bulk-seed] BEFORE: $(counts)"
+
+if [ "$VERIFY_ONLY" = "1" ]; then
+  exit 0
+fi
+
+echo "[bulk-seed] scale=${SCALE}x -> $((USERS * SCALE)) users, $((RESOURCES * SCALE)) resources (depth $DEPTH), $((ROLES * SCALE)) roles per tenant; extra tenants=$TENANTS; batch=$BATCH"
+
+SQL_FILE="$(mktemp)"
+trap 'rm -f "$SQL_FILE"' EXIT
+python3 "$HERE/bulk-seed.py" \
+  --tenant-id "$BENCH_TENANT_ID" \
+  --org-id "${BENCH_ORG_ID:-}" \
+  --scale "$SCALE" \
+  --users "$USERS" \
+  --resources "$RESOURCES" \
+  --roles "$ROLES" \
+  --tenants "$TENANTS" \
+  --depth "$DEPTH" \
+  --deny-ratio "$DENY_RATIO" \
+  --batch "$BATCH" \
+  "${EXTRA[@]+"${EXTRA[@]}"}" > "$SQL_FILE"
+
+START="$(date +%s)"
+if ! sql < "$SQL_FILE" > "$RESULTS/bulk-seed.log" 2>&1; then
+  echo "[bulk-seed] FAILED — see $RESULTS/bulk-seed.log (last 20 lines):" >&2
+  tail -20 "$RESULTS/bulk-seed.log" >&2
+  exit 1
+fi
+# `surreal sql` exits 0 even when individual statements error, so the log is
+# the real verdict. A failed transaction reports its error inline.
+if grep -qiE '"?(error|Parse error|thrown)' "$RESULTS/bulk-seed.log"; then
+  echo "[bulk-seed] FAILED — the datastore reported errors (see $RESULTS/bulk-seed.log):" >&2
+  grep -iE '"?(error|Parse error|thrown)' "$RESULTS/bulk-seed.log" | head -10 >&2
+  exit 1
+fi
+ELAPSED=$(( $(date +%s) - START ))
+
+echo "[bulk-seed] loaded in ${ELAPSED}s"
+echo "[bulk-seed] AFTER:  $(counts)"
+
+# Record the fixture scale next to the seed env so run-benchmark.sh can put it
+# in each cell's metadata — a throughput number measured against a 10x fixture
+# is not comparable to one measured against the base fixture, and the archive
+# has to say which it was.
+{
+  echo "export BENCH_SEED_SCALE=$SCALE"
+  echo "export BENCH_SEED_USERS_TOTAL=$((USERS * SCALE))"
+  echo "export BENCH_SEED_RESOURCES_TOTAL=$((RESOURCES * SCALE))"
+  echo "export BENCH_SEED_ROLES_TOTAL=$((ROLES * SCALE))"
+  echo "export BENCH_SEED_TENANTS_EXTRA=$TENANTS"
+  echo "export BENCH_SEED_DEPTH=$DEPTH"
+  echo "export BENCH_SEED_DENY_RATIO=$DENY_RATIO"
+} > "$SEED_DIR/axiam.bulk.env"
+chmod 600 "$SEED_DIR/axiam.bulk.env"
+echo "[bulk-seed] wrote $SEED_DIR/axiam.bulk.env (sourced by run-benchmark.sh into cell metadata)"

--- a/benchmarks/runner/pack-filelist.sh
+++ b/benchmarks/runner/pack-filelist.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Print, one per line, every file under a results tree that `just bench-pack`
+# should place in a shareable archive.
+#
+# This lives in its own script rather than inline in the justfile for one
+# reason: `bench-pack-selftest` has to exercise the SAME selection logic the
+# real archive uses. Run 5 shipped an archive that silently dropped every
+# investigation artifact (J13 — see PRIVATE_BENCH_ANALYSIS.md §2.6); a
+# self-test that re-implemented the patterns would have agreed with the bug.
+#
+# Usage: pack-filelist.sh [results-dir]     (default: ./results)
+set -euo pipefail
+
+ROOT="${1:-results}"
+
+# Two prune arms, both exclusions by construction rather than by after-the-fact
+# scanning:
+#
+#   <root>/dry-run — a dry run writes real-LOOKING artifacts (k6 summaries,
+#   res/host CSVs, meta.json) for 5-second unsettled windows. They are
+#   diagnostics, never measurements, so they must never reach a shared archive.
+#   meta.json does carry "dry_run": true, but pruning the whole subtree is the
+#   guarantee that does not depend on anyone reading that field.
+#
+#   *seed* — seed material (client secrets, the bench user's password) normally
+#   lives in .seed/, outside the results tree entirely, so this find never
+#   reaches it. But run-benchmark.sh still honours a LEGACY seed env at
+#   <root>/<target>.seed.env, and the include list below is broad enough to
+#   match arbitrary new artifacts. Pruning by name keeps the legacy path out
+#   without relying on bench-pack's post-pack secret scan to catch it.
+#
+# The include list is deliberately by EXTENSION, not by filename. The J13
+# failure mode was an allow-list of five exact shapes (*.k6.json, *.res.csv,
+# *.host.csv, *.meta.json, report.md) that could not anticipate
+# `rl-prod-summary.md`, `h5-revocation.log`, `nsenter.log` or `sdk-report.md`.
+# Matching *.md / *.log / *.csv / *.json means the NEXT investigation's
+# artifact is packed by default instead of discovered missing afterwards.
+find "$ROOT" \
+  \( -path "$ROOT/dry-run" -o -name '*seed*' \) -prune -o \
+  \( -name '*.json' -o -name '*.csv' -o -name '*.md' -o -name '*.log' \
+  -o -name '*.txt' -o -name '*.tsv' \) -type f -print

--- a/benchmarks/runner/pack-selftest.sh
+++ b/benchmarks/runner/pack-selftest.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# J13/E2 regression guard for the `bench-pack` manifest.
+#
+# Builds a fixture results tree carrying one of every artifact shape run 5
+# produced, runs the REAL selection logic (pack-filelist.sh — not a
+# re-implementation of it, which would have agreed with the bug) over that
+# tree, and asserts both directions:
+#
+#   * every investigation artifact survives — run 5's shareable archive
+#     silently dropped `rl-prod-summary.md`, `sdk-report.md`, `nsenter.log`
+#     and `h5-revocation.log`, i.e. exactly the files carrying the verdicts
+#     (PRIVATE_BENCH_ANALYSIS.md §2.6);
+#   * nothing from `dry-run/` or a seed file does — a dry run's artifacts are
+#     diagnostics that must never be mistaken for measurements, and seed files
+#     hold client secrets.
+#
+# Hermetic: no docker, no k6, no seeded stack. Runs in CI on every PR.
+# Usage: pack-selftest.sh          (from benchmarks/)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+
+mkdir -p "$FIX/axiam/p2-tls13" "$FIX/dry-run/axiam/p2-tls13" "$FIX/section-12_4-B1"
+
+# --- must survive: the five shapes the old allow-list already handled ...
+: > "$FIX/axiam/p2-tls13/authz_check_rest.k6.json"
+: > "$FIX/axiam/p2-tls13/authz_check_rest.res.csv"
+: > "$FIX/axiam/p2-tls13/authz_check_rest.host.csv"
+: > "$FIX/axiam/p2-tls13/authz_check_rest.meta.json"
+: > "$FIX/report.md"
+# ... and the four J13 dropped in run 5.
+: > "$FIX/rl-prod-summary.md"
+: > "$FIX/sdk-report.md"
+: > "$FIX/section-12_4-B1/nsenter.log"
+: > "$FIX/section-12_4-B1/h5-revocation.log"
+
+# --- must NOT survive
+: > "$FIX/dry-run/axiam/p2-tls13/authz_check_rest.k6.json"
+: > "$FIX/dry-run/axiam/p2-tls13/authz_check_rest.meta.json"
+: > "$FIX/dry-run/SUMMARY.md"
+: > "$FIX/axiam.seed.env"
+: > "$FIX/axiam.seed.ok"
+
+LIST="$(bash "$HERE/pack-filelist.sh" "$FIX")"
+fail=0
+
+for want in rl-prod-summary.md sdk-report.md nsenter.log h5-revocation.log \
+            report.md authz_check_rest.k6.json authz_check_rest.res.csv \
+            authz_check_rest.host.csv authz_check_rest.meta.json; do
+  printf '%s\n' "$LIST" | grep -q "/$want\$" || {
+    echo "[pack-selftest] MISSING from the archive manifest: $want" >&2; fail=1; }
+done
+
+# Match on the path RELATIVE to the fixture root: $FIX is a mktemp path that
+# could itself contain either word, which would make this assertion fire on
+# the harness rather than on the manifest.
+REL="$(printf '%s\n' "$LIST" | sed "s|^$FIX/||")"
+for deny in dry-run seed; do
+  if printf '%s\n' "$REL" | grep -q -- "$deny"; then
+    echo "[pack-selftest] LEAKED into the archive manifest (matched '$deny'):" >&2
+    printf '%s\n' "$REL" | grep -- "$deny" >&2
+    fail=1
+  fi
+done
+
+[ "$fail" -eq 0 ] || { echo "[pack-selftest] FAILED" >&2; exit 1; }
+echo "[pack-selftest] OK — $(printf '%s\n' "$LIST" | wc -l | tr -d ' ') files selected; investigation artifacts kept, dry-run/seed excluded."

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -646,16 +646,30 @@ settle_gate() {
 # packed content for SECRET/PASSWORD, specifically so these legitimately-named
 # (and fully redacted) keys don't trip it — see the comment there.
 AXIAM_ENV_REDACT_RE='PASSWORD|SECRET|KEY|PEPPER|PEM|TOKEN'
+# J9/E1: the AXIAM__* prefix is not the whole story. `RUST_LOG` governs whether
+# the `axiam::perf` stage-timing events an investigation pass depends on are
+# emitted at all, and it carries NO prefix — so run 5's I5 pass recorded a
+# complete-looking `axiam_env` while the one variable the runbook needed was
+# silently absent from the container (PRIVATE_BENCH_ANALYSIS.md §2.6). Capture
+# these unprefixed runtime knobs alongside the AXIAM__* dump so their absence
+# is visible in the metadata rather than discovered after the k6 hours are
+# spent. Extend this list, not the prefix test, when a new one matters.
+AXIAM_ENV_EXTRA_KEYS='RUST_LOG RUST_BACKTRACE'
+axiam_env_extra_re() {
+  # "^(RUST_LOG|RUST_BACKTRACE)=" — built from the list so the two never drift.
+  printf '^(%s)=' "$(printf '%s' "$AXIAM_ENV_EXTRA_KEYS" | tr ' ' '|')"
+}
 axiam_env_json() {
   [ "$TARGET" = "axiam" ] || { echo -n "{}"; return; }
   command -v docker >/dev/null 2>&1 || { echo -n "{}"; return; }
-  local env_dump line k v first=1
+  local env_dump line k v first=1 extra_re
+  extra_re="$(axiam_env_extra_re)"
   env_dump="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "bench-${TARGET}-server" 2>/dev/null)" || { echo -n "{}"; return; }
   echo -n "{"
   while IFS= read -r line; do
     case "$line" in
       AXIAM__*=*) : ;;
-      *) continue ;;
+      *) printf '%s' "$line" | grep -qE "$extra_re" || continue ;;
     esac
     k="${line%%=*}"
     v="${line#*=}"
@@ -670,6 +684,67 @@ axiam_env_json() {
   done <<< "$env_dump"
   [ "$first" -eq 1 ] || echo
   echo -n "}"
+}
+
+# --- J9/E1: required-env preflight ------------------------------------------
+# BENCH_REQUIRE_ENV is a space-separated list of environment variable NAMES a
+# runbook pass declares it depends on (e.g. `BENCH_REQUIRE_ENV="RUST_LOG"` for
+# a stage-timing investigation). Every name is checked against what the server
+# container ACTUALLY received — `docker inspect`, the same source of truth
+# axiam_env_json() and detect_rl_posture() use — because the failure mode this
+# closes is precisely a variable that the invoking shell exported and the
+# container never saw. A container is created once by `bench-up`; exporting the
+# variable later, for `bench-run`, changes nothing.
+#
+# Empty (the default) means "assert nothing", so ordinary matrix runs are
+# unaffected. Names are matched exactly against the `NAME=` prefix, so a
+# variable present but set to the empty string still counts as absent — an
+# empty RUST_LOG emits no events, which is the condition being guarded.
+#
+# Populated by env_missing() and consumed by the meta.json writer, so every
+# cell records WHICH required names were missing, not just that something was.
+AXIAM_ENV_MISSING=""
+env_missing() {
+  # Echoes the space-separated subset of $1 that the server container lacks.
+  local want="$1" name miss="" env_dump
+  [ -n "$want" ] || { echo -n ""; return; }
+  command -v docker >/dev/null 2>&1 || { echo -n "$want"; return; }
+  env_dump="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "bench-${TARGET}-server" 2>/dev/null)" || { echo -n "$want"; return; }
+  for name in $want; do
+    printf '%s\n' "$env_dump" | grep -qE "^${name}=.+" || miss="${miss:+$miss }$name"
+  done
+  echo -n "$miss"
+}
+
+# JSON array of the missing names, for meta.json.
+env_missing_json() {
+  local n first=1
+  echo -n "["
+  for n in $AXIAM_ENV_MISSING; do
+    [ "$first" -eq 1 ] || echo -n ", "
+    first=0
+    printf '"%s"' "$(json_escape "$n")"
+  done
+  echo -n "]"
+}
+
+# Fails the run before any k6 time is spent (the I18 build_ref precedent).
+# BENCH_REQUIRE_ENV_SOFT=1 downgrades to a warning for an exploratory pass.
+require_env_preflight() {
+  local want="${BENCH_REQUIRE_ENV:-}"
+  [ -n "$want" ] || return 0
+  if [ "$TARGET" != "axiam" ]; then
+    echo "[run] WARN (J9/E1): BENCH_REQUIRE_ENV is set but target is '$TARGET' — the check inspects AXIAM's server container only; skipping." >&2
+    return 0
+  fi
+  AXIAM_ENV_MISSING="$(env_missing "$want")"
+  [ -n "$AXIAM_ENV_MISSING" ] || { echo "[run] env preflight OK — bench-${TARGET}-server carries all of: $want"; return 0; }
+  echo "[run] FATAL (J9/E1): bench-${TARGET}-server is missing required env: $AXIAM_ENV_MISSING" >&2
+  echo "[run]   The container's environment is fixed when 'bench-up' creates it — exporting the variable for 'bench-run' is too late." >&2
+  echo "[run]   Fix: RUST_LOG='axiam=debug' just target=$TARGET profile=$PROFILE bench-up   (then re-run this cell)" >&2
+  echo "[run]   Or set BENCH_REQUIRE_ENV_SOFT=1 to downgrade this to a warning." >&2
+  [ "${BENCH_REQUIRE_ENV_SOFT:-0}" = "1" ] || exit 1
+  echo "[run] WARN: BENCH_REQUIRE_ENV_SOFT=1 — proceeding with incomplete env; the cell's metadata records the gap." >&2
 }
 
 # Container names that make up each target's stack, with a role used to look
@@ -972,7 +1047,10 @@ run_one() {
   "settle_probe_thr": $SETTLE_PROBE_THR_USED,
   "cell_order_index": $cell_order_index,
   "dry_run": $([ "$DRY_RUN" = "1" ] && echo true || echo false),
-  "axiam_env": $(axiam_env_json)
+  "axiam_env": $(axiam_env_json),
+  "axiam_env_required": "$(json_escape "${BENCH_REQUIRE_ENV:-}")",
+  "axiam_env_missing": $(env_missing_json),
+  "axiam_env_complete": $([ -z "$AXIAM_ENV_MISSING" ] && echo true || echo false)
 }
 EOF
   echo "[run] wrote $k6sum, $rescsv, $hostcsv, $meta"
@@ -987,6 +1065,11 @@ EOF
 }
 
 SCENARIO_COUNT=${#SCENARIOS[@]}
+
+# J9/E1: assert the runbook-required container env BEFORE the settle gate and
+# the first cell — the whole point is to fail in seconds rather than after the
+# k6 hours that produced run 5's empty stage-timing logs.
+require_env_preflight
 
 # G2 item 1: gate the FIRST cell of this run behind the settle check (once —
 # not per cell; every cell in this run records the same settle_wait_secs /

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -136,6 +136,16 @@ else
   echo "[run] WARN: no seed env ($SEED_ENV) — scenarios needing a tenant/client may fail"
 fi
 
+# E3/J12: the fixture-scale record written by runner/bulk-seed.sh. A cell run
+# against a 10x fixture is NOT comparable to one run against the base fixture,
+# so the scale has to travel with the measurement rather than with whoever
+# remembers which command they ran. Absent file = base fixture (scale 1).
+BULK_ENV="$SEED_DIR/${TARGET}.bulk.env"
+if [ -f "$BULK_ENV" ]; then
+  source "$BULK_ENV"
+  echo "[run] fixture scale: ${BENCH_SEED_SCALE}x (${BENCH_SEED_USERS_TOTAL:-?} users, ${BENCH_SEED_RESOURCES_TOTAL:-?} resources, depth ${BENCH_SEED_DEPTH:-?}, deny_ratio ${BENCH_SEED_DENY_RATIO:-0}) — see runner/bulk-seed.sh"
+fi
+
 # Refuse to start the k6 matrix without a passing post-seed smoke check for this
 # target (runner/seed.sh writes results/<target>.seed.ok only after every
 # scenario-critical flow — ROPC/login, client_credentials, introspect, refresh,
@@ -1048,6 +1058,15 @@ run_one() {
   "cell_order_index": $cell_order_index,
   "dry_run": $([ "$DRY_RUN" = "1" ] && echo true || echo false),
   "axiam_env": $(axiam_env_json),
+  "seed_scale": ${BENCH_SEED_SCALE:-1},
+  "seed_fixture": {
+    "users_total": ${BENCH_SEED_USERS_TOTAL:-null},
+    "resources_total": ${BENCH_SEED_RESOURCES_TOTAL:-null},
+    "roles_total": ${BENCH_SEED_ROLES_TOTAL:-null},
+    "tenants_extra": ${BENCH_SEED_TENANTS_EXTRA:-0},
+    "resource_depth": ${BENCH_SEED_DEPTH:-null},
+    "deny_ratio": ${BENCH_SEED_DENY_RATIO:-0}
+  },
   "axiam_env_required": "$(json_escape "${BENCH_REQUIRE_ENV:-}")",
   "axiam_env_missing": $(env_missing_json),
   "axiam_env_complete": $([ -z "$AXIAM_ENV_MISSING" ] && echo true || echo false)

--- a/benchmarks/runner/run-benchmark.sh
+++ b/benchmarks/runner/run-benchmark.sh
@@ -1058,6 +1058,9 @@ run_one() {
   "cell_order_index": $cell_order_index,
   "dry_run": $([ "$DRY_RUN" = "1" ] && echo true || echo false),
   "axiam_env": $(axiam_env_json),
+  "connection_model": "$([ "${BENCH_NO_CONN_REUSE:-false}" = "true" ] && echo no-reuse || { [ "${BENCH_NO_VU_CONN_REUSE:-false}" = "true" ] && echo per-iteration-vu-pool || echo pooled-per-vu; })",
+  "no_connection_reuse": ${BENCH_NO_CONN_REUSE:-false},
+  "no_vu_connection_reuse": ${BENCH_NO_VU_CONN_REUSE:-false},
   "seed_scale": ${BENCH_SEED_SCALE:-1},
   "seed_fixture": {
     "users_total": ${BENCH_SEED_USERS_TOTAL:-null},

--- a/benchmarks/scenarios/lib/config.js
+++ b/benchmarks/scenarios/lib/config.js
@@ -66,6 +66,13 @@ export const cfg = {
   clientCert: str('BENCH_CLIENT_CERT', ''),
   clientKey: str('BENCH_CLIENT_KEY', ''),
 
+  // --- transport (J7) ---
+  // k6's two connection knobs, surfaced as env so the shape a run used is a
+  // deliberate, recorded choice rather than an inherited default nobody wrote
+  // down. See tlsOptions()/connectionModel() for why this exists.
+  noConnectionReuse: str('BENCH_NO_CONN_REUSE', 'false') === 'true',
+  noVUConnectionReuse: str('BENCH_NO_VU_CONN_REUSE', 'false') === 'true',
+
   // --- load model ---
   vus: num('BENCH_VUS', 50),
   warmup: str('BENCH_WARMUP', '30s'),
@@ -160,7 +167,36 @@ export function tlsOptions() {
       key: open(cfg.clientKey),
     }];
   }
+  // J7: state the connection model EXPLICITLY rather than inheriting k6's
+  // defaults silently.
+  //
+  // Run 5 published a TypeScript SDK row with NEGATIVE overhead — check/batch
+  // p95 21–23 ms *below* the k6 wire baseline measured on the same host. A
+  // client cannot beat the wire doing the same work, so one of the two was not
+  // doing the same work, and nothing in the archive recorded enough about the
+  // baseline's transport to say which. These two flags are k6's whole
+  // connection story, and writing them down here means the next run's
+  // metadata answers the question instead of re-opening it.
+  //
+  // Both default false, which is k6's default and the one that matches an SDK:
+  // connections are pooled and reused per VU across iterations, exactly as a
+  // long-lived SDK client pools them. Setting BENCH_NO_CONN_REUSE=true forces
+  // a fresh TCP (and TLS) handshake per request — a legitimate thing to
+  // measure, and a baseline that must never be compared against an SDK's
+  // pooled numbers.
+  o.noConnectionReuse = cfg.noConnectionReuse;
+  o.noVUConnectionReuse = cfg.noVUConnectionReuse;
   return o;
+}
+
+// J7: a short, stable descriptor of the transport shape this run used, written
+// into every cell's meta.json by run-benchmark.sh and read by sdk/collect.py,
+// which refuses to publish an SDK-vs-wire overhead column when the baseline's
+// model is not the pooled one an SDK client uses.
+export function connectionModel() {
+  if (cfg.noConnectionReuse) return 'no-reuse';
+  if (cfg.noVUConnectionReuse) return 'per-iteration-vu-pool';
+  return 'pooled-per-vu';
 }
 
 // k6 net/grpc `Client.connect(addr, params)` params for AXIAM's dedicated gRPC

--- a/benchmarks/sdk/HARNESS-SPEC.md
+++ b/benchmarks/sdk/HARNESS-SPEC.md
@@ -199,9 +199,80 @@ aggregator (`sdk/collect.py`) reads them and folds them into the main report's
   },
   "client_cpu_ms_total": 0,             // optional: CPU consumed by the client process
   "client_rss_mib_peak": 0,             // optional: peak client memory
+  "client_worker_threads": 0,           // optional (J8b): async-runtime worker count
+  "passes_requested": 3,                // written by median.py (J8)
+  "passes_present": 3,
+  "passes_ok": 3,
+  "passes_missing": [],
   "notes": ""
 }
 ```
+
+Each op record MAY additionally carry `cpu_ms` (client CPU consumed during
+that op's timed window) and `cpu_us_per_call` (the same divided by completed
+calls). Both are optional; `collect.py` ignores them when absent.
+
+### Attributing client CPU (J8b)
+
+Run 5 published a single `client_cpu_ms_total` per SDK and nothing else, which
+produced an observation nobody could act on: **Rust 23.4 s — highest of every
+compiled SDK, 7× Go's — alongside the best latency and throughput in the
+matrix.** Two things made that number unusable, and both are harness
+properties rather than SDK ones:
+
+1. **It was a function of the host.** A bench that builds its async runtime
+   with one worker per CPU reports more client CPU on a 32-core box than on a
+   4-core one for identical work, because idle workers spin briefly before
+   parking. Every bench must size its runtime/thread pool to
+   `SDK_BENCH_CONCURRENCY`, not to the machine, and publish the resulting
+   count as `client_worker_threads`.
+2. **It was one number for four ops.** `login` builds a fresh client per
+   iteration by contract (fresh TLS material, fresh connection); the other
+   three reuse a pooled one. Aggregating them hides which is expensive.
+   Per-op `cpu_ms` / `cpu_us_per_call` is what makes the next observation
+   actionable.
+
+Fix the measurement before suspecting the SDK. If a figure is still an outlier
+with the runtime pinned and per-op attribution in hand, the finding is real.
+
+### Comparing against the wire baseline (J7)
+
+`collect.py` subtracts the matching k6 scenario's p95 from the SDK's to give a
+"p95 overhead vs wire" column. Run 5 published **negative** overhead for
+TypeScript — check/batch p95 21–23 ms *below* the baseline measured on the
+same host against the same server. A client cannot beat the wire doing the
+same work, so one side was not doing the same work, and nothing in the archive
+recorded enough about the baseline to say which.
+
+The delta is now withheld unless the baseline is comparable:
+
+- every cell's `meta.json` records `connection_model`
+  (`pooled-per-vu` | `per-iteration-vu-pool` | `no-reuse`), driven by
+  `BENCH_NO_CONN_REUSE` / `BENCH_NO_VU_CONN_REUSE`. Only `pooled-per-vu`
+  matches how an SDK client holds connections;
+- a baseline from before this field existed is treated as *not established*,
+  not as fine;
+- a negative delta that survives the model check is rendered with a `⚠` and a
+  footnote, because the remaining asymmetry (response validation, payload
+  shape, or in-flight-vs-VU concurrency accounting) has not been ruled out.
+
+The overhead column shows `n/c` where a delta was withheld. Publishing an
+SDK-vs-wire claim requires that column to carry neither `n/c` nor `⚠`.
+
+### Median-of-N provenance (J8)
+
+`median.py` merges `repeat=N` passes. Run 5's C# row read "median of 2"
+against `repeat=3`, and nothing recorded which pass vanished or why — a pass
+that produces *no record at all* is invisible to a merger that only sees the
+records it received, so "2 of 2 ok" was both true and misleading.
+
+Merged records now carry `passes_requested` / `passes_present` / `passes_ok` /
+`passes_missing` (pass directory names, not counts), `median.py` exits
+non-zero when any language merged fewer passes than requested, and
+`sdk-bench-all` prints an `SDK_BENCH_MEDIAN_INCOMPLETE` banner. The report is
+still written either way — the numbers are valid data built on fewer passes —
+but the gap can no longer be scrolled past. `SDK_BENCH_ALLOW_PARTIAL=1`
+accepts it deliberately.
 
 `status: "pending"` (the current state of the five unwired scaffolds) means "SDK
 bench glue not yet wired"; the report lists these as not-yet-measured rather than

--- a/benchmarks/sdk/collect.py
+++ b/benchmarks/sdk/collect.py
@@ -55,17 +55,49 @@ def load_sdk_records(results):
     return recs
 
 
+# J7: the transport shape a wire baseline must have before its p95 can be
+# subtracted from an SDK's. Every SDK client in this harness pools connections
+# and reuses them across calls; a k6 baseline that handshakes per request is
+# measuring a different thing, and the resulting "overhead" is the difference
+# between two transports, not the cost of an SDK.
+COMPARABLE_CONNECTION_MODEL = "pooled-per-vu"
+
+
 def server_p95(results, target, profile, scenario):
-    """Best-effort lookup of a server scenario p95 to compute overhead."""
+    """Look up a server scenario p95, and say whether it is comparable.
+
+    Returns `(p95, reason_or_None)`. A non-None reason means the number exists
+    but must NOT be turned into an overhead delta.
+
+    Run 5 published TypeScript rows showing 21-23 ms of NEGATIVE overhead —
+    the SDK apparently beating the wire baseline measured on the same host and
+    the same server. That cannot happen if both sides are doing the same work,
+    so one of them was not, and the archive recorded nothing about the
+    baseline's transport that could settle it (J7). Rather than publish a
+    number that is either wrong or unexplainable, the overhead column now
+    renders as "n/c" with the reason, and the audit is what unblocks it.
+    """
     meta = os.path.join(results, target, profile, f"{scenario}.meta.json")
     if not os.path.exists(meta):
-        return None
+        return None, None
     m = json.load(open(meta))
     k6 = os.path.join(results, target, profile, m.get("k6_summary_file", ""))
     if not os.path.exists(k6):
-        return None
+        return None, None
     data = json.load(open(k6)).get("metrics", {}).get("bench_op_latency_ms", {})
-    return float(data.get("p(95)", 0) or 0) or None
+    p95 = float(data.get("p(95)", 0) or 0) or None
+    if p95 is None:
+        return None, None
+
+    # Pre-J7 archives have no connection_model field at all. Absent is not
+    # "fine" — it is exactly the state that made run 5 unexplainable — so it
+    # blocks the delta just as an incomparable model does.
+    model = m.get("connection_model")
+    if model is None:
+        return p95, "baseline predates the J7 connection-model record"
+    if model != COMPARABLE_CONNECTION_MODEL:
+        return p95, f"baseline transport is {model}, SDK clients pool"
+    return p95, None
 
 
 def md_table(headers, rows):
@@ -106,6 +138,7 @@ def build(results, recs):
             "often negative \"overhead\" deltas purely from the load-shape "
             "mismatch, not genuine SDK cost.", "",
         ]
+        incomparable = set()
         by_profile = defaultdict(list)
         for r in measured:
             by_profile[r.get("profile", "?")].append(r)
@@ -129,10 +162,27 @@ def build(results, recs):
                 conc = r.get("concurrency", 0)
                 target_rows = serial_rows if conc == 1 else concurrent_rows
                 for op, stats in r.get("ops", {}).items():
-                    sp95 = server_p95(results, r["target"], profile,
-                                      OP_TO_SCENARIO.get(op, ""))
+                    sp95, blocked = server_p95(results, r["target"], profile,
+                                               OP_TO_SCENARIO.get(op, ""))
                     wire = ("%.2f" % sp95) if sp95 else "—"
-                    overhead = ("%+.2f" % (stats["p95_ms"] - sp95)) if sp95 else "—"
+                    if not sp95:
+                        overhead = "—"
+                    elif blocked:
+                        overhead = "n/c"
+                        incomparable.add(blocked)
+                    else:
+                        delta = stats["p95_ms"] - sp95
+                        # J7: a negative delta is not an SDK achievement, it is
+                        # a comparability failure that survived the model
+                        # check. Flag it in place rather than letting a "-23 ms
+                        # overhead" cell read as a result.
+                        overhead = ("%+.2f" % delta) + (" ⚠" if delta < 0 else "")
+                        if delta < 0:
+                            incomparable.add(
+                                "a negative overhead was computed against a "
+                                "model-matched baseline — the remaining "
+                                "asymmetry is response validation, payload, or "
+                                "concurrency accounting (J7)")
                     target_rows.append([r["sdk"], op, str(conc), f"{stats['p50_ms']:.2f}",
                                         f"{stats['p95_ms']:.2f}", wire,
                                         f"{stats['throughput_rps']:.0f}",
@@ -141,6 +191,15 @@ def build(results, recs):
                        "wire p95(ms)", "thr(rps)", "errors", "p95 overhead vs wire(ms)"]
             if concurrent_rows:
                 lines += [md_table(headers, concurrent_rows), ""]
+            if incomparable:
+                lines += [
+                    "> **J7 — `n/c` / ⚠ in the overhead column.** An SDK-vs-wire "
+                    "delta is only meaningful when both sides use the same "
+                    "transport, validate the same responses and account "
+                    "concurrency the same way. Where that could not be "
+                    "established the delta is withheld rather than published:",
+                    "",
+                ] + [f">  - {why}" for why in sorted(incomparable)] + [""]
             if serial_rows:
                 lines += [
                     "#### conc=1 — serial benches "

--- a/benchmarks/sdk/cpp/bench.cpp
+++ b/benchmarks/sdk/cpp/bench.cpp
@@ -82,6 +82,12 @@ struct Config {
     std::optional<std::string> ca_pem;
     std::optional<std::string> client_cert_pem;
     std::optional<std::string> client_key_pem;
+    // D2: SDK_BENCH_CONCURRENCY has to reach the CLIENT, not just the worker
+    // loop. Run 5's cpp row (check p50 3.2 ms, p95 280 ms) was the shape of
+    // sixteen threads queueing inside one client, and a bench that spawns
+    // sixteen workers against a client permitting one in-flight request is
+    // measuring the queue, not the SDK.
+    int concurrency = 16;
     // Non-empty when a TLS input is unusable. build_ops() rethrows it inside
     // main()'s try, so it reaches the operator as the harness' contractual
     // status:"error" record — load_config() itself must not throw, because it
@@ -146,7 +152,11 @@ axiam::Client make_client(const Config& cfg) {
     axiam::Client::Builder b = axiam::Client::builder()
         .base_url(cfg.base_url)
         .tenant_slug(cfg.tenant_slug)
-        .org_slug(cfg.org_slug);
+        .org_slug(cfg.org_slug)
+        // D2: size the client's in-flight capacity to the bench's worker
+        // count. Applied to the per-iteration `login` client too — every
+        // construction site, so the two can never drift.
+        .max_concurrent_requests(static_cast<unsigned>(cfg.concurrency < 1 ? 1 : cfg.concurrency));
     if (cfg.ca_pem) b.with_custom_ca(*cfg.ca_pem);
     if (cfg.client_cert_pem && cfg.client_key_pem) {
         b.with_client_cert(*cfg.client_cert_pem, *cfg.client_key_pem);
@@ -418,10 +428,14 @@ void assert_refresh_hit_the_wire(const OpResult& refresh, int iterations) {
 }  // namespace
 
 int main() {
-    const Config cfg = load_config();
     const int iter = env_int("SDK_BENCH_ITERATIONS", 2000);
     const int warmup = env_int("SDK_BENCH_WARMUP", 200);
     const int conc = env_int("SDK_BENCH_CONCURRENCY", 16);
+
+    // D2: the client's in-flight capacity comes from the SAME value as the
+    // worker count, resolved before the client is built.
+    Config cfg = load_config();
+    cfg.concurrency = conc;
 
     std::vector<std::pair<std::string, OpFn>> ops_fns;
     try {

--- a/benchmarks/sdk/csharp/Program.cs
+++ b/benchmarks/sdk/csharp/Program.cs
@@ -251,17 +251,33 @@ async Task<Dictionary<string, object?>> TimeForcedRefreshOp()
         if (await OneForcedRefresh() is null) errors++;
     }
 
-    var sw = Stopwatch.StartNew();
     foreach (var _ in Enumerable.Range(0, ITER))
     {
         var ms = await OneForcedRefresh();
         if (ms is null) errors++;
         else lat.Add(ms.Value);
     }
-    sw.Stop();
 
-    double secs = sw.Elapsed.TotalSeconds;
-    double rps = secs > 0 ? lat.Count / secs : 0.0;
+    // J8: throughput comes from the SUM OF THE TIMED CALLS, not from wall
+    // clock across the loop.
+    //
+    // Run 5 reported this op at 20 rps against ~55 for every other SDK, while
+    // its LATENCY (17.2 ms p50) sat right in the middle of the pack — a
+    // combination that cannot describe the same measurement. The cause is
+    // structural and lives in this method: the I9 fix gives every iteration a
+    // fresh client and an untimed `LoginAsync` to seed a fresh RefreshGuard,
+    // and login costs ~250 ms because the server's Argon2id dominates it. A
+    // wall-clock stopwatch around the loop therefore divided N timed refreshes
+    // by N x (login + refresh), reporting roughly a quarter of the real rate.
+    // Every other SDK's bench refreshes on a shared client, so its wall clock
+    // IS the sum of its refresh calls and its number was never affected.
+    //
+    // This op is serial by contract (HARNESS-SPEC.md), so 1 / mean-latency is
+    // exactly the sustained serial rate, and it is the figure that compares
+    // like-for-like with the other ten languages. Setup that exists only to
+    // defeat a cache does not belong in the denominator.
+    double timedSecs = lat.Sum() / 1000.0;
+    double rps = timedSecs > 0 ? lat.Count / timedSecs : 0.0;
     return OpRecord(Pct(lat, 50), Pct(lat, 95), Pct(lat, 99), rps, errors);
 }
 

--- a/benchmarks/sdk/median.py
+++ b/benchmarks/sdk/median.py
@@ -42,6 +42,11 @@ def median(values):
     return statistics.median(values) if values else 0.0
 
 
+def _pass_label(run_dir):
+    """Short, stable name for a pass directory (results/sdk-run-2 -> sdk-run-2)."""
+    return os.path.basename(os.path.normpath(run_dir)) or run_dir
+
+
 def load_pass_records(run_dir):
     """Load every axiam.sdk-bench/v1 record under run_dir/sdk/<profile>/<lang>.json,
     keyed by (sdk, profile). Reuses collect.py's own walker so the two stay in
@@ -62,17 +67,29 @@ def load_pass_records(run_dir):
     return by_key
 
 
-def merge_records(records):
+def merge_records(records, requested_passes=None, present_passes=None):
     """Merge N passes' records (same sdk+profile) into one median record.
 
     `records` may include non-"ok" passes (error/pending) — only "ok" passes
     contribute to the medianed numbers; the merged record's own status/notes
     reflect how many of the N passes were usable.
+
+    J8: run 5's C# row read "median of 2" against a `repeat=3` request, and
+    nothing anywhere said which pass went missing or why. A pass that produces
+    no record at all is invisible to a merger that only looks at the records
+    it received — `len(records)` was already 2, so "2 of 2 ok" was truthfully
+    reported and completely misleading. `requested_passes`/`present_passes`
+    (pass labels, not counts) let the merged record name the absentees, so the
+    next occurrence points straight at a run directory to go read.
     """
     ok = [r for r in records if r.get("status") == "ok"]
     n_total = len(records)
     n_ok = len(ok)
     base = ok[0] if ok else records[0]
+
+    requested = list(requested_passes or [])
+    present = list(present_passes or [])
+    missing = [p for p in requested if p not in present]
 
     if not ok:
         # No usable pass at all — return the first record as-is (already a
@@ -95,7 +112,20 @@ def merge_records(records):
     for f in RECORD_NUMERIC_FIELDS:
         merged[f] = median([r.get(f, 0) for r in ok])
     merged["status"] = "ok"
+    # J8: the provenance of the median travels WITH the median. A reader of a
+    # single merged record can now tell a clean 3/3 from a 2/3 without going
+    # back to the aggregator's stdout, which is not archived.
+    merged["passes_requested"] = len(requested) or n_total
+    merged["passes_present"] = n_total
+    merged["passes_ok"] = n_ok
+    merged["passes_missing"] = missing
     note_prefix = f"median of {n_total} passes ({n_ok} ok)"
+    if missing:
+        note_prefix += (
+            f"; {len(missing)} pass(es) produced NO record for this sdk/profile "
+            f"({', '.join(missing)}) — check that run's sdk log for the drop reason "
+            "(J8)"
+        )
     existing_notes = base.get("notes") or ""
     merged["notes"] = f"{note_prefix}; {existing_notes}" if existing_notes else note_prefix
     return merged
@@ -116,24 +146,58 @@ def main():
                      help="One BENCH_RESULTS_DIR root per pass (each holding sdk/<profile>/*.json)")
     ap.add_argument("--out", required=True,
                      help="Results root to write the merged sdk/<profile>/<lang>.json into")
+    ap.add_argument("--allow-partial", action="store_true",
+                     help="J8: accept a median built from fewer passes than requested. "
+                          "Off by default — a silently-partial median is what let run 5 "
+                          "publish a 'median of 2' against repeat=3 unnoticed.")
     args = ap.parse_args()
 
     by_key = {}
+    # J8: remember WHICH pass each record came from, so a pass that produced
+    # nothing for a given language can be named rather than merely subtracted.
+    seen_in = {}
     for run_dir in args.runs:
+        label = _pass_label(run_dir)
         for key, recs in load_pass_records(run_dir).items():
             by_key.setdefault(key, []).extend(recs)
+            seen_in.setdefault(key, []).append(label)
 
     if not by_key:
         print(f"[median] no SDK records found under any of: {args.runs}", file=sys.stderr)
         sys.exit(1)
 
+    requested = [_pass_label(d) for d in args.runs]
     n_passes = len(args.runs)
+    incomplete = []
     for (sdk, profile), records in sorted(by_key.items()):
-        merged = merge_records(records)
+        merged = merge_records(records, requested, seen_in.get((sdk, profile), []))
         out_path = write_merged(args.out, sdk, profile, merged)
-        n_ok = sum(1 for r in records if r.get("status") == "ok")
-        print(f"[median] {sdk}@{profile}: {n_ok}/{len(records)} pass(es) ok "
-              f"(of {n_passes} requested) -> {out_path}")
+        n_ok = merged.get("passes_ok", 0)
+        missing = merged.get("passes_missing") or []
+        line = (f"[median] {sdk}@{profile}: {n_ok}/{len(records)} pass(es) ok "
+                f"(of {n_passes} requested) -> {out_path}")
+        if missing:
+            line += f"  MISSING: {', '.join(missing)}"
+            incomplete.append(f"{sdk}@{profile} (missing {', '.join(missing)})")
+        print(line)
+
+    # J8: a silently-partial merge is how run 5 shipped a "median of 2" nobody
+    # noticed until analysis. Say it loudly at the end, where it survives a
+    # scrolled log, and make it a non-zero exit unless the operator opted in.
+    if incomplete:
+        print("", file=sys.stderr)
+        print(f"[median] {len(incomplete)} sdk/profile pair(s) merged FEWER than the "
+              f"{n_passes} requested passes:", file=sys.stderr)
+        for item in incomplete:
+            print(f"[median]   - {item}", file=sys.stderr)
+        print("[median] Each merged record names the absent pass(es) in "
+              "`passes_missing`/`notes`; the drop reason is in that pass's own "
+              "sdk log (a timeout, a port clash, or a crashed bench).", file=sys.stderr)
+        if not args.allow_partial:
+            print("[median] Failing — re-run the missing pass, or pass "
+                  "--allow-partial to accept a partial median deliberately.", file=sys.stderr)
+            sys.exit(1)
+        print("[median] --allow-partial: accepting the partial median.", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/benchmarks/sdk/python/bench.py
+++ b/benchmarks/sdk/python/bench.py
@@ -296,6 +296,16 @@ def client_resource_usage():
     return cpu_ms_total, rss_mib_peak
 
 
+# D1/J5: which event loop actually ran. Set by __main__ below. Run 5's Python
+# row (311 rps, p50 40.2 ms) turned out to be the CPython+httpx per-request
+# ceiling rather than anything AXIAM does — three client processes against a
+# ZERO-WORK stub server reached 320+308+301 rps, each capped at the same ~310
+# — and uvloop moves that ceiling by ~20% of client CPU. A CPU number that
+# does not say which loop produced it is therefore not comparable to the next
+# run's. See the Python SDK's PERFORMANCE.md.
+EVENT_LOOP = "asyncio"
+
+
 def emit(status, ops, iterations, concurrency, notes):
     cpu_ms_total, rss_mib_peak = client_resource_usage()
     print(json.dumps({
@@ -306,6 +316,11 @@ def emit(status, ops, iterations, concurrency, notes):
         "profile": os.environ.get("BENCH_PROFILE", "p0-plaintext"),
         "status": status, "iterations": iterations, "concurrency": concurrency,
         "ops": ops, "client_cpu_ms_total": cpu_ms_total, "client_rss_mib_peak": rss_mib_peak,
+        "event_loop": EVENT_LOOP,
+        # One process, one event-loop thread: `concurrency` in-flight calls all
+        # queue on it. This is published so a reader can see that the Python
+        # row's latency is dominated by client-side queueing, not by AXIAM.
+        "client_worker_threads": 1,
         "notes": notes,
     }, indent=2))
 
@@ -338,4 +353,27 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # D1/J5: prefer uvloop when the environment has it (axiam-sdk[speed]).
+    # Measured on this bench's own check_access path against a zero-work
+    # server at 16 in-flight calls: client CPU 2 182 -> 1 735 us/call (-20%),
+    # p95 68 -> 55 ms, throughput +7%. Set SDK_BENCH_EVENT_LOOP=asyncio to
+    # force the stdlib loop for an A/B; the record says which one ran either
+    # way, so the two are never silently mixed in a median.
+    _want = os.environ.get("SDK_BENCH_EVENT_LOOP", "auto")
+    if _want in ("auto", "uvloop"):
+        try:
+            import uvloop
+            EVENT_LOOP = "uvloop"
+        except ImportError:
+            if _want == "uvloop":
+                print("[python] SDK_BENCH_EVENT_LOOP=uvloop but uvloop is not "
+                      "installed — falling back to stdlib asyncio "
+                      "(pip install 'axiam-sdk[speed]')", file=sys.stderr)
+            uvloop = None
+    else:
+        uvloop = None
+
+    if uvloop is not None:
+        uvloop.run(main())
+    else:
+        asyncio.run(main())

--- a/benchmarks/sdk/python/run.sh
+++ b/benchmarks/sdk/python/run.sh
@@ -26,7 +26,13 @@ if ! "$PY" -c 'import axiam_sdk' >/dev/null 2>&1; then
   if [ -f "$SIBLING_SDK/pyproject.toml" ] || [ -f "$SIBLING_SDK/setup.py" ]; then
     echo "[python] axiam_sdk not importable in $VENV — installing from $SIBLING_SDK" >&2
     "$PY" -m pip install --quiet --upgrade pip >&2
-    "$PY" -m pip install --quiet -e "$SIBLING_SDK" >&2
+    # D1/J5: install with the [speed] extra so the bench measures the SDK's
+    # recommended async setup (uvloop) rather than the stdlib loop the
+    # recommendation exists to replace. bench.py records which loop actually
+    # ran, and falls back cleanly when the extra is unavailable (e.g. an
+    # older checkout without it, or Windows), so a run never fails over this.
+    "$PY" -m pip install --quiet -e "$SIBLING_SDK[speed]" >&2 \
+      || "$PY" -m pip install --quiet -e "$SIBLING_SDK" >&2
   fi
 fi
 

--- a/benchmarks/sdk/rust/src/main.rs
+++ b/benchmarks/sdk/rust/src/main.rs
@@ -25,6 +25,12 @@ use uuid::Uuid;
 
 const OP_KEYS: [&str; 4] = ["login", "refresh", "check_access", "batch_check"];
 
+/// Worker count the async runtime was built with, published in the record
+/// (see `main`). Global rather than threaded through `emit` because every
+/// early-exit error path emits too, and a record that omits it on exactly the
+/// runs that went wrong is the least useful place to omit it.
+static WORKER_THREADS: AtomicUsize = AtomicUsize::new(0);
+
 /// Read an env var, falling back to `default`.
 fn env(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_string())
@@ -235,6 +241,10 @@ async fn time_op(
     }
 
     let counter = Arc::new(AtomicUsize::new(0));
+    // J8b: bracket the timed window only — warm-up CPU is excluded, matching
+    // the latency numbers, so `cpu_ms` and `throughput_rps` describe the same
+    // work.
+    let cpu0 = cpu_ms_now();
     let start = Instant::now();
 
     let mut set = tokio::task::JoinSet::new();
@@ -269,6 +279,7 @@ async fn time_op(
     }
 
     let secs = start.elapsed().as_secs_f64();
+    let cpu_ms = (cpu_ms_now() - cpu0).max(0.0);
     lat.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let throughput = if secs > 0.0 {
         lat.len() as f64 / secs
@@ -282,6 +293,13 @@ async fn time_op(
         "p99_ms": pct(&lat, 99.0),
         "throughput_rps": throughput,
         "errors": errors,
+        // J8b, optional per HARNESS-SPEC.md: CPU consumed by the client
+        // process during THIS op's timed window, and the same divided by
+        // completed calls. The per-call figure is the comparable one — an op
+        // that runs longer naturally burns more CPU, which is what made the
+        // single aggregate uninterpretable.
+        "cpu_ms": cpu_ms,
+        "cpu_us_per_call": if lat.is_empty() { 0.0 } else { cpu_ms * 1000.0 / lat.len() as f64 },
     })
 }
 
@@ -353,6 +371,16 @@ fn client_resource_usage() -> (f64, f64) {
     (cpu_ms_total, rss_mib_peak)
 }
 
+/// J8b: cumulative process CPU in ms, on its own, so an op's timed window can
+/// be bracketed. Run 5 published one aggregate `client_cpu_ms_total` of 23.4 s
+/// for this bench — highest of every compiled SDK and 7x Go's — against the
+/// best latency and throughput in the matrix. One number for four ops is not
+/// something anyone can act on, so the op records now carry their own share
+/// and the next run says WHICH op owns it instead of re-opening the question.
+fn cpu_ms_now() -> f64 {
+    client_resource_usage().0
+}
+
 /// Print exactly one `axiam.sdk-bench/v1` JSON object to stdout.
 fn emit(
     status: &str,
@@ -377,6 +405,10 @@ fn emit(
         "ops": ops,
         "client_cpu_ms_total": cpu_ms_total,
         "client_rss_mib_peak": rss_mib_peak,
+        // J8b: the async runtime's worker count, so a reader can tell whether
+        // a CPU figure came from a runtime sized to the declared concurrency
+        // or (pre-J8b) to whatever core count the host happened to have.
+        "client_worker_threads": WORKER_THREADS.load(Ordering::Relaxed),
         "notes": notes,
     });
     println!(
@@ -419,8 +451,44 @@ fn assert_refresh_hit_the_wire(refresh: &serde_json::Value, iterations: usize) {
     }
 }
 
-#[tokio::main]
-async fn main() {
+/// J8b: the runtime is built by hand instead of via `#[tokio::main]`, and
+/// sized to `SDK_BENCH_CONCURRENCY` rather than to the host's core count.
+///
+/// `#[tokio::main]` defaults to a multi-thread runtime with one worker per
+/// CPU. That makes this bench's `client_cpu_ms_total` a function of the
+/// MACHINE it ran on: every worker thread spins briefly before parking on
+/// each wakeup, so a 32-core box reports more client CPU than a 4-core box
+/// for identical work against an identical server — a variable no other axis
+/// of this harness leaves uncontrolled, and one that made run 5's "Rust burns
+/// 7x Go's CPU" observation unattributable.
+///
+/// Sizing to the declared concurrency makes the number comparable across
+/// hosts AND across languages: every other bench in this harness drives
+/// `SDK_BENCH_CONCURRENCY` in-flight calls, so a runtime with exactly that
+/// many workers is the like-for-like shape. The floor of 2 keeps a
+/// `concurrency=1` serial run off the current-thread scheduler, where
+/// timer/IO behaviour differs enough to be its own confound.
+///
+/// This is the measurement fix D3 asks for BEFORE suspecting the SDK. If the
+/// next run still shows an outsized figure with the runtime pinned and the
+/// new per-op `cpu_ms` attribution in hand, the finding is real and belongs
+/// to the SDK.
+fn main() {
+    let workers = std::env::var("SDK_BENCH_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(16)
+        .clamp(2, 256);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .build()
+        .expect("tokio runtime builds");
+    WORKER_THREADS.store(workers, Ordering::Relaxed);
+    rt.block_on(run());
+}
+
+async fn run() {
     // Config / env parsing failures (e.g. a non-UUID BENCH_RESOURCE_ID) are a
     // setup error, not a crash: emit a zeroed `error` record and exit 0.
     let cfg = match Cfg::from_env() {

--- a/benchmarks/sdk/test-median-provenance.sh
+++ b/benchmarks/sdk/test-median-provenance.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# J8 regression guard for median.py's pass provenance.
+#
+# Run 5 merged two of three requested C# passes and reported it as "median of
+# 2 (2 ok)" — truthful about what it received, silent about what it never got.
+# This builds three pass directories where one language is deliberately absent
+# from one pass, and asserts the merger names the absentee and fails.
+#
+# Hermetic: stdlib python only, no SDK toolchains, no AXIAM stack.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+rec() {  # rec <dir> <sdk> <p95>
+  mkdir -p "$1/sdk/p2-tls13"
+  cat > "$1/sdk/p2-tls13/$2.json" <<EOF
+{
+  "schema": "axiam.sdk-bench/v1",
+  "sdk": "$2",
+  "profile": "p2-tls13",
+  "target": "axiam",
+  "status": "ok",
+  "iterations": 10,
+  "concurrency": 16,
+  "ops": {
+    "login":        { "p50_ms": 1, "p95_ms": $3, "p99_ms": 3, "throughput_rps": 10, "errors": 0 },
+    "refresh":      { "p50_ms": 1, "p95_ms": $3, "p99_ms": 3, "throughput_rps": 10, "errors": 0 },
+    "check_access": { "p50_ms": 1, "p95_ms": $3, "p99_ms": 3, "throughput_rps": 10, "errors": 0 },
+    "batch_check":  { "p50_ms": 1, "p95_ms": $3, "p99_ms": 3, "throughput_rps": 10, "errors": 0 }
+  },
+  "notes": ""
+}
+EOF
+}
+
+# go: present in all three passes. csharp: missing from pass 2 — the run-5 shape.
+for i in 1 2 3; do rec "$TMP/sdk-run-$i" go "$i"; done
+rec "$TMP/sdk-run-1" csharp 1
+rec "$TMP/sdk-run-3" csharp 3
+
+fail=0
+
+set +e
+OUT="$(python3 "$HERE/median.py" --runs "$TMP/sdk-run-1" "$TMP/sdk-run-2" "$TMP/sdk-run-3" --out "$TMP/merged" 2>&1)"
+RC=$?
+set -e
+
+[ "$RC" -ne 0 ] || { echo "[median-selftest] expected a non-zero exit for an incomplete merge, got 0" >&2; fail=1; }
+printf '%s\n' "$OUT" | grep -q "sdk-run-2" || {
+  echo "[median-selftest] the missing pass (sdk-run-2) is not named in the output:" >&2
+  printf '%s\n' "$OUT" >&2; fail=1; }
+
+CS="$TMP/merged/sdk/p2-tls13/csharp.json"
+GO="$TMP/merged/sdk/p2-tls13/go.json"
+[ -f "$CS" ] && [ -f "$GO" ] || { echo "[median-selftest] merged records were not written despite the failure exit — the report must still be produced" >&2; fail=1; }
+
+python3 - "$CS" "$GO" <<'PY' || fail=1
+import json, sys
+cs, go = (json.load(open(p)) for p in sys.argv[1:3])
+ok = True
+if cs.get("passes_missing") != ["sdk-run-2"]:
+    print(f"[median-selftest] csharp passes_missing={cs.get('passes_missing')!r}, want ['sdk-run-2']"); ok = False
+if cs.get("passes_requested") != 3 or cs.get("passes_present") != 2:
+    print(f"[median-selftest] csharp requested/present = {cs.get('passes_requested')}/{cs.get('passes_present')}, want 3/2"); ok = False
+if "sdk-run-2" not in (cs.get("notes") or ""):
+    print("[median-selftest] csharp notes do not name the absent pass"); ok = False
+if go.get("passes_missing"):
+    print(f"[median-selftest] go should be complete, got passes_missing={go.get('passes_missing')!r}"); ok = False
+# The median itself must still be right: go saw p95 1, 2, 3 across passes.
+if go["ops"]["check_access"]["p95_ms"] != 2:
+    print(f"[median-selftest] go median p95 = {go['ops']['check_access']['p95_ms']}, want 2"); ok = False
+sys.exit(0 if ok else 1)
+PY
+
+# --allow-partial is the deliberate opt-out and must succeed.
+python3 "$HERE/median.py" --runs "$TMP/sdk-run-1" "$TMP/sdk-run-2" "$TMP/sdk-run-3" \
+  --out "$TMP/merged2" --allow-partial >/dev/null 2>&1 || {
+  echo "[median-selftest] --allow-partial should exit 0" >&2; fail=1; }
+
+[ "$fail" -eq 0 ] || { echo "[median-selftest] FAILED" >&2; exit 1; }
+echo "[median-selftest] OK — an absent pass is named, fails the merge, and still writes the records."

--- a/benchmarks/targets/axiam/docker-compose.yml
+++ b/benchmarks/targets/axiam/docker-compose.yml
@@ -109,6 +109,21 @@ services:
       AXIAM__DB__POOL_ACQUIRE_TIMEOUT_SECS: "${AXIAM__DB__POOL_ACQUIRE_TIMEOUT_SECS:-5}"
       AXIAM__SERVER__HOST: "0.0.0.0"
       AXIAM__GRPC__HOST: "0.0.0.0"
+      # --- A4/E4: gRPC strict session-revocation mode ----------------------
+      # Shipped default is `false`: the gRPC data plane validates the JWT and
+      # stops, so its revocation bound is the token's 15-minute lifetime —
+      # which is a real part of why gRPC reads faster than REST, and is
+      # documented as a posture choice rather than an oversight. Setting this
+      # to "true" adds the session-revocation read to the interceptor (served
+      # from the session-validation cache when that is enabled), matching
+      # REST's posture.
+      #
+      # Listed here because compose forwards only the names in this block — a
+      # shell `export` of a name absent from it reaches nothing, which is
+      # exactly the J9 failure that cost run 5 its stage timings. The E4
+      # strict-revocation cell exists to publish what this posture costs, so
+      # the knob has to be reachable from `bench-up`.
+      AXIAM__GRPC__STRICT_REVOCATION: "${AXIAM__GRPC__STRICT_REVOCATION:-false}"
       # --- I5: Nagle on the REST listener ---------------------------------
       # actix-web leaves the socket at its OS default (Nagle ON) unless told
       # otherwise; tonic sets TCP_NODELAY itself. Shipped default is `true`.

--- a/claude_dev/new-feature-bench-cells.md
+++ b/claude_dev/new-feature-bench-cells.md
@@ -1,0 +1,176 @@
+# New-feature benchmark cells (E4)
+
+> Companion to [`run5-runbook.md`](run5-runbook.md) and §E4 of
+> [`improvement-after-run5-benchmark.md`](improvement-after-run5-benchmark.md).
+> Every feature this improvement round adds to the server changes something a
+> reader of the benchmark can ask about, and the project's rule is that a
+> feature ships with its measured cost rather than with an assurance. This
+> file is the list of labeled cells that obligation turns into, and the exact
+> commands for each.
+>
+> Cells are **labeled**: each one is a deliberate, non-default configuration,
+> and its numbers are not interchangeable with the default matrix's. Every
+> cell below records its distinguishing configuration in `meta.json`
+> (`axiam_env`, `seed_scale`, `connection_model`), so a labeled result can
+> never be read as a default one.
+
+## Status
+
+| Cell | Feature | State |
+|---|---|---|
+| `authz-deny-present` | B1 deny-override | **ready** — run it |
+| `grpc-strict-revocation` | A4 opt-in strict mode | **ready** — run it |
+| `seed-scale` | E3 bulk fixture | **ready** — run it |
+| `device-flow-poll` | B2 device authorization grant | blocked: the grant's core, storage and state machine landed, but no REST handlers are mounted yet |
+| `token-exchange` | B3 RFC 8693 | blocked: not implemented |
+| `amqp-tls` | A6 broker TLS | optional; see A6 step 6 |
+
+A blocked cell has no scenario file on purpose. Writing a k6 script against
+endpoints that do not exist produces a scenario that fails for the wrong
+reason and quietly rots; the cell lands with its feature.
+
+---
+
+## `authz-deny-present` — what deny-override costs when denies exist
+
+**The question.** B1's evaluation short-circuits: the second, deny-matching
+indexed query only runs for tenants that hold at least one deny rule, so the
+common case stays one indexed query and the run-5 numbers should be
+reproducible to within noise. Two things need publishing — that the
+no-denies path really is unchanged, and what the with-denies path costs.
+
+**Both arms, same fixture, same scenario.** The only difference is whether
+the tenant holds deny rules, which is what `--deny-ratio` controls.
+
+```bash
+cd benchmarks
+
+# ---- Arm A: control. No deny rules anywhere in the tenant. ----
+just target=axiam profile=p2-tls13 bench-up
+just target=axiam bench-seed
+BENCH_SEED_DENY_RATIO=0 just scale=10 bench-bulk-seed
+BENCH_RESULTS_DIR=$PWD/results/e4-deny-none \
+  just target=axiam profile=p2-tls13 scenario=authz_check_rest bench-run
+just target=axiam bench-down
+
+# ---- Arm B: 5% of grants carry effect: deny. ----
+just target=axiam profile=p2-tls13 bench-up
+just target=axiam bench-seed
+BENCH_SEED_DENY_RATIO=0.05 just scale=10 bench-bulk-seed
+BENCH_RESULTS_DIR=$PWD/results/e4-deny-present \
+  just target=axiam profile=p2-tls13 scenario=authz_check_rest bench-run
+just target=axiam bench-down
+```
+
+Tear down between arms: the fixture differs, and a re-seed over a live stack
+would leave the first arm's rows in place.
+
+**Reading it.** Arm A against the run-5 headline is the ±2% gate the plan
+sets for B1 — a regression there means the short-circuit is not
+short-circuiting. Arm B is published as its own labeled row, honestly, with
+the deny ratio named; it is a new capability's cost, not a regression.
+
+`meta.json` carries `seed_fixture.deny_ratio` for both arms, so the two are
+distinguishable from the artifacts alone.
+
+## `grpc-strict-revocation` — what the stricter posture costs
+
+**The question.** Part of gRPC's read advantage over REST is that its
+interceptor validates the token and stops, so a revoked session stays usable
+until the token expires (15 minutes). A4 added an opt-in mode that adds the
+revocation read, served from the session-validation cache. The posture is
+documented; the cost is not yet measured.
+
+```bash
+cd benchmarks
+
+# ---- Arm A: shipped default (JWT lifetime is the revocation bound). ----
+just target=axiam profile=p2-tls13 bench-up
+just target=axiam bench-seed
+BENCH_RESULTS_DIR=$PWD/results/e4-grpc-default \
+  just target=axiam profile=p2-tls13 scenario=authz_check_grpc bench-run
+just target=axiam bench-down
+
+# ---- Arm B: strict mode, with the session cache the mode is designed for. ----
+AXIAM__GRPC__STRICT_REVOCATION=true \
+AXIAM__AUTH__SESSION_VALIDATION_CACHE_TTL_SECS=5 \
+  just target=axiam profile=p2-tls13 bench-up
+just target=axiam bench-seed
+BENCH_REQUIRE_ENV="AXIAM__GRPC__STRICT_REVOCATION" \
+BENCH_RESULTS_DIR=$PWD/results/e4-grpc-strict \
+  just target=axiam profile=p2-tls13 scenario=authz_check_grpc bench-run
+just target=axiam bench-down
+```
+
+Note the two things that make this reproducible rather than hopeful:
+
+- the knob is set on **`bench-up`**, because a container's environment is
+  fixed when it is created. This is the J9 rule, and the pass that ignored it
+  cost run 5 an entire investigation.
+- `BENCH_REQUIRE_ENV` asserts the knob actually reached the container, off
+  `docker inspect`, before any k6 time is spent. Arm B without the flag would
+  otherwise be a second copy of arm A wearing arm B's directory name — the
+  single most expensive mistake this cell can make.
+
+**Reading it.** The expectation is that strict mode approaches REST's
+revocation-checked profile, and the honest framing is "here is what the
+stricter bound costs", not "gRPC is slower than we said". Publish both rows
+adjacent, with the revocation bound stated for each.
+
+## `seed-scale` — does the check path hold at 10× and 100×?
+
+See [`benchmarks/README.md`](../benchmarks/README.md#seed-size-sensitivity-bench-bulk-seed)
+for the mechanism. The cell itself:
+
+```bash
+cd benchmarks
+just target=axiam profile=p2-tls13 bench-up
+just target=axiam bench-seed
+for S in 1 10 100; do
+  [ "$S" = 1 ] || just scale=$S bench-bulk-seed
+  BENCH_RESULTS_DIR=$PWD/results/e4-seed-$S \
+    just target=axiam profile=p2-tls13 scenario=authz_check_rest bench-run
+done
+just target=axiam bench-down
+```
+
+The scales are cumulative on one fixture (the seeder upserts, so `scale=100`
+after `scale=10` adds rather than replaces), which is deliberate: the same
+seeded `benchuser`/`bench-resource` fixture is measured against a growing
+index, so the three rows differ in exactly one variable.
+
+`meta.json` carries `seed_scale` and the full `seed_fixture` block per cell.
+
+---
+
+## Cells waiting on their features
+
+### `device-flow-poll` (B2)
+
+The RFC 8628 polling loop is the interesting shape: an input-constrained
+device polls the token endpoint every `interval` seconds until the user
+approves, which is a sustained low-rate request stream from many devices at
+once — a different load profile from anything currently in the matrix, and
+one whose rate-limiting posture (A1's family for polling, distinct from the
+generic token bucket) is what the cell exists to validate.
+
+Lands with B2's REST handlers. Until then there is nothing to point k6 at:
+`crates/axiam-oauth2/src/device_service.rs` has `authorize`, `poll`,
+`lookup_for_verification` and `decide`, but no route mounts them.
+
+### `token-exchange` (B3)
+
+One exchange per request against the token endpoint, measuring the
+scope-narrowing and audience-restriction work on the hot path, plus its own
+rate-limit bucket under flood. Lands with B3.
+
+### `amqp-tls` (A6, optional)
+
+A6 ships `amqps://` support; step 6 of that task asks for one labeled cell
+comparing the AMQP async-authz path over TLS against plaintext. The expected
+result is ~nil steady-state difference, because long-lived connections
+amortize the handshake — which is exactly the kind of claim this project
+measures rather than asserts. The bench compose deliberately keeps the broker
+hop plaintext (`AXIAM__AMQP__ALLOW_PLAINTEXT: "true"`) so the standing matrix
+stays comparable to run 5; this cell is the deliberate exception, not a
+change of that default.

--- a/claude_dev/run5-runbook.md
+++ b/claude_dev/run5-runbook.md
@@ -748,6 +748,31 @@ started with the old value. So:
 - to change any of them, **`bench-down` first, then `bench-up` again**. That is
   why the A/B blocks below always tear down between arms.
 
+> **Run 5 broke Rule 2 and lost a whole investigation to it (J9).** The §4.3
+> handler-stage breakdown produced *zero* `axiam::perf` events because
+> `RUST_LOG` was exported for `bench-run` against an already-running stack. The
+> variable was in the compose allow-list the whole time; the timing was wrong,
+> and nothing checked. Post-J9 the harness makes that self-enforcing:
+>
+> - `bench-up` now sets and **echoes** `RUST_LOG` (default `axiam=warn`), so
+>   the value baked into the container is part of the bring-up record;
+> - `run-benchmark.sh` accepts `BENCH_REQUIRE_ENV="<names>"` and asserts each
+>   name off `docker inspect` **before the settle gate and the first cell**,
+>   failing in seconds rather than after hours of k6 time;
+> - every cell's `meta.json` records `axiam_env_required`,
+>   `axiam_env_missing` and `axiam_env_complete`, and `axiam_env` itself now
+>   captures `RUST_LOG`/`RUST_BACKTRACE` alongside the `AXIAM__*` dump — so a
+>   pass that ran without its required knob is visible in the artifact rather
+>   than in a post-mortem.
+>
+> Any pass that depends on debug logging must therefore run as:
+>
+> ```bash
+> RUST_LOG="axiam=warn,axiam_oauth2=debug,axiam_api_rest=debug" \
+>   just target=axiam profile=p2-tls13 bench-up
+> BENCH_REQUIRE_ENV="RUST_LOG" just target=axiam profile=p2-tls13 bench-run
+> ```
+
 `just` variables (`target=`, `profile=`, `rl=`, `dbcaps=`, `repeat=`,
 `scenario=`, `targets=`, `profiles=`) are a different mechanism — they go
 **before the recipe name**, never after, and are not environment variables:


### PR DESCRIPTION
Implements **Track E** of `claude_dev/improvement-after-run5-benchmark.md` in full, plus the server-repo half of the **Track D** SDK work (D1's harness wiring, D2's concurrency plumbing, D3's three audits).

Every item here shares one theme: run 5 produced artifacts that *looked* complete and weren't, and nothing in the pipeline could tell. Each fix closes the gap at the measurement and leaves the artifact self-explaining.

## E1 — `RUST_LOG` never reached the container (J9)

The I5 stage-timing pass logged **zero** `axiam::perf` events, so the §4.3 handler breakdown simply does not exist. The variable was in the compose allow-list all along; it was exported for `bench-run` against an already-running stack, which is too late — a container's environment is fixed when `bench-up` creates it.

- `bench-up` sets and echoes `RUST_LOG`, so the value baked in is part of the bring-up record rather than an assumption.
- `run-benchmark.sh` gains `BENCH_REQUIRE_ENV`: a list of variable names asserted off `docker inspect` **before the settle gate and the first cell**, so a missing knob costs seconds instead of a matrix. `BENCH_REQUIRE_ENV_SOFT=1` downgrades it.
- `axiam_env_json()` captures `RUST_LOG`/`RUST_BACKTRACE` alongside the `AXIAM__*` dump — the prefix test was itself why the gap was invisible — and every cell records `axiam_env_required` / `axiam_env_missing` / `axiam_env_complete`.

## E2 — `bench-pack` dropped every investigation artifact (J13)

The manifest named five exact filenames, so run 5's shareable archive silently lost `rl-prod-summary.md`, `sdk-report.md`, `nsenter.log` and `h5-revocation.log`: precisely the files carrying the verdicts.

Selection is now by extension, so the *next* investigation's artifact is packed by default. `dry-run/` and anything matching `*seed*` are pruned by construction rather than caught afterwards by the post-pack secret scan. The logic moved into `runner/pack-filelist.sh` so `runner/pack-selftest.sh` exercises the real thing rather than a re-implementation that would have agreed with the bug.

## E3 — bulk-seed tooling for the seed-size sensitivity cell (J12)

Every published AXIAM number was measured against one tenant, two users and one resource. `runner/bulk-seed.{py,sh}` writes SurrealQL directly in batched transactions (the REST path is right for the functional fixture and hopeless for 100 000 Argon2id hashes). Three properties make the cell comparable rather than merely big:

- the functional fixture is untouched — `benchuser`/`bench-resource`/`bench-reader` keep their ids, so a cell measures the same logical query against a larger index;
- the resource tree is deep (`--depth 4`, `--fanout 6`), not flat — a wide shallow fixture exercises the ancestor walk exactly as hard as one resource;
- `--deny-ratio` writes a fraction of grants as `effect: deny`, so the cell measures B1's deny-override path rather than only its short-circuit.

Bulk users cannot authenticate by construction: `password_hash` is a sentinel that is not an Argon2id encoded hash. Every write is an UPSERT against a deterministic id, edges included, so an interrupted load restarts rather than failing on duplicate keys. The scale lands in `meta.json` as `seed_scale` / `seed_fixture`.

## E4 — the three unblocked new-feature cells

`claude_dev/new-feature-bench-cells.md` gives exact commands for `authz-deny-present` (a two-arm A/B differing only in deny ratio — arm A *is* B1's ±2% gate), `grpc-strict-revocation` (A4 shipped the mode and documented the posture; nobody measured it), and `seed-scale`. `AXIAM__GRPC__STRICT_REVOCATION` is added to the bench compose's forwarded-name list, without which a shell export reaches nothing.

Three cells ship **no** scenario file on purpose: device flow (B2) has its core, storage and state machine but no mounted REST handlers, token exchange (B3) is not implemented, and the AMQP TLS cell is A6's optional step 6. A k6 script pointed at endpoints that do not exist fails for the wrong reason and rots.

## D3 — the three SDK-harness audits (J7, J8, J8b)

All three run-5 SDK anomalies are harness measurement defects, not SDK defects.

**J7 — TypeScript measured *negative* overhead** (check/batch p95 21–23 ms *below* the wire baseline on the same host and server). A client cannot beat the wire doing the same work, and nothing recorded enough about the baseline's transport to say which side differed. Scenarios now state the connection model explicitly (`BENCH_NO_CONN_REUSE` / `BENCH_NO_VU_CONN_REUSE`), every cell records it, and `collect.py` withholds the delta (`n/c`) unless the baseline is `pooled-per-vu`. A baseline predating the field counts as *not established*, not as fine; a negative delta surviving the model check is flagged with the asymmetries still unruled-out.

**J8 — C# merged 2 of 3 passes** and reported "median of 2 (2 ok)": truthful about the records received, silent about the one never got, because a pass producing no record is invisible to the merger. `median.py` now names the absent pass directory, writes `passes_requested`/`passes_present`/`passes_ok`/`passes_missing`, and exits non-zero. The report is still written — the numbers are valid, just built on fewer passes.

**J8 — C# refresh read 20 rps** against ~55 elsewhere while its latency sat mid-pack, which cannot describe one measurement. The I9 fix gives each iteration a fresh client and an untimed ~250 ms Argon2id login; the wall-clock stopwatch was dividing N timed refreshes by N × (login + refresh). Throughput now comes from the sum of the timed calls.

**J8b — Rust reported 23.4 s client CPU**, 7× Go's, alongside the best latency in the matrix. Fixed the measurement first, as the plan asks: the bench built its runtime via `#[tokio::main]` (one worker per CPU, making the figure a function of the *host*), and one aggregate covered four ops of very different shapes. The runtime is now sized to `SDK_BENCH_CONCURRENCY` and published as `client_worker_threads`; each op carries `cpu_ms` / `cpu_us_per_call`.

## D1 / D2 — server-repo halves

- **D1**: the Python bench prefers uvloop (installing the SDK's new `[speed]` extra) and records `event_loop` plus `client_worker_threads: 1` — the fact that explains the latency, since sixteen in-flight calls queue on one event-loop thread. Full evidence in ilpanich/axiam-python-sdk.
- **D2**: the cpp bench applies `SDK_BENCH_CONCURRENCY` to the *client*, not just its worker loop. Full fix in ilpanich/axiam-cplusplus-sdk.

## Tests

New CI job **Bench Harness Self-Tests**, hermetic (no docker, no k6, no seeded stack):

- `runner/pack-selftest.sh` — builds a fixture tree with one of every run-5 artifact shape and asserts both directions: investigation artifacts survive, dry-run/seed paths don't.
- `sdk/test-median-provenance.sh` — three passes with one language deliberately absent from one; asserts the absentee is named, the merge fails, and the records are still written.
- `bash -n` over every runner script — 1 000+ lines of bash that otherwise only executes inside a multi-hour matrix.

Both self-tests pass locally, as does the shell parse sweep.

## Not in this PR

D4/D5/D6 (SDK contract additions and the 11-repo fan-out) are gated on B2's REST surface, B3 and B5, none of which exist yet — writing contract sections for features the server does not implement would have eleven SDKs implementing against nothing. Track F and the extra-B features (X1–X5) are likewise outstanding; `claude_dev/new-feature-bench-cells.md` records which bench cells are waiting on which feature.

## Related

- ilpanich/axiam-python-sdk — D1
- ilpanich/axiam-cplusplus-sdk — D2

---
_Generated by [Claude Code](https://claude.ai/code/session_011ubrFbqsMkBqC5gwadPsDu)_