### PR TITLE
fix(authz): deny-override precedence pass — end-to-end tests + SEC-092

### DIFF
--- a/claude_dev/deny-override-design.md
+++ b/claude_dev/deny-override-design.md
@@ -183,6 +183,26 @@ it is the test that would catch a future "most-specific-wins" refactor.
 projected column, never a filter, so it cannot make the predicate opaque to the
 planner (which is exactly how I7(a) went wrong before).
 
+### 5.1 Where each test actually lives (added by the F4 precedence pass)
+
+The plan above was implemented in two places, and the split matters:
+
+| Layer | File | What it can prove |
+|---|---|---|
+| Pure evaluator | `crates/axiam-authz/src/engine.rs` (`mod tests`) | precedence *given* a set of applicable roles |
+| End to end | `crates/axiam-authz/tests/authz_engine_test.rs` | that the deny **reaches** the evaluator |
+
+Rows 3, 4, 7 and 8 are claims about the second layer — a deny arriving through
+the hierarchy, through a group, or through a global role — and for the first
+months of B1 they were asserted only in the first, where the test hands the
+evaluator two role IDs that are applicable by construction.
+
+That gap is not theoretical. Deleting the ancestor clause from
+`applicable_role_ids` (so an inherited deny is silently dropped) leaves **all 72
+unit tests passing** while row 4 inverts from deny to allow. Only the
+end-to-end tests fail. Anything asserting a row of §2.2 belongs in the second
+file, or in both.
+
 ## 6. Explicitly out of scope
 
 - **Deny on a permission itself** (as opposed to on a grant). A permission is a

--- a/claude_dev/security-review-b-track-2026-08-10.md
+++ b/claude_dev/security-review-b-track-2026-08-10.md
@@ -272,7 +272,101 @@ step** and is recorded here as outstanding rather than quietly counted as done.
 | SEC-089 | Audience allow-list reuses `redirect_uris` | Low-medium | **Decide** — separate column, or document loudly |
 | SEC-090 | Impersonation resets the actor-chain bound | Low | Document in the design doc |
 | SEC-091 | Exchange does not consult revocation | Accepted | Document the bound in `security-profiles.md` |
-| — | Deny-override engine (B1) | — | **Outstanding**: dedicated pass against the precedence table |
+| SEC-092 | Unrecognised grant `effect` read back as `allow` | Low | **Fixed** — the grant is dropped; see §8 |
+| — | Deny-override engine (B1) | — | **Closed** by the §8 precedence pass |
 
 None of these block the already-merged B-track. SEC-088 should be fixed while
 the surface it corrupts is still unused, which is the only reason it is cheap.
