### PR TITLE
fix(db): give resource delete and child create a key to collide on

### DIFF
--- a/crates/axiam-db/src/repository/resource.rs
+++ b/crates/axiam-db/src/repository/resource.rs
@@ -97,6 +97,69 @@ pub struct SurrealResourceRepository<C: Connection> {
     db: DbHandle<C>,
 }
 
+/// The message `claim_parent` throws when the parent is gone. Matched on the
+/// way back out, so the caller sees `NotFound` rather than an opaque error.
+const PARENT_GONE: &str = "parent resource not found";
+
+/// SQL that claims `parent_id` for a child about to be attached to it (#308).
+///
+/// # Why a write, and why it must be this write
+///
+/// `resource.delete` guards itself by reading the `child_of` range for the
+/// resource being deleted and refusing if it is non-empty. That read cannot see
+/// an edge a concurrent transaction has not written yet, and snapshot isolation
+/// does not turn a range read into a conflict against a later insert — that is
+/// a phantom, and it needs serialisable isolation. So the guard alone loses the
+/// race, reproducibly (#308: trial 0 of every run on surrealkv).
+///
+/// What these engines DO detect reliably is two transactions writing the same
+/// key; `tools/surreal-race-probe` measures them doing it 21613 times in 40000
+/// contended attempts. `delete` already writes the parent's key — it deletes
+/// the row. So every path that attaches a child writes it too, and the engine's
+/// existing conflict detection decides the race instead of a query that cannot.
+///
+/// Two things here are load-bearing and easy to strip by accident:
+///
+/// 1. **The `THROW` is not an error-message nicety.** If the parent has already
+///    been deleted, the `UPDATE` matches nothing, and *nothing matching is not
+///    a conflict* — the create would sail past and write an edge to a row that
+///    no longer exists, which is precisely the orphan being prevented. Losing
+///    the race has to be an error, so it throws.
+/// 2. **It must be in the same transaction as the `RELATE`.** Split across two
+///    transactions, the parent could be deleted in the gap.
+///
+/// The counter's value is never read. Bumping it is the entire point.
+///
+/// Reads the already-bound `$parent_id` and `$tenant_id`, so callers add no
+/// bindings; the tenant guard is what stops a child being attached under
+/// another tenant's node.
+fn claim_parent() -> String {
+    format!(
+        "LET $parent = (UPDATE type::record('resource', $parent_id) \
+             SET child_epoch = (child_epoch ?? 0) + 1 \
+             WHERE tenant_id = $tenant_id RETURN VALUE id); \
+         IF array::len($parent) = 0 {{ THROW '{PARENT_GONE}'; }};"
+    )
+}
+
+/// Turns a `claim_parent` throw into `NotFound`, and anything else into a
+/// database error.
+///
+/// Mirrors `delete`'s handling and for the same reason: a `THROW` fires on its
+/// own statement slot while the trailing statements report the generic "not
+/// executed due to a failed transaction", and `Response::check()` may surface
+/// either — so every statement error is scanned rather than just the first.
+fn parent_claim_error(errors: Vec<String>, parent_id: &str) -> AxiamError {
+    let combined = errors.join("; ");
+    if combined.contains(PARENT_GONE) {
+        return AxiamError::NotFound {
+            entity: "resource".into(),
+            id: parent_id.to_string(),
+        };
+    }
+    DbError::Migration(combined).into()
+}
+
 impl<C: Connection> SurrealResourceRepository<C> {
     pub fn new(db: impl Into<DbHandle<C>>) -> Self {
         let db = db.into();
@@ -138,13 +201,23 @@ impl<C: Connection> SurrealResourceRepository<C> {
                     metadata = $metadata, \
                     uma_registered_by = $uma_registered_by";
 
-        let query = if let Some(ref pid) = parent_id_str {
-            format!("{base}; RELATE resource:`{id_str}` -> child_of -> resource:`{pid}`;")
-        } else {
-            base.to_string()
+        // Same #308 parent claim as `create` — the Protection API attaches
+        // children through this path too, and an orphan made here is
+        // indistinguishable from one made there.
+        let (query, row_slot) = match parent_id_str.as_deref() {
+            Some(pid) => (
+                format!(
+                    "BEGIN TRANSACTION; {claim} {base}; \
+                     RELATE resource:`{id_str}` -> child_of -> resource:`{pid}`; \
+                     COMMIT TRANSACTION",
+                    claim = claim_parent(),
+                ),
+                3,
+            ),
+            None => (base.to_string(), 0),
         };
 
-        let result = self
+        let mut result = self
             .db
             .current()
             .query(query)
@@ -152,17 +225,22 @@ impl<C: Connection> SurrealResourceRepository<C> {
             .bind(("tenant_id", tenant_id_str))
             .bind(("name", input.name))
             .bind(("resource_type", input.resource_type))
-            .bind(("parent_id", parent_id_str))
+            .bind(("parent_id", parent_id_str.clone()))
             .bind(("metadata", metadata))
             .bind(("uma_registered_by", client_id.to_string()))
             .await
             .map_err(DbError::from)?;
 
-        let mut result = result
-            .check()
-            .map_err(|e| DbError::Migration(e.to_string()))?;
+        let errors = result.take_errors();
+        if !errors.is_empty() {
+            let msgs: Vec<String> = errors.into_values().map(|e| e.to_string()).collect();
+            return Err(match parent_id_str.as_deref() {
+                Some(pid) => parent_claim_error(msgs, pid),
+                None => DbError::Migration(msgs.join("; ")).into(),
+            });
+        }
 
-        let rows: Vec<ResourceRow> = result.take(0).map_err(DbError::from)?;
+        let rows: Vec<ResourceRow> = result.take(row_slot).map_err(DbError::from)?;
         let row = take_first_or_not_found(rows, "resource", &id_str)?;
 
         row_to_resource(row, id).map_err(Into::into)
@@ -187,13 +265,28 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
                     parent_id = $parent_id, \
                     metadata = $metadata";
 
-        let query = if let Some(ref pid) = parent_id_str {
-            format!("{base}; RELATE resource:`{id_str}` -> child_of -> resource:`{pid}`;")
-        } else {
-            base.to_string()
+        // #308: attaching a child claims the parent inside the same
+        // transaction as the RELATE, so a concurrent `delete` of that parent
+        // has a key to conflict on. See `claim_parent` for why the range guard
+        // in `delete` cannot do this on its own. Without a parent there is no
+        // edge, nothing to race, and no transaction needed.
+        //
+        // Slots with a parent: BEGIN=0, LET $parent=1, IF/THROW=2, CREATE=3,
+        // RELATE=4, COMMIT=5. Without: CREATE=0.
+        let (query, row_slot) = match parent_id_str.as_deref() {
+            Some(pid) => (
+                format!(
+                    "BEGIN TRANSACTION; {claim} {base}; \
+                     RELATE resource:`{id_str}` -> child_of -> resource:`{pid}`; \
+                     COMMIT TRANSACTION",
+                    claim = claim_parent(),
+                ),
+                3,
+            ),
+            None => (base.to_string(), 0),
         };
 
-        let result = self
+        let mut result = self
             .db
             .current()
             .query(query)
@@ -201,16 +294,25 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
             .bind(("tenant_id", tenant_id_str))
             .bind(("name", input.name))
             .bind(("resource_type", input.resource_type))
-            .bind(("parent_id", parent_id_str))
+            .bind(("parent_id", parent_id_str.clone()))
             .bind(("metadata", metadata))
             .await
             .map_err(DbError::from)?;
 
-        let mut result = result
-            .check()
-            .map_err(|e| DbError::Migration(e.to_string()))?;
+        // Every statement's error is scanned rather than only the first: a
+        // THROW fires on its own slot while the statements after it report the
+        // generic "not executed due to a failed transaction", and `check()` can
+        // surface either. Same reasoning as `delete`.
+        let errors = result.take_errors();
+        if !errors.is_empty() {
+            let msgs: Vec<String> = errors.into_values().map(|e| e.to_string()).collect();
+            return Err(match parent_id_str.as_deref() {
+                Some(pid) => parent_claim_error(msgs, pid),
+                None => DbError::Migration(msgs.join("; ")).into(),
+            });
+        }
 
-        let rows: Vec<ResourceRow> = result.take(0).map_err(DbError::from)?;
+        let rows: Vec<ResourceRow> = result.take(row_slot).map_err(DbError::from)?;
         let row = take_first_or_not_found(rows, "resource", &id_str)?;
 
         row_to_resource(row, id).map_err(Into::into)
@@ -304,12 +406,29 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
             // it a foreign-tenant resource id could strip another tenant's
             // parent edge.
             //
-            // Result slots become: BEGIN=0, DELETE child_of=1, UPDATE=2,
-            // [RELATE=3], COMMIT=last — so the UPDATE row lands at slot 2.
+            // #308: re-parenting inserts into the NEW parent's `child_of`
+            // range, which is the same phantom the `create` path had, so the
+            // new parent is claimed here too. Only the new one: detaching a
+            // child removes an edge, and a delete racing that either sees the
+            // child and refuses or does not and has nothing to orphan.
+            //
+            // The `get_by_id` existence check above does NOT cover this — it is
+            // a read, outside the transaction, and a read cannot conflict with
+            // the delete. The claim is a write, and it throws if the parent
+            // went away, which is what makes losing the race an error rather
+            // than an orphan.
+            //
+            // Result slots become: BEGIN=0, DELETE child_of=1, then either
+            // [LET $parent=2, IF/THROW=3, UPDATE=4, RELATE=5] when a new parent
+            // is claimed, or [UPDATE=2] when the child is being detached.
+            let claim = match &input.parent_id {
+                Some(Some(_)) => claim_parent(),
+                _ => String::new(),
+            };
             query = format!(
                 "BEGIN TRANSACTION; \
                  DELETE child_of WHERE in = resource:`{id_str}` AND in.tenant_id = $tenant_id; \
-                 {query}"
+                 {claim} {query}"
             );
 
             // If new parent is Some, create new child_of edge.
@@ -347,14 +466,26 @@ impl<C: Connection> ResourceRepository for SurrealResourceRepository<C> {
             builder = builder.bind(("metadata", metadata));
         }
 
-        let result = builder.await.map_err(DbError::from)?;
-        let mut result = result
-            .check()
-            .map_err(|e| DbError::Migration(e.to_string()))?;
+        let mut result = builder.await.map_err(DbError::from)?;
+
+        let errors = result.take_errors();
+        if !errors.is_empty() {
+            let msgs: Vec<String> = errors.into_values().map(|e| e.to_string()).collect();
+            return Err(match &input.parent_id {
+                Some(Some(new_parent)) => parent_claim_error(msgs, &new_parent.to_string()),
+                _ => DbError::Migration(msgs.join("; ")).into(),
+            });
+        }
 
         // The UPDATE statement index depends on whether we wrapped the
-        // re-parent in a transaction: BEGIN=0, DELETE child_of=1, UPDATE=2.
-        let stmt_idx = if parent_id_changed { 2 } else { 0 };
+        // re-parent in a transaction, and on whether that re-parent claimed a
+        // new parent: BEGIN=0, DELETE child_of=1, then [LET=2, IF=3, UPDATE=4]
+        // when attaching or [UPDATE=2] when detaching.
+        let stmt_idx = match (parent_id_changed, &input.parent_id) {
+            (true, Some(Some(_))) => 4,
+            (true, _) => 2,
+            (false, _) => 0,
+        };
         let rows: Vec<ResourceRow> = result.take(stmt_idx).map_err(DbError::from)?;
         let row = take_first_or_not_found(rows, "resource", &id_str)?;
 

--- a/crates/axiam-db/src/schema.rs
+++ b/crates/axiam-db/src/schema.rs
@@ -207,6 +207,11 @@ static MIGRATIONS: &[Migration] = &[
         name: "uma_resource_registration_provenance",
         sql: SCHEMA_V33,
     },
+    Migration {
+        version: 34,
+        name: "resource_child_epoch_delete_race",
+        sql: SCHEMA_V34,
+    },
 ];
 
 // -----------------------------------------------------------------------
@@ -1715,6 +1720,58 @@ DEFINE FIELD IF NOT EXISTS redemption_id ON TABLE pushed_auth_request TYPE optio
 // rather than backfilling a claim about resources nobody registered.
 const SCHEMA_V33: &str = "\
 DEFINE FIELD IF NOT EXISTS uma_registered_by ON TABLE resource TYPE option<string>;
+";
+
+// -----------------------------------------------------------------------
+// Schema v34 — a key for resource-delete and child-create to collide on (#308)
+// -----------------------------------------------------------------------
+//
+// `resource.delete` refuses to delete a resource that has children, and folds
+// the check into its own transaction:
+//
+//     BEGIN;
+//     LET $children = (SELECT VALUE id FROM child_of WHERE out = resource:<id>);
+//     IF array::len($children) > 0 { THROW ... };
+//     DELETE ...; DELETE type::record('resource', $id) ...;
+//     COMMIT;
+//
+// D-13/CQ-B46 introduced that shape to close a TOCTOU window and described it
+// as making the read-then-decide-then-delete atomic. It does make the
+// statements atomic. That is not the property the guard needs, and #308 is the
+// proof: on `surrealkv` a concurrent child-create beats it on trial 0 of every
+// run, leaving a deleted parent with a live `child_of` edge pointing at it.
+//
+// The guard is a RANGE READ — every edge whose `out` is this parent — and the
+// racing create INSERTS INTO THAT RANGE. Excluding that is the definition of a
+// phantom, and preventing phantoms takes serialisable isolation. These engines
+// give snapshot isolation: they detect write-write conflicts on the same key
+// (measured doing exactly that, 21613 aborts in 40000 contended attempts — see
+// `tools/surreal-race-probe`), and they let this through because the two
+// transactions have no key in common. The delete writes the parent row and the
+// edges it could see; the create writes a NEW edge the delete never saw.
+//
+// No query can fix that, because the guard cannot read a row that does not
+// exist yet. What fixes it is giving the two transactions a shared key, so the
+// conflict the engine already detects reliably is the one that decides the
+// race. That is what this field is for:
+//
+//   * `resource.delete` already writes the parent row — it deletes it.
+//   * Every path that adds a child edge now also writes the parent row, by
+//     bumping `child_epoch`, inside the same transaction as the RELATE.
+//
+// One of the two must now lose. If the create commits first, the delete's write
+// to the parent conflicts and it aborts, leaving parent and child intact. If
+// the delete commits first, the create's bump matches no row, its guard throws,
+// and no edge is written. Neither order produces an orphan.
+//
+// The counter's VALUE is not used for anything and deliberately so — reading it
+// would be a second way to get this wrong. Its only job is to be a write to the
+// parent's key. It is `option<int>` rather than `int DEFAULT 0` so that rows
+// predating this migration need no backfill: `child_epoch ?? 0` treats absent
+// and zero alike, and nothing distinguishes "never had a child" from "has had
+// exactly zero".
+const SCHEMA_V34: &str = "\
+DEFINE FIELD IF NOT EXISTS child_epoch ON TABLE resource TYPE option<int>;
 ";
 
 // -----------------------------------------------------------------------

--- a/crates/axiam-db/tests/resource_scope_test.rs
+++ b/crates/axiam-db/tests/resource_scope_test.rs
@@ -254,36 +254,42 @@ async fn delete_resource_blocked_by_existing_child() {
 /// exercise both possible interleavings against the engine's actual
 /// transaction isolation.
 ///
-/// # IGNORED: this FAILS on the engine we deploy (2026-08)
+/// # The shape of the fix, and why the guard alone was not it (#308)
 ///
-/// It passed for as long as it ran on `Mem`. Moved to `surrealkv` — what
-/// `docker-compose.prod.yml` and the k8s StatefulSet run — it fails on **trial
-/// 0, every run**: the delete commits and a `child_of` edge to the deleted
-/// parent survives. Exactly the orphan the D-13/CQ-B46 fix was written to make
-/// impossible.
+/// This passed for as long as it ran on `Mem`, and failed on **trial 0 of every
+/// run** the moment it moved to `surrealkv` — the engine
+/// `docker-compose.prod.yml` and the k8s StatefulSet actually run. The delete
+/// committed and a `child_of` edge to the deleted parent survived: exactly the
+/// orphan D-13/CQ-B46 was written to make impossible.
 ///
-/// The fix's premise does not hold. Folding the guard into one transaction
-/// makes the statements atomic, but the guard is a **range read** (`SELECT …
-/// FROM child_of WHERE out = resource:<id>`) and the racing create **inserts
-/// into that range**. Preventing that is a phantom-read problem, which needs
-/// serialisable isolation; snapshot isolation — which is what these engines
-/// appear to provide — detects write-write conflicts on the same key and lets
-/// this through. The two transactions never touch a common key, so there is
-/// nothing for the engine to conflict on.
+/// Folding the guard into one transaction makes the statements atomic, which is
+/// not the property needed. The guard is a **range read** (`SELECT … FROM
+/// child_of WHERE out = resource:<id>`) and the racing create **inserts into
+/// that range** — a phantom, and excluding phantoms takes serialisable
+/// isolation. These engines give snapshot isolation: they detect write-write
+/// conflicts on the same key, and the two transactions had no key in common.
 ///
-/// So this is not a flaky test and not the #302 residual: it is a reproducible
-/// defect in `SurrealResourceRepository::delete`, which `Mem` hid because its
-/// scheduling never opened the window. Fixing it means giving the two
-/// transactions a key to collide on (e.g. having child-create write the parent
-/// row) rather than tightening the query, and that is a design change to the
-/// resource repository — its own issue and its own PR.
+/// So the fix is not a better query. `create`, `create_uma_registered` and
+/// `update`'s re-parent now bump `child_epoch` on the parent inside the same
+/// transaction as the `RELATE` (schema v34), which is a write to the very row
+/// `delete` removes. One of the two must now lose: if the create commits first
+/// the delete conflicts and aborts, and if the delete commits first the create's
+/// claim matches nothing and throws. Neither order leaves an orphan.
 ///
-/// Kept here, on the right engine, rather than reverted to `Mem`: a green run
-/// against an engine AXIAM does not ship is worse than an ignored test that
-/// says what is actually true. Un-ignore it as the acceptance test for the fix.
+/// This is the acceptance test for that fix, and it was checked both ways
+/// before being trusted: with the repository change reverted it fails on trial
+/// 0 of every run, and with it applied it survived 200 trials × the same race.
+/// TRIALS is 15 because the old code never got past the first one; the margin
+/// is for scheduling luck, not for hunting a rare event.
+///
+/// One thing it does NOT prove, said here rather than left to be assumed. In
+/// the observed runs the create always commits first and `delete` then refuses
+/// through the ordinary child guard — so this exercises the fix's *atomicity*
+/// (the edge is never visible without the parent write beside it) rather than
+/// the conflict itself. `create_rejects_a_parent_that_does_not_exist` covers
+/// the other half deterministically: the branch where the claim matches nothing
+/// and must throw instead of writing a dangling edge.
 #[tokio::test]
-#[ignore = "reproduces a real orphan race in resource delete on surrealkv — see the doc comment; \
-            un-ignore as the acceptance test when delete is fixed"]
 async fn concurrent_child_create_never_orphans_after_parent_delete() {
     const TRIALS: usize = 15;
 
@@ -360,6 +366,149 @@ async fn concurrent_child_create_never_orphans_after_parent_delete() {
         // warning.
         let _ = &create_result;
     }
+}
+
+/// The other half of the #308 fix, and the half that is deterministic.
+///
+/// `claim_parent` throws when its `UPDATE` of the parent matches no row, and
+/// that `THROW` is load-bearing rather than a friendlier error message. If the
+/// parent has already been deleted, the claim matches nothing — and *nothing
+/// matching is not a conflict*, so without the throw the create would sail past
+/// and `RELATE` an edge to a record that no longer exists. That is the very
+/// orphan the concurrent test above is about, reached by a slower route.
+///
+/// Deleting the parent first makes the losing side of the race reproducible
+/// without needing to win a scheduling coin flip.
+#[tokio::test]
+async fn create_rejects_a_parent_that_does_not_exist() {
+    let (db, tenant_id) = setup().await;
+    let repo = SurrealResourceRepository::new(db.clone());
+
+    let parent = repo
+        .create(CreateResource {
+            tenant_id,
+            name: "doomed-parent".into(),
+            resource_type: "project".into(),
+            parent_id: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    let parent_id = parent.id;
+    repo.delete(tenant_id, parent_id).await.unwrap();
+
+    let result = repo
+        .create(CreateResource {
+            tenant_id,
+            name: "would-be-orphan".into(),
+            resource_type: "service".into(),
+            parent_id: Some(parent_id),
+            metadata: None,
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "attaching a child to a deleted parent must fail — before #308 this \
+         silently wrote a child_of edge to a record that no longer existed"
+    );
+
+    // And it must fail without leaving anything behind: no dangling edge, and
+    // no half-created resource. A rolled-back transaction is the point.
+    let mut edges = db
+        .query(format!(
+            "SELECT * FROM child_of WHERE out = resource:`{parent_id}`"
+        ))
+        .await
+        .unwrap();
+    let remaining: Vec<surrealdb_types::Value> = edges.take(0).unwrap();
+    assert!(
+        remaining.is_empty(),
+        "a refused create must not leave a child_of edge behind"
+    );
+}
+
+/// The same guard on the re-parent path. `update` already validated the new
+/// parent with `get_by_id`, but that is a READ outside the transaction and
+/// cannot conflict with a concurrent delete — so the claim has to hold here
+/// too, and it has to refuse the same way.
+#[tokio::test]
+async fn reparent_rejects_a_parent_that_does_not_exist() {
+    let (db, tenant_id) = setup().await;
+    let repo = SurrealResourceRepository::new(db.clone());
+
+    let child = repo
+        .create(CreateResource {
+            tenant_id,
+            name: "mover".into(),
+            resource_type: "service".into(),
+            parent_id: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let result = repo
+        .update(
+            tenant_id,
+            child.id,
+            axiam_core::models::resource::UpdateResource {
+                parent_id: Some(Some(uuid::Uuid::new_v4())),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "re-parenting onto a resource that does not exist must fail"
+    );
+
+    // The old parent edge state must be untouched: the re-parent transaction
+    // deletes the old edge before claiming the new parent, so a failed claim
+    // that did not roll back would leave the child detached from everything.
+    let unchanged = repo.get_by_id(tenant_id, child.id).await.unwrap();
+    assert!(
+        unchanged.parent_id.is_none(),
+        "a refused re-parent must leave the resource as it was"
+    );
+}
+
+/// A child may not be attached across a tenant boundary. `claim_parent` carries
+/// `WHERE tenant_id = $tenant_id`, so a parent in another tenant matches
+/// nothing and the create is refused — the same code path as a parent that does
+/// not exist, which is the correct answer: from this tenant's side, it does not.
+#[tokio::test]
+async fn create_rejects_a_parent_in_another_tenant() {
+    let (db, tenant_id) = setup().await;
+    let repo = SurrealResourceRepository::new(db.clone());
+
+    let parent = repo
+        .create(CreateResource {
+            tenant_id,
+            name: "other-tenants-parent".into(),
+            resource_type: "project".into(),
+            parent_id: None,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let intruder_tenant = uuid::Uuid::new_v4();
+    let result = repo
+        .create(CreateResource {
+            tenant_id: intruder_tenant,
+            name: "cross-tenant-child".into(),
+            resource_type: "service".into(),
+            parent_id: Some(parent.id),
+            metadata: None,
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a resource in one tenant must not be attachable under another tenant's node"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #308.

## Why the existing guard could not work

`resource.delete` refuses to delete a resource that has children. D-13/CQ-B46 folded that check into the delete's own transaction and described the result as making the read-then-decide-then-delete atomic. It does make the statements atomic — that just isn't the property the guard needs.

The guard is a **range read** (every `child_of` edge whose `out` is this parent) and the racing create **inserts into that range**. Excluding that is the definition of a phantom, and preventing phantoms takes serialisable isolation. These engines provide snapshot isolation: they detect write-write conflicts on the same key — measured doing exactly that, 21 613 aborts in 40 000 contended attempts (`tools/surreal-race-probe`) — and they let this through because **the two transactions have no key in common**. The delete writes the parent row and the edges it could see; the create writes a *new* edge the delete never saw.

It passed on `Mem` for as long as it ran there. On surrealkv it failed on trial 0 of every run: the delete commits and a `child_of` edge to the deleted parent survives.

No query rewrite fixes this. The guard cannot read a row that does not exist yet.

## The fix

Give them a shared key, so the conflict these engines *do* detect reliably is the one that decides the race.

Schema **v34** adds `child_epoch` to `resource`. `delete` already writes that row — it deletes it. Now every path that attaches a child writes it too, bumping the counter inside the same transaction as the `RELATE`: `create`, `create_uma_registered`, and `update`'s re-parent. The counter's value is never read; being a write is its entire job.

One of the two must now lose:

- create commits first → the delete's write to the parent conflicts, it aborts, parent and child both survive;
- delete commits first → the create's claim matches no row, throws, and no edge is written.

Neither order produces an orphan.

Two parts are load-bearing and are commented as such, because both look like tidying and are not:

1. **The `THROW` is not an error-message nicety.** If the parent is already deleted the claim matches nothing — and *nothing matching is not a conflict*. Without the throw the create sails past and writes the orphan anyway.
2. **It must share the transaction with the `RELATE`.** Split across two transactions, the parent can be deleted in the gap.

Note also that `update`'s existing `get_by_id` check does not cover this: it is a read, outside the transaction, and a read cannot conflict with the delete.

## Verification, both directions

| | |
|---|---|
| Change reverted | acceptance test fails on trial 0, every run |
| Change applied | 200 trials × the same 2-way race, zero orphans |

I checked it that way round deliberately — a race test that passes proves nothing until you have watched it fail.

## What the concurrent test does not prove

Said in the test rather than left to be assumed: in the observed runs the create always commits first and `delete` then refuses through the *ordinary child guard*, so that test exercises the fix's **atomicity** (an edge is never visible without the parent write beside it) rather than the conflict path itself.

Three deterministic tests cover the other branch, where the claim matches nothing and must throw:

- `create_rejects_a_parent_that_does_not_exist` — and asserts no edge is left behind
- `reparent_rejects_a_parent_that_does_not_exist` — and asserts the resource is left as it was, since the re-parent transaction deletes the old edge before claiming the new parent
- `create_rejects_a_parent_in_another_tenant` — the claim carries `WHERE tenant_id = $tenant_id`, so a parent in another tenant matches nothing, which is the right answer: from this tenant's side it does not exist

That first one also closes a quieter pre-existing bug — **`create` did no parent validation at all**, so a bogus `parent_id` silently wrote a `child_of` edge to a record that never existed.

## Tests

```
resource_scope_test            17 passed  (was 13 passed + 1 ignored)
req14_tenant_isolation_test     7 passed
resource_repository_gaps_test   5 passed
role_permission_test           21 passed
cargo fmt -p axiam-db -- --check    clean
cargo clippy -p axiam-db --lib --all-targets   clean
```

The previously-`#[ignore]`d test is un-ignored — that was always the plan for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015P5QahkVjqoBqz83H2Gqvc)_