### PR TITLE
docs(sdk): contract §20 — UMA 2.0 Protection API and ticket grant

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -64,6 +64,14 @@ service use the Token Exchange grant (RFC 8693). Delegation vs impersonation,
 the scope-narrowing rule, the lifetime cap and the error table are in
 [`token-exchange.md`](token-exchange.md).
 
+## UMA 2.0 — Protection API and ticket grant
+
+A service that guards resources it does not own registers them, asks AXIAM what
+a caller would need, and exchanges the resulting permission ticket for a
+Requesting Party Token. What maps onto what, the ticket lifecycle, the
+`WWW-Authenticate: UMA` challenge, and the single-use limitation are in
+[`uma.md`](uma.md).
+
 ## Logout — RP-initiated and back-channel
 
 Ending a session at AXIAM and telling every relying party that shared it.

--- a/docs/api/uma.md
+++ b/docs/api/uma.md
@@ -1,0 +1,231 @@
+# UMA 2.0 — Protection API and the ticket grant
+
+A service guards resources it does not own. A caller arrives without the
+authority to touch them, and the service needs a way to say *what* the caller
+would need — precisely, and without becoming the authority itself.
+
+User-Managed Access is that mechanism. The guarding service (the **resource
+server**) registers its resources, asks AXIAM to mint a **permission ticket**
+describing what a given request requires, and the ticket is exchanged for a
+**Requesting Party Token** (RPT) that says the authorization engine agreed.
+
+**The one rule everything below serves: the resource server never decides.** It
+describes what it needs; AXIAM decides whether the requesting party may have
+it, using the same RBAC check a live request would run. That is why a deny rule
+vetoes an RPT exactly as it vetoes anything else — it *is* the same check.
+
+The mapping rationale, including why a UMA scope became an AXIAM action rather
+than an AXIAM scope, is in
+[`claude_dev/uma-mapping-design.md`](../../claude_dev/uma-mapping-design.md).
+
+## What maps onto what
+
+| UMA | AXIAM | Note |
+|---|---|---|
+| resource set `_id` | the resource id | **the same id** — there is no parallel resource store |
+| resource set `name` / `type` | `resource.name` / `resource.resource_type` | |
+| `resource_scopes` | `Scope` rows on that resource | the allow-list of names a resource server may ask for |
+| a resource scope, when evaluated | the AXIAM **`action`** | `view` on the resource, not a sub-resource scope |
+| PAT | an access token with the `uma_protection` scope | ordinary client-credentials token |
+| RPT | an access token with a `permissions` claim | ordinary token; the claim is what makes it an RPT |
+
+A resource registered through UMA is an ordinary AXIAM resource. It appears in
+the admin UI, role assignments cascade through it, and the authorization engine
+already understands it. The only thing marking it as UMA-registered is a
+read-only provenance field, `uma_registered_by`, which the admin UI shows as a
+badge.
+
+## Discovery
+
+```http
+GET /.well-known/uma2-configuration
+```
+
+Advertises the token, introspection, permission and resource-registration
+endpoints. It deliberately does **not** advertise a
+`claims_interaction_endpoint`: interactive claims-gathering is not implemented,
+and advertising an endpoint that 404s is worse than staying quiet, because a
+conforming client routes on the strength of this document.
+
+## 1. Get a PAT
+
+A Protection API Token is an ordinary client-credentials token that carries the
+`uma_protection` scope.
+
+```http
+POST /oauth2/token?tenant_id=<uuid>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id=<id>&client_secret=<secret>&scope=uma_protection
+```
+
+It must be a **client** token. A user token is refused with `403`, because a
+permission ticket is bound to the `client_id` that minted it and a user token
+carries no client identity to bind to.
+
+## 2. Register a resource set
+
+```http
+POST /uma2/rreg/resource_set
+Authorization: Bearer <PAT>
+Content-Type: application/json
+
+{ "name": "invoice-7", "type": "document", "resource_scopes": ["view", "pay"] }
+```
+
+→ `201` with `_id`, which **is** the AXIAM resource id.
+
+`GET`, `PUT`, `DELETE` on `/uma2/rreg/resource_set/{id}` read, replace and
+deregister. `GET /uma2/rreg/resource_set` lists the ids **this client**
+registered — not the tenant's whole resource tree, which a protection scope
+does not entitle a caller to enumerate.
+
+**`PUT` replaces the scope list; it does not merge.** Removing a scope narrows
+what tickets may be requested, so a merge would keep an authority the resource
+server was trying to drop. A scope that survives an update keeps its id, because
+permission grants reference scope ids and recreating one would detach every
+grant that named it.
+
+## 3. Request a permission ticket
+
+```http
+POST /uma2/perm
+Authorization: Bearer <PAT>
+Content-Type: application/json
+
+[ { "resource_id": "<uuid>", "resource_scopes": ["view"] } ]
+```
+
+→ `201 { "ticket": "…" }`
+
+The ticket is opaque, 256-bit, **single-use**, and lives 60 seconds. Only its
+hash is stored.
+
+Scope names are validated **here**, against the resource's declared set, rather
+than at exchange time. Asking for a scope the resource never declared is a
+`400`, not a denial — a ticket naming an undeclared scope could never be
+redeemed, so minting one would hand back a credential guaranteed to fail a
+minute later instead of an error the caller can act on now. "Undeclared" and
+"denied" are different failures and the resource server should be able to tell
+them apart.
+
+## 4. Exchange it for an RPT
+
+```http
+POST /oauth2/token?tenant_id=<uuid>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:uma-ticket
+&client_id=<id>&client_secret=<secret>
+&ticket=<ticket>
+&claim_token=<the requesting party's access token>
+```
+
+→ `200` with an access token carrying a `permissions` claim.
+
+**`claim_token` is required**, though UMA 2.0 §3.3.1 marks it optional. Its
+other two ways to name a requesting party — an RPT presented for incremental
+authorization, and interactive claims-gathering — are both deferred, so this is
+the only channel that exists. Requiring it and saying so beats resolving to some
+default subject and minting an RPT for a party nobody named.
+
+The ticket is **consumed before the request is evaluated**. Evaluating first
+would let two concurrent redemptions both pass and both mint, which is what
+single-use exists to prevent.
+
+### Lifetime
+
+`min(claim_token's remaining life, configured ceiling, 300 s)`. An RPT must
+never outlive the token that authorised it. There is **no refresh token** —
+re-run the grant.
+
+### Partial grants are refused whole
+
+If a ticket names three pairs and the engine allows two, the answer is
+`access_denied` for the whole ticket, not a two-pair RPT. Trimming would make an
+RPT's contents depend on evaluation order and hand the client a token that
+silently does less than it asked for. UMA's own answer to this is
+claims-gathering, which v1 defers.
+
+## 5. Read an RPT
+
+The `permissions` claim is readable in the token and echoed by introspection:
+
+```http
+POST /oauth2/introspect?tenant_id=<uuid>
+```
+
+```json
+{ "active": true, "permissions": [ { "resource_id": "…", "resource_scopes": ["view"], "exp": 1760000000 } ] }
+```
+
+The shape is Keycloak's, so a resource server migrating from Keycloak reads it
+without a translation layer. A non-RPT omits the key entirely rather than
+returning an empty array, so "no permissions" and "not an RPT" stay
+distinguishable.
+
+**The claim is a record of a decision already made, not a live answer.**
+Introspection echoes it; nothing re-evaluates it. A grant revoked after issuance
+does not retroactively empty a live RPT — which is precisely why RPT lifetime is
+bounded rather than long.
+
+## The `WWW-Authenticate: UMA` challenge
+
+A resource server refusing a request can tell the caller where to get authority
+(UMA 2.0 §3.2):
+
+```http
+HTTP/1.1 403 Forbidden
+WWW-Authenticate: UMA realm="example", as_uri="https://id.example", ticket="<ticket>"
+```
+
+A client parsing this should **not** exchange the ticket automatically. The
+`as_uri` names an authorization server the client has not necessarily chosen to
+trust, and auto-exchanging would send the user's `claim_token` to whatever host
+the 403 pointed at.
+
+## Errors
+
+| Where | Status / `error` | Meaning |
+|---|---|---|
+| Protection API | `401` | PAT missing, malformed, or expired |
+| Protection API | `403` | not a PAT — wrong subject kind, or no `uma_protection` scope |
+| `/uma2/perm` | `400` | a scope the resource has not declared |
+| ticket grant | `invalid_request` | `ticket` or `claim_token` absent, or an unsupported `claim_token_format` |
+| ticket grant | `invalid_grant` | ticket unknown, expired, used, or presented by the wrong client; or `claim_token` invalid, expired, or cross-tenant |
+| ticket grant | `access_denied` (**403**) | the requesting party is not authorized for every requested pair |
+
+**The four ticket refusals answer one message on purpose.** Unknown, expired,
+consumed and wrong-client are indistinguishable to the caller, because a caller
+who could tell them apart could probe for live ticket handles.
+
+**A wrong-client attempt changes nothing.** The `client_id` is matched inside
+the consume statement rather than checked on the row afterwards, so a ticket
+leaked to another client is not merely unusable by them — their failed attempt
+does not *burn* it either. Checking after the fact would let anyone who obtained
+a ticket destroy the rightful holder's.
+
+## Known limitation: single-use is not guaranteed
+
+Ticket single-use is enforced by a per-attempt redemption nonce rather than by
+datastore conflict detection, which SurrealDB 3.2.3 was measured not to provide
+reliably. That mechanism has a **measured residual of roughly 1 in 640** under
+saturated concurrency — see
+[ilpanich/axiam#302](https://github.com/ilpanich/axiam/issues/302) for the
+measurements, the repairs that proved worse, and what closing the window would
+require.
+
+The practical consequence for a client: **never retry a ticket exchange.** A
+failed exchange has already spent the ticket, so a retry is useless — and under
+concurrency it is precisely the second redemption the residual describes.
+Request a new ticket instead.
+
+## Not implemented in v1
+
+- **Interactive claims-gathering** (`request_submitted`, the redirect dance).
+  API-to-API consumers rarely exercise it and Keycloak deployments
+  overwhelmingly use the non-interactive path.
+- **Party-to-party sharing UIs.**
+- **Incremental authorization** — presenting an existing RPT to widen it.
+
+None are advertised in discovery.

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -2295,6 +2295,193 @@ no hook installed behaves identically to one before this section existed.
 
 ---
 
+## §20 UMA 2.0 — Protection API and Ticket Grant (X2)
+
+**Requirement level: SHOULD (v1.0).** For the **resource-server** side of a
+User-Managed Access deployment: a service that guards resources on someone else's behalf
+registers them, asks the authorization server what a caller would need, and exchanges the
+resulting ticket for a Requesting Party Token.
+
+Server documentation: [`docs/api/uma.md`](../docs/api/uma.md). Wire reference:
+`/.well-known/uma2-configuration`.
+
+**The rule an SDK must not paper over: a permission ticket is single-use and is not
+retryable.** Every other refusal in this contract can be re-sent after the caller fixes
+something. This one cannot — the ticket is spent whether or not the exchange succeeded, and
+re-sending it is not a retry but a second, different request. See §20.2 rule 6.
+
+### §20.1 Canonical operations and endpoint map
+
+| Canonical operation | Wire call | Request | Success response |
+|---|---|---|---|
+| `uma_register_resource` | `POST /uma2/rreg/resource_set` | `application/json` / `ResourceSet` | `201` `ResourceSet` (carries `_id`) |
+| `uma_read_resource` | `GET /uma2/rreg/resource_set/{id}` | — | `200` `ResourceSet` |
+| `uma_update_resource` | `PUT /uma2/rreg/resource_set/{id}` | `application/json` / `ResourceSet` | `200` `ResourceSet` |
+| `uma_delete_resource` | `DELETE /uma2/rreg/resource_set/{id}` | — | `204` |
+| `uma_list_resources` | `GET /uma2/rreg/resource_set` | — | `200` array of ids |
+| `uma_request_ticket` | `POST /uma2/perm` | `application/json` / array of `RequestedPermission` | `201` `{ "ticket": "…" }` |
+| `uma_exchange_ticket` | `POST /oauth2/token?tenant_id=<uuid>` with `grant_type=urn:ietf:params:oauth:grant-type:uma-ticket` | `application/x-www-form-urlencoded` | `200` `TokenResponse` (the RPT) |
+
+Signatures (canonical order; each language's §1 casing applies):
+
+```
+uma_register_resource(name, *, type=None, resource_scopes=[])
+uma_request_ticket(permissions)            # [(resource_id, [scope, …]), …]
+uma_exchange_ticket(ticket, claim_token)
+```
+
+**The Protection API is bearer-authenticated; the ticket grant is client-authenticated.**
+The five `rreg` operations and `uma_request_ticket` carry a **PAT** — an ordinary access
+token obtained through `login_client_credentials` with the `uma_protection` scope — in the
+`Authorization` header. `uma_exchange_ticket` instead authenticates the client at the token
+endpoint (`client_secret_post`, per §12.1 rule 3), because it is a token-endpoint grant.
+§12.1's `tenant_id`-as-query rule and its slug-only-client consequence apply to
+`uma_exchange_ticket` unchanged.
+
+### §20.2 Semantics (normative)
+
+1. **A PAT is a client-credentials token, not a user token.** The server requires the
+   subject to be an OAuth2 client, because a minted ticket is bound to the `client_id` that
+   minted it. An SDK MUST NOT offer a user access token as a PAT, and MUST NOT silently fall
+   back to the client's ordinary session token if that session is a user session.
+
+2. **`claim_token` is required, though UMA 2.0 §3.3.1 marks it optional.** AXIAM v1
+   implements neither incremental authorization nor claims-gathering, so it is the only
+   channel that names a requesting party. An SDK MUST make it a required parameter rather
+   than defaulting it — in particular MUST NOT default it to the resource server's own PAT,
+   which would mint an RPT for the resource server instead of for the user.
+
+3. **Partial grants are refused whole. An SDK MUST NOT auto-narrow and re-ask.** If a ticket
+   names three pairs and the requesting party may have two, the answer is `access_denied` for
+   the whole ticket. Re-requesting a smaller ticket is a decision for the calling application,
+   not for the SDK: the SDK cannot know whether two-of-three is useful or useless to it, and a
+   library that quietly obtains a lesser authority than was asked for has answered a question
+   nobody posed. Same shape as §15.2 rule 3.
+
+4. **The RPT is not the client's session.** As in §15.2 rule 5, `uma_exchange_ticket` MUST
+   NOT adopt the returned token as the SDK client's own credentials — not behind a flag. It
+   is the requesting party's token, to be handed onward or checked; adopting it would
+   re-privilege every later call the resource server makes as that user.
+
+5. **No refresh token comes back, ever.** The grant deliberately issues none, so an RPT
+   cannot outlive the ticket that authorised it. An SDK MUST NOT synthesise one, MUST NOT
+   feed the result into the §9 single-flight refresh guard, and MUST document that re-running
+   the grant is how you get a fresh RPT.
+
+6. **A permission ticket MUST NOT be retried.** This is an exception to §16, and it is the
+   one rule in this section whose violation is a security bug rather than a usability one.
+   The ticket is consumed *before* the request is evaluated, so a failed exchange has still
+   spent it. An SDK MUST exclude `uma_exchange_ticket` from any automatic retry — including
+   §16's idempotent-retry path, including on timeout, and including on `5xx` — and MUST
+   surface the failure so the caller can request a **new** ticket.
+
+   Two reasons, and the second matters more than the first. A retried ticket answers
+   `invalid_grant`, so the retry is useless. And single-use is enforced by a mechanism with a
+   **measured residual** (ilpanich/axiam#302): under concurrency the server can admit a
+   second redemption at roughly 1 in 640. An SDK that retries is deliberately generating the
+   concurrent redemption that residual describes. Do not retry.
+
+7. **The `permissions` claim is a record, not a capability.** An RPT carries the pairs the
+   engine allowed **at mint time**. An SDK that exposes them MUST NOT present them as a live
+   authorization answer, and MUST NOT cache them beyond the RPT's own `exp`: a grant revoked
+   after issuance does not empty a live RPT, which is exactly why its lifetime is bounded to
+   the minimum of the subject token's remaining life, the server's ceiling, and 300 s.
+
+8. **Registration replaces the scope list; it does not merge.** `uma_update_resource` sends
+   the resource set's new state. An SDK MUST NOT read-modify-write the existing scopes into
+   the payload as a convenience, because that would make removing a scope impossible through
+   the SDK.
+
+### §20.3 The `WWW-Authenticate: UMA` challenge
+
+A resource server that refuses a request SHOULD tell the caller how to obtain authority, per
+UMA 2.0 §3.2. Two halves, and an SDK may ship either:
+
+- **Emit (resource-server side).** A helper that, given the required `(resource, scopes)`,
+  calls `uma_request_ticket` and formats the header:
+  `WWW-Authenticate: UMA realm="<realm>", as_uri="<issuer>", ticket="<ticket>"`.
+- **Consume (client side).** A helper that parses that header into its three fields.
+
+**The consuming helper MUST NOT automatically exchange the ticket it parsed.** Parsing a
+challenge and acting on it are separate decisions: the `as_uri` names an authorization
+server the client has not necessarily chosen to trust, and auto-exchanging would send the
+user's `claim_token` to whatever host the 403 asked it to. Return the parsed challenge and
+let the caller decide.
+
+### §20.4 Error mapping
+
+Extends §2. As in §14.2 rule 5, dispatch on the `error` field of `OAuth2ErrorResponse`
+before falling back to the status-code mapping.
+
+| Where | `error` / status | Meaning |
+|---|---|---|
+| `/uma2/perm`, `/uma2/rreg/*` | `401` | PAT missing, malformed, or expired |
+| `/uma2/perm`, `/uma2/rreg/*` | `403` | the token is not a PAT — wrong subject kind, or missing the `uma_protection` scope |
+| `/uma2/perm` | `400` | a requested scope the resource has not declared |
+| ticket grant | `invalid_request` | `ticket` or `claim_token` absent, or an unsupported `claim_token_format` |
+| ticket grant | `invalid_grant` | ticket unknown, expired, already used, or presented by a client other than the one that minted it; or `claim_token` invalid, expired, or from another tenant |
+| ticket grant | `access_denied` (**HTTP 403**) | the requesting party is not authorized for every requested pair |
+| ticket grant | `invalid_client` | client authentication failed |
+
+**`access_denied` answers 403, not 400.** UMA 2.0 §3.3.6 specifies it, and it is how a
+conforming resource server tells "you may not have this" from "your request was malformed".
+An SDK MUST map on the `error` field rather than the status, so this stays correct if either
+moves.
+
+**The four ticket refusals are one error, deliberately.** Unknown, expired, consumed and
+wrong-client all answer `invalid_grant` with one message. An SDK MUST NOT attempt to
+re-derive which one occurred or report a guess: the server collapses them because telling
+them apart lets a caller probe for live ticket handles, and reconstructing the distinction
+client-side hands back exactly what the server withheld. Same discipline as §15.3's
+cross-tenant note.
+
+### §20.5 Per-language naming map
+
+| Canonical | Rust | TypeScript | Python | Java | Kotlin | C# | PHP | Go | Swift | C | C++ |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `uma_register_resource` | `uma_register_resource` | `umaRegisterResource` | `uma_register_resource` | `umaRegisterResource` | `umaRegisterResource` | `UmaRegisterResourceAsync` | `umaRegisterResource` | `UmaRegisterResource` | `umaRegisterResource` | `axiam_uma_register_resource` | `uma_register_resource` |
+| `uma_read_resource` | `uma_read_resource` | `umaReadResource` | `uma_read_resource` | `umaReadResource` | `umaReadResource` | `UmaReadResourceAsync` | `umaReadResource` | `UmaReadResource` | `umaReadResource` | `axiam_uma_read_resource` | `uma_read_resource` |
+| `uma_update_resource` | `uma_update_resource` | `umaUpdateResource` | `uma_update_resource` | `umaUpdateResource` | `umaUpdateResource` | `UmaUpdateResourceAsync` | `umaUpdateResource` | `UmaUpdateResource` | `umaUpdateResource` | `axiam_uma_update_resource` | `uma_update_resource` |
+| `uma_delete_resource` | `uma_delete_resource` | `umaDeleteResource` | `uma_delete_resource` | `umaDeleteResource` | `umaDeleteResource` | `UmaDeleteResourceAsync` | `umaDeleteResource` | `UmaDeleteResource` | `umaDeleteResource` | `axiam_uma_delete_resource` | `uma_delete_resource` |
+| `uma_list_resources` | `uma_list_resources` | `umaListResources` | `uma_list_resources` | `umaListResources` | `umaListResources` | `UmaListResourcesAsync` | `umaListResources` | `UmaListResources` | `umaListResources` | `axiam_uma_list_resources` | `uma_list_resources` |
+| `uma_request_ticket` | `uma_request_ticket` | `umaRequestTicket` | `uma_request_ticket` | `umaRequestTicket` | `umaRequestTicket` | `UmaRequestTicketAsync` | `umaRequestTicket` | `UmaRequestTicket` | `umaRequestTicket` | `axiam_uma_request_ticket` | `uma_request_ticket` |
+| `uma_exchange_ticket` | `uma_exchange_ticket` | `umaExchangeTicket` | `uma_exchange_ticket` | `umaExchangeTicket` | `umaExchangeTicket` | `UmaExchangeTicketAsync` | `umaExchangeTicket` | `UmaExchangeTicket` | `umaExchangeTicket` | `axiam_uma_exchange_ticket` | `uma_exchange_ticket` |
+| `uma_parse_challenge` | `uma_parse_challenge` | `umaParseChallenge` | `uma_parse_challenge` | `umaParseChallenge` | `umaParseChallenge` | `UmaParseChallenge` | `umaParseChallenge` | `UmaParseChallenge` | `umaParseChallenge` | `axiam_uma_parse_challenge` | `uma_parse_challenge` |
+
+`uma_parse_challenge` is synchronous in every language — it parses a string — so it takes no
+`Async` suffix in C# and returns no future.
+
+### §20.6 `Sensitive<T>` applicability
+
+The **ticket**, the **`claim_token`**, the **PAT** and the returned **RPT** are all bearer
+credentials and MUST be wrapped in `Sensitive<T>` (§7) wherever the SDK has that type. None
+may be logged at any level, including in error paths.
+
+The ticket deserves explicit mention because its 60-second lifetime invites treating it as
+harmless. It is not: for those 60 seconds it is the credential that converts into an RPT, and
+a ticket in a log line is a live credential in a log line.
+
+`resource_scopes`, the resource `_id` and the `permissions` claim are **not** sensitive and
+MUST remain readable — an application cannot act on an RPT whose contents it may not inspect.
+
+### §20.7 Required tests
+
+Registration round-trips and the returned `_id` is usable as the `resource_id` of a
+subsequent `uma_request_ticket`; an update that omits a previously declared scope removes it
+(assert the SDK did not merge); a ticket request naming an undeclared scope surfaces the
+`400` unchanged; a happy-path exchange returns an RPT whose `permissions` carry the requested
+pairs; **a failed exchange is not retried** — assert exactly one outbound request for a
+`5xx`, for a timeout, and for `invalid_grant`, since this is the §16 exception; the RPT is
+not adopted as the client's credentials (assert the client's own token is unchanged after the
+call) and carries no refresh token; a `403 access_denied` is surfaced as such and not
+auto-narrowed into a smaller ticket request; a user token offered as a PAT is refused by the
+SDK or surfaces the server's `403` unchanged; `uma_parse_challenge` parses a well-formed
+header and does **not** perform an exchange (assert zero outbound requests); and no ticket,
+`claim_token`, PAT or RPT value appears in any log or error payload (scan the serialized
+payload for the fixture value, as §12/§14/§15 require).
+
+---
+
 ## Closing Notes
 
 ### Conformance Statement
@@ -2576,12 +2763,23 @@ recorded here until one exists.
   `check_access` could not already carry `subject_id` (Java `checkAccess` subjectId
   overload, Go `CheckAccessAs`), both additive alongside the unchanged existing signatures.
 
+- **2026-08 (§20 UMA 2.0)** — **non-breaking / additive.** Added §20 defining the
+  resource-server side of User-Managed Access: the Protection API (`uma_register_resource`
+  and the rest of the `rreg` family, `uma_request_ticket`), the `uma-ticket` grant
+  (`uma_exchange_ticket`), and the `WWW-Authenticate: UMA` challenge helpers. Purely
+  additive — no existing signature changes, and SDKs remain conformant to §1–§19 without it.
+  Two rules in it are load-bearing rather than stylistic: **§20.2 rule 6 makes the ticket
+  grant an explicit exception to §16's retry policy** (a permission ticket is spent even on
+  failure, and retrying it is the concurrent redemption that ilpanich/axiam#302's measured
+  residual describes), and **§20.3 forbids the challenge-parsing helper from auto-exchanging**
+  the ticket it parsed, since the `as_uri` names a host the client has not chosen to trust.
+
 ### OpenAPI Export Feature Flag
 
 `openapi.json` (kept in this directory, and mirrored into every SDK repo) is generated with `--no-default-features` (SAML endpoints excluded). Both the committed spec and the CI drift gate use identical flags. SDK consumers requiring SAML endpoint documentation should build AXIAM with the `saml` feature enabled and export locally.
 
 ---
 
-*Contract version: 1.9 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07; §9 rule 6 single-flight implementation invariants and the extended §9 test requirement added 2026-07; §8b AMQP transport, §10.2 gRPC revocation modes, §12.7 logout helpers, §14 device authorization grant and §15 token exchange added 2026-08; §14.3 rule 4 / §14.6 credential-adoption errata 2026-08 (contract 1.7); §16 retry policy, §17 decision memo, §18 deterministic shutdown and §19 telemetry hooks added 2026-08, with §11.2 rules 5–6 and §14.2 rule 6 amended to point at them (contract 1.8); §16 preamble errata + §19 `config_clamped` event 2026-08 (contract 1.9) — the divergence table rewritten from wire-counting conformance tests rather than greps, and a clamped setting must now be reported through §19 rather than applied silently*
+*Contract version: 1.10 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07; §9 rule 6 single-flight implementation invariants and the extended §9 test requirement added 2026-07; §8b AMQP transport, §10.2 gRPC revocation modes, §12.7 logout helpers, §14 device authorization grant and §15 token exchange added 2026-08; §14.3 rule 4 / §14.6 credential-adoption errata 2026-08 (contract 1.7); §16 retry policy, §17 decision memo, §18 deterministic shutdown and §19 telemetry hooks added 2026-08, with §11.2 rules 5–6 and §14.2 rule 6 amended to point at them (contract 1.8); §16 preamble errata + §19 `config_clamped` event 2026-08 (contract 1.9) — the divergence table rewritten from wire-counting conformance tests rather than greps, and a clamped setting must now be reported through §19 rather than applied silently; §20 UMA 2.0 Protection API and ticket grant added 2026-08 (contract 1.10), carrying the one documented exception to §16 retry policy*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*


### PR DESCRIPTION
## What this is

The normative SDK contract section for X2's UMA surface, plus the server-side reference it points at. This has to land before the eleven SDK repos can implement anything consistently — each vendors `sdks/CONTRACT.md`, so this is the source they sync from.

**Numbering note:** the X-plan called this "contract §17". §17 has been the client-side decision memo since D5 landed, so UMA takes **§20**, the next free number. The plan's numbering predates those sections.

## Two rules that are load-bearing

Most of §20 follows the shape §14 and §15 already established. Two rules do not, and both are stated as MUST because violating them is a security bug rather than a papercut.

### §20.2 rule 6 — a permission ticket must never be retried

This is an **explicit exception to §16's retry policy**, and the only one in the contract.

The ticket is consumed *before* the request is evaluated, so a failed exchange has already spent it — a retry cannot succeed. That alone makes it a usability rule. What makes it a security rule is **#302**: single-use rests on a mechanism with a measured residual of roughly 1/640 under concurrency, so an SDK that retries is deliberately generating the concurrent redemption that residual describes.

The section says this and cites the issue, rather than leaving a future implementer to infer that retrying is harmless because the endpoint looks idempotent. The required tests assert exactly one outbound request on `5xx`, on timeout, and on `invalid_grant`.

### §20.3 — the challenge-parsing helper must not auto-exchange

Parsing a `WWW-Authenticate: UMA` header and acting on it are separate decisions. The `as_uri` names an authorization server the client has not necessarily chosen to trust, and auto-exchanging would send the user's `claim_token` to whatever host returned the 403.

## The rest

Follows established discipline:

- **Don't auto-narrow a refusal.** Partial grants are refused whole; re-asking for less is the application's decision, not the SDK's (same as §15.2 rule 3).
- **Don't adopt the RPT as the client's session** (same as §15.2 rule 5) — it is the requesting party's token, and adopting it would re-privilege every later call the resource server makes as that user.
- **Don't re-derive distinctions the server collapsed.** Unknown, expired, consumed and wrong-client all answer one `invalid_grant` message, because a caller who could tell them apart could probe for live ticket handles.
- **`access_denied` maps on the `error` field, not the status** — it answers 403 here per UMA 2.0 §3.3.6, unlike RFC 8628's `access_denied`, which is correctly a 400.
- **The ticket is `Sensitive<T>`.** Its 60-second life invites treating it as harmless; for those 60 seconds it is the credential that converts into an RPT.

## Also included

`docs/api/uma.md` — the server-side reference: what maps onto what, the ticket lifecycle, the challenge, the error table. It carries the single-use limitation in its own section rather than burying it, because a client author needs to know why "just retry it" is the wrong instinct.

`docs/api/README.md` gains its index entry. `check-doc-links.sh` passes (133 links across 22 files).

## Compatibility

Contract 1.9 → 1.10. **Additive** — no existing signature changes, and an SDK remains conformant to §1–§19 without implementing any of this.

## Related

Cites #302 (the single-use residual) as the reason behind §20.2 rule 6. Does not close it — that issue tracks a datastore-layer problem this PR does not touch.

Follows #303, which landed the server surface this contract describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc

---
_Generated by [Claude Code](https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc)_