### PR TITLE
feat(uma): X2 — the UMA 2.0 server surface (permission tickets, ticket grant, resource registration)

### DIFF
--- a/claude_dev/frontend-coverage-matrix.md
+++ b/claude_dev/frontend-coverage-matrix.md
@@ -52,6 +52,7 @@
 | `service_accounts` | `service-accounts/ServiceAccountsPage` | covered | |
 | `settings` | `settings/SettingsPage` | covered | |
 | `tenants` | `tenants/TenantsPage`, `organizations/TenantDetailPage` | covered | |
+| `uma` | `resources/ResourcesPage` (UMA badge) | headless + badge | X2. The Protection API (`/uma2/perm`, `/uma2/rreg/*`) is machine-to-machine by construction: its caller is a **resource server** holding a client-credentials PAT, not a human at a screen, so there is nothing for an admin to do on those endpoints and a page would have no user. What an admin *does* need is to see the consequences, and those already have a home — a resource registered through UMA is an ordinary AXIAM resource, so it appears on the existing resources page, and its scopes on the existing scope surfaces. The one thing added is a read-only **UMA badge** on resources carrying `uma_registered_by`, so an admin can tell "a resource server created this" from "somebody made this by hand". Deliberately not editable: the badge asserts provenance, and a marker the UI could write would be decoration that reads like evidence |
 | `users` | `users/UsersPage`, `users/UserDetailPage` | covered | |
 | `webauthn` | `profile/MfaManagementPage`, `LoginPage` | covered | C1/C2 |
 | `webhooks` | `webhooks/WebhooksPage` | covered | |

--- a/crates/axiam-api-grpc/src/services/authorization.rs
+++ b/crates/axiam-api-grpc/src/services/authorization.rs
@@ -387,6 +387,7 @@ mod tests {
             // B3: this fixture is a directly-issued token, not one obtained
             // through a token exchange, so it carries no actor chain.
             act: None,
+            permissions: None,
         });
 
         let svc = AuthorizationServiceImpl::new(make_engine(&db), 2);

--- a/crates/axiam-api-rest/src/config/rate_limit.rs
+++ b/crates/axiam-api-rest/src/config/rate_limit.rs
@@ -199,6 +199,10 @@ pub const ENV_TOKEN_EXCHANGE_PER_MIN: &str = "AXIAM__RATE_LIMIT__TOKEN_EXCHANGE_
 pub const ENV_END_SESSION_PER_MIN: &str = "AXIAM__RATE_LIMIT__END_SESSION_PER_MIN";
 /// `AXIAM__RATE_LIMIT__PAR_PER_MIN` — B5.
 pub const ENV_PAR_PER_MIN: &str = "AXIAM__RATE_LIMIT__PAR_PER_MIN";
+/// `AXIAM__RATE_LIMIT__UMA_PERM_PER_MIN` — X2.
+pub const ENV_UMA_PERM_PER_MIN: &str = "AXIAM__RATE_LIMIT__UMA_PERM_PER_MIN";
+/// `AXIAM__RATE_LIMIT__UMA_TICKET_PER_MIN` — X2.
+pub const ENV_UMA_TICKET_PER_MIN: &str = "AXIAM__RATE_LIMIT__UMA_TICKET_PER_MIN";
 /// `AXIAM__RATE_LIMIT__DEVICE_AUTHORIZATION_PER_MIN` — B2, never preset.
 pub const ENV_DEVICE_AUTHORIZATION_PER_MIN: &str =
     "AXIAM__RATE_LIMIT__DEVICE_AUTHORIZATION_PER_MIN";