+
+---
+
+## 8. Addendum — the deny-override precedence pass (2026-08-10)
+
+§6 recorded the B1 engine as *sampled, not exhausted*, and said a dedicated pass
+against the precedence table — not another read-through — was the right next
+step. This is that pass. It is recorded here rather than in a new document
+because it closes an item this review opened.
+
+### 8.1 The table is enforced. The tests for it were in the wrong place.
+
+Every row of `deny-override-design.md` §2.2 is correctly implemented, and
+`evaluate_grants` is a clean one-pass deny-short-circuit whose result provably
+does not depend on scan order. No precedence defect was found.
+
+But the *tests* for rows 3, 4, 7 and 8 all lived in `engine.rs`'s unit module,
+against `evaluate_grants` — a function that takes the applicable role IDs as an
+argument. Those four rows are claims about a layer that function never runs:
+that a deny arriving through the hierarchy, through a group, or through a global
+role is *applicable* and reaches the evaluator at all. The unit test for row 4
+even says so in its own comment ("the ancestor-scoped role carries the deny"),
+then constructs two role IDs that are applicable by construction.
+
+**Demonstration, not argument.** Delete the ancestor clause from
+`applicable_role_ids` — a one-line change that silently drops every inherited
+deny:
+
+```
+--- integration ---   3 failed  (2 of them the new deny-override rows)
+--- unit ---         72 passed
+```
+
+Row 4 inverts from `DeniedByRule` to `Allow` — a privilege escalation — and the
+entire unit suite stays green. That is the shape of gap §6 predicted, found by
+attacking the tests rather than the code.
+
+**Closed by** seven end-to-end tests in
+`crates/axiam-authz/tests/authz_engine_test.rs` covering rows 3, 4, 5, 7, 8,
+§2.3's scope interaction, and batch-vs-single equivalence. All seven fail when
+the deny short-circuit is disabled; two fail under the applicability mutation
+above.
+
+The batch case is worth naming separately: `evaluate_batch` re-derives
+applicability from its own coalesced lookups rather than calling `check_access`,
+so it is a genuinely independent traversal of the same table. It asserts
+equality against the single path rather than against a literal, so the two
+cannot drift even if both change.
+
+### 8.2 SEC-092 — an uninterpretable grant read back as permission
+
+`PermissionGrantRow::try_into_grant` mapped an **unrecognised** `effect` to
+`PermissionEffect::Allow`. The comment defending that choice weighed exactly two
+options — fail the read, or default to allow — and picked the second because the
+first takes authorization down over one bad row. Both are worse than the third
+option it did not consider.
+
+`from_wire` trims and lowercases, so casing is *not* how this happens; the
+realistic paths are a truncated write, a row edited outside the API, and — the
+one worth planning for — a **rolling upgrade in which a newer node writes a
+third effect** an older node cannot parse. Under the old default every such
+grant read back as an allow on the old node: deny-override defeated by version
+skew.
+
+Defaulting to `Deny` is not the fix either. In this engine `Deny` is not "ignore
+this grant", it is an active override that masks the action for every holder of
+the role — one malformed row would revoke access tenant-wide.
+
+**Fixed** by dropping the grant (`Ok(None)`): it contributes neither an allow nor
+a deny, the decision falls through to the remaining grants and ultimately to
+default-deny, and the row is logged at `error` rather than `warn`, because
+reaching that branch means the datastore was written outside both the API
+validator and the v25 schema `ASSERT`.
+
+Severity is **low**: the write path and the schema constraint both reject these
+values, so no supported path produces one today. It is recorded because the
+*direction* of the old default was wrong, and because the version-skew case is a
+future this design should not have to be lucky about.
+
+### 8.3 Two things deliberately left alone
+
+- **`unwrap_or(&empty_ancestors)` in `evaluate_batch`.** If the coalesced
+  ancestors lookup ever missed, an ancestor-scoped deny would be silently
+  dropped — a widening fallback. It is unreachable today (the same `has_roles`
+  filter gates both the population loop and the consumer), so changing it would
+  be an untestable edit to a live authorization path. Named here so the next
+  person to touch that filter knows what it is holding up.
+- **`grants_by_role` is keyed by bare `role_id` across tenants** in the batch
+  path, while the dedup set is keyed by `(tenant_id, role_id)`. A cross-tenant
+  batch therefore rests on UUIDv4 uniqueness rather than on the key. Not a
+  finding — a collision is not a thing that happens — but the isolation
+  invariant is stated in the wrong place, and a future non-random ID scheme
+  would make it a real one.

--- a/crates/axiam-authz/tests/authz_engine_test.rs
+++ b/crates/axiam-authz/tests/authz_engine_test.rs
@@ -3,7 +3,7 @@
 use axiam_authz::{AccessDecision, AccessRequest, AuthorizationEngine};
 use axiam_core::models::group::CreateGroup;
 use axiam_core::models::organization::CreateOrganization;
-use axiam_core::models::permission::CreatePermission;
+use axiam_core::models::permission::{CreatePermission, PermissionEffect};
 use axiam_core::models::resource::CreateResource;
 use axiam_core::models::role::CreateRole;
 use axiam_core::models::scope::CreateScope;
