### PR TITLE
docs(sdk): §16 preamble errata — five SDKs diverged (1.8.2)

### DIFF
--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -1933,28 +1933,41 @@ with no attempt to refine it.
 Two earlier clauses — [§11.2](#§112-semantics-normative-identical-in-all-sdks) rule 5 and
 [§14.2](#§142-polling-normative--the-part-implementations-get-wrong) — instruct SDKs to retry
 "under the SDK's existing bounded read-only retry policy". **No such policy was ever defined
-here.** In practice **three** SDKs had one and all three disagreed; the other eight had none
-at all — only §9's refresh-then-retry-once, which is a different mechanism entirely.
+here.** In practice **five** SDKs had one and all five disagreed; the other six had none at
+all — only §9's refresh-then-retry-once, which is a different mechanism entirely.
 
-| SDK | Attempts | Base | Cap | Jitter | `Retry-After` |
-|---|---|---|---|---|---|
-| Java | 3 | 200 ms | 5 s | full | honored as a floor |
-| Rust | 3 | library default | — | none | ignored |
-| TypeScript | 3 | 1000 ms | 8 s | partial (`base + 0–20%`) | **replaced** the backoff |
+| SDK | Attempts | Base | Cap | Jitter | `Retry-After` | Wired in? |
+|---|---|---|---|---|---|---|
+| Java | 3 | 200 ms | 5 s | full | floor | yes |
+| C# | 3 | 200 ms | 5 s | yes | — | yes |
+| Rust | 3 | library default | — | none | ignored | yes |
+| Go | 3 | 100 ms | **none** | **none** | ignored | yes |
+| TypeScript | 3 | 1000 ms | 8 s | partial | **replaced** the backoff | **no** |
 
-Two things about the TypeScript row.
+Three of those cells are worth stating plainly, because each is a distinct way the same
+clause gets got wrong.
 
-It is why "floor, never a ceiling" is stated so bluntly in §16.1: `retryAfterMs ??
-backoffDelayMs(attempt)` means a `Retry-After: 0` retries **immediately**, defeating the
-backoff entirely. That clause was written on principle and then found to describe a defect
-one of these SDKs already shipped.
+*The TypeScript row, `Retry-After`.* `retryAfterMs ?? backoffDelayMs(attempt)` means the
+server's hint **replaces** the computed backoff instead of flooring it, so a `Retry-After: 0`
+retries **immediately**, defeating the backoff entirely. §16.1's "floor, never a ceiling" was
+written on principle and then found to describe a defect already shipped.
 
-And its helper was **exported and unit-tested but never called by any production path** —
-`check_access` did not route through it — so that SDK performed no read-only retries at
-all while appearing to. A tested helper nobody calls is worse than an absent one: the tests
-report green and the gap stays invisible. **An SDK claiming §16 conformance MUST assert the
-policy through its public `check_access` surface, not only against the helper in isolation**
-(see §16.7's required non-idempotent test, which asserts the request count *on the wire*).
+*The TypeScript row, "wired in".* Its helper was exported and unit-tested but **never called
+by any production path** — `check_access` did not route through it — so that SDK performed no
+read-only retries at all while appearing to. A tested helper nobody calls is worse than an
+absent one: the tests report green and the gap stays invisible. **An SDK claiming §16
+conformance MUST assert the policy through its public `check_access` surface, not only
+against the helper in isolation** (see §16.7's required non-idempotent test, which asserts the
+request count *on the wire*).
+
+*The Go row.* An uncapped, unjittered `backoff *= 2` is the shape this section most wants to
+eliminate: without a cap the third wait is unbounded by anything but the attempt count, and
+without jitter every client retries in lockstep.
+
+One further non-conformance, of a different kind: **C# exposes `MaxRetryAttempts`,
+`RetryBaseDelay` and `RetryMaxDelay` as public settable options.** Its *defaults* match this
+table exactly, but §16.1 permits only *lowering* the attempt cap or disabling retry outright —
+a caller able to raise them can turn one client into the herd this policy exists to prevent.
 
 This section is the missing policy, so the two forward references resolve to one table
 instead of eleven guesses.
@@ -2550,6 +2563,6 @@ recorded here until one exists.
 
 ---
 
-*Contract version: 1.8.1 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07; §9 rule 6 single-flight implementation invariants and the extended §9 test requirement added 2026-07; §8b AMQP transport, §10.2 gRPC revocation modes, §12.7 logout helpers, §14 device authorization grant and §15 token exchange added 2026-08; §14.3 rule 4 / §14.6 credential-adoption errata 2026-08 (contract 1.7); §16 retry policy, §17 decision memo, §18 deterministic shutdown and §19 telemetry hooks added 2026-08, with §11.2 rules 5–6 and §14.2 rule 6 amended to point at them (contract 1.8); §16 preamble errata — three SDKs had a divergent retry policy, not two 2026-08 (contract 1.8.1)*
+*Contract version: 1.8.2 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07; §9 rule 6 single-flight implementation invariants and the extended §9 test requirement added 2026-07; §8b AMQP transport, §10.2 gRPC revocation modes, §12.7 logout helpers, §14 device authorization grant and §15 token exchange added 2026-08; §14.3 rule 4 / §14.6 credential-adoption errata 2026-08 (contract 1.7); §16 retry policy, §17 decision memo, §18 deterministic shutdown and §19 telemetry hooks added 2026-08, with §11.2 rules 5–6 and §14.2 rule 6 amended to point at them (contract 1.8); §16 preamble errata 2026-08 (contract 1.8.2) — five SDKs had a divergent retry policy, not two (1.8.1 said three; both earlier counts came from partial greps, see the commit message)*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*


### PR DESCRIPTION
**Second correction to the same paragraph.** The count has been wrong twice, and both times the fault was the survey method rather than the writing — so this records the method as well as the answer.

| Revision | Claimed | Missing |
|---|---|---|
| 1.8 | two (Java, Rust) | TypeScript, Go, C# |
| 1.8.1 | three (+ TypeScript) | Go, C# |
| **1.8.2** | **five** (+ Go, C#) | — verified exhaustively |

## Why it was wrong twice

1.8's survey grepped only parts of each repo. 1.8.1's follow-up grepped `$repo/src` uniformly — which **silently skipped Go entirely**, because its sources live at the repo root, not under `src/`. Neither pass looked at C# at all. A grep that finds nothing looks exactly like a repo with nothing to find, which is what made the same mistake survive a correction.

The command behind this table makes no path assumption and enumerates per-language extensions:

```
grep -rlniE "backoff|jitter" $repo --include="*.go" --include="*.cs" --include="*.kt" ...
```

I also confirmed the six negatives rather than inferring them, and checked one false positive by hand: PHP's `for ($attempt = 0; $attempt < 3; $attempt++)` in `OidcClient.php` is §9 single-flight coordination, not a §16 transport retry.

## The verified table

| SDK | Attempts | Base | Cap | Jitter | `Retry-After` | Wired in? |
|---|---|---|---|---|---|---|
| Java | 3 | 200 ms | 5 s | full | floor | yes |
| C# | 3 | 200 ms | 5 s | yes | — | yes |
| Rust | 3 | library default | — | none | ignored | yes |
| Go | 3 | 100 ms | **none** | **none** | ignored | yes |
| TypeScript | 3 | 1000 ms | 8 s | partial | **replaced** the backoff | **no** |

Six had none at all: Python, Kotlin, PHP, Swift, C, C++.

Three cells are called out in the text, because each is a distinct way the clause gets got wrong:

- **TypeScript, `Retry-After`** — `retryAfterMs ?? backoffDelayMs(attempt)` lets a `Retry-After: 0` retry immediately, defeating the backoff. §16.1's "floor, never a ceiling" was written on principle and turned out to describe shipped code.
- **TypeScript, "wired in"** — the helper was exported and unit-tested but called by nothing. Already carried into 1.8.1 as the requirement to assert §16 through the public `check_access` surface.
- **Go** — `backoff *= 2` with **no cap and no jitter** is the shape this section most wants to eliminate. Uncapped, the third wait is bounded by nothing but the attempt count; unjittered, every client retries in lockstep.

## A non-conformance the contract can't fix

**C# exposes `MaxRetryAttempts`, `RetryBaseDelay` and `RetryMaxDelay` as public settable options.** Its *defaults* match the table exactly — it is the closest of the five — but §16.1 permits only *lowering* the cap or disabling retry outright. A caller who can raise them turns one client into the herd the policy exists to prevent.

That is a code fix, tracked to the C# SDK's own D5 PR. Noted here so the table isn't read as "C# conforms".

## Verification

`scripts/check-doc-links.sh` — 129 relative links resolved across 21 files. Version footer `1.8.1 → 1.8.2`.

## Notes

- Docs only: one paragraph in `sdks/CONTRACT.md` plus the footer. No code, no OpenAPI, no proto.
- Branch restarted from `main` after #284 merged, per the merged-PR rule.
- No open issues in this repository to reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ubrFbqsMkBqC5gwadPsDu)_