@@ -355,6 +359,24 @@ pub struct RateLimitConfig {
     /// holding one stolen token would hammer looking for a widening path.
     /// A shared bucket would let ordinary token traffic hide that.
     pub token_exchange_per_min: u32,
+    /// Max `/uma2/perm` requests per minute per authenticated resource server
+    /// (default: 120 — X2).
+    ///
+    /// Sized like the other machine endpoints, and kept in its own bucket for
+    /// the same reason as PAR: the endpoint **allocates state** — one stored
+    /// ticket row per call, each with a 60 s TTL — so a flood here costs
+    /// storage rather than just CPU. Sharing the token bucket would let
+    /// ordinary token traffic pay for that, or mask it.
+    pub uma_perm_per_min: u32,
+    /// Max uma-ticket grant redemptions per minute per authenticated client
+    /// (default: 120 — X2).
+    ///
+    /// Separate from `uma_perm_per_min` because minting and redeeming are
+    /// different costs against different pressure: a redemption runs one
+    /// authorization check per requested `(resource, scope)` pair, so a ticket
+    /// naming many pairs is the expensive direction, and it is the one an
+    /// attacker holding a stolen ticket would retry.
+    pub uma_ticket_per_min: u32,
     /// Max `/oauth2/par` requests per minute per authenticated client
     /// (default: 120 — B5).
     ///
@@ -436,6 +458,8 @@ impl Default for RateLimitConfig {
             device_authorization_per_min: 12,
             device_verify_per_min: 10,
             token_exchange_per_min: 120,
+            uma_perm_per_min: 120,
+            uma_ticket_per_min: 120,
             par_per_min: 120,
             end_session_per_min: 30,
             key: RateLimitKeyMode::Ip,
@@ -612,6 +636,11 @@ impl RateLimitConfig {
         assert!(
             self.token_exchange_per_min >= 1,
             "token_exchange_per_min must be >= 1"
+        );
+        assert!(self.uma_perm_per_min >= 1, "uma_perm_per_min must be >= 1");
+        assert!(
+            self.uma_ticket_per_min >= 1,
+            "uma_ticket_per_min must be >= 1"
         );
         assert!(self.par_per_min >= 1, "par_per_min must be >= 1");
         assert!(

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -157,9 +157,9 @@ impl actix_web::FromRequest for AuthenticatedServiceAccount {
 // Shared token extraction
 // ---------------------------------------------------------------------------
 
-/// Decode and validate the JWT from the request — shared between both
+/// Decode and validate the JWT from the request — shared between the
 /// extractors. Does not apply audience narrowing.
-fn parse_validated_claims(req: &HttpRequest) -> Result<ValidatedClaims, AxiamApiError> {
+pub(crate) fn parse_validated_claims(req: &HttpRequest) -> Result<ValidatedClaims, AxiamApiError> {
     let config = req
         .app_data::<web::Data<AuthConfig>>()
         .ok_or(AxiamError::Internal("missing auth config".into()))?;
@@ -605,6 +605,7 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=\n\
             scope: None,
             sub_kind: SubjectKind::User,
             act: None,
+            permissions: None,
         };
         let key = EncodingKey::from_ed_pem(config.jwt_private_key_pem.as_bytes()).unwrap();
         let header = Header::new(Algorithm::EdDSA);

--- a/crates/axiam-api-rest/src/handlers/mod.rs
+++ b/crates/axiam-api-rest/src/handlers/mod.rs
@@ -25,6 +25,7 @@ pub mod scopes;
 pub mod service_accounts;
 pub mod settings;
 pub mod tenants;
+pub mod uma;
 pub mod users;
 pub mod webauthn;
 pub mod webhooks;

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -2,6 +2,7 @@
 
 use actix_web::{HttpRequest, HttpResponse, web};
 use axiam_auth::config::AuthConfig;
+use axiam_core::models::uma::{UMA_CLAIM_TOKEN_FORMAT, UMA_TICKET_GRANT_TYPE};
 use axiam_core::repository::{OAuth2ClientRepository, SessionClientRepository, UserRepository};
 use axiam_oauth2::authorize::AuthorizeRequest;
 use axiam_oauth2::device_service::{
@@ -16,6 +17,7 @@ use axiam_oauth2::token::{
     IntrospectRequest, IntrospectionResponse, RevokeRequest, TokenRequest, TokenResponse,
 };
 use axiam_oauth2::token_exchange::TOKEN_EXCHANGE_GRANT_TYPE;
+use axiam_oauth2::uma::UmaError;
 use serde::{Deserialize, Serialize};
 use surrealdb::Connection;
 use uuid::Uuid;
@@ -349,6 +351,25 @@ pub async fn token<C: Connection + Clone>(
     // precisely the operation that should be attributable.
     if grant_type == TOKEN_EXCHANGE_GRANT_TYPE {
         return handle_token_exchange(tenant_id, form, &state).await;
+    }
+
+    // X2 / UMA 2.0 §3.3.1. Third grant dispatched here for the same structural
+    // reason as the other two: the body is deserialized once, so the grant is
+    // only knowable after `grant_type` has been read out of it.
+    if grant_type == UMA_TICKET_GRANT_TYPE {
+        // The authz checker is pulled from the request here rather than taken
+        // as a handler parameter on purpose. `/oauth2/token` serves five
+        // grants, and only this one evaluates anything against the RBAC
+        // engine; making it an extractor would make the checker a hard
+        // requirement of the whole endpoint, so a deployment (or a test
+        // harness) that never uses UMA would start answering 500 to ordinary
+        // token requests because of a dependency none of them use.
+        let Some(authz) = req.app_data::<crate::authz::AuthzData>().cloned() else {
+            return build_oauth2_error_response(&OAuth2Error::ServerError(
+                "the uma-ticket grant requires an authorization checker".into(),
+            ));
+        };
+        return handle_uma_ticket(tenant_id, form, &state, &authz).await;
     }
 
     match state.token_service.exchange(tenant_id, form).await {
@@ -903,6 +924,242 @@ pub async fn device_authorization<C: Connection + Clone>(
 /// parameters are disjoint from RFC 6749's and actix deserializes one body
 /// once — so `TokenRequest` carries the shared fields and the
 /// exchange-specific ones are pulled from the raw form here.
+/// X2 — `grant_type=urn:ietf:params:oauth:grant-type:uma-ticket`.
+///
+/// Redeems a permission ticket for an RPT. Four things are worth naming.
+///
+/// **The client authenticates, and the ticket is bound to it.** A ticket is
+/// minted by a resource server through the Protection API and redeemed by that
+/// same resource server; `consume` matches on `client_id`, so a ticket leaked
+/// to another client is not a usable credential — and a wrong-client attempt
+/// changes nothing rather than burning the rightful holder's ticket.
+///
+/// **`claim_token` is required, though UMA 2.0 calls it optional.** The spec's
+/// other two ways to name a requesting party — an RPT presented for
+/// incremental authorization, and interactive claims-gathering — are both
+/// deferred to v2, so this is the only channel that exists. Requiring it and
+/// saying so beats resolving to some default subject, which would mint an RPT
+/// for a party nobody named.
+///
+/// **The subject token is validated, not trusted.** It is a signed AXIAM access
+/// token; its remaining life bounds the RPT's, which is what stops an RPT from
+/// outliving the authorization it rests on.
+///
+/// **Refusals are uniform.** Every ticket rejection — unknown, consumed,
+/// expired, wrong client — answers `invalid_grant` with one message, because a
+/// caller that could tell them apart could probe for live ticket handles.
+async fn handle_uma_ticket<C: Connection + Clone>(
+    tenant_id: Uuid,
+    form: TokenRequest,
+    state: &web::Data<AppState<C>>,
+    authz: &crate::authz::AuthzData,
+) -> HttpResponse {
+    let (Some(client_id), Some(client_secret)) =
+        (form.client_id.as_deref(), form.client_secret.as_deref())
+    else {
+        return build_oauth2_error_response(&OAuth2Error::InvalidClient(
+            "the uma-ticket grant requires client authentication".into(),
+        ));
+    };
+
+    let client = match state
+        .token_service
+        .authenticate_client(tenant_id, client_id, client_secret)
+        .await
+    {
+        Ok(client) => client,
+        Err(e) => return build_oauth2_error_response(&e),
+    };
+
+    // Counted after authentication, keyed by the authenticated client — the
+    // same reasoning as the token-exchange bucket: an unauthenticated caller
+    // must not be able to consume a real client's allowance, and per-IP would
+    // collapse a whole mesh behind one NAT into a single bucket.
+    if !state.shared_rate_limit.check_at(
+        &format!("oauth2_uma_ticket:{}:{}", tenant_id, client.client_id),
+        chrono::Utc::now(),
+        state.rate_limit_cfg.uma_ticket_per_min,
+    ) {
+        return HttpResponse::TooManyRequests()
+            .append_header(("Cache-Control", "no-store"))
+            .json(OAuth2ErrorResponse {
+                error: "slow_down".into(),
+                error_description: "uma-ticket rate limit exceeded for this client".into(),
+            });
+    }
+
+    let Some(ticket) = form.ticket.as_deref().filter(|t| !t.is_empty()) else {
+        return build_oauth2_error_response(&OAuth2Error::InvalidRequest(
+            "ticket is required for the uma-ticket grant".into(),
+        ));
+    };
+
+    let Some(claim_token) = form.claim_token.as_deref().filter(|t| !t.is_empty()) else {
+        return build_oauth2_error_response(&OAuth2Error::InvalidRequest(
+            "claim_token is required for the uma-ticket grant: it names the \
+             requesting party, and v1 implements neither incremental \
+             authorization nor claims-gathering"
+                .into(),
+        ));
+    };
+
+    // An unrecognised format is refused rather than assumed. Guessing would
+    // mean validating a foreign token with the wrong verifier.
+    if let Some(format) = form.claim_token_format.as_deref().filter(|f| !f.is_empty())
+        && format != UMA_CLAIM_TOKEN_FORMAT
+    {
+        return build_oauth2_error_response(&OAuth2Error::InvalidRequest(format!(
+            "unsupported claim_token_format '{format}'; v1 accepts only \
+             '{UMA_CLAIM_TOKEN_FORMAT}'"
+        )));
+    }
+
+    let claims = match axiam_auth::token::validate_access_token(claim_token, &state.auth_config) {
+        Ok(validated) => validated.0,
+        Err(_) => {
+            return build_oauth2_error_response(&OAuth2Error::InvalidGrant(
+                "claim_token is not a valid access token".into(),
+            ));
+        }
+    };
+
+    let Ok(subject_id) = claims.sub.parse::<Uuid>() else {
+        return build_oauth2_error_response(&OAuth2Error::InvalidGrant(
+            "claim_token does not name a user as its subject".into(),
+        ));
+    };
+
+    // The requesting party must belong to the tenant the ticket was minted in.
+    // Without this a token from tenant A could redeem a ticket in tenant B and
+    // be evaluated against B's grants under A's subject id.
+    if claims.tenant_id != tenant_id.to_string() {
+        return build_oauth2_error_response(&OAuth2Error::InvalidGrant(
+            "claim_token belongs to a different tenant".into(),
+        ));
+    }
+
+    let subject_remaining_secs = claims.exp - chrono::Utc::now().timestamp();
+
+    let granted = match state
+        .uma_service(authz.get_ref().clone())
+        .exchange_ticket(
+            tenant_id,
+            &client.client_id,
+            ticket,
+            subject_id,
+            subject_remaining_secs,
+        )
+        .await
+    {
+        Ok(granted) => granted,
+        Err(e) => {
+            tracing::info!(
+                target: "axiam::audit",
+                event = "uma.rpt_refused",
+                tenant_id = %tenant_id,
+                client_id = %client.client_id,
+                subject = %subject_id,
+                error = e.wire_error(),
+                "uma-ticket grant refused"
+            );
+            return uma_refusal_response(e);
+        }
+    };
+
+    let org_id = match claims.org_id.parse::<Uuid>() {
+        Ok(id) => id,
+        Err(_) => {
+            return build_oauth2_error_response(&OAuth2Error::ServerError(
+                "claim_token carries an unparseable org_id".into(),
+            ));
+        }
+    };
+
+    let rpt = match axiam_auth::token::issue_rpt(
+        subject_id,
+        tenant_id,
+        org_id,
+        granted.permissions.clone(),
+        granted.lifetime_secs,
+        &state.auth_config,
+    ) {
+        Ok(token) => token,
+        Err(e) => return build_oauth2_error_response(&OAuth2Error::ServerError(e.to_string())),
+    };
+
+    // Audited before the token is returned: the ticket is already consumed at
+    // this point, so a crash between issuing and logging would leave a spent
+    // ticket with no record of what it bought.
+    tracing::info!(
+        target: "axiam::audit",
+        event = "uma.rpt_issued",
+        tenant_id = %tenant_id,
+        client_id = %client.client_id,
+        subject = %subject_id,
+        pairs = granted.permissions.len(),
+        lifetime_secs = granted.lifetime_secs,
+        "RPT issued"
+    );
+
+    HttpResponse::Ok()
+        .append_header(("Cache-Control", "no-store"))
+        .append_header(("Pragma", "no-cache"))
+        .json(TokenResponse {
+            access_token: rpt,
+            token_type: "Bearer".into(),
+            expires_in: granted.lifetime_secs as u64,
+            refresh_token: None,
+            scope: None,
+            id_token: None,
+        })
+}
+
+/// Render a [`UmaError`] as the token endpoint's error response.
+///
+/// # Why `access_denied` does not go through `build_oauth2_error_response`
+///
+/// That helper maps everything except `invalid_client` and `server_error` to
+/// **400**, which is right for RFC 6749 and right for RFC 8628 — the device
+/// grant's `access_denied` (the user said no) is a 400 and must stay one.
+///
+/// UMA 2.0 §3.3.6 specifies **403** for a request the authorization server
+/// refuses on the merits, and a UMA-conforming resource server distinguishes
+/// "you may not have this" from "your request was malformed" by exactly that
+/// status. Routing the UMA refusal through the shared helper would answer 400
+/// and quietly fail conformance, so this one status is built here. Every other
+/// UMA error keeps the shared mapping.
+fn uma_refusal_response(e: UmaError) -> HttpResponse {
+    if matches!(e, UmaError::AccessDenied) {
+        return HttpResponse::Forbidden()
+            .append_header(("Cache-Control", "no-store"))
+            .append_header(("Pragma", "no-cache"))
+            .json(OAuth2ErrorResponse {
+                // v1 sends no `need_info` alongside it: that field exists to
+                // steer a client into claims-gathering, which is deferred, so
+                // sending it would point at a flow that does not run.
+                error: "access_denied".into(),
+                error_description:
+                    "the requesting party is not authorized for every requested permission".into(),
+            });
+    }
+    build_oauth2_error_response(&uma_error_to_oauth2(e))
+}
+
+/// Map a [`UmaError`] onto the OAuth2 error shape the token endpoint answers.
+fn uma_error_to_oauth2(e: UmaError) -> OAuth2Error {
+    match e {
+        UmaError::InvalidRequest(m) => OAuth2Error::InvalidRequest(m),
+        UmaError::InvalidGrant(m) => OAuth2Error::InvalidGrant(m),
+        UmaError::AccessDenied => OAuth2Error::AccessDenied(
+            "the requesting party is not authorized for every requested permission".into(),
+        ),
+        UmaError::ExpiredSubjectToken => {
+            OAuth2Error::InvalidGrant("the presented claim_token has expired".into())
+        }
+        UmaError::Server(m) => OAuth2Error::ServerError(m),
+    }
+}
+
 async fn handle_token_exchange<C: Connection + Clone>(
     tenant_id: Uuid,
     form: TokenRequest,

--- a/crates/axiam-api-rest/src/handlers/uma.rs
+++ b/crates/axiam-api-rest/src/handlers/uma.rs
@@ -9,10 +9,13 @@ use actix_web::{HttpResponse, web};
 use axiam_auth::config::AuthConfig;
 use axiam_auth::token::SubjectKind;
 use axiam_core::error::AxiamError;
+use axiam_core::models::resource::{CreateResource, UpdateResource};
+use axiam_core::models::scope::CreateScope;
 use axiam_core::models::uma::{
     RequestedPermission, TICKET_TTL_SECS, UMA_CLAIM_TOKEN_FORMAT, UMA_PROTECTION_SCOPE,
     UMA_TICKET_GRANT_TYPE,
 };
+use axiam_core::repository::{Pagination, ResourceRepository, ScopeRepository};
 use axiam_oauth2::uma::UmaError;
 use serde::{Deserialize, Serialize};
 use surrealdb::Connection;
@@ -115,6 +118,7 @@ pub struct Uma2Configuration {
     pub token_endpoint: String,
     pub introspection_endpoint: String,
     pub permission_endpoint: String,
+    pub resource_registration_endpoint: String,
     pub jwks_uri: String,
     pub grant_types_supported: Vec<String>,
     pub uma_profiles_supported: Vec<String>,
@@ -183,10 +187,9 @@ pub async fn permission_request<C: Connection + Clone>(
 /// `GET /.well-known/uma2-configuration` — UMA 2.0 discovery (§2).
 ///
 /// Advertises only what v1 actually serves. Claims-gathering
-/// (`claims_interaction_endpoint`) and the resource registration endpoint are
-/// absent because they are not implemented; advertising an endpoint that 404s
-/// is worse than not advertising it, since a conforming client would route to
-/// it on the strength of this document.
+/// (`claims_interaction_endpoint`) is absent because it is not implemented;
+/// advertising an endpoint that 404s is worse than not advertising it, since a
+/// conforming client would route to it on the strength of this document.
 #[utoipa::path(
     get,
     path = "/.well-known/uma2-configuration",
@@ -203,12 +206,316 @@ pub async fn uma2_configuration(auth_config: web::Data<AuthConfig>) -> HttpRespo
         token_endpoint: format!("{issuer}/oauth2/token"),
         introspection_endpoint: format!("{issuer}/oauth2/introspect"),
         permission_endpoint: format!("{issuer}/uma2/perm"),
+        resource_registration_endpoint: format!("{issuer}/uma2/rreg/resource_set"),
         jwks_uri: format!("{issuer}/.well-known/jwks.json"),
         issuer,
         grant_types_supported: vec![UMA_TICKET_GRANT_TYPE.to_string()],
         uma_profiles_supported: vec![],
         permission_ticket_lifetime: TICKET_TTL_SECS,
     })
+}
+
+// ---------------------------------------------------------------------------
+// Resource registration API (UMA 2.0 FedAuthz §2)
+// ---------------------------------------------------------------------------
+
+/// A resource set as UMA describes it, mapped onto an AXIAM resource.
+///
+/// # The mapping, in one place
+///
+/// | UMA | AXIAM |
+/// |---|---|
+/// | `_id` | the resource id — **not** a parallel identifier |
+/// | `name` | `resource.name` |
+/// | `type` | `resource.resource_type` |
+/// | `resource_scopes` | the `Scope` rows on that resource |
+///
+/// There is no second resource store. A resource registered here is an
+/// ordinary AXIAM resource that the admin UI lists, that role assignments
+/// cascade through, and that the authorization engine already understands —
+/// which is the entire reason UMA `_id` is the AXIAM id rather than a
+/// translation key.
+#[derive(Debug, Deserialize, Serialize, utoipa::ToSchema)]
+pub struct ResourceSet {
+    /// Present on responses, absent on registration — the server assigns it.
+    #[serde(rename = "_id", default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<Uuid>,
+    pub name: String,
+    #[serde(rename = "type", default)]
+    pub resource_type: String,
+    #[serde(default)]
+    pub resource_scopes: Vec<String>,
+}
+
+/// `POST /uma2/rreg/resource_set` — register a resource set (FedAuthz §2.2.1).
+///
+/// Creates the resource **and** its declared scopes. The scope set is what the
+/// permission endpoint later validates ticket requests against, so registering
+/// a resource with no scopes produces one that can never appear in a ticket —
+/// legal, and worth knowing.
+#[utoipa::path(
+    post,
+    path = "/uma2/rreg/resource_set",
+    tag = "uma",
+    request_body = ResourceSet,
+    responses(
+        (status = 201, description = "Resource set registered", body = ResourceSet),
+        (status = 401, description = "Missing or invalid PAT"),
+        (status = 403, description = "Token lacks the uma_protection scope"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn register_resource_set<C: Connection + Clone>(
+    pat: ProtectionApiToken,
+    state: web::Data<AppState<C>>,
+    body: web::Json<ResourceSet>,
+) -> Result<HttpResponse, AxiamApiError> {
+    let body = body.into_inner();
+
+    let resource = state
+        .resource_repo
+        .create_uma_registered(
+            CreateResource {
+                tenant_id: pat.tenant_id,
+                name: body.name,
+                // UMA's `type` is a free-form string and AXIAM's is too, but a
+                // resource server that omits it should not end up with an
+                // empty-string type that sorts oddly in the admin UI.
+                resource_type: if body.resource_type.is_empty() {
+                    "uma_resource".to_string()
+                } else {
+                    body.resource_type
+                },
+                parent_id: None,
+                metadata: None,
+            },
+            &pat.client_id,
+        )
+        .await?;
+
+    let scopes = sync_scopes(&state, pat.tenant_id, resource.id, &body.resource_scopes).await?;
+
+    tracing::info!(
+        target: "axiam::audit",
+        event = "uma.resource_registered",
+        tenant_id = %pat.tenant_id,
+        client_id = %pat.client_id,
+        resource_id = %resource.id,
+        "resource set registered"
+    );
+
+    Ok(HttpResponse::Created().json(ResourceSet {
+        id: Some(resource.id),
+        name: resource.name,
+        resource_type: resource.resource_type,
+        resource_scopes: scopes,
+    }))
+}
+
+/// `GET /uma2/rreg/resource_set/{id}` — read a resource set (FedAuthz §2.2.2).
+#[utoipa::path(
+    get,
+    path = "/uma2/rreg/resource_set/{id}",
+    tag = "uma",
+    params(("id" = Uuid, Path, description = "Resource set id")),
+    responses(
+        (status = 200, description = "Resource set", body = ResourceSet),
+        (status = 404, description = "No such resource set"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn read_resource_set<C: Connection + Clone>(
+    pat: ProtectionApiToken,
+    state: web::Data<AppState<C>>,
+    path: web::Path<Uuid>,
+) -> Result<HttpResponse, AxiamApiError> {
+    let id = path.into_inner();
+    let resource = state.resource_repo.get_by_id(pat.tenant_id, id).await?;
+    let scopes = declared_scope_names(&state, pat.tenant_id, id).await?;
+
+    Ok(HttpResponse::Ok().json(ResourceSet {
+        id: Some(resource.id),
+        name: resource.name,
+        resource_type: resource.resource_type,
+        resource_scopes: scopes,
+    }))
+}
+
+/// `PUT /uma2/rreg/resource_set/{id}` — update a resource set (FedAuthz §2.2.3).
+///
+/// The scope list is **replaced**, not merged: FedAuthz defines the update as
+/// putting the resource set's new state, and a merge would make it impossible
+/// to remove a scope. Removing a scope narrows what tickets may be requested,
+/// so a silent merge would keep an authority the resource server tried to drop.
+#[utoipa::path(
+    put,
+    path = "/uma2/rreg/resource_set/{id}",
+    tag = "uma",
+    params(("id" = Uuid, Path, description = "Resource set id")),
+    request_body = ResourceSet,
+    responses(
+        (status = 200, description = "Resource set updated", body = ResourceSet),
+        (status = 404, description = "No such resource set"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn update_resource_set<C: Connection + Clone>(
+    pat: ProtectionApiToken,
+    state: web::Data<AppState<C>>,
+    path: web::Path<Uuid>,
+    body: web::Json<ResourceSet>,
+) -> Result<HttpResponse, AxiamApiError> {
+    let id = path.into_inner();
+    let body = body.into_inner();
+
+    // Read first so an unknown id answers 404 before anything is written.
+    state.resource_repo.get_by_id(pat.tenant_id, id).await?;
+
+    let resource = state
+        .resource_repo
+        .update(
+            pat.tenant_id,
+            id,
+            UpdateResource {
+                name: Some(body.name),
+                resource_type: if body.resource_type.is_empty() {
+                    None
+                } else {
+                    Some(body.resource_type)
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let scopes = sync_scopes(&state, pat.tenant_id, id, &body.resource_scopes).await?;
+
+    Ok(HttpResponse::Ok().json(ResourceSet {
+        id: Some(resource.id),
+        name: resource.name,
+        resource_type: resource.resource_type,
+        resource_scopes: scopes,
+    }))
+}
+
+/// `DELETE /uma2/rreg/resource_set/{id}` — deregister (FedAuthz §2.2.4).
+#[utoipa::path(
+    delete,
+    path = "/uma2/rreg/resource_set/{id}",
+    tag = "uma",
+    params(("id" = Uuid, Path, description = "Resource set id")),
+    responses(
+        (status = 204, description = "Resource set deleted"),
+        (status = 404, description = "No such resource set"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn delete_resource_set<C: Connection + Clone>(
+    pat: ProtectionApiToken,
+    state: web::Data<AppState<C>>,
+    path: web::Path<Uuid>,
+) -> Result<HttpResponse, AxiamApiError> {
+    let id = path.into_inner();
+    state.resource_repo.get_by_id(pat.tenant_id, id).await?;
+    state.resource_repo.delete(pat.tenant_id, id).await?;
+
+    tracing::info!(
+        target: "axiam::audit",
+        event = "uma.resource_deregistered",
+        tenant_id = %pat.tenant_id,
+        client_id = %pat.client_id,
+        resource_id = %id,
+        "resource set deregistered"
+    );
+
+    Ok(HttpResponse::NoContent().finish())
+}
+
+/// `GET /uma2/rreg/resource_set` — list registered ids (FedAuthz §2.2.5).
+///
+/// Lists only the resources **this client** registered. FedAuthz says the
+/// listing is of the resource sets the PAT's owner registered, and a resource
+/// server has no business enumerating the tenant's whole resource tree through
+/// an endpoint whose only credential is a protection scope.
+#[utoipa::path(
+    get,
+    path = "/uma2/rreg/resource_set",
+    tag = "uma",
+    responses((status = 200, description = "Registered resource set ids", body = Vec<Uuid>)),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_resource_sets<C: Connection + Clone>(
+    pat: ProtectionApiToken,
+    state: web::Data<AppState<C>>,
+) -> Result<HttpResponse, AxiamApiError> {
+    let page = state
+        .resource_repo
+        .list(pat.tenant_id, Pagination::default())
+        .await?;
+
+    let ids: Vec<Uuid> = page
+        .items
+        .into_iter()
+        .filter(|r| r.uma_registered_by.as_deref() == Some(pat.client_id.as_str()))
+        .map(|r| r.id)
+        .collect();
+
+    Ok(HttpResponse::Ok().json(ids))
+}
+
+/// Replace a resource's declared scopes with `wanted`, returning the result.
+///
+/// Adds what is missing and removes what is no longer named. Scopes that are
+/// already correct are left alone rather than deleted and recreated, because
+/// their ids are referenced by permission grants — recreating a scope would
+/// silently detach every grant that named it.
+async fn sync_scopes<C: Connection + Clone>(
+    state: &web::Data<AppState<C>>,
+    tenant_id: Uuid,
+    resource_id: Uuid,
+    wanted: &[String],
+) -> Result<Vec<String>, AxiamApiError> {
+    let existing = state
+        .scope_repo
+        .list_by_resource(tenant_id, resource_id)
+        .await?;
+
+    for scope in &existing {
+        if !wanted.contains(&scope.name) {
+            state.scope_repo.delete(tenant_id, scope.id).await?;
+        }
+    }
+
+    for name in wanted {
+        if existing.iter().any(|s| &s.name == name) {
+            continue;
+        }
+        state
+            .scope_repo
+            .create(CreateScope {
+                tenant_id,
+                resource_id,
+                name: name.clone(),
+                description: String::new(),
+            })
+            .await?;
+    }
+
+    Ok(wanted.to_vec())
+}
+
+async fn declared_scope_names<C: Connection + Clone>(
+    state: &web::Data<AppState<C>>,
+    tenant_id: Uuid,
+    resource_id: Uuid,
+) -> Result<Vec<String>, AxiamApiError> {
+    Ok(state
+        .scope_repo
+        .list_by_resource(tenant_id, resource_id)
+        .await?
+        .into_iter()
+        .map(|s| s.name)
+        .collect())
 }
 
 /// A 403 with no `action`/`resource_id` hints.

--- a/crates/axiam-api-rest/src/handlers/uma.rs
+++ b/crates/axiam-api-rest/src/handlers/uma.rs
@@ -1,0 +1,252 @@
+//! X2 — the UMA 2.0 HTTP surface: the permission endpoint and discovery.
+//!
+//! The uma-ticket grant itself lives in [`crate::handlers::oauth2`], because
+//! actix deserializes the token endpoint's body once and the grant is not
+//! knowable until `grant_type` has been read out of it — the same reason the
+//! device and token-exchange grants are dispatched there rather than routed.
+
+use actix_web::{HttpResponse, web};
+use axiam_auth::config::AuthConfig;
+use axiam_auth::token::SubjectKind;
+use axiam_core::error::AxiamError;
+use axiam_core::models::uma::{
+    RequestedPermission, TICKET_TTL_SECS, UMA_CLAIM_TOKEN_FORMAT, UMA_PROTECTION_SCOPE,
+    UMA_TICKET_GRANT_TYPE,
+};
+use axiam_oauth2::uma::UmaError;
+use serde::{Deserialize, Serialize};
+use surrealdb::Connection;
+use uuid::Uuid;
+
+use crate::authz::AuthzData;
+use crate::error::AxiamApiError;
+use crate::state::AppState;
+
+/// A validated **Protection API Token** and the resource server it names.
+///
+/// Its own extractor rather than [`AuthenticatedUser`] or
+/// `AuthenticatedPrincipal`, because a PAT is a third principal shape and
+/// neither of those can carry it:
+///
+/// - `AuthenticatedUser` narrows the audience to `axiam:user`, and a PAT is a
+///   client-credentials token carrying `axiam:m2m`.
+/// - `AuthenticatedPrincipal` accepts `axiam:m2m` but parses `sub` as a UUID,
+///   which deliberately excludes OAuth2 clients — their `sub` is a `client_id`
+///   string, and they have no row in the role-assignment graph.
+///
+/// That exclusion is right for RBAC subjects and wrong for this endpoint: the
+/// Protection API does not evaluate the caller against grants at all. It only
+/// needs to know **which client is speaking**, because that is what the minted
+/// ticket is bound to. So this extractor keeps `sub` as the string it is.
+pub struct ProtectionApiToken {
+    /// The resource server's `client_id` — the token's `sub`, unparsed.
+    pub client_id: String,
+    pub tenant_id: Uuid,
+}
+
+impl actix_web::FromRequest for ProtectionApiToken {
+    type Error = AxiamApiError;
+    type Future = std::future::Ready<Result<Self, Self::Error>>;
+
+    fn from_request(
+        req: &actix_web::HttpRequest,
+        _payload: &mut actix_web::dev::Payload,
+    ) -> Self::Future {
+        std::future::ready(extract_pat(req))
+    }
+}
+
+fn extract_pat(req: &actix_web::HttpRequest) -> Result<ProtectionApiToken, AxiamApiError> {
+    let claims = crate::extractors::auth::parse_validated_claims(req)?.0;
+
+    // Checked before the scope, so a user token gets the answer that names the
+    // real problem rather than being told it is missing a scope it could add.
+    if claims.sub_kind != SubjectKind::OAuth2Client {
+        return Err(forbidden(
+            "a protection API token must be issued to an OAuth2 client, because \
+             a permission ticket is bound to the client that minted it"
+                .into(),
+        ));
+    }
+
+    // The `uma_protection` scope is the only thing that distinguishes a PAT
+    // from any other client-credentials token, so it is not optional.
+    if !claims
+        .scope
+        .as_deref()
+        .is_some_and(|s| s.split(' ').any(|granted| granted == UMA_PROTECTION_SCOPE))
+    {
+        return Err(forbidden(format!(
+            "the protection API requires the '{UMA_PROTECTION_SCOPE}' scope"
+        )));
+    }
+
+    let tenant_id = Uuid::parse_str(&claims.tenant_id).map_err(|_| {
+        AxiamApiError(AxiamError::AuthenticationFailed {
+            reason: "invalid tenant_id claim".into(),
+        })
+    })?;
+
+    Ok(ProtectionApiToken {
+        client_id: claims.sub,
+        tenant_id,
+    })
+}
+
+/// Body of `POST /uma2/perm` — what the resource server requires.
+///
+/// UMA 2.0 §3.2 allows either a single object or an array; AXIAM accepts the
+/// array form only, because a resource server that needs one pair can send an
+/// array of one, and accepting both shapes means two parsers for one meaning.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct PermissionRequestBody(pub Vec<RequestedPermission>);
+
+/// `201 Created` body of the permission endpoint (UMA 2.0 §3.2).
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct PermissionTicketResponse {
+    /// The opaque handle. Returned exactly once — only its hash is stored.
+    pub ticket: String,
+}
+
+/// The UMA 2.0 discovery document (§2).
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct Uma2Configuration {
+    pub issuer: String,
+    pub token_endpoint: String,
+    pub introspection_endpoint: String,
+    pub permission_endpoint: String,
+    pub jwks_uri: String,
+    pub grant_types_supported: Vec<String>,
+    pub uma_profiles_supported: Vec<String>,
+    /// Advertised so a resource server can size its retry window against the
+    /// ticket TTL instead of discovering it by having a ticket expire.
+    pub permission_ticket_lifetime: i64,
+}
+
+/// `POST /uma2/perm` — mint a permission ticket (UMA 2.0 §3.2).
+///
+/// # Who may call this
+///
+/// A **Protection API Token**: an ordinary AXIAM access token carrying the
+/// `uma_protection` scope. Two further conditions, both deliberate:
+///
+/// 1. **The token must be an OAuth2 client token** (`sub_kind` =
+///    `OAuth2Client`). A ticket is bound to the `client_id` that minted it, and
+///    for a client-credentials token `sub` *is* the `client_id`. A user token
+///    has no client identity in it, so binding one would mean inventing a
+///    value and calling it a binding.
+/// 2. **The scope is checked here, not by a route guard.** The `uma_protection`
+///    scope is what makes an access token a PAT; nothing else about the token
+///    distinguishes it.
+#[utoipa::path(
+    post,
+    path = "/uma2/perm",
+    tag = "uma",
+    request_body = PermissionRequestBody,
+    responses(
+        (status = 201, description = "Ticket minted", body = PermissionTicketResponse),
+        (status = 400, description = "Malformed request or undeclared scope"),
+        (status = 401, description = "Missing or invalid PAT"),
+        (status = 403, description = "Token lacks the uma_protection scope"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn permission_request<C: Connection + Clone>(
+    pat: ProtectionApiToken,
+    authz: AuthzData,
+    state: web::Data<AppState<C>>,
+    body: web::Json<PermissionRequestBody>,
+) -> Result<HttpResponse, AxiamApiError> {
+    let minted = state
+        .uma_service(authz.get_ref().clone())
+        .request_ticket(pat.tenant_id, &pat.client_id, body.into_inner().0)
+        .await
+        .map_err(uma_error_to_api)?;
+
+    tracing::info!(
+        target: "axiam::audit",
+        event = "uma.ticket_minted",
+        tenant_id = %pat.tenant_id,
+        client_id = %pat.client_id,
+        ticket_id = %minted.ticket_id,
+        "permission ticket minted"
+    );
+
+    Ok(HttpResponse::Created()
+        .append_header(("Cache-Control", "no-store"))
+        .append_header(("Pragma", "no-cache"))
+        .json(PermissionTicketResponse {
+            ticket: minted.ticket,
+        }))
+}
+
+/// `GET /.well-known/uma2-configuration` — UMA 2.0 discovery (§2).
+///
+/// Advertises only what v1 actually serves. Claims-gathering
+/// (`claims_interaction_endpoint`) and the resource registration endpoint are
+/// absent because they are not implemented; advertising an endpoint that 404s
+/// is worse than not advertising it, since a conforming client would route to
+/// it on the strength of this document.
+#[utoipa::path(
+    get,
+    path = "/.well-known/uma2-configuration",
+    tag = "uma",
+    responses((status = 200, description = "UMA 2.0 configuration", body = Uma2Configuration))
+)]
+pub async fn uma2_configuration(auth_config: web::Data<AuthConfig>) -> HttpResponse {
+    let issuer = auth_config
+        .oauth2_issuer_url
+        .trim_end_matches('/')
+        .to_string();
+
+    HttpResponse::Ok().json(Uma2Configuration {
+        token_endpoint: format!("{issuer}/oauth2/token"),
+        introspection_endpoint: format!("{issuer}/oauth2/introspect"),
+        permission_endpoint: format!("{issuer}/uma2/perm"),
+        jwks_uri: format!("{issuer}/.well-known/jwks.json"),
+        issuer,
+        grant_types_supported: vec![UMA_TICKET_GRANT_TYPE.to_string()],
+        uma_profiles_supported: vec![],
+        permission_ticket_lifetime: TICKET_TTL_SECS,
+    })
+}
+
+/// A 403 with no `action`/`resource_id` hints.
+fn forbidden(reason: String) -> AxiamApiError {
+    AxiamApiError(AxiamError::AuthorizationDenied {
+        reason,
+        action: None,
+        resource_id: None,
+    })
+}
+
+/// Map a [`UmaError`] onto the REST error shape.
+///
+/// `AccessDenied` becomes 403 and every ticket rejection becomes 400 with one
+/// message — the service already collapses unknown, consumed, expired and
+/// wrong-client into a single `InvalidGrant`, and re-separating them here would
+/// undo that.
+fn uma_error_to_api(e: UmaError) -> AxiamApiError {
+    let inner = match e {
+        UmaError::InvalidRequest(message) | UmaError::InvalidGrant(message) => {
+            AxiamError::Validation { message }
+        }
+        UmaError::AccessDenied => AxiamError::AuthorizationDenied {
+            reason: "the requesting party is not authorized for every requested permission".into(),
+            // Deliberately not naming the pair that failed. A resource server
+            // that could tell which of several pairs was refused could probe
+            // the grant table one scope at a time.
+            action: None,
+            resource_id: None,
+        },
+        UmaError::ExpiredSubjectToken => AxiamError::Validation {
+            message: "the presented token has expired".into(),
+        },
+        UmaError::Server(m) => AxiamError::Internal(m),
+    };
+    AxiamApiError(inner)
+}
+
+/// The claim-token format v1 accepts, re-exported so the token endpoint and
+/// discovery agree on one constant.
+pub const ACCEPTED_CLAIM_TOKEN_FORMAT: &str = UMA_CLAIM_TOKEN_FORMAT;

--- a/crates/axiam-api-rest/src/lib.rs
+++ b/crates/axiam-api-rest/src/lib.rs
@@ -14,6 +14,7 @@ pub mod permissions;
 pub mod server;
 pub mod state;
 pub mod tenant_org_cache;
+pub mod uma;
 pub mod webhook;
 pub mod webhook_consumer;
 

--- a/crates/axiam-api-rest/src/openapi.rs
+++ b/crates/axiam-api-rest/src/openapi.rs
@@ -168,6 +168,11 @@ use crate::handlers;
         // UMA 2.0 (X2)
         handlers::uma::permission_request,
         handlers::uma::uma2_configuration,
+        handlers::uma::register_resource_set,
+        handlers::uma::read_resource_set,
+        handlers::uma::update_resource_set,
+        handlers::uma::delete_resource_set,
+        handlers::uma::list_resource_sets,
         // Settings
         handlers::settings::get_org_settings,
         handlers::settings::set_org_settings,
@@ -376,6 +381,7 @@ use crate::handlers;
         handlers::uma::PermissionRequestBody,
         handlers::uma::PermissionTicketResponse,
         handlers::uma::Uma2Configuration,
+        handlers::uma::ResourceSet,
         // OIDC
         axiam_oauth2::oidc::OidcDiscoveryDocument,
         axiam_oauth2::oidc::JwksDocument,

--- a/crates/axiam-api-rest/src/openapi.rs
+++ b/crates/axiam-api-rest/src/openapi.rs
@@ -165,6 +165,9 @@ use crate::handlers;
         handlers::oauth2::discovery,
         handlers::oauth2::jwks,
         handlers::oauth2::userinfo,
+        // UMA 2.0 (X2)
+        handlers::uma::permission_request,
+        handlers::uma::uma2_configuration,
         // Settings
         handlers::settings::get_org_settings,
         handlers::settings::set_org_settings,
@@ -364,6 +367,15 @@ use crate::handlers;
         // distinct response body, both of which an SDK generator needs.
         axiam_oauth2::token_exchange::TokenExchangeRequest,
         axiam_oauth2::token_exchange::TokenExchangeResponse,
+        // UMA 2.0 (X2). The ticket grant's request rides on `TokenRequest` at
+        // `POST /oauth2/token` — the `ticket` / `claim_token` fields — so only
+        // the Protection API's own bodies and the discovery document are
+        // distinct shapes an SDK generator needs.
+        axiam_core::models::uma::RequestedPermission,
+        axiam_core::models::uma::RptPermission,
+        handlers::uma::PermissionRequestBody,
+        handlers::uma::PermissionTicketResponse,
+        handlers::uma::Uma2Configuration,
         // OIDC
         axiam_oauth2::oidc::OidcDiscoveryDocument,
         axiam_oauth2::oidc::JwksDocument,

--- a/crates/axiam-api-rest/src/permissions.rs
+++ b/crates/axiam-api-rest/src/permissions.rs
@@ -242,6 +242,10 @@ pub const PUBLIC_PATHS: &[&str] = &[
     "/ready",
     // OIDC discovery and token endpoints
     "/.well-known/openid-configuration",
+    // UMA 2.0 discovery (X2). Public for the same reason as OIDC discovery:
+    // §2 makes it the document a resource server fetches *before* it holds any
+    // credential, and it carries only endpoint URLs the deployment publishes.
+    "/.well-known/uma2-configuration",
     "/oauth2/jwks",
     "/oauth2/authorize",
     "/oauth2/token",

--- a/crates/axiam-api-rest/src/server.rs
+++ b/crates/axiam-api-rest/src/server.rs
@@ -274,6 +274,27 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
         "/.well-known/openid-configuration",
         web::get().to(handlers::oauth2::discovery),
     );
+    // X2 / UMA 2.0 §2. Outside the `/oauth2` scope for the same reason as OIDC
+    // discovery: the spec fixes the path at the host root.
+    cfg.route(
+        "/.well-known/uma2-configuration",
+        web::get().to(handlers::uma::uma2_configuration),
+    );
+    // X2 — the UMA Protection API. Its own scope rather than a route under
+    // `/oauth2`, because UMA 2.0 §3.2 fixes the path and because these
+    // endpoints are PAT-protected bearer routes, not client-credential form
+    // posts like the token endpoint family.
+    cfg.service(
+        web::scope("/uma2").wrap(AuthzMiddleware).service(
+            web::resource("/perm")
+                .wrap(build_governor(rate_limit_cfg.uma_perm_per_min))
+                .wrap(RateLimitShared::<C>::new(
+                    "uma_perm",
+                    rate_limit_cfg.uma_perm_per_min,
+                ))
+                .route(web::post().to(handlers::uma::permission_request::<C>)),
+        ),
+    );
     cfg.service(
         web::scope("/oauth2")
             .wrap(AuthzMiddleware)

--- a/crates/axiam-api-rest/src/server.rs
+++ b/crates/axiam-api-rest/src/server.rs
@@ -285,15 +285,43 @@ pub fn register_api_v1_routes<C: surrealdb::Connection + Clone>(
     // endpoints are PAT-protected bearer routes, not client-credential form
     // posts like the token endpoint family.
     cfg.service(
-        web::scope("/uma2").wrap(AuthzMiddleware).service(
-            web::resource("/perm")
-                .wrap(build_governor(rate_limit_cfg.uma_perm_per_min))
-                .wrap(RateLimitShared::<C>::new(
-                    "uma_perm",
-                    rate_limit_cfg.uma_perm_per_min,
-                ))
-                .route(web::post().to(handlers::uma::permission_request::<C>)),
-        ),
+        web::scope("/uma2")
+            .wrap(AuthzMiddleware)
+            .service(
+                web::resource("/perm")
+                    .wrap(build_governor(rate_limit_cfg.uma_perm_per_min))
+                    .wrap(RateLimitShared::<C>::new(
+                        "uma_perm",
+                        rate_limit_cfg.uma_perm_per_min,
+                    ))
+                    .route(web::post().to(handlers::uma::permission_request::<C>)),
+            )
+            // FedAuthz §2.2. Shares the `uma_perm` bucket sizing but gets its
+            // own counter name: registration is administrative traffic (a
+            // resource server registers at deploy time, not per request), so
+            // letting it consume the permission endpoint's allowance would let
+            // a registration loop starve live authorization.
+            .service(
+                web::resource("/rreg/resource_set")
+                    .wrap(build_governor(rate_limit_cfg.uma_perm_per_min))
+                    .wrap(RateLimitShared::<C>::new(
+                        "uma_rreg",
+                        rate_limit_cfg.uma_perm_per_min,
+                    ))
+                    .route(web::post().to(handlers::uma::register_resource_set::<C>))
+                    .route(web::get().to(handlers::uma::list_resource_sets::<C>)),
+            )
+            .service(
+                web::resource("/rreg/resource_set/{id}")
+                    .wrap(build_governor(rate_limit_cfg.uma_perm_per_min))
+                    .wrap(RateLimitShared::<C>::new(
+                        "uma_rreg",
+                        rate_limit_cfg.uma_perm_per_min,
+                    ))
+                    .route(web::get().to(handlers::uma::read_resource_set::<C>))
+                    .route(web::put().to(handlers::uma::update_resource_set::<C>))
+                    .route(web::delete().to(handlers::uma::delete_resource_set::<C>)),
+            ),
     );
     cfg.service(
         web::scope("/oauth2")

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -52,6 +52,7 @@ use axiam_auth::{
 };
 use axiam_authz::AuthzConfig;
 use axiam_db::DbHandle;
+use axiam_db::repository::SurrealPermissionTicketRepository;
 use axiam_db::{
     SharedRateLimitCounter, SurrealAccountDeletionRepository, SurrealAssertionReplayRepository,
     SurrealAuditLogRepository, SurrealAuthorizationCodeRepository, SurrealCertificateRepository,
@@ -309,6 +310,17 @@ pub struct AppState<C: Connection + Clone> {
     pub token_exchange_service: TokenExchangeServiceT<C>,
     /// B5 — pushed authorization requests (RFC 9126).
     pub par_service: ParServiceT<C>,
+    /// X2 — UMA 2.0 permission tickets.
+    ///
+    /// The repository rather than an assembled `UmaService`, because the
+    /// service also needs the [`crate::authz::AuthzChecker`], which is a
+    /// separate `web::Data` and not part of this state. Handlers assemble the
+    /// service with [`AppState::uma_service`].
+    pub permission_ticket_repo: SurrealPermissionTicketRepository<C>,
+    /// X2 — deployment ceiling on RPT lifetime, in seconds. The effective
+    /// lifetime is the minimum of this, the protocol default (300 s), and the
+    /// subject token's own remaining life.
+    pub rpt_max_lifetime_secs: i64,
     /// B5 — which clients joined which session, for the back-channel logout
     /// fan-out.
     pub session_client_repo: SurrealSessionClientRepository<C>,
@@ -383,6 +395,30 @@ pub struct AppState<C: Connection + Clone> {
 }
 
 impl<C: Connection + Clone> AppState<C> {
+    /// Assemble the X2 UMA service for one request.
+    ///
+    /// Built per call rather than stored, because it needs the
+    /// [`crate::authz::AuthzChecker`] — which arrives as its own `web::Data`
+    /// so that deployments can swap the checker without rebuilding this state.
+    /// The three parts it composes are all cheap handles (two repository
+    /// structs wrapping a cloned connection, and an `Arc`), so this is a
+    /// handful of refcount bumps, not a connection or a query.
+    pub fn uma_service(
+        &self,
+        authz: std::sync::Arc<dyn crate::authz::AuthzChecker>,
+    ) -> axiam_oauth2::uma::UmaService<
+        SurrealPermissionTicketRepository<C>,
+        crate::uma::EngineEvaluator,
+        crate::uma::ResourceScopeCatalog<SurrealScopeRepository<C>>,
+    > {
+        axiam_oauth2::uma::UmaService::new(
+            self.permission_ticket_repo.clone(),
+            crate::uma::EngineEvaluator::new(authz),
+            crate::uma::ResourceScopeCatalog::new(self.scope_repo.clone()),
+            self.rpt_max_lifetime_secs,
+        )
+    }
+
     /// Dispatch a domain event to any webhooks subscribed to `event_type` in
     /// `tenant_id` (CQ-B22). Best-effort: if no AMQP publisher is wired
     /// (`webhook_publisher` is `None`, e.g. tests or AMQP disabled) this is a
@@ -583,6 +619,11 @@ impl<C: Connection + Clone> AppState<C> {
             token_service,
             device_authorization_service,
             par_service,
+            permission_ticket_repo: SurrealPermissionTicketRepository::new(db.clone()),
+            // X2: the protocol default is the ceiling until an operator lowers
+            // it. Raising it past `DEFAULT_RPT_MAX_LIFETIME_SECS` buys nothing
+            // — the effective lifetime is a minimum over all three bounds.
+            rpt_max_lifetime_secs: axiam_core::models::uma::DEFAULT_RPT_MAX_LIFETIME_SECS,
             session_client_repo,
             token_exchange_service,
             device_grant_repo,

--- a/crates/axiam-api-rest/src/tests/authz_check_test.rs
+++ b/crates/axiam-api-rest/src/tests/authz_check_test.rs
@@ -70,6 +70,7 @@ fn make_user(tenant_id: Uuid, user_id: Uuid) -> AuthenticatedPrincipal {
         scope: None,
         sub_kind: SubjectKind::User,
         act: None,
+        permissions: None,
     });
     AuthenticatedPrincipal {
         subject_id: user_id,
@@ -95,6 +96,7 @@ fn make_machine(tenant_id: Uuid, service_account_id: Uuid) -> AuthenticatedPrinc
         scope: None,
         sub_kind: axiam_auth::token::SubjectKind::ServiceAccount,
         act: None,
+        permissions: None,
     });
 
     AuthenticatedPrincipal {

--- a/crates/axiam-api-rest/src/tests/route_openapi_parity_test.rs
+++ b/crates/axiam-api-rest/src/tests/route_openapi_parity_test.rs
@@ -71,6 +71,11 @@ const AUTHENTICATED_SELF_SERVICE_PATHS: &[&str] = &[
     // operator grants to make a client a resource server, and a second named
     // permission on top would be a different answer to the same question.
     "/uma2/perm",
+    // UMA 2.0 resource registration (FedAuthz §2.2), same PAT gate as
+    // `/uma2/perm`. Not in ROUTE_PERMISSION_MAP for the same reason: the
+    // `uma_protection` scope is the gate.
+    "/uma2/rreg/resource_set",
+    "/uma2/rreg/resource_set/{id}",
 ];
 
 /// Returns true if `openapi_path` is covered by any `PUBLIC_PATHS` entry.

--- a/crates/axiam-api-rest/src/tests/route_openapi_parity_test.rs
+++ b/crates/axiam-api-rest/src/tests/route_openapi_parity_test.rs
@@ -65,6 +65,12 @@ const AUTHENTICATED_SELF_SERVICE_PATHS: &[&str] = &[
     // authorised here is the caller acting on their own behalf.
     "/api/v1/device/verify",
     "/api/v1/device/decide",
+    // UMA 2.0 Protection API (X2). Authenticated by the `ProtectionApiToken`
+    // extractor — a client-credentials token carrying `uma_protection` — and
+    // deliberately not permission-gated. The scope IS the gate: it is what an
+    // operator grants to make a client a resource server, and a second named
+    // permission on top would be a different answer to the same question.
+    "/uma2/perm",
 ];
 
 /// Returns true if `openapi_path` is covered by any `PUBLIC_PATHS` entry.

--- a/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
+++ b/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
@@ -102,6 +102,7 @@ fn make_admin(tenant_id: Uuid) -> AuthenticatedUser {
             scope: None,
             sub_kind: SubjectKind::User,
             act: None,
+            permissions: None,
         }),
     }
 }

--- a/crates/axiam-api-rest/src/uma.rs
+++ b/crates/axiam-api-rest/src/uma.rs
@@ -1,0 +1,129 @@
+//! X2 — the two adapters that connect [`UmaService`] to the running system.
+//!
+//! `axiam-oauth2` defines the UMA grant against two narrow traits
+//! ([`PermissionEvaluator`], [`ScopeCatalog`]) rather than against the RBAC
+//! engine and the scope store directly, so that its own tests can drive it
+//! without a datastore. Those traits need production implementations, and this
+//! is where they live: `axiam-api-rest` is the first crate that has both an
+//! [`AuthzChecker`] and the repositories in scope.
+//!
+//! Both adapters are deliberately thin. Any logic that lands here is logic the
+//! UMA unit tests cannot see.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use axiam_authz::types::{AccessDecision, AccessRequest};
+use axiam_core::repository::ScopeRepository;
+use axiam_oauth2::uma::{PairOutcome, PermissionEvaluator, ScopeCatalog};
+use uuid::Uuid;
+
+use crate::authz::AuthzChecker;
+
+/// Evaluates a UMA `(resource, scope)` pair as an ordinary access check.
+///
+/// # The mapping, and why it is not configurable
+///
+/// A UMA resource scope is the AXIAM **`action`**, evaluated against the
+/// registered resource with no AXIAM scope named
+/// (`claude_dev/uma-mapping-design.md`):
+///
+/// ```text
+/// AccessRequest { tenant_id, subject_id, action: <uma scope>, resource_id, scope: None }
+/// ```
+///
+/// Riding UMA scopes on the AXIAM `scope` field instead would be unsafe, not
+/// merely different: `grant_applies` treats a grant with an empty `scope_ids`
+/// as matching *any* requested scope, so one unscoped grant of a fixed
+/// `uma:access` action would satisfy every scope on the resource at once —
+/// registering a new `delete` scope would silently widen every existing grant
+/// to include it.
+///
+/// # Deny-override comes for free
+///
+/// Because this **is** the same check a live request makes, a
+/// `PermissionEffect::Deny` grant vetoes an RPT exactly as it vetoes a live
+/// check (B1). That is X2's stated requirement, and it holds here without any
+/// UMA-specific code — which is the point of the mapping, and the reason
+/// `DeniedByRule` is carried through as its own outcome instead of being
+/// flattened into "not allowed".
+pub struct EngineEvaluator {
+    authz: Arc<dyn AuthzChecker>,
+}
+
+impl EngineEvaluator {
+    pub fn new(authz: Arc<dyn AuthzChecker>) -> Self {
+        Self { authz }
+    }
+}
+
+impl PermissionEvaluator for EngineEvaluator {
+    fn evaluate<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        subject_id: Uuid,
+        resource_id: Uuid,
+        scope: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<PairOutcome, String>> + Send + 'a>> {
+        Box::pin(async move {
+            let request = AccessRequest {
+                tenant_id,
+                subject_id,
+                action: scope.to_string(),
+                resource_id,
+                scope: None,
+            };
+
+            match self.authz.check_access(&request).await {
+                Ok(AccessDecision::Allow) => Ok(PairOutcome::Allowed),
+                Ok(AccessDecision::Deny(_)) => Ok(PairOutcome::NoGrant),
+                Ok(AccessDecision::DeniedByRule(_)) => Ok(PairOutcome::DeniedByRule),
+                // A failed check is not a denial. Reporting it as one would
+                // turn a datastore blip into `access_denied`, which tells the
+                // resource server the requesting party lacks authority — a
+                // claim this adapter is in no position to make.
+                Err(e) => Err(e.to_string()),
+            }
+        })
+    }
+}
+
+/// Answers "which scope names has this resource declared", from the ordinary
+/// AXIAM scope rows on that resource.
+///
+/// UMA's `_id` **is** the AXIAM resource id — there is no parallel resource
+/// store to translate through — so a resource's declared scopes are just its
+/// `Scope` rows. That set is the allow-list of names a resource server may ask
+/// for, not an input to any decision: an undeclared scope is refused when the
+/// ticket is minted, so the resource server learns it named something that does
+/// not exist rather than being told the requesting party was denied.
+pub struct ResourceScopeCatalog<R> {
+    scopes: R,
+}
+
+impl<R> ResourceScopeCatalog<R> {
+    pub fn new(scopes: R) -> Self {
+        Self { scopes }
+    }
+}
+
+impl<R> ScopeCatalog for ResourceScopeCatalog<R>
+where
+    R: ScopeRepository + Send + Sync,
+{
+    fn declared_scopes<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        resource_id: Uuid,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            let scopes = self
+                .scopes
+                .list_by_resource(tenant_id, resource_id)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(scopes.into_iter().map(|s| s.name).collect())
+        })
+    }
+}

--- a/crates/axiam-api-rest/tests/uma_test.rs
+++ b/crates/axiam-api-rest/tests/uma_test.rs
@@ -1,0 +1,788 @@
+//! Integration tests for the UMA 2.0 HTTP surface (X2).
+//!
+//! The ticket arithmetic and the grant's own refusal logic are unit-tested in
+//! `axiam-oauth2::uma`. What this file exercises is what only exists once the
+//! endpoints are mounted: that `/uma2/perm` is routed and rejects a token that
+//! is not a PAT, that the uma-ticket grant reaches the **real** RBAC engine —
+//! so a deny rule vetoes an RPT exactly as it vetoes a live check — and that
+//! the RPT carries the permissions claim.
+//!
+//! The authz checker here is a real [`AuthorizationEngine`], not
+//! `AllowAllAuthzChecker`. That is the point: X2's acceptance criterion is
+//! about what the engine decides, and an allow-all fake would pass every test
+//! in this file while proving nothing.
+//!
+//! Every test is named after the thing it stops.
+
+use actix_web::{App, test, web};
+use axiam_api_rest::RateLimitConfig;
+use axiam_api_rest::authz::AuthzChecker;
+use axiam_api_rest::register_api_v1_routes;
+use axiam_api_rest::state::AppState;
+use axiam_auth::config::AuthConfig;
+use axiam_auth::token::{AUD_M2M, AUD_USER, SubjectKind, issue_access_token};
+use axiam_authz::AuthorizationEngine;
+use axiam_core::models::oauth2_client::CreateOAuth2Client;
+use axiam_core::models::organization::CreateOrganization;
+use axiam_core::models::permission::{CreatePermission, PermissionEffect};
+use axiam_core::models::resource::CreateResource;
+use axiam_core::models::role::CreateRole;
+use axiam_core::models::scope::CreateScope;
+use axiam_core::models::tenant::CreateTenant;
+use axiam_core::models::uma::UMA_TICKET_GRANT_TYPE;
+use axiam_core::models::user::{CreateUser, UpdateUser, UserStatus};
+use axiam_core::repository::{
+    GroupRepository, OAuth2ClientRepository, OrganizationRepository, PermissionRepository,
+    ResourceRepository, RoleRepository, ScopeRepository, TenantRepository, UserRepository,
+};
+use axiam_db::repository::{
+    SurrealGroupRepository, SurrealOAuth2ClientRepository, SurrealOrganizationRepository,
+    SurrealPermissionRepository, SurrealResourceRepository, SurrealRoleRepository,
+    SurrealScopeRepository, SurrealTenantRepository, SurrealUserRepository,
+};
+use serde_json::{Value, json};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use surrealdb::Surreal;
+use surrealdb::engine::local::Mem;
+use uuid::Uuid;
+
+type TestDb = surrealdb::engine::local::Db;
+
+const TEST_PASSWORD: &str = "test-only-placeholder-not-a-real-password"; // gitleaks:allow
+const TEST_PEER: &str = "127.0.0.1:34567";
+
+const REDIRECT_URI: &str = "https://rs.test.example/callback";
+
+fn test_keypair() -> (String, String) {
+    let kp =
+        rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).expect("ed25519 keypair generation");
+    (kp.serialize_pem(), kp.public_key_pem())
+}
+
+fn test_auth_config() -> AuthConfig {
+    let (private_key, public_key) = test_keypair();
+    AuthConfig {
+        jwt_private_key_pem: private_key,
+        jwt_public_key_pem: public_key,
+        access_token_lifetime_secs: 900,
+        jwt_issuer: "axiam-test".into(),
+        oauth2_issuer_url: "https://id.test.example".into(),
+        ..AuthConfig::default()
+    }
+}
+
+struct Fixture {
+    db: Surreal<TestDb>,
+    auth: AuthConfig,
+    tenant_id: Uuid,
+    org_id: Uuid,
+    /// The requesting party — granted `view` on `resource_id`, denied
+    /// `redact` by an explicit deny rule.
+    user_id: Uuid,
+    resource_id: Uuid,
+    /// The resource server. The Protection API binds a ticket to whichever
+    /// client minted it, so the binding tests need a second registered client
+    /// to present the same ticket as somebody else.
+    rs_client_id: String,
+    rs_client_secret: String,
+    other_client_id: String,
+    other_client_secret: String,
+}
+
+fn make_authz(db: &Surreal<TestDb>) -> Arc<dyn AuthzChecker> {
+    Arc::new(AuthorizationEngine::new(
+        SurrealRoleRepository::new(db.clone()),
+        SurrealPermissionRepository::new(db.clone()),
+        SurrealResourceRepository::new(db.clone()),
+        SurrealScopeRepository::new(db.clone()),
+        SurrealGroupRepository::new(db.clone()),
+    ))
+}
+
+/// Seeds one resource declaring three scopes, and a user holding a role that
+/// **allows** `view`, **denies** `redact`, and says nothing about `export`.
+///
+/// Those three cases are the whole point of the fixture: allow, explicit deny,
+/// and default-deny are three different outcomes and the grant must tell them
+/// apart.
+async fn setup() -> Fixture {
+    let db = Surreal::new::<Mem>(()).await.unwrap();
+    db.use_ns("test").use_db("test").await.unwrap();
+    axiam_db::run_migrations(&db).await.unwrap();
+
+    let org = SurrealOrganizationRepository::new(db.clone())
+        .create(CreateOrganization {
+            name: "UMA Org".into(),
+            slug: "org-uma".into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    let tenant = SurrealTenantRepository::new(db.clone())
+        .create(CreateTenant {
+            organization_id: org.id,
+            name: "UMA Tenant".into(),
+            slug: "tenant-uma".into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let user_repo = SurrealUserRepository::new(db.clone());
+    let user = user_repo
+        .create(CreateUser {
+            tenant_id: tenant.id,
+            username: "requesting-party".into(),
+            email: "rq@example.com".into(),
+            password: TEST_PASSWORD.into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    user_repo
+        .update(
+            tenant.id,
+            user.id,
+            UpdateUser {
+                status: Some(UserStatus::Active),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let resource = SurrealResourceRepository::new(db.clone())
+        .create(CreateResource {
+            tenant_id: tenant.id,
+            name: "patient-record-42".into(),
+            resource_type: "document".into(),
+            parent_id: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    // The declared scope set: the allow-list of names a resource server may
+    // ask for. `export` is declared but never granted, which is what makes
+    // "declared but denied" distinguishable from "never declared".
+    let scope_repo = SurrealScopeRepository::new(db.clone());
+    for name in ["view", "redact", "export"] {
+        scope_repo
+            .create(CreateScope {
+                tenant_id: tenant.id,
+                resource_id: resource.id,
+                name: name.into(),
+                description: String::new(),
+            })
+            .await
+            .unwrap();
+    }
+
+    let role_repo = SurrealRoleRepository::new(db.clone());
+    let perm_repo = SurrealPermissionRepository::new(db.clone());
+    let role = role_repo
+        .create(CreateRole {
+            tenant_id: tenant.id,
+            name: "record-reader".into(),
+            description: String::new(),
+            is_global: false,
+        })
+        .await
+        .unwrap();
+
+    let view = perm_repo
+        .create(CreatePermission {
+            tenant_id: tenant.id,
+            action: "view".into(),
+            description: String::new(),
+        })
+        .await
+        .unwrap();
+    let redact = perm_repo
+        .create(CreatePermission {
+            tenant_id: tenant.id,
+            action: "redact".into(),
+            description: String::new(),
+        })
+        .await
+        .unwrap();
+
+    perm_repo
+        .grant_to_role_with_effect(tenant.id, role.id, view.id, vec![], PermissionEffect::Allow)
+        .await
+        .unwrap();
+    perm_repo
+        .grant_to_role_with_effect(
+            tenant.id,
+            role.id,
+            redact.id,
+            vec![],
+            PermissionEffect::Deny,
+        )
+        .await
+        .unwrap();
+
+    role_repo
+        .assign_to_user(tenant.id, user.id, role.id, Some(resource.id))
+        .await
+        .unwrap();
+
+    let client_repo = SurrealOAuth2ClientRepository::new(db.clone());
+    let (rs, rs_secret) = client_repo
+        .create(CreateOAuth2Client {
+            tenant_id: tenant.id,
+            name: "resource-server-1".into(),
+            redirect_uris: vec![REDIRECT_URI.into()],
+            grant_types: vec!["client_credentials".into()],
+            scopes: vec!["uma_protection".into()],
+            post_logout_redirect_uris: Vec::new(),
+            backchannel_logout_uri: None,
+            require_par: false,
+        })
+        .await
+        .unwrap();
+    let (other, other_secret) = client_repo
+        .create(CreateOAuth2Client {
+            tenant_id: tenant.id,
+            name: "resource-server-2".into(),
+            redirect_uris: vec![REDIRECT_URI.into()],
+            grant_types: vec!["client_credentials".into()],
+            scopes: vec!["uma_protection".into()],
+            post_logout_redirect_uris: Vec::new(),
+            backchannel_logout_uri: None,
+            require_par: false,
+        })
+        .await
+        .unwrap();
+
+    Fixture {
+        db,
+        auth: test_auth_config(),
+        tenant_id: tenant.id,
+        org_id: org.id,
+        user_id: user.id,
+        resource_id: resource.id,
+        rs_client_id: rs.client_id,
+        rs_client_secret: rs_secret,
+        other_client_id: other.client_id,
+        other_client_secret: other_secret,
+    }
+}
+
+macro_rules! test_app {
+    ($f:expr) => {
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new($f.auth.clone()))
+                .app_data(web::Data::new(AppState::for_test(
+                    $f.db.clone(),
+                    $f.auth.clone(),
+                )))
+                .app_data(web::Data::new(make_authz(&$f.db)))
+                .configure(|cfg| {
+                    register_api_v1_routes::<TestDb>(cfg, &RateLimitConfig::default())
+                }),
+        )
+        .await
+    };
+}
+
+/// A Protection API Token: an OAuth2-client-subject token carrying
+/// `uma_protection`. `sub` is the client id, which is what the ticket binds to.
+fn pat(f: &Fixture, client_id: &str) -> String {
+    client_token(f, client_id, &["uma_protection".to_string()])
+}
+
+/// A client-credentials-shaped token. Built with the same claim shape
+/// `issue_client_credentials_token` produces (`sub` = client id, `sub_kind` =
+/// `OAuth2Client`, `aud` = m2m) so the PAT checks see a realistic token.
+fn client_token(f: &Fixture, client_id: &str, scopes: &[String]) -> String {
+    axiam_auth::token::issue_client_credentials_token(
+        client_id,
+        f.tenant_id,
+        f.org_id,
+        scopes,
+        &f.auth,
+    )
+    .unwrap()
+}
+
+/// The requesting party's own access token — the `claim_token` of the grant.
+fn user_token(f: &Fixture) -> String {
+    issue_access_token(
+        f.user_id,
+        f.tenant_id,
+        f.org_id,
+        &[],
+        &f.auth,
+        Uuid::new_v4().to_string(),
+        AUD_USER,
+    )
+    .unwrap()
+}
+
+/// POST /uma2/perm with the given bearer token and requested pairs.
+macro_rules! perm {
+    ($app:expr, $f:expr, $token:expr, $body:expr) => {{
+        let req = test::TestRequest::post()
+            .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+            .uri("/uma2/perm")
+            .insert_header(("Authorization", format!("Bearer {}", $token)))
+            .set_json($body)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        let status = resp.status().as_u16();
+        let json: Value = test::read_body_json(resp).await;
+        (status, json)
+    }};
+}
+
+/// Redeem a ticket at the token endpoint.
+macro_rules! redeem {
+    ($app:expr, $f:expr, $client_id:expr, $secret:expr, $ticket:expr, $claim_token:expr) => {{
+        let body = format!(
+            "grant_type={}&client_id={}&client_secret={}&ticket={}&claim_token={}",
+            UMA_TICKET_GRANT_TYPE.replace(':', "%3A"),
+            $client_id,
+            $secret,
+            $ticket,
+            $claim_token
+        );
+        let req = test::TestRequest::post()
+            .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+            .uri(&format!("/oauth2/token?tenant_id={}", $f.tenant_id))
+            .insert_header(("content-type", "application/x-www-form-urlencoded"))
+            .set_payload(body)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        let status = resp.status().as_u16();
+        let json: Value = test::read_body_json(resp).await;
+        (status, json)
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/// The discovery document must not advertise an endpoint that does not exist:
+/// a conforming client routes on the strength of it.
+#[actix_web::test]
+async fn discovery_advertises_only_the_endpoints_v1_actually_serves() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let req = test::TestRequest::get()
+        .uri("/.well-known/uma2-configuration")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 200);
+    let doc: Value = test::read_body_json(resp).await;
+
+    assert_eq!(
+        doc["permission_endpoint"],
+        "https://id.test.example/uma2/perm"
+    );
+    assert_eq!(
+        doc["token_endpoint"],
+        "https://id.test.example/oauth2/token"
+    );
+    assert_eq!(
+        doc["grant_types_supported"][0], UMA_TICKET_GRANT_TYPE,
+        "the ticket grant must be advertised"
+    );
+    assert!(
+        doc.get("claims_interaction_endpoint").is_none(),
+        "claims-gathering is deferred to v2 and must not be advertised"
+    );
+    assert!(
+        doc.get("resource_registration_endpoint").is_none(),
+        "the rreg API is not implemented yet and must not be advertised"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The permission endpoint authenticates as a PAT
+// ---------------------------------------------------------------------------
+
+/// Without the `uma_protection` scope an ordinary client token is not a PAT,
+/// and the Protection API must say so rather than minting a ticket.
+#[actix_web::test]
+async fn permission_endpoint_refuses_a_token_without_the_protection_scope() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let token = client_token(&f, &f.rs_client_id, &["openid".to_string()]);
+    let (status, _) = perm!(
+        app,
+        f,
+        token,
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    assert_eq!(status, 403, "a token without uma_protection is not a PAT");
+}
+
+/// A user token has no client identity in it. Minting a ticket from one would
+/// mean inventing the `client_id` the ticket is bound to.
+#[actix_web::test]
+async fn permission_endpoint_refuses_a_user_token_even_with_the_scope() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    // A user-subject token that nonetheless carries the scope.
+    let token = issue_access_token(
+        f.user_id,
+        f.tenant_id,
+        f.org_id,
+        &["uma_protection".to_string()],
+        &f.auth,
+        Uuid::new_v4().to_string(),
+        AUD_USER,
+    )
+    .unwrap();
+
+    let (status, _) = perm!(
+        app,
+        f,
+        token,
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    assert_eq!(
+        status, 403,
+        "a permission ticket must be bound to a client, and a user token names none"
+    );
+}
+
+/// A scope the resource never declared is refused at mint time. The resource
+/// server learns it asked for something that does not exist, rather than
+/// receiving a credential guaranteed to fail 60 seconds later.
+#[actix_web::test]
+async fn permission_endpoint_refuses_an_undeclared_scope_rather_than_minting() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (status, _) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["incinerate"] }])
+    );
+    assert_eq!(
+        status, 400,
+        "an undeclared scope is a bad request, not a denial"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The grant reaches the real engine
+// ---------------------------------------------------------------------------
+
+/// The happy path, end to end: mint a ticket for an allowed pair, redeem it,
+/// and get an RPT whose `permissions` claim names what was granted.
+#[actix_web::test]
+async fn an_allowed_pair_yields_an_rpt_carrying_the_permissions_claim() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (status, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    assert_eq!(status, 201, "minting failed: {body}");
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let (status, body) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    assert_eq!(status, 200, "redemption failed: {body}");
+
+    let rpt = body["access_token"].as_str().unwrap();
+    let claims = axiam_auth::token::validate_access_token(rpt, &f.auth)
+        .expect("the RPT must be an ordinary, verifiable AXIAM access token")
+        .0;
+
+    assert_eq!(
+        claims.sub,
+        f.user_id.to_string(),
+        "the RPT is the requesting party's"
+    );
+    assert_eq!(claims.sub_kind, SubjectKind::User);
+    let permissions = claims
+        .permissions
+        .expect("an RPT without a permissions claim is not an RPT");
+    assert_eq!(permissions.len(), 1);
+    assert_eq!(permissions[0].resource_id, f.resource_id);
+    assert_eq!(permissions[0].resource_scopes, vec!["view".to_string()]);
+
+    // X2: an RPT must never outlive the authorization it rests on.
+    let expires_in = body["expires_in"].as_i64().unwrap();
+    assert!(
+        expires_in <= 300,
+        "RPT lifetime {expires_in} exceeds the 300 s protocol ceiling"
+    );
+}
+
+/// **The X2 acceptance criterion.** An explicit deny rule must veto an RPT
+/// exactly as it vetoes a live check. This is the test that would fail if the
+/// UMA scope were ever remapped onto the AXIAM `scope` field instead of the
+/// action, because deny-override would stop applying.
+#[actix_web::test]
+async fn a_deny_rule_vetoes_an_rpt_exactly_as_it_vetoes_a_live_check() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (status, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["redact"] }])
+    );
+    assert_eq!(
+        status, 201,
+        "the ticket mints — `redact` is a declared scope"
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let (status, body) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    assert_eq!(status, 403, "a deny rule must refuse the exchange: {body}");
+    assert_eq!(body["error"], "access_denied");
+}
+
+/// Default-deny is a refusal too: a declared scope nobody granted must not
+/// produce an RPT just because no deny rule names it.
+#[actix_web::test]
+async fn a_scope_with_no_grant_at_all_is_refused() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["export"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let (status, _) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    assert_eq!(status, 403, "no grant means no RPT");
+}
+
+/// Partial grants are refused whole, never trimmed. A trimmed RPT would hand
+/// the client a token that silently does less than it asked for.
+#[actix_web::test]
+async fn a_ticket_mixing_an_allowed_and_a_denied_pair_is_refused_whole() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view", "redact"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let (status, _) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    assert_eq!(
+        status, 403,
+        "one denied pair refuses the whole ticket rather than trimming it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ticket single-use and binding
+// ---------------------------------------------------------------------------
+
+/// UMA 2.0 §3.3 requires a ticket to be single-use. This is the HTTP-level
+/// regression test for it; the datastore-level race is covered — and its
+/// residual documented — in `axiam-db`.
+#[actix_web::test]
+async fn a_ticket_cannot_be_redeemed_twice() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let (first, _) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket.clone(),
+        user_token(&f)
+    );
+    assert_eq!(first, 200);
+
+    let (second, body) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    assert_eq!(second, 400, "a replayed ticket must be refused");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+/// A ticket leaked to another client is not a usable credential — and, just as
+/// importantly, the wrong client's attempt must not **burn** it. Destroying the
+/// rightful holder's ticket on someone else's failed attempt would turn a leak
+/// into a denial of service.
+#[actix_web::test]
+async fn a_wrong_client_redemption_neither_succeeds_nor_burns_the_ticket() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let (status, _) = redeem!(
+        app,
+        f,
+        f.other_client_id,
+        f.other_client_secret,
+        ticket.clone(),
+        user_token(&f)
+    );
+    assert_eq!(
+        status, 400,
+        "a ticket is bound to the client that minted it"
+    );
+
+    let (status, body) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    assert_eq!(
+        status, 200,
+        "the rightful holder's ticket must survive someone else's attempt: {body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The grant's own required parameters
+// ---------------------------------------------------------------------------
+
+/// `claim_token` is the only channel through which v1 can name a requesting
+/// party. Its absence must be an explicit refusal, not a default subject.
+#[actix_web::test]
+async fn the_grant_refuses_a_ticket_with_no_claim_token() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap();
+
+    let body = format!(
+        "grant_type={}&client_id={}&client_secret={}&ticket={}",
+        UMA_TICKET_GRANT_TYPE.replace(':', "%3A"),
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket
+    );
+    let req = test::TestRequest::post()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/oauth2/token?tenant_id={}", f.tenant_id))
+        .insert_header(("content-type", "application/x-www-form-urlencoded"))
+        .set_payload(body)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 400);
+    let json: Value = test::read_body_json(resp).await;
+    assert_eq!(json["error"], "invalid_request");
+}
+
+/// A claim token from another tenant must not be evaluated against this
+/// tenant's grants. Without the check, tenant isolation would depend on the
+/// subject id not colliding across tenants.
+#[actix_web::test]
+async fn the_grant_refuses_a_claim_token_from_another_tenant() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+
+    let foreign = issue_access_token(
+        f.user_id,
+        Uuid::new_v4(), // a tenant this ticket was not minted in
+        f.org_id,
+        &[],
+        &f.auth,
+        Uuid::new_v4().to_string(),
+        AUD_USER,
+    )
+    .unwrap();
+
+    let (status, body) = redeem!(app, f, f.rs_client_id, f.rs_client_secret, ticket, foreign);
+    assert_eq!(status, 400, "cross-tenant redemption must be refused");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+/// The PAT audience is a machine audience — asserted so that a future change to
+/// `issue_client_credentials_token` cannot silently turn PATs into user tokens.
+#[actix_web::test]
+async fn a_pat_is_a_machine_token() {
+    let f = setup().await;
+    let claims = axiam_auth::token::validate_access_token(&pat(&f, &f.rs_client_id), &f.auth)
+        .unwrap()
+        .0;
+    assert_eq!(claims.aud.as_deref(), Some(AUD_M2M));
+    assert_eq!(claims.sub, f.rs_client_id);
+    assert_eq!(claims.sub_kind, SubjectKind::OAuth2Client);
+}

--- a/crates/axiam-api-rest/tests/uma_test.rs
+++ b/crates/axiam-api-rest/tests/uma_test.rs
@@ -392,13 +392,13 @@ async fn discovery_advertises_only_the_endpoints_v1_actually_serves() {
         doc["grant_types_supported"][0], UMA_TICKET_GRANT_TYPE,
         "the ticket grant must be advertised"
     );
+    assert_eq!(
+        doc["resource_registration_endpoint"],
+        "https://id.test.example/uma2/rreg/resource_set"
+    );
     assert!(
         doc.get("claims_interaction_endpoint").is_none(),
         "claims-gathering is deferred to v2 and must not be advertised"
-    );
-    assert!(
-        doc.get("resource_registration_endpoint").is_none(),
-        "the rreg API is not implemented yet and must not be advertised"
     );
 }
 
@@ -785,4 +785,422 @@ async fn a_pat_is_a_machine_token() {
     assert_eq!(claims.aud.as_deref(), Some(AUD_M2M));
     assert_eq!(claims.sub, f.rs_client_id);
     assert_eq!(claims.sub_kind, SubjectKind::OAuth2Client);
+}
+
+// ---------------------------------------------------------------------------
+// Resource registration (FedAuthz §2.2)
+// ---------------------------------------------------------------------------
+
+/// Register a resource set.
+macro_rules! rreg_create {
+    ($app:expr, $f:expr, $body:expr) => {{
+        let req = test::TestRequest::post()
+            .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+            .uri("/uma2/rreg/resource_set")
+            .insert_header((
+                "Authorization",
+                format!("Bearer {}", pat(&$f, &$f.rs_client_id)),
+            ))
+            .set_json($body)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        let status = resp.status().as_u16();
+        let json: Value = test::read_body_json(resp).await;
+        (status, json)
+    }};
+}
+
+/// A registered resource set is an ordinary AXIAM resource: the `_id` the
+/// Protection API hands back is the resource id, not a parallel identifier, and
+/// the declared scopes are real `Scope` rows the permission endpoint validates
+/// against.
+#[actix_web::test]
+async fn a_registered_resource_set_is_an_ordinary_axiam_resource() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (status, body) = rreg_create!(
+        app,
+        f,
+        json!({ "name": "invoice-7", "type": "document", "resource_scopes": ["view", "pay"] })
+    );
+    assert_eq!(status, 201, "registration failed: {body}");
+
+    let id: Uuid = serde_json::from_value(body["_id"].clone()).unwrap();
+
+    // The id resolves in the ordinary resource store — no translation layer.
+    let resource = SurrealResourceRepository::new(f.db.clone())
+        .get_by_id(f.tenant_id, id)
+        .await
+        .expect("the UMA _id must BE the AXIAM resource id");
+    assert_eq!(resource.name, "invoice-7");
+
+    // The declared scopes are real scope rows.
+    let scopes: Vec<String> = SurrealScopeRepository::new(f.db.clone())
+        .list_by_resource(f.tenant_id, id)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    assert!(scopes.contains(&"view".to_string()));
+    assert!(scopes.contains(&"pay".to_string()));
+}
+
+/// Registration is what makes a scope askable. A resource registered through
+/// the Protection API must be immediately usable at `/uma2/perm` — the two
+/// endpoints share one scope store, and this is the test that would fail if a
+/// parallel one were ever introduced.
+#[actix_web::test]
+async fn a_scope_declared_through_rreg_is_immediately_askable_at_the_permission_endpoint() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = rreg_create!(
+        app,
+        f,
+        json!({ "name": "invoice-8", "type": "document", "resource_scopes": ["pay"] })
+    );
+    let id: Uuid = serde_json::from_value(body["_id"].clone()).unwrap();
+
+    let (status, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": id, "resource_scopes": ["pay"] }])
+    );
+    assert_eq!(
+        status, 201,
+        "a freshly declared scope must be askable: {body}"
+    );
+
+    // And one that was never declared still is not.
+    let (status, _) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": id, "resource_scopes": ["shred"] }])
+    );
+    assert_eq!(status, 400);
+}
+
+/// An update **replaces** the scope list. A merge would make removal
+/// impossible, which would keep an authority the resource server tried to drop.
+#[actix_web::test]
+async fn updating_a_resource_set_removes_scopes_it_no_longer_names() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = rreg_create!(
+        app,
+        f,
+        json!({ "name": "invoice-9", "type": "document", "resource_scopes": ["view", "pay"] })
+    );
+    let id: Uuid = serde_json::from_value(body["_id"].clone()).unwrap();
+
+    let req = test::TestRequest::put()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/uma2/rreg/resource_set/{id}"))
+        .insert_header((
+            "Authorization",
+            format!("Bearer {}", pat(&f, &f.rs_client_id)),
+        ))
+        .set_json(json!({ "name": "invoice-9", "type": "document", "resource_scopes": ["view"] }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let scopes: Vec<String> = SurrealScopeRepository::new(f.db.clone())
+        .list_by_resource(f.tenant_id, id)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|s| s.name)
+        .collect();
+    assert_eq!(scopes, vec!["view".to_string()], "`pay` should be gone");
+
+    // And the dropped scope is no longer askable.
+    let (status, _) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": id, "resource_scopes": ["pay"] }])
+    );
+    assert_eq!(status, 400, "a removed scope must stop being askable");
+}
+
+/// A scope that survives an update keeps its id, because permission grants
+/// reference scope ids — recreating it would silently detach every grant that
+/// named it.
+#[actix_web::test]
+async fn an_unchanged_scope_keeps_its_id_across_an_update() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = rreg_create!(
+        app,
+        f,
+        json!({ "name": "invoice-10", "type": "document", "resource_scopes": ["view", "pay"] })
+    );
+    let id: Uuid = serde_json::from_value(body["_id"].clone()).unwrap();
+
+    let scope_repo = SurrealScopeRepository::new(f.db.clone());
+    let before = scope_repo
+        .list_by_resource(f.tenant_id, id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|s| s.name == "view")
+        .unwrap()
+        .id;
+
+    let req = test::TestRequest::put()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/uma2/rreg/resource_set/{id}"))
+        .insert_header((
+            "Authorization",
+            format!("Bearer {}", pat(&f, &f.rs_client_id)),
+        ))
+        .set_json(json!({ "name": "invoice-10", "type": "document", "resource_scopes": ["view", "refund"] }))
+        .to_request();
+    test::call_service(&app, req).await;
+
+    let after = scope_repo
+        .list_by_resource(f.tenant_id, id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|s| s.name == "view")
+        .unwrap()
+        .id;
+
+    assert_eq!(
+        before, after,
+        "an untouched scope must not be deleted and recreated"
+    );
+}
+
+/// The listing is scoped to the calling client. A resource server holding only
+/// a protection scope must not be able to enumerate the tenant's whole resource
+/// tree through it.
+#[actix_web::test]
+async fn the_listing_shows_only_what_this_client_registered() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = rreg_create!(
+        app,
+        f,
+        json!({ "name": "mine", "type": "document", "resource_scopes": [] })
+    );
+    let mine: Uuid = serde_json::from_value(body["_id"].clone()).unwrap();
+
+    let req = test::TestRequest::get()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri("/uma2/rreg/resource_set")
+        .insert_header((
+            "Authorization",
+            format!("Bearer {}", pat(&f, &f.rs_client_id)),
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let ids: Vec<Uuid> = test::read_body_json(resp).await;
+
+    assert!(ids.contains(&mine));
+    assert!(
+        !ids.contains(&f.resource_id),
+        "the fixture's hand-made resource was not registered through UMA and \
+         must not appear"
+    );
+
+    // The other resource server sees none of it.
+    let req = test::TestRequest::get()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri("/uma2/rreg/resource_set")
+        .insert_header((
+            "Authorization",
+            format!("Bearer {}", pat(&f, &f.other_client_id)),
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let other_ids: Vec<Uuid> = test::read_body_json(resp).await;
+    assert!(!other_ids.contains(&mine));
+}
+
+/// Provenance must be unforgeable through the ordinary resource API — the
+/// badge asserts that the Protection API registered the resource, so a marker
+/// any admin could write would be decoration that reads like evidence.
+#[actix_web::test]
+async fn provenance_cannot_be_forged_through_the_ordinary_resource_api() {
+    let f = setup().await;
+
+    let repo = SurrealResourceRepository::new(f.db.clone());
+
+    // A hand-made resource carries no provenance...
+    let plain = repo
+        .create(CreateResource {
+            tenant_id: f.tenant_id,
+            name: "hand-made".into(),
+            resource_type: "document".into(),
+            parent_id: None,
+            metadata: Some(json!({ "uma_registered_by": "resource-server-1" })),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        plain.uma_registered_by, None,
+        "metadata must not be able to spoof the provenance field"
+    );
+
+    // ...and `UpdateResource` has no way to set one: the struct has no such
+    // field, so this is enforced by the type, not by a runtime check.
+    let updated = repo
+        .update(
+            f.tenant_id,
+            plain.id,
+            axiam_core::models::resource::UpdateResource {
+                name: Some("renamed".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.uma_registered_by, None);
+}
+
+/// Deregistration removes the resource.
+#[actix_web::test]
+async fn deregistering_a_resource_set_removes_it() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = rreg_create!(
+        app,
+        f,
+        json!({ "name": "temporary", "type": "document", "resource_scopes": [] })
+    );
+    let id: Uuid = serde_json::from_value(body["_id"].clone()).unwrap();
+
+    let req = test::TestRequest::delete()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/uma2/rreg/resource_set/{id}"))
+        .insert_header((
+            "Authorization",
+            format!("Bearer {}", pat(&f, &f.rs_client_id)),
+        ))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 204);
+
+    assert!(
+        SurrealResourceRepository::new(f.db.clone())
+            .get_by_id(f.tenant_id, id)
+            .await
+            .is_err(),
+        "the resource should be gone"
+    );
+}
+
+/// The rreg endpoints are behind the same PAT gate as the permission endpoint.
+#[actix_web::test]
+async fn rreg_refuses_a_token_without_the_protection_scope() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let req = test::TestRequest::post()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri("/uma2/rreg/resource_set")
+        .insert_header((
+            "Authorization",
+            format!(
+                "Bearer {}",
+                client_token(&f, &f.rs_client_id, &["openid".to_string()])
+            ),
+        ))
+        .set_json(json!({ "name": "nope", "type": "document", "resource_scopes": [] }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 403);
+}
+
+// ---------------------------------------------------------------------------
+// RPT introspection
+// ---------------------------------------------------------------------------
+
+/// Introspecting an RPT returns the `permissions` array in the Keycloak-
+/// compatible shape, so a resource server migrating from Keycloak reads it
+/// without a translation layer.
+#[actix_web::test]
+async fn introspecting_an_rpt_returns_its_permissions() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let (_, body) = perm!(
+        app,
+        f,
+        pat(&f, &f.rs_client_id),
+        json!([{ "resource_id": f.resource_id, "resource_scopes": ["view"] }])
+    );
+    let ticket = body["ticket"].as_str().unwrap().to_string();
+    let (_, body) = redeem!(
+        app,
+        f,
+        f.rs_client_id,
+        f.rs_client_secret,
+        ticket,
+        user_token(&f)
+    );
+    let rpt = body["access_token"].as_str().unwrap().to_string();
+
+    let form = format!(
+        "token={}&client_id={}&client_secret={}",
+        rpt, f.rs_client_id, f.rs_client_secret
+    );
+    let req = test::TestRequest::post()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/oauth2/introspect?tenant_id={}", f.tenant_id))
+        .insert_header(("content-type", "application/x-www-form-urlencoded"))
+        .set_payload(form)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status().as_u16(), 200);
+    let json: Value = test::read_body_json(resp).await;
+
+    assert_eq!(json["active"], true);
+    let permissions = json["permissions"]
+        .as_array()
+        .expect("an RPT's introspection must carry the permissions array");
+    assert_eq!(permissions.len(), 1);
+    assert_eq!(permissions[0]["resource_id"], f.resource_id.to_string());
+    assert_eq!(permissions[0]["resource_scopes"][0], "view");
+}
+
+/// An ordinary access token is not an RPT, so introspecting one must omit the
+/// key entirely rather than returning an empty array — a resource server tells
+/// "no permissions" from "not an RPT" by its absence.
+#[actix_web::test]
+async fn introspecting_a_plain_access_token_omits_the_permissions_key() {
+    let f = setup().await;
+    let app = test_app!(f);
+
+    let form = format!(
+        "token={}&client_id={}&client_secret={}",
+        user_token(&f),
+        f.rs_client_id,
+        f.rs_client_secret
+    );
+    let req = test::TestRequest::post()
+        .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+        .uri(&format!("/oauth2/introspect?tenant_id={}", f.tenant_id))
+        .insert_header(("content-type", "application/x-www-form-urlencoded"))
+        .set_payload(form)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let json: Value = test::read_body_json(resp).await;
+
+    assert_eq!(json["active"], true);
+    assert!(
+        json.get("permissions").is_none(),
+        "a non-RPT must not carry the key at all"
+    );
 }

--- a/crates/axiam-api-rest/tests/uma_test.rs
+++ b/crates/axiam-api-rest/tests/uma_test.rs
@@ -32,8 +32,8 @@ use axiam_core::models::tenant::CreateTenant;
 use axiam_core::models::uma::UMA_TICKET_GRANT_TYPE;
 use axiam_core::models::user::{CreateUser, UpdateUser, UserStatus};
 use axiam_core::repository::{
-    GroupRepository, OAuth2ClientRepository, OrganizationRepository, PermissionRepository,
-    ResourceRepository, RoleRepository, ScopeRepository, TenantRepository, UserRepository,
+    OAuth2ClientRepository, OrganizationRepository, PermissionRepository, ResourceRepository,
+    RoleRepository, ScopeRepository, TenantRepository, UserRepository,
 };
 use axiam_db::repository::{
     SurrealGroupRepository, SurrealOAuth2ClientRepository, SurrealOrganizationRepository,

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use axiam_core::models::uma::RptPermission;
+
 use crate::config::AuthConfig;
 use crate::error::AuthError;
 
@@ -97,6 +99,20 @@ pub struct AccessTokenClaims {
     /// inside a signed token.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub act: Option<ActClaim>,
+    /// UMA 2.0 `permissions` claim (X2) — present **only** on an RPT.
+    ///
+    /// Its presence is what makes a token an RPT; there is no separate token
+    /// type, because an RPT is an ordinary AXIAM access token that additionally
+    /// says which `(resource, scopes)` pairs were allowed when it was issued.
+    ///
+    /// These are a **record of a decision already made**, not an input to a
+    /// future one. Nothing in the authorization path reads this claim to grant
+    /// anything: a live check re-evaluates against the engine. That matters
+    /// because a grant revoked after issuance does not retroactively empty a
+    /// live RPT — which is why RPT lifetime is bounded to the minimum of the
+    /// subject token's remaining life, the configured maximum, and 300 s.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Vec<RptPermission>>,
 }
 
 /// RFC 8693 §4.1 `act` claim: who is acting on the subject's behalf.
@@ -163,6 +179,7 @@ pub fn issue_access_token(
         scope,
         sub_kind: SubjectKind::User,
         act: None,
+        permissions: None,
     };
 
     // CQ-B14: Use pre-parsed key cache when available; fall back to PEM parsing.
@@ -231,6 +248,11 @@ pub fn issue_exchanged_token(
         scope,
         sub_kind,
         act,
+        // An exchanged token is not an RPT. A UMA permission set is minted by
+        // the uma-ticket grant against a consumed ticket, and re-stamping it
+        // through an exchange would carry a decision past the ticket that
+        // authorised it.
+        permissions: None,
     };
 
     let owned;
@@ -282,9 +304,70 @@ pub fn issue_client_credentials_token(
         scope,
         sub_kind: SubjectKind::OAuth2Client,
         act: None,
+        permissions: None,
     };
 
     // CQ-B14: Use pre-parsed key cache when available; fall back to PEM parsing.
+    let owned;
+    let key: &EncodingKey = if let Some(ref cached) = config.jwt_encoding_key {
+        cached.as_ref()
+    } else {
+        owned = EncodingKey::from_ed_pem(config.jwt_private_key_pem.as_bytes())
+            .map_err(|e| AuthError::Crypto(format!("bad private key: {e}")))?;
+        &owned
+    };
+
+    let header = Header::new(Algorithm::EdDSA);
+    jsonwebtoken::encode(&header, &claims, key)
+        .map_err(|e| AuthError::Crypto(format!("JWT encode: {e}")))
+}
+
+/// Issue an RPT — the requesting party token of the UMA 2.0 grant (X2).
+///
+/// An RPT is an ordinary AXIAM access token for `subject_id` that additionally
+/// carries the [`AccessTokenClaims::permissions`] claim. It is deliberately not
+/// a distinct token type: every existing validator, audience check and
+/// revocation path applies to it unchanged, which is what stops the RPT from
+/// becoming a second credential format with its own gaps.
+///
+/// `lifetime_secs` is decided by the caller — `axiam_oauth2::uma` computes it
+/// as the minimum of the subject token's remaining life, the deployment
+/// ceiling, and the protocol default. It is **not** re-derived from
+/// `config.access_token_lifetime_secs`, because an RPT must never outlive the
+/// token that authorised it.
+///
+/// `aud` is [`AUD_USER`]: the subject is the requesting party, a user, and the
+/// RPT authenticates as that user.
+pub fn issue_rpt(
+    subject_id: Uuid,
+    tenant_id: Uuid,
+    org_id: Uuid,
+    permissions: Vec<RptPermission>,
+    lifetime_secs: i64,
+    config: &AuthConfig,
+) -> Result<String, AuthError> {
+    let now = Utc::now().timestamp();
+
+    let claims = AccessTokenClaims {
+        sub: subject_id.to_string(),
+        tenant_id: tenant_id.to_string(),
+        org_id: org_id.to_string(),
+        iss: config.effective_issuer().to_owned(),
+        iat: now,
+        exp: now + lifetime_secs,
+        // No session row backs an RPT — it is minted from a ticket, not a
+        // login — so `jti` is a plain uniqueness marker, as it is for M2M.
+        jti: Uuid::new_v4().to_string(),
+        aud: Some(AUD_USER.to_string()),
+        // The `permissions` claim carries the authority. Stamping an OAuth2
+        // `scope` too would give a resource server two disagreeing places to
+        // read authority from, and only one of them was evaluated.
+        scope: None,
+        sub_kind: SubjectKind::User,
+        act: None,
+        permissions: Some(permissions),
+    };
+
     let owned;
     let key: &EncodingKey = if let Some(ref cached) = config.jwt_encoding_key {
         cached.as_ref()
@@ -349,6 +432,7 @@ pub fn issue_service_account_token(
         scope: None,
         sub_kind: SubjectKind::ServiceAccount,
         act: None,
+        permissions: None,
     };
 
     // CQ-B14: Use pre-parsed key cache when available; fall back to PEM parsing.
@@ -418,6 +502,7 @@ pub fn issue_service_account_client_credentials_token(
         scope,
         sub_kind: SubjectKind::ServiceAccount,
         act: None,
+        permissions: None,
     };
 
     let owned;

--- a/crates/axiam-authz/tests/batch_coalescing_test.rs
+++ b/crates/axiam-authz/tests/batch_coalescing_test.rs
@@ -79,6 +79,7 @@ fn resource(id: Uuid, tenant: Uuid) -> Resource {
         resource_type: "service".into(),
         parent_id: None,
         metadata: serde_json::Value::Null,
+        uma_registered_by: None,
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }

--- a/crates/axiam-core/src/models/resource.rs
+++ b/crates/axiam-core/src/models/resource.rs
@@ -17,6 +17,16 @@ pub struct Resource {
     /// Parent resource ID for hierarchical organization. `None` for root resources.
     pub parent_id: Option<Uuid>,
     pub metadata: serde_json::Value,
+    /// The `client_id` that registered this resource through the UMA
+    /// Protection API (X2), or `None` for a resource created any other way.
+    ///
+    /// Read-only from every ordinary path: [`UpdateResource`] cannot set it and
+    /// [`CreateResource`] cannot either, so the only writer is the
+    /// resource-registration handler. That is deliberate — the field backs a
+    /// provenance badge in the admin UI, and a provenance marker anyone can
+    /// write is decoration that reads like evidence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uma_registered_by: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/crates/axiam-core/src/models/uma.rs
+++ b/crates/axiam-core/src/models/uma.rs
@@ -45,6 +45,15 @@ pub const UMA_PROTECTION_SCOPE: &str = "uma_protection";
 /// The grant type that exchanges a ticket for an RPT (UMA 2.0 §3.3.1).
 pub const UMA_TICKET_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:uma-ticket";
 
+/// The only `claim_token_format` v1 accepts: an ordinary AXIAM access token.
+///
+/// UMA 2.0 leaves the format open so a deployment can accept foreign claim
+/// tokens. Accepting one would mean trusting an external issuer's statement of
+/// who the requesting party is, and the RPT minted from it authorises real
+/// access — so v1 accepts exactly one format, and an unrecognised value is
+/// refused rather than treated as this one.
+pub const UMA_CLAIM_TOKEN_FORMAT: &str = "urn:ietf:params:oauth:token-type:access_token";
+
 // ---------------------------------------------------------------------------
 // Requested and granted permissions
 // ---------------------------------------------------------------------------

--- a/crates/axiam-db/src/repository/resource.rs
+++ b/crates/axiam-db/src/repository/resource.rs
@@ -20,6 +20,10 @@ struct ResourceRow {
     resource_type: String,
     parent_id: Option<String>,
     metadata: serde_json::Value,
+    /// X2 provenance. `Option` at the row level too, because rows written
+    /// before schema v33 simply do not carry the field.
+    #[surreal(default)]
+    uma_registered_by: Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -32,6 +36,8 @@ struct ResourceRowWithId {
     resource_type: String,
     parent_id: Option<String>,
     metadata: serde_json::Value,
+    #[surreal(default)]
+    uma_registered_by: Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -54,6 +60,7 @@ impl ResourceRowWithId {
             resource_type: self.resource_type,
             parent_id,
             metadata: self.metadata,
+            uma_registered_by: self.uma_registered_by,
             created_at: self.created_at,
             updated_at: self.updated_at,
         })
@@ -75,6 +82,7 @@ fn row_to_resource(row: ResourceRow, id: Uuid) -> Result<Resource, DbError> {
         resource_type: row.resource_type,
         parent_id,
         metadata: row.metadata,
+        uma_registered_by: row.uma_registered_by,
         created_at: row.created_at,
         updated_at: row.updated_at,
     })
@@ -93,6 +101,71 @@ impl<C: Connection> SurrealResourceRepository<C> {
     pub fn new(db: impl Into<DbHandle<C>>) -> Self {
         let db = db.into();
         Self { db }
+    }
+
+    /// Create a resource and stamp the UMA client that registered it (X2).
+    ///
+    /// # Why this is an inherent method and not on `ResourceRepository`
+    ///
+    /// Provenance has exactly one writer — the resource-registration handler —
+    /// and putting it on the trait would offer it to every caller that holds
+    /// any `impl ResourceRepository`, which is the opposite of the point. The
+    /// handler reaches this repository concretely through `AppState`, so the
+    /// narrower home costs nothing and keeps `uma_registered_by` unreachable
+    /// from `create`/`update`.
+    ///
+    /// One statement rather than create-then-mark: a crash between two writes
+    /// would leave a resource that the Protection API registered but that
+    /// claims it did not, and an unmarked resource is indistinguishable from
+    /// one an administrator made by hand.
+    pub async fn create_uma_registered(
+        &self,
+        input: CreateResource,
+        client_id: &str,
+    ) -> AxiamResult<Resource> {
+        let id = new_id();
+        let id_str = id.to_string();
+        let tenant_id_str = input.tenant_id.to_string();
+        let parent_id_str = input.parent_id.map(|p| p.to_string());
+        let metadata = input
+            .metadata
+            .unwrap_or(serde_json::Value::Object(Default::default()));
+
+        let base = "CREATE type::record('resource', $id) SET \
+                    tenant_id = $tenant_id, \
+                    name = $name, resource_type = $resource_type, \
+                    parent_id = $parent_id, \
+                    metadata = $metadata, \
+                    uma_registered_by = $uma_registered_by";
+
+        let query = if let Some(ref pid) = parent_id_str {
+            format!("{base}; RELATE resource:`{id_str}` -> child_of -> resource:`{pid}`;")
+        } else {
+            base.to_string()
+        };
+
+        let result = self
+            .db
+            .current()
+            .query(query)
+            .bind(("id", id_str.clone()))
+            .bind(("tenant_id", tenant_id_str))
+            .bind(("name", input.name))
+            .bind(("resource_type", input.resource_type))
+            .bind(("parent_id", parent_id_str))
+            .bind(("metadata", metadata))
+            .bind(("uma_registered_by", client_id.to_string()))
+            .await
+            .map_err(DbError::from)?;
+
+        let mut result = result
+            .check()
+            .map_err(|e| DbError::Migration(e.to_string()))?;
+
+        let rows: Vec<ResourceRow> = result.take(0).map_err(DbError::from)?;
+        let row = take_first_or_not_found(rows, "resource", &id_str)?;
+
+        row_to_resource(row, id).map_err(Into::into)
     }
 }
 

--- a/crates/axiam-db/src/schema.rs
+++ b/crates/axiam-db/src/schema.rs
@@ -202,6 +202,11 @@ static MIGRATIONS: &[Migration] = &[
         name: "single_use_redemption_nonce_device_grant_and_par",
         sql: SCHEMA_V32,
     },
+    Migration {
+        version: 33,
+        name: "uma_resource_registration_provenance",
+        sql: SCHEMA_V33,
+    },
 ];
 
 // -----------------------------------------------------------------------
@@ -1632,6 +1637,30 @@ DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE permission_ticket TYPE option<
 const SCHEMA_V32: &str = "\
 DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE device_grant TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE pushed_auth_request TYPE option<string>;
+";
+
+// -----------------------------------------------------------------------
+// Schema v33 — which client registered a resource through the UMA
+// Protection API (X2)
+// -----------------------------------------------------------------------
+//
+// X2 asks for a read-only "UMA" badge on resources registered via the
+// Protection API. The obvious place to put that is `metadata`, which already
+// exists on `resource` and is already returned by the API — no migration, no
+// new field.
+//
+// It is the wrong place. `metadata` is writable through the ordinary resource
+// endpoints, so any caller who may edit a resource could set the marker on a
+// resource the Protection API never touched. A badge that asserts provenance
+// and can be written by anyone is not a provenance record; it is decoration
+// that reads like evidence.
+//
+// So it is its own field, written only by the resource-registration handler
+// and never by `UpdateResource`. `None` means "not registered through UMA",
+// which is also what every pre-existing row means — the migration adds a field
+// rather than backfilling a claim about resources nobody registered.
+const SCHEMA_V33: &str = "\
+DEFINE FIELD IF NOT EXISTS uma_registered_by ON TABLE resource TYPE option<string>;
 ";
 
 // -----------------------------------------------------------------------

--- a/crates/axiam-oauth2/src/token.rs
+++ b/crates/axiam-oauth2/src/token.rs
@@ -11,6 +11,7 @@ use axiam_auth::token::{
 use axiam_core::error::AxiamError;
 use axiam_core::models::oauth2_client::{CreateRefreshToken, OAuth2Client};
 use axiam_core::models::service_account::{SERVICE_ACCOUNT_CLIENT_ID_PREFIX, ServiceAccount};
+use axiam_core::models::uma::RptPermission;
 use axiam_core::models::user::UserStatus;
 use axiam_core::repository::{
     AuthorizationCodeRepository, OAuth2ClientRepository, RefreshTokenRepository,
@@ -171,6 +172,20 @@ pub struct IntrospectionResponse {
     pub iat: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_type: Option<String>,
+    /// UMA 2.0 `permissions` (X2) — present only when the introspected token
+    /// is an RPT.
+    ///
+    /// Keycloak's authorization services put the same array under the same key
+    /// in an introspection response, so a resource server migrating from
+    /// Keycloak reads an AXIAM RPT without a translation layer.
+    ///
+    /// This is **echoed from the token, not re-evaluated**. Introspection
+    /// answers "what does this token say", and the permissions claim is a
+    /// record of a decision made when the RPT was minted. A resource server
+    /// that needs a live answer must ask the authorization endpoints — which is
+    /// why RPT lifetime is bounded rather than long.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Vec<RptPermission>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1179,6 +1194,7 @@ where
                 exp: Some(claims.exp),
                 iat: Some(claims.iat),
                 token_type: Some("Bearer".into()),
+                permissions: claims.permissions.clone(),
             });
         }
 
@@ -1211,6 +1227,10 @@ where
                 exp: Some(stored.expires_at.timestamp()),
                 iat: Some(stored.created_at.timestamp()),
                 token_type: Some("refresh_token".into()),
+                // A refresh token is never an RPT: the uma-ticket grant issues
+                // no refresh token, precisely so that an RPT cannot be renewed
+                // past the ticket that authorised it.
+                permissions: None,
             });
         }
 

--- a/crates/axiam-oauth2/src/token.rs
+++ b/crates/axiam-oauth2/src/token.rs
@@ -81,6 +81,22 @@ pub struct TokenRequest {
     pub actor_token_type: Option<String>,
     pub audience: Option<String>,
     pub resource: Option<String>,
+
+    // --- X2 / UMA 2.0 ticket grant --------------------------------------
+    /// The permission ticket minted by `/uma2/perm`, for
+    /// `grant_type=urn:ietf:params:oauth:grant-type:uma-ticket`.
+    pub ticket: Option<String>,
+    /// The requesting party's identity, as an AXIAM access token.
+    ///
+    /// UMA 2.0 §3.3.1 makes this optional because a client may instead present
+    /// its own RPT for incremental authorization, which v1 does not implement.
+    /// With claims-gathering also deferred, this is the only channel through
+    /// which a requesting party can be named — so the grant requires it and
+    /// says so, rather than resolving to some default subject.
+    pub claim_token: Option<String>,
+    /// Declared format of `claim_token`. Only the AXIAM access-token URN is
+    /// accepted in v1; anything else is refused rather than guessed at.
+    pub claim_token_format: Option<String>,
 }
 
 impl TokenRequest {

--- a/crates/axiam-oauth2/tests/token_service.rs
+++ b/crates/axiam-oauth2/tests/token_service.rs
@@ -610,6 +610,9 @@ fn base_req(grant: &str) -> TokenRequest {
         actor_token_type: None,
         audience: None,
         resource: None,
+        ticket: None,
+        claim_token: None,
+        claim_token_format: None,
     }
 }
 

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -735,6 +735,10 @@ async fn main() -> std::io::Result<()> {
     // that only the test builder populates is exactly the gap that left B2's
     // grant unreachable in a real deployment.
     let session_client_repo = SurrealSessionClientRepository::new(pool.handle_for_repo());
+    // X2 — UMA 2.0 permission tickets. Built here with the other repositories
+    // because `pool` is moved before the `AppState` literal is assembled.
+    let permission_ticket_repo =
+        axiam_db::repository::SurrealPermissionTicketRepository::new(pool.handle_for_repo());
     let par_service = ParService::new(
         oauth2_client_repo.clone(),
         SurrealPushedAuthRequestRepository::new(pool.handle_for_repo()),
@@ -1527,6 +1531,12 @@ async fn main() -> std::io::Result<()> {
         device_authorization_service: device_authorization_service.clone(),
         token_exchange_service: token_exchange_service.clone(),
         par_service: par_service.clone(),
+        // X2 — UMA 2.0. The repository rather than an assembled service,
+        // because the service also needs the `AuthzChecker`, which is
+        // registered as its own `web::Data`; handlers compose the two with
+        // `AppState::uma_service`.
+        permission_ticket_repo: permission_ticket_repo.clone(),
+        rpt_max_lifetime_secs: axiam_core::models::uma::DEFAULT_RPT_MAX_LIFETIME_SECS,
         session_client_repo: session_client_repo.clone(),
         device_grant_repo: device_grant_repo.clone(),
         // The device endpoints size their own governors from this (see

--- a/frontend/src/pages/resources/ResourcesPage.test.tsx
+++ b/frontend/src/pages/resources/ResourcesPage.test.tsx
@@ -29,6 +29,13 @@ const resources = [
     resource_type: "widget",
     created_at: "2026-01-03T00:00:00Z",
   },
+  {
+    id: "r4",
+    name: "Invoice",
+    resource_type: "document",
+    uma_registered_by: "resource-server-1",
+    created_at: "2026-01-04T00:00:00Z",
+  },
 ];
 
 beforeEach(() => {
@@ -210,5 +217,22 @@ describe("ResourcesPage", () => {
     await waitFor(() => expect(apiMock.get).toHaveBeenCalled());
     await userEvent.click(screen.getByRole("button", { name: "List view" }));
     expect(await screen.findByText("No resources defined yet.")).toBeInTheDocument();
+  });
+
+  it("badges only resources registered through the UMA Protection API", async () => {
+    // The badge asserts provenance, so it must appear exactly where the
+    // backend recorded one and nowhere else — a badge on a hand-made resource
+    // would be a claim the server never made.
+    apiMock.get.mockResolvedValue(res(resources));
+    renderWithProviders(<ResourcesPage />);
+    await screen.findByText("Gateway");
+    await userEvent.click(screen.getByRole("button", { name: "List view" }));
+
+    const badges = await screen.findAllByText("UMA");
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveAttribute(
+      "title",
+      "Registered through the UMA Protection API by resource-server-1",
+    );
   });
 });

--- a/frontend/src/pages/resources/ResourcesPage.tsx
+++ b/frontend/src/pages/resources/ResourcesPage.tsx
@@ -357,7 +357,21 @@ export function ResourcesPage() {
       key: "name",
       header: "Name",
       render: (row) => (
-        <span className="font-medium text-foreground/90">{row.name}</span>
+        <span className="flex items-center gap-2">
+          <span className="font-medium text-foreground/90">{row.name}</span>
+          {/* X2: read-only provenance. The backend sets `uma_registered_by`
+              only in the UMA resource-registration handler and accepts it on
+              no create/update payload, so this badge reports a fact rather
+              than echoing something an editor could have typed. */}
+          {row.uma_registered_by && (
+            <span
+              title={`Registered through the UMA Protection API by ${row.uma_registered_by}`}
+              className="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-violet-500/15 text-violet-300 border border-violet-400/30"
+            >
+              UMA
+            </span>
+          )}
+        </span>
       ),
     },
     {

--- a/frontend/src/services/resources.ts
+++ b/frontend/src/services/resources.ts
@@ -37,6 +37,16 @@ export interface Resource {
   parent_id?: string;
   /** Backend has no `description` column — it lives under `metadata.description`. */
   metadata?: ResourceMetadata;
+  /**
+   * The OAuth2 `client_id` that registered this resource through the UMA
+   * Protection API (X2), absent for a resource created any other way.
+   *
+   * Read-only: the backend accepts it on no create or update payload, so the
+   * badge this drives cannot be set by editing a resource. Do not add it to
+   * `CreateResourcePayload` or `UpdateResourcePayload` — a provenance marker
+   * the UI can write is decoration that reads like evidence.
+   */
+  uma_registered_by?: string;
   created_at: string;
 }
 

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -34,6 +34,28 @@
         }
       }
     },
+    "/.well-known/uma2-configuration": {
+      "get": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`GET /.well-known/uma2-configuration` — UMA 2.0 discovery (§2).",
+        "description": "Advertises only what v1 actually serves. Claims-gathering\n(`claims_interaction_endpoint`) is absent because it is not implemented;\nadvertising an endpoint that 404s is worse than not advertising it, since a\nconforming client would route to it on the strength of this document.",
+        "operationId": "uma2_configuration",
+        "responses": {
+          "200": {
+            "description": "UMA 2.0 configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Uma2Configuration"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/audit-logs": {
       "get": {
         "tags": [
@@ -5059,6 +5081,13 @@
                             "type": "string",
                             "format": "uuid"
                           },
+                          "uma_registered_by": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "description": "The `client_id` that registered this resource through the UMA\nProtection API (X2), or `None` for a resource created any other way.\n\nRead-only from every ordinary path: [`UpdateResource`] cannot set it and\n[`CreateResource`] cannot either, so the only writer is the\nresource-registration handler. That is deliberate — the field backs a\nprovenance badge in the admin UI, and a provenance marker anyone can\nwrite is decoration that reads like evidence."
+                          },
                           "updated_at": {
                             "type": "string",
                             "format": "date-time"
@@ -8120,6 +8149,247 @@
           }
         }
       }
+    },
+    "/uma2/perm": {
+      "post": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`POST /uma2/perm` — mint a permission ticket (UMA 2.0 §3.2).",
+        "description": "# Who may call this\n\nA **Protection API Token**: an ordinary AXIAM access token carrying the\n`uma_protection` scope. Two further conditions, both deliberate:\n\n1. **The token must be an OAuth2 client token** (`sub_kind` =\n   `OAuth2Client`). A ticket is bound to the `client_id` that minted it, and\n   for a client-credentials token `sub` *is* the `client_id`. A user token\n   has no client identity in it, so binding one would mean inventing a\n   value and calling it a binding.\n2. **The scope is checked here, not by a route guard.** The `uma_protection`\n   scope is what makes an access token a PAT; nothing else about the token\n   distinguishes it.",
+        "operationId": "permission_request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermissionRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Ticket minted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionTicketResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request or undeclared scope"
+          },
+          "401": {
+            "description": "Missing or invalid PAT"
+          },
+          "403": {
+            "description": "Token lacks the uma_protection scope"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/uma2/rreg/resource_set": {
+      "get": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`GET /uma2/rreg/resource_set` — list registered ids (FedAuthz §2.2.5).",
+        "description": "Lists only the resources **this client** registered. FedAuthz says the\nlisting is of the resource sets the PAT's owner registered, and a resource\nserver has no business enumerating the tenant's whole resource tree through\nan endpoint whose only credential is a protection scope.",
+        "operationId": "list_resource_sets",
+        "responses": {
+          "200": {
+            "description": "Registered resource set ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`POST /uma2/rreg/resource_set` — register a resource set (FedAuthz §2.2.1).",
+        "description": "Creates the resource **and** its declared scopes. The scope set is what the\npermission endpoint later validates ticket requests against, so registering\na resource with no scopes produces one that can never appear in a ticket —\nlegal, and worth knowing.",
+        "operationId": "register_resource_set",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceSet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Resource set registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceSet"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid PAT"
+          },
+          "403": {
+            "description": "Token lacks the uma_protection scope"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/uma2/rreg/resource_set/{id}": {
+      "get": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`GET /uma2/rreg/resource_set/{id}` — read a resource set (FedAuthz §2.2.2).",
+        "operationId": "read_resource_set",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource set id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceSet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such resource set"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`PUT /uma2/rreg/resource_set/{id}` — update a resource set (FedAuthz §2.2.3).",
+        "description": "The scope list is **replaced**, not merged: FedAuthz defines the update as\nputting the resource set's new state, and a merge would make it impossible\nto remove a scope. Removing a scope narrows what tickets may be requested,\nso a silent merge would keep an authority the resource server tried to drop.",
+        "operationId": "update_resource_set",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource set id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceSet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Resource set updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceSet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such resource set"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "uma"
+        ],
+        "summary": "`DELETE /uma2/rreg/resource_set/{id}` — deregister (FedAuthz §2.2.4).",
+        "operationId": "delete_resource_set",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource set id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Resource set deleted"
+          },
+          "404": {
+            "description": "No such resource set"
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -9977,6 +10247,16 @@
             ],
             "format": "int64"
           },
+          "permissions": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/RptPermission"
+            },
+            "description": "UMA 2.0 `permissions` (X2) — present only when the introspected token\nis an RPT.\n\nKeycloak's authorization services put the same array under the same key\nin an introspection response, so a resource server migrating from\nKeycloak reads an AXIAM RPT without a translation layer.\n\nThis is **echoed from the token, not re-evaluated**. Introspection\nanswers \"what does this token say\", and the permissions claim is a\nrecord of a decision made when the RPT was minted. A resource server\nthat needs a live answer must ask the authorization endpoints — which is\nwhy RPT lifetime is bounded rather than long."
+          },
           "scope": {
             "type": [
               "string",
@@ -11092,6 +11372,26 @@
           }
         }
       },
+      "PermissionRequestBody": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/RequestedPermission"
+        },
+        "description": "Body of `POST /uma2/perm` — what the resource server requires.\n\nUMA 2.0 §3.2 allows either a single object or an array; AXIAM accepts the\narray form only, because a resource server that needs one pair can send an\narray of one, and accepting both shapes means two parsers for one meaning."
+      },
+      "PermissionTicketResponse": {
+        "type": "object",
+        "description": "`201 Created` body of the permission endpoint (UMA 2.0 §3.2).",
+        "required": [
+          "ticket"
+        ],
+        "properties": {
+          "ticket": {
+            "type": "string",
+            "description": "The opaque handle. Returned exactly once — only its hash is stored."
+          }
+        }
+      },
       "PgpKey": {
         "type": "object",
         "description": "An OpenPGP key stored by AXIAM.",
@@ -11541,6 +11841,28 @@
           }
         }
       },
+      "RequestedPermission": {
+        "type": "object",
+        "description": "One `(resource, scopes)` pair a resource server requires, as posted to\n`/uma2/perm`.",
+        "required": [
+          "resource_id",
+          "resource_scopes"
+        ],
+        "properties": {
+          "resource_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The AXIAM resource id. UMA's `_id` **is** the AXIAM resource id — there\nis no parallel resource store to translate through."
+          },
+          "resource_scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Scope names, each of which must be declared by the resource. Matched\nexactly: no prefix or wildcard semantics in either direction."
+          }
+        }
+      },
       "ResendVerificationRequest": {
         "type": "object",
         "description": "Body for the resend-verification endpoint.",
@@ -11598,9 +11920,45 @@
             "type": "string",
             "format": "uuid"
           },
+          "uma_registered_by": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The `client_id` that registered this resource through the UMA\nProtection API (X2), or `None` for a resource created any other way.\n\nRead-only from every ordinary path: [`UpdateResource`] cannot set it and\n[`CreateResource`] cannot either, so the only writer is the\nresource-registration handler. That is deliberate — the field backs a\nprovenance badge in the admin UI, and a provenance marker anyone can\nwrite is decoration that reads like evidence."
+          },
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "ResourceSet": {
+        "type": "object",
+        "description": "A resource set as UMA describes it, mapped onto an AXIAM resource.\n\n# The mapping, in one place\n\n| UMA | AXIAM |\n|---|---|\n| `_id` | the resource id — **not** a parallel identifier |\n| `name` | `resource.name` |\n| `type` | `resource.resource_type` |\n| `resource_scopes` | the `Scope` rows on that resource |\n\nThere is no second resource store. A resource registered here is an\nordinary AXIAM resource that the admin UI lists, that role assignments\ncascade through, and that the authorization engine already understands —\nwhich is the entire reason UMA `_id` is the AXIAM id rather than a\ntranslation key.",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "Present on responses, absent on registration — the server assigns it."
+          },
+          "name": {
+            "type": "string"
+          },
+          "resource_scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "type": "string"
           }
         }
       },
@@ -11727,6 +12085,32 @@
         "properties": {
           "client_secret": {
             "type": "string"
+          }
+        }
+      },
+      "RptPermission": {
+        "type": "object",
+        "description": "One entry of an RPT's `permissions` claim.\n\nField names are Keycloak's (`rsid`/`rsname` aliases aside) so that a\nresource server migrating from Keycloak can read an AXIAM RPT without a\ntranslation layer — the compatibility the §X2 introspection test pins.",
+        "required": [
+          "resource_id",
+          "resource_scopes",
+          "exp"
+        ],
+        "properties": {
+          "exp": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Absolute expiry, seconds since the epoch. Carried per-permission\nbecause UMA allows an RPT to accumulate permissions with different\nlifetimes; AXIAM issues them uniformly in v1 but the shape must not\nforeclose that."
+          },
+          "resource_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "resource_scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -12620,6 +13004,20 @@
               "null"
             ]
           },
+          "claim_token": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The requesting party's identity, as an AXIAM access token.\n\nUMA 2.0 §3.3.1 makes this optional because a client may instead present\nits own RPT for incremental authorization, which v1 does not implement.\nWith claims-gathering also deferred, this is the only channel through\nwhich a requesting party can be named — so the grant requires it and\nsays so, rather than resolving to some default subject."
+          },
+          "claim_token_format": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Declared format of `claim_token`. Only the AXIAM access-token URN is\naccepted in v1; anything else is refused rather than guessed at."
+          },
           "client_id": {
             "type": [
               "string",
@@ -12695,6 +13093,13 @@
               "string",
               "null"
             ]
+          },
+          "ticket": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The permission ticket minted by `/uma2/perm`, for\n`grant_type=urn:ietf:params:oauth:grant-type:uma-ticket`."
           }
         }
       },
