### PR TITLE
fix(oauth2): stop device-grant and PAR single-use depending on conflict detection

### DIFF
--- a/crates/axiam-db/src/repository/device_grant.rs
+++ b/crates/axiam-db/src/repository/device_grant.rs
@@ -245,47 +245,79 @@ impl<C: Connection> DeviceGrantRepository for SurrealDeviceGrantRepository<C> {
         tenant_id: Uuid,
         device_code_hash: &str,
     ) -> AxiamResult<Option<DeviceGrant>> {
-        // Single-use, in one TRANSACTION. `RETURN BEFORE` yields the
-        // pre-transition row, so exactly one concurrent poll sees a non-empty
-        // result and the others see nothing.
+        // Single-use. `RETURN BEFORE` yields the pre-transition row, and the
+        // `status = 'approved'` guard is what makes a later, non-concurrent
+        // poll match nothing.
         //
-        // The BEGIN/COMMIT is what makes that true. A multi-statement query is
-        // not atomic in SurrealDB — each statement runs in its own transaction
-        // — so the `status = 'approved'` guard alone does not serialise
-        // concurrent polls: this redeem was measured letting 4 of 8 win, which
-        // is one user approval minting four token sets. A device that polls on
-        // a short interval and retries is not an exotic case; it is the normal
-        // shape of RFC 8628 §3.4.
+        // The guard does not decide a *concurrent* race, and neither does the
+        // `BEGIN`/`COMMIT` this used to rely on. SurrealDB 3.2.3 does not
+        // reliably detect the write-write conflict — measured on the
+        // permission-ticket consume, which is this same shape, two transactions
+        // both commit with zero errors and both return the pre-transition row.
+        // Here that is one user approval minting two token sets, and a device
+        // polling on a short interval and retrying is the normal shape of
+        // RFC 8628 §3.4, not an exotic case.
+        //
+        // So the race is decided here instead: each attempt stamps a nonce, the
+        // last write persists, and the third statement reads back to see whose
+        // it was. Exactly one nonce can be the stored one. See `SCHEMA_V31` for
+        // the measurements, including two repairs that proved worse than the
+        // defect, and for why this is a narrower window rather than a guarantee.
+        //
+        // Deliberately **not** in a transaction: inside one the read-back would
+        // see this caller's own write under snapshot isolation and every racer
+        // would believe it won.
+        let nonce = new_id().to_string();
         let result = self
             .db
             .current()
             .query(format!(
-                "BEGIN TRANSACTION; \
-                 LET $before = (UPDATE device_grant SET status = 'redeemed' \
+                "LET $before = (UPDATE device_grant \
+                     SET status = 'redeemed', redemption_id = $nonce \
                      WHERE tenant_id = $tenant_id AND device_code_hash = $hash \
                      AND status = 'approved' AND expires_at > time::now() \
                      RETURN BEFORE); \
                  SELECT {SELECT_FIELDS} FROM $before; \
-                 COMMIT TRANSACTION"
+                 SELECT VALUE redemption_id FROM device_grant \
+                     WHERE tenant_id = $tenant_id AND device_code_hash = $hash LIMIT 1"
             ))
             .bind(("tenant_id", tenant_id.to_string()))
             .bind(("hash", device_code_hash.to_string()))
+            .bind(("nonce", nonce.clone()))
             .await;
 
-        // A loser's transaction is aborted by the conflict — that is this
-        // method's "already redeemed" answer, not a server fault.
+        // Each statement is its own transaction, so a conflict is still
+        // possible. A loser's conflict is this method's "already redeemed"
+        // answer, not a server fault.
         let mut result = match result {
             Ok(r) => r,
             Err(e) if is_transaction_conflict(&e) => return Ok(None),
             Err(e) => return Err(DbError::from(e).into()),
         };
 
-        // BEGIN=0, LET=1, SELECT=2, COMMIT=3.
-        let rows: Vec<DeviceGrantRow> = match result.take::<Vec<DeviceGrantRow>>(2) {
+        // LET=0, SELECT rows=1, SELECT nonce=2.
+        let rows: Vec<DeviceGrantRow> = match result.take::<Vec<DeviceGrantRow>>(1) {
             Ok(rows) => rows,
             Err(e) if is_transaction_conflict(&e) => return Ok(None),
             Err(e) => return Err(DbError::from(e).into()),
         };
+        if rows.is_empty() {
+            // Unknown, not approved, already redeemed, or expired. Nothing was
+            // written, so nothing was burned.
+            return Ok(None);
+        }
+
+        let stored: Vec<Option<String>> = match result.take::<Vec<Option<String>>>(2) {
+            Ok(v) => v,
+            Err(e) if is_transaction_conflict(&e) => return Ok(None),
+            Err(e) => return Err(DbError::from(e).into()),
+        };
+        if stored.into_iter().flatten().next().as_deref() != Some(nonce.as_str()) {
+            // Our write landed but another poll's landed after it. That poll
+            // holds the redemption; this one must not also mint a token set.
+            return Ok(None);
+        }
+
         rows.into_iter()
             .next()
             .map(DeviceGrantRow::try_into_grant)

--- a/crates/axiam-db/src/repository/pushed_auth_request.rs
+++ b/crates/axiam-db/src/repository/pushed_auth_request.rs
@@ -161,48 +161,79 @@ impl<C: Connection> PushedAuthRequestRepository for SurrealPushedAuthRequestRepo
         tenant_id: Uuid,
         request_uri_hash: &str,
     ) -> AxiamResult<Option<PushedAuthRequest>> {
-        // `RETURN BEFORE` yields the pre-transition row, so exactly one
-        // concurrent authorize request sees a non-empty result and any other
-        // sees nothing. Marking `consumed` rather than deleting keeps
-        // "already used" distinguishable from "never existed" in an audit
-        // trail, even though both answer `invalid_request` on the wire.
-        // The BEGIN/COMMIT is load-bearing, not decoration. A multi-statement
-        // query is not atomic in SurrealDB — each statement runs in its own
-        // transaction — so the `consumed = false` guard alone does not
-        // serialise concurrent callers, and this consume was measured letting
-        // 2 of 8 concurrent redemptions win. RFC 9126 §2.2 makes `request_uri`
-        // one-time-use precisely because a replayable one is a replayable
-        // authorization request.
+        // `RETURN BEFORE` yields the pre-transition row. Marking `consumed`
+        // rather than deleting keeps "already used" distinguishable from
+        // "never existed" in an audit trail, even though both answer
+        // `invalid_request` on the wire.
+        //
+        // The `consumed = false` guard is what makes a later, non-concurrent
+        // authorize request match nothing. It does not decide a *concurrent*
+        // one, and neither did the `BEGIN`/`COMMIT` this used to rely on:
+        // SurrealDB 3.2.3 does not reliably detect the write-write conflict —
+        // measured on the permission-ticket consume, which is this same shape,
+        // two transactions both commit with zero errors and both return the
+        // pre-transition row. RFC 9126 §2.2 makes `request_uri` one-time-use
+        // precisely because a replayable one is a replayable authorization
+        // request.
+        //
+        // So the race is decided here: each attempt stamps a nonce, the last
+        // write persists, and the third statement reads back to see whose it
+        // was. See `SCHEMA_V31` for the measurements and for why this narrows
+        // the window rather than closing it.
+        //
+        // Deliberately **not** in a transaction: inside one the read-back would
+        // see this caller's own write under snapshot isolation and every racer
+        // would believe it won.
+        let nonce = new_id().to_string();
         let result = self
             .db
             .current()
             .query(format!(
-                "BEGIN TRANSACTION; \
-                 LET $before = (UPDATE pushed_auth_request SET consumed = true \
+                "LET $before = (UPDATE pushed_auth_request \
+                     SET consumed = true, redemption_id = $nonce \
                      WHERE tenant_id = $tenant_id AND request_uri_hash = $hash \
                      AND consumed = false AND expires_at > time::now() \
                      RETURN BEFORE); \
                  SELECT {SELECT_FIELDS} FROM $before; \
-                 COMMIT TRANSACTION"
+                 SELECT VALUE redemption_id FROM pushed_auth_request \
+                     WHERE tenant_id = $tenant_id AND request_uri_hash = $hash LIMIT 1"
             ))
             .bind(("tenant_id", tenant_id.to_string()))
             .bind(("hash", request_uri_hash.to_string()))
+            .bind(("nonce", nonce.clone()))
             .await;
 
-        // A loser's transaction is aborted by the conflict. That is this
-        // method's "someone else consumed it" answer, not a server fault.
+        // Each statement is its own transaction, so a conflict is still
+        // possible. A loser's conflict is this method's "someone else consumed
+        // it" answer, not a server fault.
         let mut result = match result {
             Ok(r) => r,
             Err(e) if is_transaction_conflict(&e) => return Ok(None),
             Err(e) => return Err(DbError::from(e).into()),
         };
 
-        // BEGIN=0, LET=1, SELECT=2, COMMIT=3.
-        let rows: Vec<PushedAuthRequestRow> = match result.take::<Vec<PushedAuthRequestRow>>(2) {
+        // LET=0, SELECT rows=1, SELECT nonce=2.
+        let rows: Vec<PushedAuthRequestRow> = match result.take::<Vec<PushedAuthRequestRow>>(1) {
             Ok(rows) => rows,
             Err(e) if is_transaction_conflict(&e) => return Ok(None),
             Err(e) => return Err(DbError::from(e).into()),
         };
+        if rows.is_empty() {
+            // Unknown, already consumed, or expired. Nothing was written.
+            return Ok(None);
+        }
+
+        let stored: Vec<Option<String>> = match result.take::<Vec<Option<String>>>(2) {
+            Ok(v) => v,
+            Err(e) if is_transaction_conflict(&e) => return Ok(None),
+            Err(e) => return Err(DbError::from(e).into()),
+        };
+        if stored.into_iter().flatten().next().as_deref() != Some(nonce.as_str()) {
+            // Our write landed but another authorize request's landed after it.
+            // That one holds the consumption; this one must not replay it.
+            return Ok(None);
+        }
+
         rows.into_iter()
             .next()
             .map(PushedAuthRequestRow::try_into_request)

--- a/crates/axiam-db/src/schema.rs
+++ b/crates/axiam-db/src/schema.rs
@@ -197,6 +197,11 @@ static MIGRATIONS: &[Migration] = &[
         name: "uma_permission_ticket_redemption_nonce",
         sql: SCHEMA_V31,
     },
+    Migration {
+        version: 32,
+        name: "single_use_redemption_nonce_device_grant_and_par",
+        sql: SCHEMA_V32,
+    },
 ];
 
 // -----------------------------------------------------------------------
@@ -1594,6 +1599,39 @@ DEFINE INDEX IF NOT EXISTS idx_permission_ticket_tenant_expiry
 // undisturbed.
 const SCHEMA_V31: &str = "\
 DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE permission_ticket TYPE option<string>;
+";
+
+// -----------------------------------------------------------------------
+// Schema v32 — the same nonce for the other two single-use consumes
+// -----------------------------------------------------------------------
+//
+// v31 fixed `permission_ticket.consume`. `device_grant.redeem` and
+// `pushed_auth_request.consume` were written in the same shape, at the same
+// time, on the same understanding — that `BEGIN`/`COMMIT` makes SurrealDB
+// detect the write-write conflict and abort every loser. It does not, so those
+// two carry the same defect, and their doc comments carry the same false
+// claim.
+//
+// They were not measured failing. That is not evidence they are sound: the
+// permission-ticket race needed coverage instrumentation *plus* a saturated
+// machine to show up at roughly 1 in 320, and these two are tested exactly the
+// same way the ticket was when its own test was passing. "Not yet observed" and
+// "cannot happen" are different statements, and the mechanism is shared.
+//
+// What each protects, if it does fail:
+//
+//   device_grant.redeem          — one user approval minting two token sets
+//                                  (RFC 8628 §3.4 polls on a short interval and
+//                                  retries, so concurrency here is the normal
+//                                  shape of the flow, not an exotic case)
+//   pushed_auth_request.consume  — a replayable RFC 9126 `request_uri`, which
+//                                  is a replayable authorization request
+//
+// See `SCHEMA_V31` for the mechanism and the measurements behind choosing it,
+// including the two repairs that turned out worse than the defect.
+const SCHEMA_V32: &str = "\
+DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE device_grant TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE pushed_auth_request TYPE option<string>;
 ";
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #292. That PR changed `permission_ticket.consume` to decide its own single-use race, because SurrealDB 3.2.3 does not reliably detect the write-write conflict the `BEGIN`/`COMMIT` design was waiting for. `device_grant.redeem` and `pushed_auth_request.consume` were written in the same shape, at the same time, on the same understanding — so they carry the same defect, and until now the same false claim in their doc comments.

Both now stamp a per-attempt nonce and read the row back; the caller whose nonce persisted holds the redemption. Nothing depends on conflict detection or on constraint enforcement — the two things this engine was measured not to provide. Schema v32 adds `redemption_id` to each table.

## What these protect

| Site | If it double-wins |
|---|---|
| `device_grant.redeem` | One user approval minting two token sets. RFC 8628 §3.4 devices poll on a short interval and retry, so concurrency here is the normal shape of the flow, not an exotic case. |
| `pushed_auth_request.consume` | A replayable RFC 9126 `request_uri` — which is a replayable authorization request. |

## On the evidence — please read this part

**Neither site was ever observed double-winning, so this PR does not claim a measured improvement.** Under the same harness that caught the ticket race (coverage instrumentation on a saturated machine) both come back 0/80, which on its own bounds very little.

The justification is the shared mechanism, not a rate. The ticket race needed that harness to surface at roughly 1/320, and these two are exercised exactly the way the ticket was while its own test was still passing. *Not yet observed* and *cannot happen* are different claims.

For context, the measurements from #292 on the ticket path — including two repairs that turned out **worse** than the defect:

| Mechanism | Wrong |
|---|---|
| Transaction + `WHERE consumed = false` (what this replaces) | 1 / 320 |
| Claim keyed on a record ID | 30 / 1200 |
| Claim on a `UNIQUE INDEX`, inside a transaction | 3 / 320 |
| Per-attempt nonce (this) | 1 / 640 |

1/640 against 1/320 is a single event either way and does **not** establish that the nonce double-redeems less often. It establishes that it is not worse. It is preferred because its residual window is nameable — a write landing after another racer's read-back — where a silent failure to detect a conflict is not analysable at all.

**Single-use is still not guaranteed.** No mechanism tested reaches zero. `SCHEMA_V31` records what closing the window would actually take: a guarantee from below this layer — a storage engine that serialises, or single-writer serialisation in front of it.

## Design notes

The `WHERE` guards (`status = 'approved'`, `consumed = false`) are kept. They are what makes a later, *non-concurrent* attempt match nothing; they simply no longer carry the whole burden.

The read-back is deliberately **not** inside a transaction. Inside one it would see the caller's own write under snapshot isolation and every racer would believe it won — turning an occasional double-redemption into a certain one.

A non-matching attempt writes no nonce, so nothing is burned by an unknown, expired, or not-yet-approved code.

## Verification

- `cargo fmt --check` and `clippy -D warnings` clean
- `axiam-db` lib 144, `axiam-oauth2` lib 88
- `device_grant_test` 11, `permission_ticket_test` 14 (including all four `single_use_serialisation` cases)
- `schema_test` and `oauth2_refresh_revoke_all` for the v32 migration
- Both sites 0/80 under coverage instrumentation on a saturated machine

Concurrency was measured against the in-memory engine the tests use; behaviour on a production datastore has not been measured.

No issues are open in this repository, so none are referenced or closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc)_