### PR TITLE
docs(contract): lift the §12.6 Swift/C/C++ deferral (contract 1.11)

### DIFF
--- a/claude_dev/extra-B-track-features.md
+++ b/claude_dev/extra-B-track-features.md
@@ -163,8 +163,9 @@ immediately (documented as back-pressure semantics).
   (`fn(event) -> Allow | Deny(reason) | Mutate(patch)`), signs and
   publishes the reply, and handles reconnect/heartbeat
   (`last_seen_at`). Graceful shutdown drains in-flight events.
-- **Deferred runtimes** (swift, c, cpp — extend the contract §12.6
-  carve-out): no bundled runtime in v1 (no maintained AMQP client we
+- **Deferred runtimes** (swift, c, cpp — a §8 AMQP carve-out of their own;
+  the §12.6 deferral this once rode alongside was lifted in contract 1.11):
+  no bundled runtime in v1 (no maintained AMQP client we
   are willing to vendor on embedded targets); they get the **normative
   wire-protocol chapter** so integrators can hand-roll, plus a C++
   example against a commonly-used AMQP library as a non-normative

--- a/claude_dev/improvement-after-run5-benchmark.md
+++ b/claude_dev/improvement-after-run5-benchmark.md
@@ -822,9 +822,11 @@ pass).
 `axiam-<lang>-sdk` repo; implement the new contract sections; each SDK
 adds the required conformance tests + one runnable example per new
 feature (`examples/` dir convention); README feature-matrix row flips.
-Swift/C/C++ keep their §12.6 deferred-scope rules — extend that section
-to say which of §14/§15 they defer (recommend: C defers device-flow
-helper UI polling to the app, implements the raw endpoints).
+Swift/C/C++ no longer have a §12 deferral to work around: contract 1.11
+lifted it and ported §12 + §12.7 to all three, so they implement §14/§15
+on the same §12 discovery cache and token endpoint as everyone else
+(C still leaves device-flow *UI* polling cadence to the app and ships the
+raw endpoints plus the composed helper).
 Per-repo PRs on the designated branch, one repo at a time, kept small.
 
 **Model: Sonnet 5** per repo (mechanical against a pinned contract);

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -475,13 +475,18 @@ Per-language implementation guidance:
 | Go         | String type with `String()` method returning `"[SENSITIVE]"`     |
 | Kotlin     | `value class Sensitive<T>` (or final class); `toString()` returns `"[SENSITIVE]"`, no `data class` auto-`toString` leak |
 | Swift      | `struct Sensitive<T>: CustomStringConvertible` whose `description` returns `"[SENSITIVE]"`; not `Encodable` in a way that emits the value |
-| C          | Opaque `axiam_sensitive_t` handle; there is no public accessor returning the raw string, and it is never written to logs/`printf` output |
-| C++        | `class Sensitive<T>` with `operator<<`/`to_string` returning `"[SENSITIVE]"`; raw value only via a private/friend accessor |
+| C          | Opaque `axiam_sensitive_t` handle; `axiam_sensitive_reveal()` is the single explicit accessor (rule 3), and the value is never written to logs/`printf` output |
+| C++        | `class Sensitive<T>` with `operator<<`/`to_string` returning `"[SENSITIVE]"`; `expose()` is the single explicit accessor (rule 3) |
 