@@ -844,4 +844,504 @@ async fn one_of_two_applicable_roles_has_no_grants_still_allows() {
         .unwrap();
 
     assert_eq!(decision, AccessDecision::Allow);
+}
+
+// -----------------------------------------------------------------------
+// B1 deny-override — the precedence table, END TO END
+// (claude_dev/deny-override-design.md §2.2)
+//
+// The unit tests in `engine.rs` assert this table against `evaluate_grants`,
+// which takes the applicable role IDs as an argument. That is the right place
+// to pin the precedence rule, but it assumes away the layer the table's most
+// important rows are actually *about*: rows 3, 4, 7 and 8 are claims that a
+// deny arriving through the hierarchy, through a group, or through a global
+// role survives `applicable_role_ids` and reaches the evaluator at all. A
+// regression there would silently invert row 4 from deny to allow — a
+// privilege escalation — while every unit test stayed green, because each one
+// hands the evaluator two role IDs that are applicable by construction.
+//
+// These go through the real repositories, the real hierarchy walk and the real
+// group/global applicability filter. They are the tests that would fail.
+// -----------------------------------------------------------------------
+
+/// Create the permission for `action`, or return the existing one.
+///
+/// Permissions are unique per (tenant, action), and every one of these tests
+/// needs two *grants* of the same action with opposite effects — which is the
+/// whole point of the table. So the permission is shared and the two grant
+/// edges differ, which is also how a real tenant would express it.
+async fn ensure_permission(db: &Surreal<TestDb>, tenant_id: Uuid, action: &str) -> Uuid {
+    let perm_repo = SurrealPermissionRepository::new(db.clone());
+    match perm_repo
+        .create(CreatePermission {
+            tenant_id,
+            action: action.into(),
+            description: format!("Can {action}"),
+        })
+        .await
+    {
+        Ok(perm) => perm.id,
+        Err(_) => {
+            perm_repo
+                .list(tenant_id, Default::default())
+                .await
+                .unwrap()
+                .items
+                .into_iter()
+                .find(|p| p.action == action)
+                .expect("permission exists after AlreadyExists")
+                .id
+        }
+    }
+}
+
+/// One role's worth of grant: what it permits or refuses, and where it applies.
+struct RoleSpec<'a> {
+    name: &'a str,
+    action: &'a str,
+    effect: PermissionEffect,
+    /// Empty means wildcard — see `deny-override-design.md` §2.3.
+    scope_ids: Vec<Uuid>,
+    /// `None` assigns the role globally (§2.2 row 8).
+    resource_id: Option<Uuid>,
+}
+
+impl<'a> RoleSpec<'a> {
+    fn allow(name: &'a str, action: &'a str, resource_id: Uuid) -> Self {
+        Self {
+            name,
+            action,
+            effect: PermissionEffect::Allow,
+            scope_ids: Vec::new(),
+            resource_id: Some(resource_id),
+        }
+    }
+
+    fn deny(name: &'a str, action: &'a str, resource_id: Uuid) -> Self {
+        Self {
+            name,
+            action,
+            effect: PermissionEffect::Deny,
+            scope_ids: Vec::new(),
+            resource_id: Some(resource_id),
+        }
+    }
+
+    fn global(mut self) -> Self {
+        self.resource_id = None;
+        self
+    }
+
+    fn scoped(mut self, scope_ids: Vec<Uuid>) -> Self {
+        self.scope_ids = scope_ids;
+        self
+    }
+}
+
+/// Create a role carrying a single grant with an explicit effect, and assign it
+/// to `user_id` where `spec` says.
+async fn assign_role_with_effect(
+    db: &Surreal<TestDb>,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    spec: RoleSpec<'_>,
+) -> Uuid {
+    let RoleSpec {
+        name: role_name,
+        action,
+        effect,
+        scope_ids,
+        resource_id,
+    } = spec;
+    let is_global = resource_id.is_none();
+    let role_repo = SurrealRoleRepository::new(db.clone());
+    let perm_repo = SurrealPermissionRepository::new(db.clone());
+
+    let role = role_repo
+        .create(CreateRole {
+            tenant_id,
+            name: role_name.into(),
+            description: format!("Role: {role_name}"),
+            is_global,
+        })
+        .await
+        .unwrap();
+
+    let permission_id = ensure_permission(db, tenant_id, action).await;
+
+    perm_repo
+        .grant_to_role_with_effect(tenant_id, role.id, permission_id, scope_ids, effect)
+        .await
+        .unwrap();
+
+    role_repo
+        .assign_to_user(tenant_id, user_id, role.id, resource_id)
+        .await
+        .unwrap();
+
+    role.id
+}
+
+async fn check(
+    engine: &TestEngine,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    action: &str,
+    resource_id: Uuid,
+    scope: Option<&str>,
+) -> AccessDecision {
+    engine
+        .check_access(&AccessRequest {
+            tenant_id,
+            subject_id: user_id,
+            action: action.into(),
+            resource_id,
+            scope: scope.map(Into::into),
+        })
+        .await
+        .unwrap()
+}
+
+/// Row 3: allow on `/fleet`, deny on `/fleet/decommissioned`. The deny cascades
+/// down to `unit-7` and beats the ancestor allow.
+#[tokio::test]
+async fn deny_on_an_ancestor_cascades_down_and_beats_a_higher_allow() {
+    let (db, tenant_id, user_id) = setup().await;
+    let fleet = create_resource(&db, tenant_id, "fleet", None).await;
+    let decommissioned = create_resource(&db, tenant_id, "decommissioned", Some(fleet)).await;
+    let unit7 = create_resource(&db, tenant_id, "unit-7", Some(decommissioned)).await;
+
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("fleet-reader", "read", fleet),
+    )
+    .await;
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::deny("decom-blocked", "read", decommissioned),
+    )
+    .await;
+
+    let engine = make_engine(&db);
+
+    // The allow alone still works one level up, which is what makes the deny
+    // below a *change* rather than an absence.
+    assert_eq!(
+        check(&engine, tenant_id, user_id, "read", fleet, None).await,
+        AccessDecision::Allow
+    );
+    assert!(matches!(
+        check(&engine, tenant_id, user_id, "read", unit7, None).await,
+        AccessDecision::DeniedByRule(_)
+    ));
+}
+
+/// Row 4 — **the row to read twice.** Deny on `/fleet`, allow on
+/// `/fleet/decommissioned`. A child allow does NOT override an inherited deny.
+///
+/// This is the row that distinguishes deny-override from most-specific-wins:
+/// under most-specific-wins the nearer allow would win and the check would
+/// return Allow. If this test ever goes green with `AccessDecision::Allow`, the
+/// engine has silently switched semantics.
+#[tokio::test]
+async fn a_child_allow_does_not_override_an_inherited_deny_end_to_end() {
+    let (db, tenant_id, user_id) = setup().await;
+    let fleet = create_resource(&db, tenant_id, "fleet", None).await;
+    let decommissioned = create_resource(&db, tenant_id, "decommissioned", Some(fleet)).await;
+
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::deny("fleet-blocked", "read", fleet),
+    )
+    .await;
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("decom-reader", "read", decommissioned),
+    )
+    .await;
+
+    let engine = make_engine(&db);
+
+    assert!(
+        matches!(
+            check(&engine, tenant_id, user_id, "read", decommissioned, None).await,
+            AccessDecision::DeniedByRule(_)
+        ),
+        "a nearer allow must not overturn an inherited deny — that is \
+         most-specific-wins, which this engine deliberately does not implement"
+    );
+}
+
+/// Row 7: the deny arrives through a group-inherited role while the allow is
+/// assigned directly. Denies inherit through groups exactly as allows do.
+#[tokio::test]
+async fn a_group_inherited_deny_beats_a_directly_assigned_allow() {
+    let (db, tenant_id, user_id) = setup().await;
+    let resource_id = create_resource(&db, tenant_id, "svc-a", None).await;
+
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("direct-reader", "read", resource_id),
+    )
+    .await;
+
+    let group_repo = SurrealGroupRepository::new(db.clone());
+    let group = group_repo
+        .create(CreateGroup {
+            tenant_id,
+            name: "quarantined".into(),
+            description: "membership refuses read".into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    group_repo
+        .add_member(tenant_id, user_id, group.id)
+        .await
+        .unwrap();
+
+    let role_repo = SurrealRoleRepository::new(db.clone());
+    let perm_repo = SurrealPermissionRepository::new(db.clone());
+    let role = role_repo
+        .create(CreateRole {
+            tenant_id,
+            name: "quarantine".into(),
+            description: "deny read".into(),
+            is_global: false,
+        })
+        .await
+        .unwrap();
+    let perm_id = ensure_permission(&db, tenant_id, "read").await;
+    perm_repo
+        .grant_to_role_with_effect(tenant_id, role.id, perm_id, vec![], PermissionEffect::Deny)
+        .await
+        .unwrap();
+    role_repo
+        .assign_to_group(tenant_id, group.id, role.id, Some(resource_id))
+        .await
+        .unwrap();
+
+    let engine = make_engine(&db);
+
+    assert!(matches!(
+        check(&engine, tenant_id, user_id, "read", resource_id, None).await,
+        AccessDecision::DeniedByRule(_)
+    ));
+}
+
+/// Row 8: a global deny against a resource-scoped allow. Global vs
+/// resource-scoped changes applicability, not precedence — and a global role is
+/// applicable to *every* resource, so the deny reaches a resource the allow was
+/// scoped to.
+#[tokio::test]
+async fn a_global_deny_beats_a_resource_scoped_allow() {
+    let (db, tenant_id, user_id) = setup().await;
+    let resource_id = create_resource(&db, tenant_id, "svc-a", None).await;
+
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("svc-a-reader", "read", resource_id),
+    )
+    .await;
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::deny("org-wide-block", "read", Uuid::nil()).global(),
+    )
+    .await;
+
+    let engine = make_engine(&db);
+
+    assert!(matches!(
+        check(&engine, tenant_id, user_id, "read", resource_id, None).await,
+        AccessDecision::DeniedByRule(_)
+    ));
+}
+
+/// Row 5, end to end: denies are per action. A deny on `write` says nothing
+/// about `read`, even when it sits on the same node.
+#[tokio::test]
+async fn a_deny_on_one_action_does_not_mask_another_end_to_end() {
+    let (db, tenant_id, user_id) = setup().await;
+    let resource_id = create_resource(&db, tenant_id, "svc-a", None).await;
+
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("reader", "read", resource_id),
+    )
+    .await;
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::deny("no-write", "write", resource_id),
+    )
+    .await;
+
+    let engine = make_engine(&db);
+
+    assert_eq!(
+        check(&engine, tenant_id, user_id, "read", resource_id, None).await,
+        AccessDecision::Allow
+    );
+    assert!(matches!(
+        check(&engine, tenant_id, user_id, "write", resource_id, None).await,
+        AccessDecision::DeniedByRule(_)
+    ));
+}
+
+/// §2.3, end to end: an unscoped deny is a wildcard that masks the action for
+/// every scope, while a scoped deny masks only the scope it names.
+///
+/// Both halves run against real `Scope` rows, so the scope-name → scope-id
+/// resolution the engine does before evaluating is exercised rather than
+/// assumed.
+#[tokio::test]
+async fn scope_interaction_end_to_end() {
+    let (db, tenant_id, user_id) = setup().await;
+    let resource_id = create_resource(&db, tenant_id, "api", None).await;
+
+    let scope_repo = SurrealScopeRepository::new(db.clone());
+    let pii = scope_repo
+        .create(CreateScope {
+            tenant_id,
+            resource_id,
+            name: "pii".into(),
+            description: "personal data".into(),
+        })
+        .await
+        .unwrap();
+    let billing = scope_repo
+        .create(CreateScope {
+            tenant_id,
+            resource_id,
+            name: "billing".into(),
+            description: "billing data".into(),
+        })
+        .await
+        .unwrap();
+
+    // Wildcard allow (no scopes) + a deny scoped to `pii` only.
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("reader", "read", resource_id),
+    )
+    .await;
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::deny("no-pii", "read", resource_id).scoped(vec![pii.id]),
+    )
+    .await;
+
+    let engine = make_engine(&db);
+
+    assert!(matches!(
+        check(
+            &engine,
+            tenant_id,
+            user_id,
+            "read",
+            resource_id,
+            Some("pii")
+        )
+        .await,
+        AccessDecision::DeniedByRule(_)
+    ));
+    assert_eq!(
+        check(
+            &engine,
+            tenant_id,
+            user_id,
+            "read",
+            resource_id,
+            Some("billing")
+        )
+        .await,
+        AccessDecision::Allow,
+        "a deny scoped to `pii` must not touch `billing`"
+    );
+    // An unscoped request against a scoped deny still matches it: the request
+    // names no scope, so the grant applies. Getting this wrong in the deny
+    // direction is a silent privilege escalation.
+    assert!(matches!(
+        check(&engine, tenant_id, user_id, "read", resource_id, None).await,
+        AccessDecision::DeniedByRule(_)
+    ));
+
+    let _ = billing;
+}
+
+/// The batch path must produce byte-identical decisions to the single path,
+/// including deny-override and its reason. `evaluate_batch` re-derives
+/// applicability from its own coalesced lookups rather than calling
+/// `check_access`, so this is a genuinely separate code path through the same
+/// precedence table — the one place the two could drift.
+#[tokio::test]
+async fn the_batch_path_applies_deny_override_identically() {
+    let (db, tenant_id, user_id) = setup().await;
+    let fleet = create_resource(&db, tenant_id, "fleet", None).await;
+    let unit7 = create_resource(&db, tenant_id, "unit-7", Some(fleet)).await;
+
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::allow("fleet-reader", "read", fleet),
+    )
+    .await;
+    assign_role_with_effect(
+        &db,
+        tenant_id,
+        user_id,
+        RoleSpec::deny("unit7-blocked", "read", unit7),
+    )
+    .await;
+
+    let engine = make_engine(&db);
+
+    let requests = vec![
+        AccessRequest {
+            tenant_id,
+            subject_id: user_id,
+            action: "read".into(),
+            resource_id: fleet,
+            scope: None,
+        },
+        AccessRequest {
+            tenant_id,
+            subject_id: user_id,
+            action: "read".into(),
+            resource_id: unit7,
+            scope: None,
+        },
+    ];
+
+    let batched = engine.check_access_batch(&requests).await.unwrap();
+    let mut singly = Vec::new();
+    for req in &requests {
+        singly.push(engine.check_access(req).await.unwrap());
+    }
+
+    assert_eq!(batched, singly, "batch and single paths must not diverge");
+    assert_eq!(batched[0], AccessDecision::Allow);
+    assert!(matches!(batched[1], AccessDecision::DeniedByRule(_)));
 }