@@ -12735,6 +13140,58 @@
           },
           "token_type": {
             "type": "string"
+          }
+        }
+      },
+      "Uma2Configuration": {
+        "type": "object",
+        "description": "The UMA 2.0 discovery document (§2).",
+        "required": [
+          "issuer",
+          "token_endpoint",
+          "introspection_endpoint",
+          "permission_endpoint",
+          "resource_registration_endpoint",
+          "jwks_uri",
+          "grant_types_supported",
+          "uma_profiles_supported",
+          "permission_ticket_lifetime"
+        ],
+        "properties": {
+          "grant_types_supported": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "introspection_endpoint": {
+            "type": "string"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "jwks_uri": {
+            "type": "string"
+          },
+          "permission_endpoint": {
+            "type": "string"
+          },
+          "permission_ticket_lifetime": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Advertised so a resource server can size its retry window against the\nticket TTL instead of discovering it by having a ticket expire."
+          },
+          "resource_registration_endpoint": {
+            "type": "string"
+          },
+          "token_endpoint": {
+            "type": "string"
+          },
+          "uma_profiles_supported": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },


### PR DESCRIPTION
## What this is

X2's **server side**, complete. X2a and X2b had landed the permission-ticket model and the `UmaService`, but neither was reachable: no route, no grant arm, and the two traits the service is written against had only test fakes. Two commits close that.

- **X2c** (`982e13b`) — the HTTP surface: permission endpoint, uma-ticket grant, RPT minting, discovery.
- **X2d** (`323835b`) — resource registration, RPT introspection, provenance.

## X2c — the UMA HTTP surface

**Adapters.** `PermissionEvaluator` and `ScopeCatalog` now have production implementations against the real RBAC engine and scope store. A UMA resource scope maps to the AXIAM **`action`**, evaluated against the registered resource — which is what makes deny-override apply to an RPT for free, because it *is* the same check a live request makes.

Riding UMA scopes on the AXIAM `scope` field instead would have been unsafe rather than merely different: `grant_applies` treats a grant with empty `scope_ids` as matching *any* scope, so one unscoped grant of a fixed `uma:access` action would satisfy every scope on the resource at once — registering a new `delete` scope would silently widen every existing grant.

**The RPT** is an ordinary access token carrying a new `permissions` claim, not a new token type: every existing validator, audience check, and revocation path applies unchanged. Lifetime is the minimum of the subject token's remaining life, the configured ceiling, and 300 s.

Four decisions worth naming:

| Decision | Why |
|---|---|
| A PAT gets its own extractor | `AuthenticatedUser` narrows to `axiam:user`; `AuthenticatedPrincipal` parses `sub` as a UUID, deliberately excluding OAuth2 clients. Right for RBAC subjects, wrong here — the Protection API only needs to know which client is speaking, because that is what the ticket binds to. |
| `claim_token` is **required**, though UMA 2.0 calls it optional | Its other two ways to name a requesting party (incremental authorization, claims-gathering) are both deferred, so this is the only channel that exists. Better than resolving to a default subject nobody named. |
| `access_denied` answers **403**, not the shared 400 | UMA 2.0 §3.3.6 specifies it. The shared helper stays as it is — RFC 8628's `access_denied` is correctly a 400 and the device grant keeps it. |
| The authz checker is read from the request, not extracted | `/oauth2/token` serves five grants and only this one touches the engine. As a handler parameter it would become a hard requirement of the whole endpoint, so a deployment that never uses UMA would answer 500 to ordinary token requests. |

## X2d — registration, introspection, provenance

**Resource registration** (FedAuthz §2.2) at `/uma2/rreg/resource_set`, behind the same PAT gate. UMA's `_id` **is** the AXIAM resource id — there is no parallel store — so a registered resource set is an ordinary resource the admin UI lists and the engine already understands. The test that matters is the one asserting a scope declared through rreg is immediately askable at `/uma2/perm`; it is what fails if a second scope store ever appears.

- **Update replaces the scope list rather than merging.** A merge would make removal impossible, so a resource server trying to drop an authority would silently keep it.
- **A surviving scope keeps its id.** Permission grants reference scope ids; delete-and-recreate would detach every grant that named it.
- **The listing is scoped to the calling client.** A resource server holding only a protection scope has no business enumerating the tenant's resource tree.

**Introspection** returns `permissions` for an RPT in Keycloak's shape, so a resource server migrating from Keycloak reads it without a translation layer. It is echoed from the token, never re-evaluated — introspection answers what a token *says*, and the claim records a decision already made. A non-RPT omits the key entirely rather than sending an empty array, so "no permissions" and "not an RPT" stay distinguishable.

**Provenance is its own column (schema v33), not `metadata`.** `metadata` was the zero-migration option and the wrong one: it is writable through the ordinary resource endpoints, so anyone who may edit a resource could stamp the marker on a resource the Protection API never touched. A badge that asserts provenance and anyone can write is decoration that reads like evidence. `uma_registered_by` is written only by the registration handler — `CreateResource` and `UpdateResource` have no such field, so the *type* enforces the single writer — and the admin UI badge reads it.

## Testing

- **23 UMA integration tests**, each named after the thing it stops
- 150 api-rest lib tests, 144 axiam-db, plus `resource_scope`, `token_exchange`, `oauth2_flow`, `device_flow`, `batch_coalescing`, and both rate-limit suites
- Frontend: lint, `tsc`, and 13 `ResourcesPage` tests including the badge
- fmt and clippy clean

The deny-override test runs against a **real `AuthorizationEngine`**, not `AllowAllAuthzChecker`. X2's acceptance criterion is about what the engine decides, and an allow-all fake would pass every test in that file while proving nothing.

## Scope — what is deliberately not here

- **SDK helpers** (contract §17, D6 fan-out) and the concept/Keycloak-migration docs. Both still open in X2.
- **Claims-gathering** and party-to-party sharing, deferred to v2 by X2's own scope decision. Discovery does not advertise them, because advertising an endpoint that 404s is worse than staying quiet — a conforming client routes on the strength of that document.

## Related

Touches the permission-ticket path discussed in #302, but does **not** close it. That issue tracks the single-use residual (~1/640), which is a datastore-layer problem this PR does not address and does not claim to. The doc comments continue to say single-use is not guaranteed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc

---
_Generated by [Claude Code](https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc)_