-The **C** and **C++** rows keep their "no public accessor" wording deliberately: both SDKs defer
-§12 in its entirety ([§12.6](#§126-deferred-sdks-swift-c-c)), so no token material is ever handed
-to their callers outside the §4 cookie jar and rule 3 above has nothing to enable there. Should a
-later §12 port land in either, rule 3 applies to it unchanged.
+**The C and C++ rows changed in contract 1.11.** Through 1.10 both read "no public accessor",
+and that wording was correct for as long as it was true that no token material ever reached
+their callers: both SDKs deferred §12 in its entirety, so everything they held lived in the §4
+cookie jar and rule 3 had nothing to enable. §12.6's 1.11 port removes that premise — §12 hands
+the caller an `OidcTokenSet`, and a token no caller can read cannot be persisted, forwarded or
+revoked. This is the same collision contract 1.5 resolved for the other eight SDKs, resolved the
+same way: **one** explicit accessor, documented as the single one, never reached from a
+log/trace/serialization sink. Swift already exposed `expose()` for the §20 requesting-party
+token and is unchanged here.
 
 **Why §7 reads this way (contract 1.5, non-breaking clarification).** Contract 1.4's §7 said
 flatly that "the raw token string MUST NOT be exposed via any public getter API". That was written
@@ -1004,8 +1009,9 @@ as a service account (`client_credentials`), to introspect/revoke tokens, and to
 server's upstream-IdP federation endpoints. It is **additive to §1**: the nine operations
 below are part of the same locked method vocabulary and are subject to the same
 "no diverging names" rule. An SDK that ships §1–§11 without these helpers remains conformant;
-an SDK that ships them states conformance to §1–§12. Three SDKs defer the whole section —
-see [§12.6](#§126-deferred-sdks-swift-c-c).
+an SDK that ships them states conformance to §1–§12. All eleven SDKs implement the section as of
+contract 1.11 — Swift, C and C++ deferred it through contract 1.10 and were ported in 1.11; see
+[§12.6](#§126-swift-c-and-c-ported--contract-111).
 
 These helpers MUST be built on the SDK's existing machinery — the §4 cookie jar, the §6/§6.1
 TLS configuration, the §7 `Sensitive<T>` wrapper, the §9 single-flight refresh guard, and the
@@ -1272,10 +1278,11 @@ prohibited (SDK-Q08).
 **Additional languages (Kotlin, Swift, C, C++).** **Kotlin** implements §12 and uses camelCase
 `suspend` functions identical to the TypeScript column (`oidcDiscover`, `oidcBegin`,
 `oidcExchange`, `oidcRefresh`, `loginClientCredentials`, `introspect`, `revoke`, `ssoStart`,
-`ssoComplete`); no `*Async` twins. **Swift**, **C**, and **C++** defer the whole section
-([§12.6](#§126-deferred-sdks-swift-c-c)), but the names are reserved now so a later port cannot
-diverge: **Swift** camelCase and **C++** snake_case exactly as the TypeScript and Rust columns
-above; **C** snake_case with the mandatory `axiam_` prefix — `axiam_oidc_discover`,
+`ssoComplete`); no `*Async` twins. **Swift**, **C**, and **C++** implement the section as of contract
+1.11 ([§12.6](#§126-swift-c-and-c-ported--contract-111)), using the names reserved for them here
+while it was deferred — a port that diverged from them was never an option: **Swift** camelCase
+and **C++** snake_case exactly as the TypeScript and Rust columns above; **C** snake_case with
+the mandatory `axiam_` prefix — `axiam_oidc_discover`,
 `axiam_oidc_begin`, `axiam_oidc_exchange`, `axiam_oidc_refresh`,
 `axiam_login_client_credentials`, `axiam_introspect`, `axiam_revoke`, `axiam_sso_start`,
 `axiam_sso_complete`. No login/auth/authz method names beyond this map and the §1 map are
@@ -1469,24 +1476,50 @@ the §7 table for the authoritative per-language row. Two additions specific to 
 other structured serialization of `OidcTokenSet`, `AuthorizationRequest`, or an
 `OidcStateStore` entry MUST NOT emit the wrapped values.
 
-### §12.6 Deferred SDKs (Swift, C, C++)
+### §12.6 Swift, C and C++ (ported — contract 1.11)
 
-`axiam-swift-sdk`, `axiam-c-sdk`, and `axiam-cplusplus-sdk` **defer §12 in its entirety**, with
-the same carve-out discipline §1/§1.1 already applies to their `get_user_info`/gRPC deferral.
-These are device- and IoT-oriented SDKs: the Swift SDK ships NIOSSL specifically for client-cert
-mTLS, and the C/C++ SDKs target embedded consumers. The browser-redirect relying-party flow has
+**This section previously deferred §12 in these three SDKs. Contract 1.11 reverses that.**
+`axiam-swift-sdk`, `axiam-c-sdk`, and `axiam-cplusplus-sdk` implement §12 in full, using the
+names already reserved for them in [§12.2](#§122-per-language-naming-map), and satisfy
+§12.1–§12.5 unchanged. Their conformance statements say §1–§12 alongside whatever else they
+ship.
+
+**Why the deferral was written, and why it no longer holds.** The original text reasoned from
+persona: these are device- and IoT-oriented SDKs, the browser-redirect relying-party flow has
 no natural home in any of them, and their authentication story — §6.1 mTLS, password login,
-service credentials — is already complete without it.
+service credentials — was already complete without it. That reasoning covered `oidc_begin` and
+`oidc_exchange`, the two operations that genuinely assume a browser. It never covered the other
+seven. `login_client_credentials` is exactly the machine-to-machine login an embedded consumer
+wants; `introspect` and `revoke` are ordinary token-endpoint calls a device makes about its own
+credentials; `oidc_refresh` is the grant the §9 single-flight guard was built for. §12.6 itself
+recorded "adding `login_client_credentials` alone to C/C++" as an open follow-up — an admission
+that the all-or-nothing deferral was cutting across the wrong seam.
 
-Accordingly, each of these three SDKs MUST document §12 as a deferred follow-up in its scope
-section (same wording pattern as its existing "gRPC transport deferred" carve-out), MUST NOT
-partially implement the vocabulary, and MUST NOT substitute a hand-rolled OAuth2 flow for it.
-Their conformance statement stays at "§1–§10" (or "§1–§11" where the §11 helpers ship) and MUST
-NOT claim §12. If a later port lands, it MUST use the reserved names already fixed in
-[§12.2](#§122-per-language-naming-map) and MUST satisfy §12.1–§12.5 unchanged. Two follow-up
-decisions are recorded as open rather than resolved here: a server-side-Swift (Vapor) port
-cloned from the Kotlin shape, and adding `login_client_credentials` alone to C/C++ for
-machine-to-machine use.
+Two later sections settled it from the other direction. §14 (device authorization grant) exists
+precisely *because* a device cannot show a browser, and its naming map lists all three; §20 gave
+all three a token-endpoint call (`uma_exchange_ticket`) and its own discovery document. By
+contract 1.10 these SDKs were already speaking OAuth2 at `/oauth2/token` — the "second, parallel
+OIDC stack" the deferral warned about had arrived anyway, in pieces, without the shared discovery
+cache and ID-token validation §12 specifies. Porting §12 removes a divergence rather than adding
+one.
+
+**What the port must satisfy.** §12.1's endpoint map, §12.3's cross-cutting rules (statelessness
+above all — the caller owns `state`/`nonce`/`code_verifier`), §12.4's ID-token validation
+checklist, and §12.5's `Sensitive<T>` applicability, all unchanged and all as binding here as in
+the eight SDKs that shipped them first. Two consequences follow that these three did not
+previously have to face:
+
+1. **§7 rule 3 now applies to C and C++.** §12 returns tokens *to* the caller, so each of the
+   three needs the single explicit accessor rule 3 permits — see the §7 table, whose C and C++
+   rows change with this revision. A `Sensitive<T>` a §12 caller can never read makes §12
+   unusable, which is the same reasoning contract 1.5 recorded when it restructured §7.
+2. **`oidc_begin` stays synchronous and network-free** in all three, exactly as §12.1 requires.
+   In C that means it allocates a URL string and a `code_verifier` the caller frees; it does not
+   acquire the client's transport.
+
+The remaining open follow-up from the original text — a server-side-Swift (Vapor) integration
+cloned from the Kotlin shape — is unaffected: it concerns a framework binding, not the §12
+vocabulary, and stays open.
 
 ### §12.7 Logout helpers (B5)
 
@@ -1581,7 +1614,9 @@ server refuses to make, and SDK documentation MUST say so.
 
 Both are synchronous where the language has the distinction (as `oidc_begin`
 is): neither performs network I/O of its own, so C# takes no `Async` suffix
-here. The three §12.6 deferrals (Swift, C, C++) defer §12.7 with it.
+here. Swift, C and C++ deferred §12.7 with §12 through contract 1.10; since
+their 1.11 port ([§12.6](#§126-swift-c-and-c-ported--contract-111)) the same
+SHOULD applies to them as to everyone else.
 
 #### §12.7.5 `Sensitive<T>` applicability
 
@@ -2523,8 +2558,10 @@ ships both writes:
 and one that ships only the device grant names only §14. Writing "§1–§15" would claim the
 other section by implication, which is the failure mode a range invites.
 
-The three SDKs that defer §12 ([§12.6](#§126-deferred-sdks-swift-c-c)) keep their existing
-statement and MUST NOT claim §12.
+Swift, C and C++ claimed no §12 through contract 1.10. Since their 1.11 port
+([§12.6](#§126-swift-c-and-c-ported--contract-111)) they state it like everyone else — but only
+once the port has actually landed in that repository: the statement follows the code, never the
+contract's expectation of it.
 
 §16 (retry policy) and §18 (deterministic shutdown) are **MUST**-level and land with contract
 1.8, so unlike §14/§15 they are not optional and are not named in the statement — an SDK is
@@ -2558,9 +2595,12 @@ three defer it and are unchanged:
 | C# | §1–§12 | `*Async` throughout except the deliberate synchronous `OidcBegin` |
 | PHP | §1–§12 | — |
 | Go | §1–§12 | — |
-| Swift | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
-| C | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
-| C++ | unchanged (no §12) | [§12.6](#§126-deferred-sdks-swift-c-c) deferral |
+| Swift | unchanged (no §12) | [§12.6](#§126-swift-c-and-c-ported--contract-111) deferral — **lifted in contract 1.11** |
+| C | unchanged (no §12) | [§12.6](#§126-swift-c-and-c-ported--contract-111) deferral — **lifted in contract 1.11** |
+| C++ | unchanged (no §12) | [§12.6](#§126-swift-c-and-c-ported--contract-111) deferral — **lifted in contract 1.11** |
+
+The table above is a snapshot of contract 1.5 and is kept as written; the three deferrals in it
+were lifted by contract 1.11, and each of those SDKs states §1–§12 once its port lands.
 
 `login_client_credentials` credential adoption is a §12.1 **MAY**: TypeScript, PHP, and Go
 implement it as an opt-in flag; Rust, Python, Java, and Kotlin skip it; C# exposes the flag and
@@ -2721,8 +2761,8 @@ recorded here until one exists.
   `error_description`), plus two endpoint-qualified rows in the HTTP-status mapping; the three
   existing top-level error types are unchanged. No existing signature changes. The eight
   backend-capable SDKs (Rust, TypeScript, Python, Java, Kotlin, C#, PHP, Go) add the operations
-  and state "§1–§12"; the device-oriented SDKs (Swift, C, C++) document §12 as a deferred
-  follow-up and keep their existing statement (§12.6).
+  and state "§1–§12"; the device-oriented SDKs (Swift, C, C++) documented §12 as a deferred
+  follow-up and kept their existing statement (§12.6 — deferral lifted in contract 1.11).
 
 - **2026-07 (§1.1 gRPC userinfo, contract 1.3)** — **non-breaking / additive.** Added a new
   canonical operation `get_user_info` (§1 naming map + §1.1 normative semantics), served only
@@ -2774,12 +2814,39 @@ recorded here until one exists.
   residual describes), and **§20.3 forbids the challenge-parsing helper from auto-exchanging**
   the ticket it parsed, since the `as_uri` names a host the client has not chosen to trust.
 
+- **2026-08 (§12.6 deferral lifted for Swift, C and C++)** — **non-breaking / additive**, with
+  one narrow widening. §12.6 previously required `axiam-swift-sdk`, `axiam-c-sdk` and
+  `axiam-cplusplus-sdk` to defer §12 in its entirety, forbade partial implementation, and
+  forbade their conformance statements from claiming it. Contract 1.11 reverses that: all three
+  implement §12 — and, with it, §12.7 — using the names §12.2 had already reserved for them,
+  satisfying §12.1–§12.5 unchanged.
+
+  The deferral reasoned from persona (device- and IoT-oriented SDKs have no browser to redirect),
+  which is true of `oidc_begin`/`oidc_exchange` and of nothing else in the section:
+  `login_client_credentials` is the machine-to-machine login an embedded consumer actually wants,
+  `introspect`/`revoke` are ordinary token-endpoint calls about a device's own credentials, and
+  §12.6 itself recorded "adding `login_client_credentials` alone to C/C++" as an open follow-up.
+  §14 and §20 then settled it from the other side: §14 exists because a device cannot show a
+  browser and lists all three, and §20 gave all three a `/oauth2/token` call and a discovery
+  document of their own. By 1.10 the "second, parallel OIDC stack" the deferral warned about had
+  arrived anyway, in pieces. Porting §12 removes a divergence rather than adding one.
+
+  **The one widening:** §7's C and C++ rows no longer read "no public accessor". That wording was
+  load-bearing only while those SDKs handed their callers no token material; §12 returns tokens
+  *to* the caller, so rule 3's **single** explicit accessor now applies to them — `expose()` in
+  C++, `axiam_sensitive_reveal()` in C — exactly as contract 1.5 resolved the same collision for
+  the other eight. Every redaction surface (`operator<<`/`to_string`, log output) is unchanged.
+
+  No existing signature changes anywhere, and no SDK that already shipped §12 is affected. A
+  conformance statement still follows the code: each of the three claims §1–§12 only once its own
+  port has landed.
+
 ### OpenAPI Export Feature Flag
 
 `openapi.json` (kept in this directory, and mirrored into every SDK repo) is generated with `--no-default-features` (SAML endpoints excluded). Both the committed spec and the CI drift gate use identical flags. SDK consumers requiring SAML endpoint documentation should build AXIAM with the `saml` feature enabled and export locally.
 
 ---
 
-*Contract version: 1.10 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07; §9 rule 6 single-flight implementation invariants and the extended §9 test requirement added 2026-07; §8b AMQP transport, §10.2 gRPC revocation modes, §12.7 logout helpers, §14 device authorization grant and §15 token exchange added 2026-08; §14.3 rule 4 / §14.6 credential-adoption errata 2026-08 (contract 1.7); §16 retry policy, §17 decision memo, §18 deterministic shutdown and §19 telemetry hooks added 2026-08, with §11.2 rules 5–6 and §14.2 rule 6 amended to point at them (contract 1.8); §16 preamble errata + §19 `config_clamped` event 2026-08 (contract 1.9) — the divergence table rewritten from wire-counting conformance tests rather than greps, and a clamped setting must now be reported through §19 rather than applied silently; §20 UMA 2.0 Protection API and ticket grant added 2026-08 (contract 1.10), carrying the one documented exception to §16 retry policy*
+*Contract version: 1.11 — Phase 15 (sdk-foundation); §11 declarative authorization helpers added 2026-07; §6.1 mTLS client certificates and Kotlin/Swift/C/C++ SDK columns added 2026-07; §1.1 gRPC-only `get_user_info` operation added 2026-07; §12 OIDC/SSO relying-party helpers and the `OAuthProtocolError` taxonomy sub-type added 2026-07; §7 accessor rules, §9 rule 5, and the §12 cross-SDK clarifications from the eight-SDK conformance review added 2026-07; §9 rule 6 single-flight implementation invariants and the extended §9 test requirement added 2026-07; §8b AMQP transport, §10.2 gRPC revocation modes, §12.7 logout helpers, §14 device authorization grant and §15 token exchange added 2026-08; §14.3 rule 4 / §14.6 credential-adoption errata 2026-08 (contract 1.7); §16 retry policy, §17 decision memo, §18 deterministic shutdown and §19 telemetry hooks added 2026-08, with §11.2 rules 5–6 and §14.2 rule 6 amended to point at them (contract 1.8); §16 preamble errata + §19 `config_clamped` event 2026-08 (contract 1.9) — the divergence table rewritten from wire-counting conformance tests rather than greps, and a clamped setting must now be reported through §19 rather than applied silently; §20 UMA 2.0 Protection API and ticket grant added 2026-08 (contract 1.10), carrying the one documented exception to §16 retry policy; §12.6's Swift/C/C++ deferral lifted 2026-08 (contract 1.11), porting §12 and §12.7 to those three SDKs and widening §7's C/C++ rows to rule 3's single explicit accessor*
 *Binding since: 2026-06-30*
 *Reference: D-09, D-10 in `.planning/phases/15-sdk-foundation/15-CONTEXT.md`*


### PR DESCRIPTION
## What

§12.6 required `axiam-swift-sdk`, `axiam-c-sdk` and `axiam-cplusplus-sdk` to **defer §12 in its
entirety**, forbade partial implementation, and forbade their conformance statements from claiming
it. This reverses that. All three implement §12 — and with it §12.7 — using the names §12.2 had
already reserved for them, satisfying §12.1–§12.5 unchanged.

Contract version → **1.11**.

## Why

The deferral reasoned from persona: device- and IoT-oriented SDKs have no browser to redirect.
That is true of `oidc_begin` and `oidc_exchange`, and of nothing else in the section:

- `login_client_credentials` is exactly the machine-to-machine login an embedded consumer wants.
- `introspect` / `revoke` are ordinary token-endpoint calls a device makes about its own credentials.
- `oidc_refresh` is the grant the §9 single-flight guard was built for.

§12.6 itself recorded *"adding `login_client_credentials` alone to C/C++"* as an open follow-up —
an admission that an all-or-nothing deferral was cutting across the wrong seam.

Two later sections settled it from the other direction. **§14** exists precisely *because* a device
cannot show a browser, and its naming map lists all three. **§20** gave all three a `/oauth2/token`
call (`uma_exchange_ticket`) and a discovery document of their own. By contract 1.10 these SDKs
were already speaking OAuth2 at the token endpoint — the "second, parallel OIDC stack" the deferral
warned about had arrived anyway, in pieces, without the shared discovery cache and ID-token
validation §12 specifies. Porting §12 removes a divergence rather than adding one.

## The one widening

§7's **C and C++ rows** no longer read "no public accessor". That wording was load-bearing only
while those SDKs handed their callers no token material; §12 returns tokens *to* the caller, and a
`Sensitive<T>` no §12 caller can read makes §12 unusable. Rule 3's **single** explicit accessor now
applies to them — `expose()` in C++, `axiam_sensitive_reveal()` in C — exactly as contract 1.5
resolved the same collision for the other eight SDKs. Every redaction surface
(`operator<<`/`to_string`, log output) is unchanged. Swift already exposed `expose()` for the §20
requesting-party token and is unchanged.

## Sections touched

| Passage | Change |
|---|---|
| §7 `Sensitive<T>` table + note | C/C++ rows gain rule 3's accessor; the note explains the reversal rather than deleting the old reasoning |
| §12 preamble | "Three SDKs defer the whole section" → all eleven implement it as of 1.11 |
| §12.2 naming map | reserved-names paragraph now reads as shipped, not reserved |
| §12.6 | rewritten: what the deferral said, why it no longer holds, what the port must satisfy |
| §12.7 | the "three §12.6 deferrals defer §12.7 with it" note |
| conformance-statement rules | the "MUST NOT claim §12" rule, replaced with "the statement follows the code" |
| contract-1.5 snapshot table | kept as a snapshot, annotated as lifted |
| revision log + version line | new 1.11 entry |

Nothing else in the contract changes: **no existing signature changes anywhere**, and no SDK that
already ships §12 is affected. A conformance statement still follows the code — each of the three
claims §1–§12 only once its own port lands.

Two `claude_dev/` documents referenced the deferral as live (the D6 fan-out instructions and the
B-track AMQP carve-out); both are updated so neither points at a carve-out that no longer exists.

## Next

The three SDK ports (§12, §12.7, §14, §15) follow as one PR per repository, each re-vendoring this
file at 1.11.

Refs ilpanich/axiam#292.

---
_Generated by [Claude Code](https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc)_