### PR TITLE
docs(authz): correct the deny-override claim across the live doc set (F2)

### DIFF
--- a/benchmarks/PUBLIC_BENCH_ANALYSIS.md
+++ b/benchmarks/PUBLIC_BENCH_ANALYSIS.md
@@ -641,12 +641,23 @@ regression and a gRPC flood-behavior bug in public view. We think an IAM
 vendor that measures itself adversarially and publishes the misses is
 itself a security feature.
 
+**4. Protocol surface has grown since this run, and is not yet in these
+numbers.** Deny-override RBAC (an explicit `effect: deny` that beats every
+allow, at any hierarchy depth), the OAuth2 Device Authorization Grant
+(RFC 8628), Token Exchange (RFC 8693), and the RP-initiated / back-channel
+logout and PAR triad have all landed since the run-5 measurements below.
+Two of those were in this document's own cons list until now. They are
+listed here as **shipped and unmeasured**: the deny-ratio seeding that
+exercises the deny path exists in the harness (`--deny-ratio`, default
+`0.05`), but the labelled cells are a run-6 deliverable, and every number
+in §§1–9 is from the pre-B-track build. A feature we have not measured is
+a feature we will not claim a cost for.
+
 **And the honest cons, in the same breath.** AXIAM is alpha: it has a
 fraction of Keycloak's protocol surface, extension ecosystem, hosting
 options and community; Zitadel's resting stack is smaller than ours
 (SurrealDB + RabbitMQ ride along in every AXIAM deployment); Keycloak
-wins one whole-stack efficiency cell outright (§5); our RBAC engine is
-additive-only in v1.0-beta (no deny-override); SurrealDB is a younger
+wins one whole-stack efficiency cell outright (§5); SurrealDB is a younger
 storage engine than Postgres by a decade; and every number in this
 document comes from one consumer laptop until the server-class re-run
 lands. Choosing AXIAM today means choosing a young system whose

--- a/claude_dev/token-exchange-design.md
+++ b/claude_dev/token-exchange-design.md
@@ -79,6 +79,18 @@ chains nest the claim (`act.act`), and the chain is **capped at depth 3** —
 beyond that nobody is reading it, and an uncapped chain is an unbounded field
 in a signed token.
 