--- a/crates/axiam-db/src/repository/permission.rs
+++ b/crates/axiam-db/src/repository/permission.rs
@@ -82,7 +82,9 @@ struct RolePermissionGrantRow {
 }
 
 impl RolePermissionGrantRow {
-    fn try_into_role_grant(self) -> Result<(Uuid, PermissionGrant), DbError> {
+    /// `Ok(None)` when the row's `effect` is unrecognised — see
+    /// [`PermissionGrantRow::try_into_grant`] (SEC-092).
+    fn try_into_role_grant(self) -> Result<Option<(Uuid, PermissionGrant)>, DbError> {
         let role_id = Uuid::parse_str(&self.role_id)
             .map_err(|e| DbError::Migration(format!("invalid role UUID: {e}")))?;
         let grant = PermissionGrantRow {
@@ -96,12 +98,15 @@ impl RolePermissionGrantRow {
             effect: self.effect,
         }
         .try_into_grant()?;
-        Ok((role_id, grant))
+        Ok(grant.map(|g| (role_id, g)))
     }
 }
 
 impl PermissionGrantRow {
-    fn try_into_grant(self) -> Result<PermissionGrant, DbError> {
+    /// `Ok(None)` means "this grant edge is malformed and contributes nothing"
+    /// — not an error, and deliberately not an allow. See the `effect` match
+    /// below (SEC-092).
+    fn try_into_grant(self) -> Result<Option<PermissionGrant>, DbError> {
         let id = Uuid::parse_str(&self.record_id)
             .map_err(|e| DbError::Migration(format!("invalid UUID: {e}")))?;
         let tenant_id = Uuid::parse_str(&self.tenant_id)
@@ -117,33 +122,57 @@ impl PermissionGrantRow {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        // B1: an absent or unrecognised `effect` reads back as Allow.
+        // B1: an ABSENT `effect` reads back as Allow; an UNRECOGNISED one
+        // drops the grant entirely (`Ok(None)`).
         //
         // Absent is the backward-compatibility case and is simply correct:
         // every edge written before deny-override existed means "allow".
         //
-        // *Unrecognised* is the interesting one. Defaulting a garbage value to
-        // Allow looks like the wrong direction for a security decision — but
-        // the write path validates `effect` before it ever reaches the
-        // database (`PermissionEffect::from_wire` rejects anything that is not
-        // exactly "allow" or "deny"), so a value that is neither can only come
-        // from someone editing rows by hand. Failing the read would take the
-        // whole authorization path down for that tenant; defaulting to Allow
-        // reproduces exactly the pre-B1 behaviour of a row that has no effect
-        // at all. It is logged so it is not silent.
+        // Unrecognised is the security-relevant one, and it has three possible
+        // answers, not two:
+        //
+        // 1. **Fail the read.** Takes the whole authorization path down for the
+        //    tenant over a single malformed row. Rejected.
+        // 2. **Default to Allow** — what this did until SEC-092. A grant edge
+        //    nobody can interpret became a *permissive* one. `from_wire` trims
+        //    and lowercases, so casing and whitespace are not how this happens;
+        //    the realistic paths are a truncated or partially-written value, a
+        //    row edited outside the API, and — the one worth planning for — a
+        //    **rolling upgrade in which a newer node writes a third effect** a
+        //    node still on this version does not know. Under the old default,
+        //    every one of those grants read back as allow on the old node,
+        //    which is deny-override defeated by a version skew.
+        // 3. **Default to Deny.** Tempting, and wrong for a different reason:
+        //    `PermissionEffect::Deny` is not "ignore this grant", it is an
+        //    active override that masks the action for *everyone* holding the
+        //    role. One malformed row would revoke access tenant-wide.
+        //
+        // Dropping the grant is the only answer that fails closed without
+        // being weaponisable: the row contributes neither an allow nor a deny,
+        // so the decision falls through to the other grants and ultimately to
+        // default-deny. It is logged at `error` — the write path validates
+        // `effect` (`PermissionEffect::from_wire`) and the v25 schema ASSERT
+        // rejects anything else, so reaching this branch means either a
+        // datastore modified outside both, or exactly the version skew above.
         let effect = match self.effect.as_deref() {
             None => PermissionEffect::Allow,
-            Some(raw) => PermissionEffect::from_wire(raw).unwrap_or_else(|| {
-                tracing::warn!(
-                    effect = %raw,
-                    "grant edge carries an unrecognised effect; treating it as \
-                     'allow' (the pre-deny-override meaning of an absent effect)"
-                );
-                PermissionEffect::Allow
-            }),
+            Some(raw) => match PermissionEffect::from_wire(raw) {
+                Some(effect) => effect,
+                None => {
+                    tracing::error!(
+                        effect = %raw,
+                        permission_id = %id,
+                        "grant edge carries an unrecognised effect; DROPPING the \
+                         grant (SEC-092). It contributes neither an allow nor a \
+                         deny — treating it as 'allow' would let a malformed \
+                         value defeat deny-override"
+                    );
+                    return Ok(None);
+                }
+            },
         };
 
-        Ok(PermissionGrant {
+        Ok(Some(PermissionGrant {
             permission: Permission {
                 id,
                 tenant_id,
@@ -154,7 +183,7 @@ impl PermissionGrantRow {
             },
             scope_ids,
             effect,
-        })
+        }))
     }
 }
 
@@ -649,7 +678,10 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
         let grants = rows
             .into_iter()
             .map(|row| row.try_into_grant())
-            .collect::<Result<Vec<_>, DbError>>()?;
+            .collect::<Result<Vec<_>, DbError>>()?
+            .into_iter()
+            .flatten()
+            .collect();
 
         Ok(grants)
     }
@@ -713,10 +745,122 @@ impl<C: Connection> PermissionRepository for SurrealPermissionRepository<C> {
 
         let mut grouped: HashMap<Uuid, Vec<PermissionGrant>> = HashMap::new();
         for row in rows {
-            let (role_id, grant) = row.try_into_role_grant()?;
+            // A dropped grant (SEC-092) contributes no entry at all, so a role
+            // whose ONLY grant is malformed is absent from the map rather than
+            // present-and-empty. The engine's `grants_by_role.get(role_id)`
+            // miss and an empty Vec are already equivalent, so both spellings
+            // reach the same decision.
+            let Some((role_id, grant)) = row.try_into_role_grant()? else {
+                continue;
+            };
             grouped.entry(role_id).or_default().push(grant);
         }
 
         Ok(grouped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn row(effect: Option<&str>) -> PermissionGrantRow {
+        PermissionGrantRow {
+            record_id: Uuid::new_v4().to_string(),
+            tenant_id: Uuid::new_v4().to_string(),
+            action: "read".into(),
+            description: "read".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            scope_ids: None,
+            effect: effect.map(str::to_string),
+        }
+    }
+
+    /// The backward-compatibility case: every grant edge written before B1 has
+    /// no `effect` at all, and every one of them means allow.
+    #[test]
+    fn an_absent_effect_reads_back_as_allow() {
+        let grant = row(None).try_into_grant().unwrap().expect("kept");
+        assert_eq!(grant.effect, PermissionEffect::Allow);
+    }
+
+    #[test]
+    fn the_two_valid_effects_round_trip() {
+        assert_eq!(
+            row(Some("allow")).try_into_grant().unwrap().unwrap().effect,
+            PermissionEffect::Allow
+        );
+        assert_eq!(
+            row(Some("deny")).try_into_grant().unwrap().unwrap().effect,
+            PermissionEffect::Deny
+        );
+    }
+
+    /// Casing and surrounding whitespace are *not* malformed — `from_wire`
+    /// trims and lowercases. Pinned here so the SEC-092 drop below is not
+    /// mistaken for strictness it does not have.
+    #[test]
+    fn casing_and_whitespace_still_parse() {
+        for raw in ["DENY", "Deny", " deny ", "ALLOW"] {
+            assert!(
+                row(Some(raw)).try_into_grant().unwrap().is_some(),
+                "effect {raw:?} is well-formed and must not be dropped"
+            );
+        }
+    }
+
+    /// **SEC-092.** An unrecognised effect drops the grant. It must be neither
+    /// an allow (which would let an uninterpretable value read back as
+    /// permission) nor a deny (which would let one malformed row mask the
+    /// action for every holder of the role), and it must not be an error
+    /// (which would take the whole authorization path down for the tenant).
+    ///
+    /// `"restrict"` stands in for the case worth planning for: a **third
+    /// effect written by a newer node** during a rolling upgrade. Before
+    /// SEC-092 every such grant read back as **allow** on the old node.
+    #[test]
+    fn an_unrecognised_effect_drops_the_grant() {
+        for raw in ["restrict", "audit", "den", "", "true"] {
+            let outcome = row(Some(raw)).try_into_grant().unwrap();
+            assert!(
+                outcome.is_none(),
+                "effect {raw:?} must drop the grant, not resolve to an effect"
+            );
+        }
+    }
+
+    /// The batched shape drops the same rows, and drops them *without* losing
+    /// the role id of the rows that survive — a bug here would silently empty a
+    /// role that has perfectly good grants alongside a malformed one.
+    #[test]
+    fn the_batched_row_drops_malformed_grants_and_keeps_the_rest() {
+        let role_id = Uuid::new_v4();
+        let batched = |effect: Option<&str>| RolePermissionGrantRow {
+            role_id: role_id.to_string(),
+            record_id: Uuid::new_v4().to_string(),
+            tenant_id: Uuid::new_v4().to_string(),
+            action: "read".into(),
+            description: "read".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            scope_ids: None,
+            effect: effect.map(str::to_string),
+        };
+
+        assert!(
+            batched(Some("nonsense"))
+                .try_into_role_grant()
+                .unwrap()
+                .is_none()
+        );
+
+        let (kept_role, kept) = batched(Some("deny"))
+            .try_into_role_grant()
+            .unwrap()
+            .expect("kept");
+        assert_eq!(kept_role, role_id);
+        assert_eq!(kept.effect, PermissionEffect::Deny);
     }
 }


### PR DESCRIPTION
## What

Closes the one item the F4 security review (#287) left **explicitly outstanding**: a dedicated pass against the deny-override precedence table, rather than another read-through of the engine.

> "the deny-override engine in particular is 1120 lines of precedence logic where the failure mode is a privilege escalation that no amount of reading reliably catches … a dedicated review pass against that table, not another read-through, is the right next step"

## The table is enforced. The tests for it were in the wrong place.

Every row of `deny-override-design.md` §2.2 is correctly implemented. `evaluate_grants` is a clean one-pass deny short-circuit whose result provably does not depend on scan order. **No precedence defect was found.**

But the *tests* for rows 3, 4, 7 and 8 all lived in `engine.rs`'s unit module, against `evaluate_grants` — a function that takes the applicable role IDs **as an argument**. Those four rows are claims about the layer that function never runs: that a deny arriving through the hierarchy, through a group, or through a global role is *applicable* and reaches the evaluator at all.

The row-4 test even says so in its own comment ("the ancestor-scoped role carries the deny") and then constructs two role IDs that are applicable by construction.

### Demonstration, not argument

Delete the ancestor clause from `applicable_role_ids` — one line, silently dropping every inherited deny:

```
--- integration ---   3 failed
--- unit ---         72 passed
```

Row 4 inverts from `DeniedByRule` to **`Allow`** — a privilege escalation — and the entire unit suite stays green. That is the shape of gap the review predicted, found by attacking the tests rather than the code.

### Closed by seven end-to-end tests

In `crates/axiam-authz/tests/authz_engine_test.rs`, through the real repositories, the real hierarchy walk and the real group/global applicability filter:

| Test | Table row |
| --- | --- |
| `deny_on_an_ancestor_cascades_down_and_beats_a_higher_allow` | 3 |
| `a_child_allow_does_not_override_an_inherited_deny_end_to_end` | **4 — the row to read twice** |
| `a_deny_on_one_action_does_not_mask_another_end_to_end` | 5 |
| `a_group_inherited_deny_beats_a_directly_assigned_allow` | 7 |
| `a_global_deny_beats_a_resource_scoped_allow` | 8 |
| `scope_interaction_end_to_end` | §2.3 |
| `the_batch_path_applies_deny_override_identically` | both paths |

All seven fail when the deny short-circuit is disabled; two fail under the applicability mutation above.

The batch case is worth naming separately: `evaluate_batch` re-derives applicability from its own coalesced lookups rather than calling `check_access`, so it is a genuinely independent traversal of the same table. It asserts **equality against the single path** rather than against a literal, so the two cannot drift even if both change.

## SEC-092 — an uninterpretable grant read back as permission

`PermissionGrantRow::try_into_grant` mapped an **unrecognised** `effect` to `PermissionEffect::Allow`. The comment defending that choice weighed exactly two options — fail the read, or default to allow — and picked the second. Both are worse than the third it did not consider.

`from_wire` trims and lowercases, so casing is *not* how this happens. The realistic paths are a truncated write, a row edited outside the API, and — the one worth planning for — a **rolling upgrade in which a newer node writes a third effect** an older node cannot parse. Under the old default every such grant read back as an allow on the old node: **deny-override defeated by version skew.**

Defaulting to `Deny` is not the fix either. In this engine `Deny` is not "ignore this grant", it is an active override that masks the action for *every* holder of the role — one malformed row would revoke access tenant-wide.

**Fixed** by dropping the grant (`Ok(None)`): it contributes neither an allow nor a deny, the decision falls through to the remaining grants and ultimately to default-deny, and the row is logged at `error` rather than `warn`, because reaching that branch means the datastore was written outside *both* the API validator and the v25 schema `ASSERT`.

Severity **low** — no supported path produces such a value today — but the *direction* of the old default was wrong, and the version-skew case is a future this design should not have to be lucky about.

## Two things deliberately left alone

Recorded in the review addendum rather than changed:

- **`unwrap_or(&empty_ancestors)` in `evaluate_batch`** — if the coalesced ancestors lookup ever missed, an ancestor-scoped deny would be silently dropped, a *widening* fallback. Unreachable today (the same `has_roles` filter gates both the population loop and the consumer), so changing it would be an untestable edit to a live authorization path. Named so the next person to touch that filter knows what it holds up.
- **`grants_by_role` is keyed by bare `role_id` across tenants** in the batch path, while the dedup set is keyed by `(tenant_id, role_id)`. Tenant isolation there rests on UUIDv4 uniqueness rather than on the key. Not a finding — but the invariant is stated in the wrong place, and a future non-random ID scheme would make it a real one.

## Verification

| Gate | Result |
| --- | --- |
| `cargo test -p axiam-authz --lib` | 72 passed |
| `cargo test -p axiam-authz --test authz_engine_test` | **22 passed** (15 → 22) |
| `cargo test -p axiam-db --lib` | **141 passed** (136 → 141) |
| Mutation: deny short-circuit disabled | 7 fail |
| Mutation: ancestor clause removed | 3 integration fail, 72 unit **pass** |
| `cargo clippy … -D warnings`, `cargo fmt --check` | clean on both crates |

Docs updated: the review's disposition table (SEC-092 added, the outstanding item closed) plus a new §8 addendum, and `deny-override-design.md` §5.1 recording which layer each test belongs in and why.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ubrFbqsMkBqC5gwadPsDu)_