+**The cap is per unbroken delegation chain, and impersonation starts a new one**
+(SEC-090). An impersonation exchange deliberately emits no `act` claim, so the
+subject's existing chain is dropped rather than extended — which is the correct
+behaviour for impersonation, whose entire point is a token indistinguishable
+from one the user obtained directly. The side effect is that the depth counter
+resets: three delegations, one impersonation, three more delegations. That is
+recorded here so the next reader meets it as a stated property rather than a
+surprise. It buys nothing — impersonation needs the `may_impersonate` grant,
+and the lifetime cap applies at every hop regardless of depth — but the audit
+linkage back through the chain is lost at the impersonation step, which is the
+same fact the impersonation section below is already built around.
+
 **Impersonation** (no `actor_token`) — "service S is now U, and nothing in the
 token records that." The issued token is indistinguishable from one the user
 obtained directly. This is genuinely useful (support tooling, admin

--- a/crates/axiam-api-rest/src/handlers/roles.rs
+++ b/crates/axiam-api-rest/src/handlers/roles.rs
@@ -307,8 +307,13 @@ pub async fn unassign_from_user<C: Connection + Clone>(
         .await?;
     // D7 (REVOCATION — security critical): unassigning a role removes access
     // for exactly this subject. Invalidate immediately so a cached allow cannot
-    // survive; the additive allow-wins model makes this stale-allow the only
-    // dangerous staleness direction.
+    // survive — a stale allow is the dangerous staleness direction, because a
+    // deny is the restrictive outcome and costs only a redundant re-check.
+    //
+    // (Pre-B1 this was justified by the engine being allow-wins. Under
+    // deny-override that premise no longer holds, but the conclusion does:
+    // see the decision_cache module docs for why, and for the addition that
+    // *can* narrow.)
     authz
         .get_ref()
         .as_ref()

--- a/crates/axiam-authz/src/config.rs
+++ b/crates/axiam-authz/src/config.rs
@@ -99,11 +99,14 @@ pub struct AuthzConfig {
     ///
     /// Configure via `AXIAM__AUTHZ__DECISION_CACHE_ENABLED` (default `false`).
     ///
-    /// SECURITY: the cache is safe under AXIAM's additive allow-wins /
-    /// default-deny model *only because* every access-narrowing mutation
+    /// SECURITY: the cache is safe under AXIAM's default-deny /
+    /// **deny-override** model *only because* every access-narrowing mutation
     /// invalidates the affected entries immediately (see
-    /// `decision_cache` module docs). A stale allow can outlive a revocation
-    /// by at most `decision_cache_ttl_secs` even if an invalidation is missed.
+    /// `decision_cache` module docs). Since B1 that set includes *adding* a
+    /// grant whose effect is `Deny` — an addition that narrows, which the
+    /// pre-B1 additive model had no way to express. A stale allow can outlive
+    /// a revocation by at most `decision_cache_ttl_secs` even if an
+    /// invalidation is missed.
     ///
     /// SECURITY — **multi-replica caveat, read before enabling**: on its own
     /// the cache and its invalidation are **process-local**. "Revocation is

--- a/crates/axiam-authz/src/decision_cache.rs
+++ b/crates/axiam-authz/src/decision_cache.rs
@@ -18,22 +18,48 @@
 //!
 //! # Security property (CRITICAL — read before changing invalidation)
 //!
-//! AXIAM's RBAC is **additive, allow-wins, default-deny** (CLAUDE.md /
-//! SEC-040). There is no deny-override. That asymmetry means the two staleness
-//! directions are NOT equally dangerous:
+//! AXIAM's RBAC is **default-deny with deny-override**: an absent grant
+//! refuses, an `effect: Allow` grant permits, and an `effect: Deny` grant
+//! refuses and **beats every allow**, at any depth of the hierarchy (CLAUDE.md;
+//! SEC-040 closed by B1; precedence table in
+//! `claude_dev/deny-override-design.md`).
 //!
-//! - A **stale DENY** is *safe*: it only costs a redundant re-evaluation; the
-//!   subject is momentarily under-privileged, never over-privileged.
-//! - A **stale ALLOW after a revocation** is *dangerous*: a subject keeps
-//!   access they no longer have. This is the only direction we must protect
-//!   against, and TTL alone is not enough.
+//! The two staleness directions are still NOT equally dangerous, but note *why*
+//! — the reason changed when B1 landed and the distinction matters below:
 //!
-//! Therefore every mutation that can *narrow* access (role unassignment, grant
-//! removal, role/permission deletion, group membership removal, resource
-//! reparent/delete) MUST invalidate the affected entries **immediately** via
+//! - A **stale DENY** is *safe* because a deny is the restrictive outcome: the
+//!   subject is momentarily under-privileged, never over-privileged. (Before
+//!   B1 this was phrased as a consequence of the engine being allow-wins. It is
+//!   not — it follows from deny being restrictive, which is why it survived
+//!   the change.)
+//! - A **stale ALLOW** is *dangerous*: a subject keeps access they no longer
+//!   have. This is the direction we must protect against, and TTL alone is not
+//!   enough.
+//!
+//! ## What B1 changed about which mutations need a hook
+//!
+//! Under the pre-B1 additive model, "narrowing" and "removing" were the same
+//! set: **adding** a grant could only ever widen, so an addition was safe to
+//! leave stale. That is no longer true. Granting a role an `effect: Deny`
+//! permission is an *addition* that **narrows**, and a cached allow that
+//! outlives it is a subject exercising access an administrator has explicitly
+//! forbidden.
+//!
+//! **Do not reintroduce the "additions are safe, skip the flush" optimisation.**
+//! It was sound under allow-wins and is a privilege bug under deny-override.
+//! `permissions::grant_to_role` flushes the tenant for exactly this reason and
+//! says so at the call site.
+//!
+//! Every mutation that can narrow access — role unassignment, grant removal,
+//! role/permission deletion, group membership removal, resource
+//! reparent/delete, **and any grant whose effect is `Deny`** — MUST invalidate
+//! the affected entries **immediately** via
 //! [`DecisionCache::invalidate_subject`] or [`DecisionCache::invalidate_tenant`]
 //! — wired to the mutation path, not left to TTL. The REST handlers in
-//! `axiam-api-rest` do exactly this through the `AuthzChecker` trait.
+//! `axiam-api-rest` do exactly this through the `AuthzChecker` trait, and in
+//! practice they invalidate on widening mutations too, which is what keeps the
+//! deny case covered rather than depending on every author classifying their
+//! mutation correctly.
 //!
 //! # Bounded staleness fallback
 //!

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -11,9 +11,11 @@ and permissions, and assigning roles. See also:
 
 All endpoints below require a bearer JWT (`Authorization: Bearer <token>`,
 obtained via `POST /api/v1/auth/login`) except the bootstrap endpoint itself.
-AXIAM's RBAC engine is **additive-only** (allow-wins, default-deny) — there is
-no explicit deny-override in v1.0-beta; a caller needs an explicit permission
-grant (directly or via role/group) to perform any action.
+AXIAM's RBAC engine is **default-deny with deny-override**: a caller needs an
+explicit permission grant (directly or via role/group) to perform any action,
+and an explicit `effect: "deny"` grant refuses regardless of what else allows
+it — at any depth of the resource hierarchy, and at equal specificity. See
+[Deny grants](#deny-grants-effect-deny) below.
 
 ## First-run admin bootstrap
 
@@ -147,6 +149,37 @@ A role's `is_global` flag controls whether it applies tenant-wide or must be
 assigned per-resource; resource-scoped roles cascade to child resources in
 the hierarchy unless overridden.
 
+### Deny grants (`effect: "deny"`)
+
+A grant carries an `effect`, which is `"allow"` when omitted. Every grant
+written before this existed, and every request that sends no `effect`, means
+allow — so nothing changed for existing configurations.
+
+```
+POST /api/v1/roles/{role_id}/permissions
+{ "permission_id": "<uuid>", "scope_ids": [], "effect": "deny" }
+```
+
+**A deny beats every allow.** Not "the most specific rule wins", not "the
+nearest ancestor wins" — a matching deny refuses at any depth of the resource
+hierarchy and at equal specificity. The precedence table and the reasoning for
+choosing deny-override over most-specific-wins are in
+[`claude_dev/deny-override-design.md`](../../claude_dev/deny-override-design.md).
+
+Two consequences worth planning around before you write one:
+
+- **A deny cannot be out-granted.** Adding an allow at a deeper resource, a
+  more specific scope, or a higher-privileged role will *not* restore access.
+  The only way back is to remove the deny. This is the property that makes a
+  deny useful for "this contractor may never touch payroll, whatever else they
+  are given" — and the same property makes an over-broad deny quietly
+  unfixable from the direction most admins will try first.
+- **The refusal is distinguishable.** A denied caller gets
+  `reason_code: "denied_by_rule"` rather than `"no_grant"`. Both are a 403, but
+  they mean opposite things to the person on the other end — *an admin already
+  decided* versus *ask an admin for access* — so a UI that collapses them sends
+  people to raise tickets that will be refused.
+
 ## Assigning roles
 
 To assign a role directly to a user (optionally scoped to a specific
@@ -191,13 +224,17 @@ hit is indistinguishable from a fresh evaluation.
 
 ### Why it is safe: immediate invalidation on revocation
 
-AXIAM's RBAC is **additive, allow-wins, default-deny** (no deny-override). That
-makes the two staleness directions asymmetric:
+AXIAM's RBAC is **default-deny with deny-override**. The two staleness
+directions are asymmetric:
 
 - A **stale deny** is harmless — it only forces a redundant re-check; the
   subject is briefly under-privileged, never over-privileged.
-- A **stale allow after a revocation** is the *only* dangerous case — a subject
-  keeping access they no longer have.
+- A **stale allow** is the dangerous case — a subject keeping access they no
+  longer have. Two mutations produce it: revoking something that allowed, and
+  **adding a grant whose effect is `deny`**. The second only became possible
+  when deny-override shipped, and it is an *addition* — so "additions widen,
+  and widening is safe to leave stale" is no longer a valid shortcut. Every
+  grant mutation flushes the tenant regardless of its effect.
 
 So the cache is not left to expire on its own for security. Every mutation that
 can narrow access **invalidates the affected cache entries immediately**, wired

--- a/docs/api/token-exchange.md
+++ b/docs/api/token-exchange.md
@@ -120,10 +120,23 @@ narrowing, it is a mistake best diagnosed here.
 
 ## Audience
 
-`audience` and `resource` both narrow the issued token's `aud`, and when
-supplied must match one of the exchanging client's registered audiences.
-An unconstrained `aud` would let a service mint tokens addressed at systems it
-has no relationship with. When both are supplied they must agree.
+`audience` and `resource` both narrow the issued token's `aud`. An
+unconstrained `aud` would let a service mint tokens addressed at systems it has
+no relationship with. When both are supplied they must agree.
+
+**The allow-list is the client's `redirect_uris`** (SEC-089). There is no
+separate audience field in v1: a target is accepted if it appears in the
+client's registered redirect URIs, or is one of AXIAM's own audiences below.
+
+> **Operators:** this means **adding a redirect URI also authorises it as a
+> token audience.** A redirect URI is normally reviewed as *"where may this
+> client send a user's browser"* — a routine, low-privilege edit. Here it also
+> answers *"for whom may this client mint tokens"*. The two lists also drift
+> for ordinary reasons: prune the redirect URIs of a client that stopped using
+> the browser flow and it silently loses exchange targets. Review redirect-URI
+> changes on clients holding the exchange grant with that second question in
+> mind. A dedicated `allowed_token_targets` registration field is the intended
+> fix and is not in v1.
 
 AXIAM's own audiences (`axiam:user`, `axiam:m2m`) are always addressable.
 When neither parameter is supplied the issued token keeps the subject token's
@@ -142,6 +155,29 @@ hold the result for a further 15 minutes.
 Revoking the subject's session does **not** retroactively revoke tokens
 exchanged from it — they are separate tokens. That is why the cap matters and
 why it is documented rather than left to be discovered.
+
+### Revocation is not consulted at exchange time (SEC-091)
+
+The subject token is validated for signature, issuer, audience and expiry. It
+is **not** checked against session revocation, which is the standing posture
+for access tokens across AXIAM (see
+[Session-revocation posture](../security-profiles.md#session-revocation-posture-rest-vs-grpc-a4j10)).
+A logged-out-but-unexpired access token can therefore still be exchanged.
+
+Two properties bound what that costs, and both are enforced in code rather than
+by convention:
+
+- **Lifetime cannot be laundered** — the cap above means the exchanged token
+  dies no later than its subject would have.
+- **Privilege cannot be widened** — the scope intersection refuses anything the
+  subject or the client does not already hold.
+
+So the window is *at most the subject's remaining lifetime, at no more than the
+subject's privilege* — the same window a revoked access token already has
+everywhere else in the product. This is not a new exposure introduced by token
+exchange; it is the existing one, unchanged. If you need sign-out to be
+immediate, shorten `AXIAM__AUTH__ACCESS_TOKEN_LIFETIME_SECS` — that is the knob
+that bounds this posture, here as elsewhere.
 
 ## Response
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -257,11 +257,13 @@ performance only, never the decision an endpoint returns.
 | `AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_ENABLED` | Cross-replica invalidation over RabbitMQ. Default `false`. See [below](#cross-replica-invalidation-42). Requires the cache to be enabled. |
 | `AXIAM__AUTHZ__DECISION_CACHE_BROADCAST_SKEW_SECS` | Freshness window for an inbound invalidation broadcast (default `30`). Only used when the broadcast channel is on. |
 
-**Security posture (safe under AXIAM's additive allow-wins / default-deny
-model):** every access-*narrowing* mutation (role/grant/group/resource change)
-invalidates the affected cache entries immediately, wired into the mutation
-handlers — so on the replica that handled the mutation **no revocation leaves a
-stale allow**. The TTL is the bounded-staleness backstop: a missed invalidation
+**Security posture (safe under AXIAM's default-deny / deny-override model):**
+every access-*narrowing* mutation (role/grant/group/resource change) invalidates
+the affected cache entries immediately, wired into the mutation handlers — so on
+the replica that handled the mutation **no revocation leaves a stale allow**.
+Since deny-override shipped, "narrowing" includes *adding* a grant whose effect
+is `deny`; grant mutations flush the tenant regardless of effect, so that case
+is covered on the same path. The TTL is the bounded-staleness backstop: a missed invalidation
 self-heals within `AXIAM__AUTHZ__DECISION_CACHE_TTL_SECS`. Full rationale and
 the per-mutation invalidation table are in the
 [Admin Guide](../admin/README.md#authorization-decision-cache-optional-d7).

--- a/docs/deployment/authz-read-path.md
+++ b/docs/deployment/authz-read-path.md
@@ -105,13 +105,15 @@ group repositories used by `AuthorizationEngine::evaluate` are read-only on
 that path and could be constructed against a replica pool, while every
 write-carrying repository keeps the primary.
 
-**The blocking problem is not plumbing, it is staleness semantics.** AXIAM's
-RBAC is additive/allow-wins/default-deny, so the dangerous direction is a
-*stale allow after a revocation* — exactly the property the decision cache's
-invalidation hooks exist to protect. A read replica reintroduces that window at
-the storage layer, where the invalidation hooks cannot reach it: unassigning a
-role commits to the primary and the replica serves the pre-unassign row until
-it catches up. Unlike the caches, that window is **not** bounded by a
+**The blocking problem is not plumbing, it is staleness semantics.** A deny is
+the restrictive outcome, so the dangerous direction is a *stale allow* —
+exactly the property the decision cache's invalidation hooks exist to protect.
+Under deny-override that covers two mutations, not one: revoking something that
+allowed, and **adding an `effect: deny` grant**. A read replica reintroduces the
+window for both at the storage layer, where the invalidation hooks cannot reach
+it: the write commits to the primary and the replica serves the pre-mutation
+rows until it catches up — so a freshly-written deny is simply not there yet,
+and the engine evaluates as though an administrator had never written it. Unlike the caches, that window is **not** bounded by a
 configured TTL; it is bounded by replication lag, which is an operational
 property that can degrade without any signal in AXIAM.
 


### PR DESCRIPTION
## What

B1 shipped deny-override and closed SEC-040. Six live documents and three source comments still said the opposite — *"there is no deny-override"*, *"additive-only"*, *"additive, allow-wins"* — including the one module a maintainer is explicitly told to read **before** changing cache invalidation.

**The code is correct.** `permissions::grant_to_role` already flushes the tenant for a deny grant and explains why at the call site. What was stale is the reasoning everywhere else — and one piece of it is a trap, not a cosmetic error.

## The trap

Under the pre-B1 additive model, "narrowing" and "removing" were the same set: **adding** a grant could only widen, so an addition was safe to leave stale — and `decision_cache.rs` said so, as a stated rule, in a section headed *"SECURITY (CRITICAL — read before changing invalidation)"*.

Under deny-override, granting a role an `effect: deny` permission is **an addition that narrows**.

Anyone who reads that module and applies its rule as an optimisation — *"additions widen, skip the flush"* — reintroduces a stale allow over an administrator's explicit deny. The module now names the trap instead of setting it.

The staleness asymmetry itself survives, but for a different reason, and the docs now say which: **a stale deny is safe because a deny is the restrictive outcome**, not because the engine is allow-wins. That distinction is the entire reason the conclusion outlived its premise, and it was nowhere in the text.

## Corrected

| File | What was wrong |
| --- | --- |
| `crates/axiam-authz/src/decision_cache.rs` | the security-property section, incl. the additions-are-safe rule |
| `crates/axiam-authz/src/config.rs` | the cache `SECURITY:` note |
| `crates/axiam-api-rest/src/handlers/roles.rs` | the unassign-invalidation justification |
| `docs/admin/README.md` | two operator-facing claims that AXIAM has no deny-override |
| `docs/deployment/README.md` | the cache posture note |
| `docs/deployment/authz-read-path.md` | the read-replica staleness case |
| `benchmarks/PUBLIC_BENCH_ANALYSIS.md` | the public §10 cons list |

`.planning/` records keep the old wording — they are a correct history of what was decided at the time.

## New for operators

`docs/admin/README.md` gains a **Deny grants** section. The feature has shipped since B1 with *no* operator documentation: how to write one, that **it cannot be out-granted** from any direction (deeper resource, narrower scope, higher role — the only way back is removing the deny), and that the refusal reports `denied_by_rule` rather than `no_grant` because the two mean opposite things to the person who hit it.

## Lands the three F4 write-ups that were deferred

Rather than leaving them in a review document nobody operating the system will read:

- **SEC-089** — `docs/api/token-exchange.md` now states that the audience allow-list **is** the client's `redirect_uris`, and warns that adding a redirect URI also authorises it as a token audience. That is a change normally reviewed as *"where may this client send a browser"* silently answering *"for whom may this client mint tokens"*.
- **SEC-090** — `claude_dev/token-exchange-design.md` records that the `act`-chain cap is per unbroken delegation chain and that impersonation starts a new one.
- **SEC-091** — `docs/api/token-exchange.md` states that revocation is not consulted at exchange time, with the two properties that bound it (lifetime cannot be laundered, privilege cannot be widened) and the knob that governs it.

## Public benchmark analysis

Deny-override and the other B-track features move out of the cons list into a strengths entry marked **shipped and unmeasured** — every number in that document predates them, the deny-ratio seeding exists in the harness but the labelled cells are a run-6 deliverable, and a feature we have not measured is one we will not claim a cost for. Same honesty discipline the document already applies to its open regressions.

## Verification

| Gate | Result |
| --- | --- |
| `cargo fmt -p axiam-authz -p axiam-api-rest -- --check` | clean |
| `cargo clippy -p axiam-authz --lib -- -D warnings` | clean |
| `cargo clippy -p axiam-api-rest --lib --no-default-features -- -D warnings` | clean |
| `cargo test -p axiam-authz --lib` | 72 passed |
| `cargo doc -p axiam-authz` | 2 warnings, unchanged — both pre-existing (verified by stashing) |
| stale-claim sweep over `docs/ crates/ benchmarks/ README.md` | no matches remain |

Markdown anchors and relative links added here were checked against their targets.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ubrFbqsMkBqC5gwadPsDu)_