### PR TITLE
feat(oauth2): X4 — external-IdP token exchange (RFC 8693, cross-domain)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "hex",
  "jsonwebtoken 11.0.0",
  "rand 0.10.2",
+ "rcgen",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/ThreatDragonModels/Axiam/Axiam.json
+++ b/ThreatDragonModels/Axiam/Axiam.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "summary": {
     "title": "Axiam",
     "owner": "ilpanich",
@@ -5602,6 +5602,61 @@
                   "mitigation": "state and nonce are both required, generated with a CSPRNG, stored server-side against the pending flow, and verified before any identity is established.",
                   "modelType": "STRIDE",
                   "number": 66
+                },
+                {
+                  "id": "54bac98f-8186-571d-aa62-e6e737a7aed5",
+                  "title": "A partner's token is accepted as an AXIAM credential (X4)",
+                  "status": "Mitigated",
+                  "severity": "Critical",
+                  "type": "Elevation of privilege",
+                  "description": "External-IdP token exchange (RFC 8693, X4) lets a client present a token minted by a partner's IdP and receive an AXIAM token. If the partner's assertions were trusted as authorization, the partner's administrator would be able to name AXIAM scopes and grant their own users authority in this tenant.",
+                  "mitigation": "An external subject token is treated as evidence of authentication only. The issued token's scopes are the intersection of an AXIAM-admin-authored deny-by-default scope_map, the exchanging client's registration, and the RBAC engine's answer for the resolved user at mint time (deny-override applied at its broadest reading). Trust is off by default per provider, and enabling it requires a non-empty accepted_audiences list.",
+                  "modelType": "STRIDE",
+                  "number": 155
+                },
+                {
+                  "id": "fe285bf2-cfb5-5fc0-8094-56e9158b1565",
+                  "title": "A token not addressed to AXIAM is replayed at the exchange (X4)",
+                  "status": "Mitigated",
+                  "severity": "High",
+                  "type": "Spoofing",
+                  "description": "A token the partner minted for a third party \u2014 or for their own internal service \u2014 is captured and presented to AXIAM's token endpoint. Without an audience check, any token from the partner's estate becomes an AXIAM credential.",
+                  "mitigation": "accepted_audiences is required and non-empty whenever token exchange is enabled; there is deliberately no accept-all value. Matching is exact string equality in both directions (no trailing-slash forgiveness, no case folding), and aud may be a string or an array, of which at least one member must match.",
+                  "modelType": "STRIDE",
+                  "number": 156
+                },
+                {
+                  "id": "bc4a8f6c-9204-5601-87ca-a126d6f50a59",
+                  "title": "Trust composes transitively across three domains (X4)",
+                  "status": "Mitigated",
+                  "severity": "High",
+                  "type": "Elevation of privilege",
+                  "description": "AXIAM trusts partner B; B trusts partner C. Without a barrier, a token C minted can be exchanged at B and the result exchanged at AXIAM, giving C authority nobody configured and neither configuration reveals.",
+                  "mitigation": "Every token minted from an external subject token carries an ext_exchange provenance claim naming the foreign issuer, and BOTH exchange paths refuse a subject token that carries it. An exchanged token can never be re-exchanged, ours or theirs.",
+                  "modelType": "STRIDE",
+                  "number": 157
+                },
+                {
+                  "id": "8b667b1d-7e90-5802-a208-b84bffb3bdc4",
+                  "title": "A long-lived partner token becomes a long replay window (X4)",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Elevation of privilege",
+                  "description": "A partner IdP that issues 24-hour access tokens would, without an independent bound, hand a captured token a 24-hour window in which it can be turned into AXIAM credentials.",
+                  "mitigation": "max_token_age_secs bounds the token's age independently of its own exp (default 300 s, hard ceiling 3600 s), and an iat in the future beyond 60 s of skew is refused. The issued token's lifetime is the minimum of the partner token's remaining life, the per-provider ceiling, and the server-wide exchange maximum.",
+                  "modelType": "STRIDE",
+                  "number": 158
+                },
+                {
+                  "id": "82310a4d-6f0c-526e-9be9-0553bb1ba203",
+                  "title": "An ID token or refresh token is presented as a subject token (X4)",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Spoofing",
+                  "description": "An ID token is an assertion to a client about a login, which an OIDC deployment distributes more widely and gives a longer life than an access token; a refresh token is a re-authentication credential. Either accepted as a subject token would let an artefact the partner considers low-risk buy an AXIAM credential.",
+                  "mitigation": "Both are refused by name at the subject_token_type check, and \u2014 since a caller can mislabel a token \u2014 again by shape: the ID-token-only claims nonce, at_hash, c_hash and s_hash, and typ headers or claims naming an ID or refresh token, are rejected even when the signature verifies.",
+                  "modelType": "STRIDE",
+                  "number": 159
                 }
               ]
             }
@@ -5769,7 +5824,7 @@
               "isTrustBoundary": false,
               "outOfScope": false,
               "reasonOutOfScope": "",
-              "hasOpenThreats": false,
+              "hasOpenThreats": true,
               "handlesCardPayment": false,
               "handlesGoodsOrServices": false,
               "isWebApplication": false,
@@ -5796,6 +5851,28 @@
                   "mitigation": "JIT provisioning is opt-in per federation config and the created users hold no roles beyond those the mapping allow-list grants.",
                   "modelType": "STRIDE",
                   "number": 73
+                },
+                {
+                  "id": "0010f3ef-fd9d-5a95-85fb-fb26d3a70da6",
+                  "title": "A suspended user is revived through the exchange path (X4)",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Elevation of privilege",
+                  "description": "An AXIAM user who has been locked, deactivated or anonymized would, if the exchange path skipped the status gate, still be able to obtain tokens for as long as their partner IdP kept authenticating them.",
+                  "mitigation": "The resolved user's status is checked after subject resolution and before any token is minted; Locked, Inactive and Anonymized are refused. PendingVerification is allowed deliberately: federation provisioning never moves a federated user off it, so requiring Active would refuse the whole population the feature serves while stopping nobody.",
+                  "modelType": "STRIDE",
+                  "number": 160
+                },
+                {
+                  "id": "96f5b87b-821e-5380-a623-2285211bd217",
+                  "title": "A partner's IdP silently populates the AXIAM user table (X4)",
+                  "status": "Open",
+                  "severity": "Low",
+                  "type": "Denial of service",
+                  "description": "With subject_mapping set to jit_provision, every previously-unseen subject the partner vouches for creates an AXIAM user row. A partner with a large or hostile user population can grow the table without an AXIAM administrator acting.",
+                  "mitigation": "Off by default (linked_only refuses unknown subjects). Every JIT provision is audited with the provider and the external subject, and a provisioned user holds no roles, so the exchange that created them still yields no token. Residual risk accepted: the same exposure the browser SSO JIT path already carries, bounded by the same per-client exchange rate limit.",
+                  "modelType": "STRIDE",
+                  "number": 161
                 }
               ]
             }
@@ -5852,6 +5929,17 @@
                   "mitigation": "SECHRD-09: the federation secret type carries a manual Debug impl that redacts the value, and the secret is encrypted at rest. The same treatment was applied to webhook secrets under SEC-067.",
                   "modelType": "STRIDE",
                   "number": 74
+                },
+                {
+                  "id": "de9240f5-0275-5a1e-b4da-021453bc8734",
+                  "title": "A malformed trust block is enabled without review (X4)",
+                  "status": "Mitigated",
+                  "severity": "Medium",
+                  "type": "Tampering",
+                  "description": "A scope_map entry mapping to no scopes, an out-of-range token age, or an unknown subject_mapping value stored while token exchange is disabled becomes live the moment an administrator ticks the enable box \u2014 which is not where they expect to be told their configuration was wrong.",
+                  "mitigation": "The trust block is validated at the API edge on every write, whether or not it is enabled (only the non-empty-audience rule is conditional). On read, every hydration failure resolves towards the default, and enabled is read from its own column so a corrupt neighbouring column can never switch exchange on. A provider whose stored trust block fails validation is skipped at resolution time with a warning rather than being used.",
+                  "modelType": "STRIDE",
+                  "number": 162
                 }
               ]
             }

--- a/claude_dev/external-token-exchange-design.md
+++ b/claude_dev/external-token-exchange-design.md
@@ -1,0 +1,241 @@
+# External-IdP token exchange (RFC 8693, cross-domain) — design
+
+> X4 of [`extra-B-track-features.md`](extra-B-track-features.md). Companion to
+> [`token-exchange-design.md`](token-exchange-design.md), which this extends
+> rather than replaces: **every B3 rule still applies**, and X4 only widens
+> *which subject tokens are admissible* — never what an exchange may produce.
+>
+> Written before the code, for the same reason B3's was: on this path a
+> plausible-but-wrong validation order is a cross-domain privilege escalation
+> that looks like a successful request.
+
+## What it is for
+
+A partner, or a sibling business unit, runs its own IdP — Entra, Okta,
+Keycloak. Their service calls ours. Today the only options are to provision
+partner credentials in AXIAM (a second identity to keep in sync) or to let the
+partner's token in unverified (no).
+
+X4 is the third option and the enterprise pattern the plan names: **accept a
+trusted partner's token at the mesh edge, emit a scoped AXIAM token.** The
+partner's IdP stays the authority on *who authenticated*; AXIAM stays the
+authority on *what they may do here*.
+
+## The rule B3 states, restated for a foreign issuer
+
+B3: *an exchange may only ever narrow.* With an external subject token there
+is nothing to narrow *from* — the partner's scopes are not AXIAM's scopes and
+carry no authority in this tenant. So the rule becomes:
+
+> **An external subject token is evidence of authentication, never a grant of
+> authorization.** What the resulting AXIAM token may do is decided entirely
+> by AXIAM state: the admin's `scope_map`, the exchanging client's
+> registration, and the RBAC engine's answer for the resolved user. The
+> partner's token can only ever *reduce* that set, never add to it.
+
+Everything below is that sentence applied to one dimension at a time.
+
+## Trust configuration
+
+Per **OIDC federation provider** (the rows `axiam-federation` already owns —
+same `discovery_cache` / `jwks_cache` / SSRF paths, no new fetch surface), a
+new `token_exchange` block:
+
+```
+token_exchange {
+  enabled: bool                       // default FALSE — X4 is opt-in per provider
+  accepted_audiences: [string]        // non-empty REQUIRED when enabled
+  subject_mapping: "linked_only" | "jit_provision"   // default linked_only
+  scope_map: { external value -> [AXIAM scopes] }    // deny-by-default
+  max_token_age_secs: int             // default 300, 1..=3600
+  max_lifetime_secs: option<int>      // per-provider ceiling on the issued token
+}
+```
+
+Notes that are decisions, not defaults:
+
+- **`enabled` defaults to false.** An operator who configured Okta for
+  *login* did not thereby agree to accept Okta tokens as API credentials.
+  Those are different trust statements and they get different switches.
+- **`accepted_audiences` must be non-empty.** A token that was not addressed
+  to us is a token we captured, not a token we were given. Accepting any
+  audience turns every partner-issued token anywhere in their estate into an
+  AXIAM credential — including ones minted for a third party who is not us.
+  There is no "accept all" value; refusing to configure one is the point.
+- **`scope_map` is deny-by-default.** An external value with no entry
+  contributes nothing. There is no passthrough mode, and no identity mapping,
+  because an identity mapping makes the *partner's* admin able to name AXIAM
+  scopes.
+- **`max_token_age_secs`** bounds `now - iat` independently of `exp`. A
+  partner IdP that issues 24-hour access tokens should not thereby be handing
+  out 24-hour-replayable AXIAM entry.
+
+## Which path a subject token takes
+
+The grant reads `iss` from the subject token **without verifying it**, purely
+to route:
+
+| unverified `iss` | path |
+|---|---|
+| equals AXIAM's own issuer | B3 internal path — signature checked against our key |
+| anything else | X4 external path — issuer must match a trusted, exchange-enabled provider |
+
+Routing on an unauthenticated claim is safe **because neither destination
+trusts it**. Claiming to be us lands in a branch that verifies against our
+signing key and fails. Claiming to be a partner lands in a branch that
+verifies against that partner's JWKS and fails. The claim selects which key
+the token is checked against; it never selects *whether* it is checked.
+
+A provider whose discovery document advertises AXIAM's own issuer is refused
+at resolution time, so the two branches can never overlap.
+
+## Validation pipeline (order is normative)
+
+1. **Client**: registered for the exchange grant (B3, unchanged).
+2. **Types**: `subject_token_type` ∈ {`…:access_token`, `…:jwt`}.
+   `…:refresh_token` and `…:id_token` are refused *by name* — a distinct
+   error, because a caller passing one has made a specific mistake.
+3. **`actor_token` is refused on the external path.** Delegation across a
+   trust boundary needs a second trust decision X4 does not make (v1).
+4. **Issuer → provider.** Enabled OIDC providers of this tenant whose
+   `token_exchange.enabled` is true; each one's issuer resolved from its
+   cached discovery document; **exact string match**, no normalisation, no
+   trailing-slash forgiveness. No match ⇒ refuse.
+5. **Signature.** `alg` allow-list from the provider's `allowed_algorithms`
+   (`none` refused twice, raw and parsed — same code path OIDC login uses),
+   JWKS from the cache, unknown-`kid` forced refetch (existing rollover
+   behaviour).
+6. **Claims.** `iss` bound to the discovery issuer; `exp`, `iat` required;
+   `nbf` honoured when present; 60 s skew. Then `now - iat ≤
+   max_token_age_secs`, and an `iat` in the future beyond skew is refused.
+7. **Audience.** `aud` (string or array) ∩ `accepted_audiences` ≠ ∅.
+8. **Shape.** ID tokens and refresh tokens are refused even when correctly
+   signed: an ID token is an assertion *to a client about a login*, not a
+   credential for an API, and OIDC deliberately gives it a longer-lived,
+   more widely-distributed life. Detected by `nonce` / `at_hash` / `c_hash` /
+   `s_hash` claims and by a `typ` header naming an ID or refresh token.
+9. **No transitivity.** A token carrying `ext_exchange` is refused —
+   here *and* on the internal path. See below.
+10. **Subject.** `(provider, sub)` → federation link → AXIAM user. Unlinked
+    ⇒ refuse under `linked_only`, or provision via the existing federation
+    JIT path under `jit_provision`, audited as such. The resolved user must
+    be **active**; a suspended user is not resurrected by a partner token.
+11. **Scopes** (below).
+12. **Audience of the issued token** — B3's rule, with one change: when the
+    request names no `audience`/`resource`, the issued token gets
+    `axiam:user`. It **never inherits the external token's `aud`**, which
+    names the partner's resource server and would be meaningless — or worse,
+    coincidentally meaningful — here.
+13. **Lifetime** = min(subject token remaining, provider `max_lifetime_secs`,
+    B3's configured exchange maximum).
+
+## Scopes: three gates, in this order
+
+```
+candidate = ⋃ scope_map[v]  for each v the external token asserts
+granted   = requested ∩ candidate ∩ client.scopes ∩ engine(user)
+```
+
+The external token's assertions are read from the `scope`/`scp` string claims
+and the `roles`/`groups` array claims — the four shapes Entra, Okta and
+Keycloak actually emit. Anything else is invisible to the map, which is the
+conservative direction.
+
+`engine(user)` is the RBAC engine consulted at mint time, using the mapping
+X2 already pinned: **an AXIAM scope name is an action**. A scope survives
+only if the user holds an `allow` grant for that action and **no `deny` grant
+for it anywhere in their applicable roles** — deny-override (B1) at its
+broadest reading, deliberately: this is a cross-domain path, and the cheap
+conservative answer is the right one.
+
+**Explicit requests refuse; the default drops.** If the caller names `scope`,
+a value it cannot have is `invalid_scope` naming the offender (B3's rule — a
+silently-narrowed token fails at the second service instead of at the
+exchange). If the caller names nothing, the result is whatever survives all
+four gates. This *is* a divergence from B3, and it is deliberate: B3's
+default is the subject token's own scopes, which pass the subject gate by
+construction, whereas `scope_map` output is admin-configured for a provider
+and routinely exceeds what any individual user holds. Refusing there would
+make the no-`scope` call fail for everyone but the most privileged user.
+
+An empty result is `invalid_scope`, never a scopeless token.
+
+## No transitive exchange
+
+Every token minted from an external subject token carries
+
+```json
+{ "ext_exchange": { "iss": "https://partner.example/" } }
+```
+
+alongside B3's `act`, and **both exchange paths refuse a subject token that
+carries it**. So:
+
+- an AXIAM token minted from a partner token cannot be exchanged again, and
+- a partner token that itself carries the claim (because the partner runs
+  AXIAM, or copied the convention) cannot be exchanged here.
+
+Without this, trust composes silently: A trusts B, B trusts C, therefore A
+trusts C — which nobody configured and nobody can see in either config.
+
+The claim is also the audit trail's anchor and is visible via introspection,
+so a resource server can tell a cross-domain token from a locally-issued one
+without asking us.
+
+## Why `may_impersonate` is *not* required here
+
+An external exchange emits no `act` claim, which in B3 terms looks like
+impersonation. It is not. Impersonation is "this client asserts it may be the
+user, on its own authority". An external exchange is "a trusted IdP asserts
+the user authenticated, and the token was addressed to us". The evidence is
+different in kind, so the gate is different: the per-provider `enabled` flag
+plus `accepted_audiences`, not a per-client impersonation grant.
+
+What is the same is the audit obligation — see below.
+
+## Rejections
+
+| Condition | Error | Description says |
+|---|---|---|
+| Issuer matches no exchange-enabled provider | `invalid_grant` | "…issuer is not configured for token exchange" |
+| Signature / claim / age / audience failure | `invalid_grant` | generic |
+| `subject_token_type` is a refresh or ID token type | `invalid_request` | names the type |
+| Token is shaped like an ID/refresh token | `invalid_grant` | generic |
+| `actor_token` present on the external path | `invalid_request` | v1 unsupported |
+| Subject token carries `ext_exchange` | `invalid_request` | "already the product of an exchange" |
+| Unlinked subject under `linked_only` | `invalid_grant` | generic |
+| Resolved user not active | `invalid_grant` | generic |
+| Requested scope outside the map / client / engine | `invalid_scope` | names the scope |
+| Empty scope result | `invalid_scope` | generic |
+
+Untrusted-issuer is the one failure given a *distinguishable* description,
+because the exchanging client is an authenticated confidential client of this
+tenant, not an anonymous prober — telling it that a partner it named is not
+configured leaks nothing it could not get from the admin, and without it the
+SDK cannot tell "fix your config" from "fix your token".
+
+## Audit
+
+Every external exchange, successful or refused, records: exchanging client,
+external issuer, external subject, provider config id, resolved AXIAM user,
+whether the user was JIT-provisioned, granted scopes, audience, and outcome.
+For a JIT provision this is the only record that a partner's IdP created an
+AXIAM user.
+
+## Tests, mapped to rules
+
+- Validation matrix: each invariant violated **in isolation** produces its
+  own error — untrusted issuer, bad signature, expired, `iat` too old,
+  audience disjoint, ID-token shape, refresh-token type, `actor_token`
+  present, unlinked, inactive user.
+- JWKS rollover mid-flight (unknown `kid` → forced refetch → success).
+- JIT on and off against the same unlinked subject.
+- Transitive rejection **both directions**: our `ext_exchange` token refused
+  on the internal path; a foreign token carrying it refused on the external
+  path.
+- Scope-map property test: output ⊆ map range ∩ client scopes ∩ engine
+  answer, over generated inputs.
+- `aud` never inherited from the external token.
+- Lifetime never exceeds the external token's remaining life.
+- Cross-vendor proof: fixtures minted by a real Keycloak container in the
+  e2e suite.

--- a/crates/axiam-api-grpc/src/services/authorization.rs
+++ b/crates/axiam-api-grpc/src/services/authorization.rs
@@ -388,6 +388,7 @@ mod tests {
             // through a token exchange, so it carries no actor chain.
             act: None,
             permissions: None,
+            ext_exchange: None,
         });
 
         let svc = AuthorizationServiceImpl::new(make_engine(&db), 2);

--- a/crates/axiam-api-rest/src/extractors/auth.rs
+++ b/crates/axiam-api-rest/src/extractors/auth.rs
@@ -606,6 +606,7 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=\n\
             sub_kind: SubjectKind::User,
             act: None,
             permissions: None,
+            ext_exchange: None,
         };
         let key = EncodingKey::from_ed_pem(config.jwt_private_key_pem.as_bytes()).unwrap();
         let header = Header::new(Algorithm::EdDSA);

--- a/crates/axiam-api-rest/src/handlers/federation.rs
+++ b/crates/axiam-api-rest/src/handlers/federation.rs
@@ -5,8 +5,8 @@
 
 use actix_web::{HttpResponse, web};
 use axiam_core::models::federation::{
-    CreateFederationConfig, FederationConfig, FederationLink, FederationProtocol,
-    UpdateFederationConfig,
+    CreateFederationConfig, FederationConfig, FederationLink, FederationProtocol, SubjectMapping,
+    TokenExchangeTrust, UpdateFederationConfig,
 };
 use axiam_core::repository::{
     FederationConfigRepository, FederationLinkRepository, PaginatedResult, Pagination,
@@ -34,6 +34,96 @@ use crate::state::AppState;
 // Request / response DTOs
 // ---------------------------------------------------------------------------
 
+/// X4 trust for exchanging this provider's tokens (RFC 8693, external issuer).
+///
+/// Mirrors [`TokenExchangeTrust`] on the wire rather than reusing it directly
+/// so the API surface can carry its own defaults: an admin PUTting a partial
+/// block gets the documented default for anything they omitted, instead of a
+/// deserialization error listing fields they have never heard of.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct TokenExchangeTrustRequest {
+    /// Off unless explicitly enabled. Configuring a provider for *login* is
+    /// not agreement to accept its tokens as API credentials.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Audiences an incoming subject token may name. Required (non-empty)
+    /// when `enabled`; there is deliberately no accept-all value.
+    #[serde(default)]
+    pub accepted_audiences: Vec<String>,
+    /// `linked_only` (default) or `jit_provision`.
+    #[serde(default)]
+    pub subject_mapping: Option<String>,
+    /// External asserted value -> AXIAM scopes. Deny-by-default: an external
+    /// value with no entry contributes nothing.
+    #[serde(default)]
+    pub scope_map: std::collections::BTreeMap<String, Vec<String>>,
+    /// Bound on `now - iat`, independent of the token's own `exp`.
+    #[serde(default)]
+    pub max_token_age_secs: Option<i64>,
+    /// Per-provider ceiling on the issued AXIAM token's lifetime.
+    #[serde(default)]
+    pub max_lifetime_secs: Option<i64>,
+}
+
+impl TokenExchangeTrustRequest {
+    /// Convert and validate in one step.
+    ///
+    /// Validation happens **here**, at the edge, rather than in the
+    /// repository: this is the only layer that can tell an operator *which*
+    /// field they got wrong, and a trust block that reaches storage malformed
+    /// is one an admin later enables without being told.
+    fn into_domain(self) -> Result<TokenExchangeTrust, AxiamApiError> {
+        let subject_mapping = match self.subject_mapping.as_deref() {
+            None => SubjectMapping::default(),
+            Some(raw) => SubjectMapping::from_wire(raw).ok_or_else(|| {
+                validation_err(
+                    "token_exchange.subject_mapping must be 'linked_only' or 'jit_provision'",
+                )
+            })?,
+        };
+        let trust = TokenExchangeTrust {
+            enabled: self.enabled,
+            accepted_audiences: self.accepted_audiences,
+            subject_mapping,
+            scope_map: self.scope_map,
+            max_token_age_secs: self
+                .max_token_age_secs
+                .unwrap_or(axiam_core::models::federation::DEFAULT_MAX_TOKEN_AGE_SECS),
+            max_lifetime_secs: self.max_lifetime_secs,
+        };
+        trust
+            .validate()
+            .map_err(|e| validation_err(e.to_string()))?;
+        Ok(trust)
+    }
+}
+
+/// X4 trust as returned. Same shape as the request; nothing here is secret —
+/// an operator reading a provider needs to see exactly what it trusts.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct TokenExchangeTrustResponse {
+    pub enabled: bool,
+    pub accepted_audiences: Vec<String>,
+    pub subject_mapping: String,
+    pub scope_map: std::collections::BTreeMap<String, Vec<String>>,
+    pub max_token_age_secs: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_lifetime_secs: Option<i64>,
+}
+
+impl From<TokenExchangeTrust> for TokenExchangeTrustResponse {
+    fn from(t: TokenExchangeTrust) -> Self {
+        Self {
+            enabled: t.enabled,
+            accepted_audiences: t.accepted_audiences,
+            subject_mapping: t.subject_mapping.as_str().to_owned(),
+            scope_map: t.scope_map,
+            max_token_age_secs: t.max_token_age_secs,
+            max_lifetime_secs: t.max_lifetime_secs,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct CreateFederationConfigRequest {
     /// Display name for the identity provider (e.g., "Google", "Okta").
@@ -54,6 +144,8 @@ pub struct CreateFederationConfigRequest {
     /// Accepted JWT signing algorithms (OIDC) or signature algorithms (SAML).
     /// Defaults to `["RS256"]` when not provided (CQ-B40/REQ-14 AC-5).
     pub allowed_algorithms: Option<Vec<String>>,
+    /// X4 external token-exchange trust. Omitted means disabled.
+    pub token_exchange: Option<TokenExchangeTrustRequest>,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -69,6 +161,10 @@ pub struct UpdateFederationConfigRequest {
     pub idp_signing_cert_pem: Option<Option<String>>,
     /// Accepted signature algorithms (CQ-B40/REQ-14 AC-5).
     pub allowed_algorithms: Option<Vec<String>>,
+    /// X4 external token-exchange trust. Replaced **wholesale** when present:
+    /// a partial merge of a trust configuration is how an operator ends up
+    /// keeping an `accepted_audiences` entry they believed they had removed.
+    pub token_exchange: Option<TokenExchangeTrustRequest>,
 }
 
 /// Federation config response -- omits client_secret.
@@ -82,6 +178,8 @@ pub struct FederationConfigResponse {
     pub client_id: String,
     pub attribute_map: serde_json::Value,
     pub enabled: bool,
+    /// X4 external token-exchange trust.
+    pub token_exchange: TokenExchangeTrustResponse,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -97,6 +195,7 @@ impl From<FederationConfig> for FederationConfigResponse {
             client_id: c.client_id,
             attribute_map: c.attribute_map,
             enabled: c.enabled,
+            token_exchange: c.token_exchange.into(),
             created_at: c.created_at,
             updated_at: c.updated_at,
         }
@@ -240,6 +339,21 @@ pub async fn create<C: Connection + Clone>(
         _ => return Err(validation_err("protocol must be 'OidcConnect' or 'Saml'")),
     };
 
+    // X4: validated before anything is written, and refused outright on SAML.
+    // A SAML provider has no issuer to match and no JWKS to verify against, so
+    // an enabled trust block on one is not a harmless no-op — it is a claim in
+    // the admin UI that tokens are being accepted when nothing could accept
+    // them.
+    let token_exchange = req.token_exchange.map(|t| t.into_domain()).transpose()?;
+    if let Some(ref t) = token_exchange
+        && t.enabled
+        && protocol != FederationProtocol::OidcConnect
+    {
+        return Err(validation_err(
+            "token_exchange is only supported for OidcConnect providers",
+        ));
+    }
+
     // Validate IdP signing cert PEM before storage so garbage certs are
     // rejected at upload rather than at assertion-verification time (CQ-B40).
     if let Some(ref pem) = req.idp_signing_cert_pem {
@@ -275,6 +389,7 @@ pub async fn create<C: Connection + Clone>(
             attribute_map: req.attribute_map,
             idp_signing_cert_pem: req.idp_signing_cert_pem,
             allowed_algorithms: req.allowed_algorithms,
+            token_exchange,
         })
         .await?;
 
@@ -421,6 +536,24 @@ pub async fn update<C: Connection + Clone>(
             .map_err(|e| validation_err(format!("idp_signing_cert_pem is invalid: {e}")))?;
     }
 
+    // X4: validated before the write, and refused on a SAML row for the same
+    // reason `create` refuses it — the protocol is immutable after creation,
+    // so the existing row's protocol is the one that matters.
+    let token_exchange = req.token_exchange.map(|t| t.into_domain()).transpose()?;
+    if let Some(ref t) = token_exchange
+        && t.enabled
+    {
+        let existing = state
+            .federation_config_repo
+            .get_by_id(user.tenant_id, id)
+            .await?;
+        if existing.protocol != FederationProtocol::OidcConnect {
+            return Err(validation_err(
+                "token_exchange is only supported for OidcConnect providers",
+            ));
+        }
+    }
+
     // If the caller is rotating the client_secret, encrypt it before storage
     // (SEC-045). Plaintext never reaches the DB layer.
     let new_secret_plaintext = req.client_secret.clone();
@@ -441,6 +574,7 @@ pub async fn update<C: Connection + Clone>(
                 enabled: req.enabled,
                 idp_signing_cert_pem: req.idp_signing_cert_pem,
                 allowed_algorithms: req.allowed_algorithms,
+                token_exchange,
             },
         )
         .await?;

--- a/crates/axiam-api-rest/src/handlers/oauth2.rs
+++ b/crates/axiam-api-rest/src/handlers/oauth2.rs
@@ -1229,6 +1229,12 @@ async fn handle_token_exchange<C: Connection + Clone>(
             // the acting party was not the subject — the token deliberately
             // carries no `act` claim — so it must not be lost to a crash
             // between issuing and logging.
+            // X4: an external exchange's provenance is recorded in the same
+            // entry, not a second one. A reader correlating two lines by
+            // timestamp is a reader who can be made to correlate the wrong
+            // two, and for a JIT provision this is the only record that a
+            // partner's IdP created an AXIAM user.
+            let ext = outcome.external.as_ref();
             tracing::info!(
                 target: "axiam::audit",
                 event = "oauth2.token_exchange",
@@ -1239,6 +1245,13 @@ async fn handle_token_exchange<C: Connection + Clone>(
                 actor = outcome.actor.as_deref().unwrap_or("-"),
                 granted_scopes = %outcome.granted_scopes.join(" "),
                 audience = %outcome.audience,
+                external_issuer = ext.map(|e| e.issuer.as_str()).unwrap_or("-"),
+                external_subject = ext.map(|e| e.external_subject.as_str()).unwrap_or("-"),
+                federation_provider = ext.map(|e| e.provider_name.as_str()).unwrap_or("-"),
+                federation_config_id = ext
+                    .map(|e| e.provider_id.to_string())
+                    .unwrap_or_else(|| "-".into()),
+                jit_provisioned = ext.is_some_and(|e| e.newly_provisioned),
                 "token exchange"
             );
             HttpResponse::Ok()

--- a/crates/axiam-api-rest/src/lib.rs
+++ b/crates/axiam-api-rest/src/lib.rs
@@ -14,6 +14,7 @@ pub mod permissions;
 pub mod server;
 pub mod state;
 pub mod tenant_org_cache;
+pub mod token_exchange;
 pub mod uma;
 pub mod webhook;
 pub mod webhook_consumer;

--- a/crates/axiam-api-rest/src/openapi.rs
+++ b/crates/axiam-api-rest/src/openapi.rs
@@ -353,6 +353,9 @@ use crate::handlers;
         handlers::federation::CreateFederationConfigRequest,
         handlers::federation::UpdateFederationConfigRequest,
         handlers::federation::FederationConfigResponse,
+        // X4 — external-IdP token-exchange trust.
+        handlers::federation::TokenExchangeTrustRequest,
+        handlers::federation::TokenExchangeTrustResponse,
         handlers::federation::OidcAuthorizeRequest,
         handlers::federation::OidcCallbackRequest,
         handlers::federation::OidcCallbackResponse,

--- a/crates/axiam-api-rest/src/state.rs
+++ b/crates/axiam-api-rest/src/state.rs
@@ -428,6 +428,39 @@ pub struct AppState<C: Connection + Clone> {
 }
 
 impl<C: Connection + Clone> AppState<C> {
+    /// Switch on X4's external token-exchange path.
+    ///
+    /// A method on the assembled state rather than a constructor parameter,
+    /// because the collaborator it needs — the OIDC federation service — is
+    /// itself conditional on `AXIAM__AUTH__FEDERATION_ENCRYPTION_KEY` and is
+    /// installed after this state is built.
+    ///
+    /// **No federation service ⇒ no external path**, and that is the correct
+    /// coupling rather than an accident of ordering: without the encryption
+    /// key there is no way to read a provider's configuration, so there is
+    /// nothing to trust an external issuer *with*. Returns whether it was
+    /// enabled, so a caller can log the posture instead of guessing at it.
+    #[must_use = "the return value says whether the external path is actually live"]
+    pub fn enable_external_token_exchange(&mut self) -> bool {
+        let Some(federation) = self.oidc_federation_service.clone() else {
+            return false;
+        };
+        let (resolver, authority) = crate::token_exchange::external_collaborators(
+            federation,
+            self.role_repo.clone(),
+            self.permission_repo.clone(),
+        );
+        // `with_external_subjects` consumes and returns, so the field is
+        // rebuilt rather than mutated in place — the service is a handful of
+        // cheap handles, so this costs nothing and keeps the "both or
+        // neither" pairing enforced by the type.
+        self.token_exchange_service = self
+            .token_exchange_service
+            .clone()
+            .with_external_subjects(resolver, authority);
+        true
+    }
+
     /// Assemble the X2 UMA service for one request.
     ///
     /// Built per call rather than stored, because it needs the

--- a/crates/axiam-api-rest/src/tests/authz_check_test.rs
+++ b/crates/axiam-api-rest/src/tests/authz_check_test.rs
@@ -71,6 +71,7 @@ fn make_user(tenant_id: Uuid, user_id: Uuid) -> AuthenticatedPrincipal {
         sub_kind: SubjectKind::User,
         act: None,
         permissions: None,
+        ext_exchange: None,
     });
     AuthenticatedPrincipal {
         subject_id: user_id,
@@ -97,6 +98,7 @@ fn make_machine(tenant_id: Uuid, service_account_id: Uuid) -> AuthenticatedPrinc
         sub_kind: axiam_auth::token::SubjectKind::ServiceAccount,
         act: None,
         permissions: None,
+        ext_exchange: None,
     });
 
     AuthenticatedPrincipal {

--- a/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
+++ b/crates/axiam-api-rest/src/tests/user_invalidation_test.rs
@@ -103,6 +103,7 @@ fn make_admin(tenant_id: Uuid) -> AuthenticatedUser {
             sub_kind: SubjectKind::User,
             act: None,
             permissions: None,
+            ext_exchange: None,
         }),
     }
 }

--- a/crates/axiam-api-rest/src/token_exchange.rs
+++ b/crates/axiam-api-rest/src/token_exchange.rs
@@ -1,0 +1,525 @@
+//! X4 — the two adapters that connect the external token-exchange path to the
+//! running system.
+//!
+//! Same seam, and the same reasoning, as [`crate::uma`]: `axiam-oauth2` defines
+//! the grant against narrow traits rather than against `axiam-federation` and
+//! `axiam-authz` directly, so its own tests can drive every branch without a
+//! datastore or a network. This is where those traits get production
+//! implementations, because `axiam-api-rest` is the first crate holding both.
+//!
+//! Both adapters are deliberately thin — logic that lands here is logic the
+//! exchange's unit tests cannot see. The one exception is
+//! [`RbacScopeAuthority`], whose deny-override reading is genuinely a decision
+//! and is argued in full on the type.
+
+use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use axiam_core::models::permission::PermissionEffect;
+use axiam_core::repository::{PermissionRepository, RoleRepository};
+use axiam_federation::oidc::OidcFederationService;
+use axiam_federation::token_exchange::ExternalSubjectError;
+use axiam_oauth2::token_exchange::{
+    ExternalSubjectRejection, ExternalSubjectResolver, ResolvedExternalSubject,
+    SubjectScopeAuthority,
+};
+use uuid::Uuid;
+
+/// Resolves an external IdP's subject token through `axiam-federation`.
+///
+/// Pure translation: every decision — which providers are trusted, how the
+/// signature is checked, which user an `(issuer, sub)` pair means — belongs to
+/// [`OidcFederationService::verify_external_subject_token`], where it sits
+/// beside the login path that answers the same questions.
+pub struct FederationSubjectResolver<FC, FL, UR> {
+    federation: OidcFederationService<FC, FL, UR>,
+}
+
+impl<FC, FL, UR> FederationSubjectResolver<FC, FL, UR> {
+    pub fn new(federation: OidcFederationService<FC, FL, UR>) -> Self {
+        Self { federation }
+    }
+}
+
+impl<FC, FL, UR> ExternalSubjectResolver for FederationSubjectResolver<FC, FL, UR>
+where
+    FC: axiam_core::repository::FederationConfigRepository,
+    FL: axiam_core::repository::FederationLinkRepository,
+    UR: axiam_core::repository::UserRepository,
+{
+    fn resolve<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        subject_token: &'a str,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<ResolvedExternalSubject, ExternalSubjectRejection>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            let now = chrono::Utc::now().timestamp();
+            match self
+                .federation
+                .verify_external_subject_token(tenant_id, subject_token, now)
+                .await
+            {
+                Ok(s) => Ok(ResolvedExternalSubject {
+                    issuer: s.issuer,
+                    provider_id: s.provider_id,
+                    provider_name: s.provider_name,
+                    external_subject: s.external_subject,
+                    user_id: s.user_id,
+                    newly_provisioned: s.newly_provisioned,
+                    candidate_scopes: s.candidate_scopes,
+                    subject_exp: s.subject_exp,
+                    max_lifetime_secs: s.max_lifetime_secs,
+                }),
+                Err(ExternalSubjectError::IssuerNotTrusted) => {
+                    Err(ExternalSubjectRejection::IssuerNotTrusted)
+                }
+                Err(ExternalSubjectError::Server(m)) => Err(ExternalSubjectRejection::Server(m)),
+                // "Not linked", "not active" and every token-level failure
+                // collapse to one wire answer on purpose: they are all facts
+                // about the *presented token's subject*, and distinguishing
+                // them for the caller would turn the grant into a probe for
+                // which partner identities exist in this tenant and what state
+                // they are in. The distinction survives where it is useful —
+                // the reason code below goes to the audit record.
+                Err(other) => Err(ExternalSubjectRejection::Rejected(
+                    other.reason_code().to_string(),
+                )),
+            }
+        })
+    }
+}
+
+/// Answers "which of these AXIAM scope names does this user actually hold",
+/// from the RBAC engine's own data.
+///
+/// # The mapping
+///
+/// An AXIAM scope name is checked as an **`action`**, the same mapping X2
+/// pinned for UMA resource scopes (`claude_dev/uma-mapping-design.md`). Using
+/// one vocabulary across both features means an operator writes `read:orders`
+/// once and it means the same thing in a permission grant, a UMA ticket and a
+/// `scope_map` entry.
+///
+/// # Why it is not a `check_access` call
+///
+/// [`AccessRequest`](axiam_authz::types::AccessRequest) is *resource-scoped*,
+/// and an OAuth2 scope is not: `read:orders` in a token is a claim about the
+/// bearer, not about one row. There is no resource id to put in the request,
+/// and inventing one — a tenant root, a per-provider configured resource —
+/// would be inventing a policy surface X4 was not asked to add.
+///
+/// So this reads the same two tables the engine reads and answers the question
+/// the engine is never asked: **does this user hold this action anywhere in
+/// this tenant?**
+///
+/// # Deny-override, at its broadest reading
+///
+/// A scope survives only if the user has an `allow` grant for the action **and
+/// no `deny` grant for it anywhere in their applicable roles**. A deny scoped
+/// to one resource therefore withholds the *scope* entirely, even though the
+/// same deny would only veto that one resource in a live `check_access`.
+///
+/// That asymmetry is deliberate, and it is the conservative direction. A
+/// bearer scope cannot express "except on resource X" — it travels in a token
+/// with no resource attached — so the only two honest answers are "grant it
+/// everywhere" or "do not grant it". On a cross-domain path, taking the
+/// narrower answer costs an operator one extra grant and buys the property
+/// that **adding a deny rule can never widen what a partner token can reach**,
+/// which is exactly the property B1 chose deny-override to get.
+///
+/// The live check still governs every actual request: a token carrying
+/// `read:orders` does not thereby read anything, it merely presents a scope
+/// the engine then evaluates per resource.
+pub struct RbacScopeAuthority<RR, PR> {
+    role_repo: RR,
+    permission_repo: PR,
+}
+
+impl<RR, PR> RbacScopeAuthority<RR, PR> {
+    pub fn new(role_repo: RR, permission_repo: PR) -> Self {
+        Self {
+            role_repo,
+            permission_repo,
+        }
+    }
+}
+
+impl<RR, PR> SubjectScopeAuthority for RbacScopeAuthority<RR, PR>
+where
+    RR: RoleRepository + Send + Sync,
+    PR: PermissionRepository + Send + Sync,
+{
+    fn held_scopes<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        subject_id: Uuid,
+        candidates: &'a [String],
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            if candidates.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            let assignments = self
+                .role_repo
+                .get_user_role_assignments(tenant_id, subject_id)
+                .await
+                .map_err(|e| e.to_string())?;
+            if assignments.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            // Deduplicated: a user assigned the same role globally and on a
+            // resource yields two assignments and one role's grants.
+            let mut role_ids: Vec<Uuid> = Vec::with_capacity(assignments.len());
+            for a in &assignments {
+                if !role_ids.contains(&a.role.id) {
+                    role_ids.push(a.role.id);
+                }
+            }
+
+            let grants_by_role = self
+                .permission_repo
+                .get_role_permission_grants_for_roles(tenant_id, &role_ids)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let wanted: HashSet<&str> = candidates.iter().map(String::as_str).collect();
+            let mut allowed: HashSet<String> = HashSet::new();
+            let mut denied: HashSet<String> = HashSet::new();
+            for grants in grants_by_role.values() {
+                for grant in grants {
+                    if !wanted.contains(grant.permission.action.as_str()) {
+                        continue;
+                    }
+                    match grant.effect {
+                        PermissionEffect::Allow => {
+                            allowed.insert(grant.permission.action.clone());
+                        }
+                        PermissionEffect::Deny => {
+                            denied.insert(grant.permission.action.clone());
+                        }
+                    }
+                }
+            }
+
+            // Order follows `candidates`, not the datastore's, so the result
+            // is deterministic and the issued token's `scope` string is stable
+            // across calls.
+            Ok(candidates
+                .iter()
+                .filter(|c| allowed.contains(*c) && !denied.contains(*c))
+                .cloned()
+                .collect())
+        })
+    }
+}
+
+/// Boxed pair, as the exchange service takes them.
+pub fn external_collaborators<FC, FL, UR, RR, PR>(
+    federation: OidcFederationService<FC, FL, UR>,
+    role_repo: RR,
+    permission_repo: PR,
+) -> (
+    Arc<dyn ExternalSubjectResolver>,
+    Arc<dyn SubjectScopeAuthority>,
+)
+where
+    FC: axiam_core::repository::FederationConfigRepository + 'static,
+    FL: axiam_core::repository::FederationLinkRepository + 'static,
+    UR: axiam_core::repository::UserRepository + 'static,
+    RR: RoleRepository + Send + Sync + 'static,
+    PR: PermissionRepository + Send + Sync + 'static,
+{
+    (
+        Arc::new(FederationSubjectResolver::new(federation)),
+        Arc::new(RbacScopeAuthority::new(role_repo, permission_repo)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axiam_core::error::AxiamResult;
+    use axiam_core::models::permission::{Permission, PermissionGrant};
+    use axiam_core::models::role::{Role, RoleAssignment};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    // ---- minimal stubs over just the two methods the authority uses ----
+
+    #[derive(Clone, Default)]
+    struct StubRoles(Vec<RoleAssignment>);
+
+    fn role(name: &str) -> Role {
+        Role {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            name: name.into(),
+            description: String::new(),
+            is_global: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn grant(action: &str, effect: PermissionEffect) -> PermissionGrant {
+        PermissionGrant {
+            permission: Permission {
+                id: Uuid::new_v4(),
+                tenant_id: Uuid::new_v4(),
+                action: action.into(),
+                description: String::new(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            },
+            scope_ids: Vec::new(),
+            effect,
+        }
+    }
+
+    /// Only `get_user_role_assignments` and
+    /// `get_role_permission_grants_for_roles` are reachable from the adapter;
+    /// the rest of both traits is `unimplemented!()` so a future refactor that
+    /// starts calling something else fails loudly instead of silently reading
+    /// a stub's default.
+    macro_rules! unreachable_method {
+        ($name:ident ( $($arg:ty),* ) -> $ret:ty) => {
+            async fn $name(&self, $(_: $arg),*) -> AxiamResult<$ret> { unimplemented!() }
+        };
+    }
+
+    impl RoleRepository for StubRoles {
+        async fn get_user_role_assignments(
+            &self,
+            _tenant_id: Uuid,
+            _user_id: Uuid,
+        ) -> AxiamResult<Vec<RoleAssignment>> {
+            Ok(self.0.clone())
+        }
+        unreachable_method!(create(axiam_core::models::role::CreateRole) -> Role);
+        unreachable_method!(get_by_id(Uuid, Uuid) -> Role);
+        unreachable_method!(update(Uuid, Uuid, axiam_core::models::role::UpdateRole) -> Role);
+        unreachable_method!(delete(Uuid, Uuid) -> ());
+        async fn list(
+            &self,
+            _t: Uuid,
+            _p: axiam_core::repository::Pagination,
+        ) -> AxiamResult<axiam_core::repository::PaginatedResult<Role>> {
+            unimplemented!()
+        }
+        unreachable_method!(assign_to_user(Uuid, Uuid, Uuid, Option<Uuid>) -> ());
+        unreachable_method!(unassign_from_user(Uuid, Uuid, Uuid, Option<Uuid>) -> ());
+        unreachable_method!(get_user_roles(Uuid, Uuid) -> Vec<Role>);
+        unreachable_method!(assign_to_group(Uuid, Uuid, Uuid, Option<Uuid>) -> ());
+        unreachable_method!(unassign_from_group(Uuid, Uuid, Uuid, Option<Uuid>) -> ());
+        unreachable_method!(get_group_roles(Uuid, Uuid) -> Vec<Role>);
+        unreachable_method!(get_role_user_ids(Uuid, Uuid) -> Vec<Uuid>);
+        unreachable_method!(get_role_group_ids(Uuid, Uuid) -> Vec<Uuid>);
+    }
+
+    #[derive(Clone, Default)]
+    struct StubPermissions(HashMap<Uuid, Vec<PermissionGrant>>);
+
+    impl PermissionRepository for StubPermissions {
+        async fn get_role_permission_grants_for_roles(
+            &self,
+            _tenant_id: Uuid,
+            role_ids: &[Uuid],
+        ) -> AxiamResult<HashMap<Uuid, Vec<PermissionGrant>>> {
+            Ok(role_ids
+                .iter()
+                .filter_map(|id| self.0.get(id).map(|g| (*id, g.clone())))
+                .collect())
+        }
+        unreachable_method!(create(axiam_core::models::permission::CreatePermission) -> Permission);
+        unreachable_method!(get_by_id(Uuid, Uuid) -> Permission);
+        unreachable_method!(
+            update(Uuid, Uuid, axiam_core::models::permission::UpdatePermission) -> Permission
+        );
+        unreachable_method!(delete(Uuid, Uuid) -> ());
+        async fn list(
+            &self,
+            _t: Uuid,
+            _p: axiam_core::repository::Pagination,
+        ) -> AxiamResult<axiam_core::repository::PaginatedResult<Permission>> {
+            unimplemented!()
+        }
+        unreachable_method!(grant_to_role(Uuid, Uuid, Uuid) -> ());
+        unreachable_method!(revoke_from_role(Uuid, Uuid, Uuid) -> ());
+        unreachable_method!(get_role_permissions(Uuid, Uuid) -> Vec<Permission>);
+        unreachable_method!(grant_to_role_with_scopes(Uuid, Uuid, Uuid, Vec<Uuid>) -> ());
+        unreachable_method!(
+            grant_to_role_with_effect(Uuid, Uuid, Uuid, Vec<Uuid>, PermissionEffect) -> ()
+        );
+        unreachable_method!(get_role_permission_grants(Uuid, Uuid) -> Vec<PermissionGrant>);
+    }
+
+    fn authority(
+        assignments: Vec<RoleAssignment>,
+        grants: HashMap<Uuid, Vec<PermissionGrant>>,
+    ) -> RbacScopeAuthority<StubRoles, StubPermissions> {
+        RbacScopeAuthority::new(StubRoles(assignments), StubPermissions(grants))
+    }
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn a_user_with_no_roles_holds_nothing() {
+        let a = authority(vec![], HashMap::new());
+        assert!(
+            a.held_scopes(Uuid::new_v4(), Uuid::new_v4(), &v(&["read:orders"]))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_allow_grant_for_the_action_holds_the_scope() {
+        let r = role("reader");
+        let mut grants = HashMap::new();
+        grants.insert(r.id, vec![grant("read:orders", PermissionEffect::Allow)]);
+        let a = authority(
+            vec![RoleAssignment {
+                role: r,
+                resource_id: None,
+            }],
+            grants,
+        );
+
+        assert_eq!(
+            a.held_scopes(Uuid::new_v4(), Uuid::new_v4(), &v(&["read:orders"]))
+                .await
+                .unwrap(),
+            v(&["read:orders"])
+        );
+    }
+
+    /// The decision this type exists to make explicit: a deny anywhere in the
+    /// user's applicable roles withholds the scope, even alongside an allow.
+    /// A bearer scope cannot say "except on resource X", so the only honest
+    /// answers are "everywhere" and "not at all".
+    #[tokio::test]
+    async fn a_deny_anywhere_withholds_the_scope_even_against_an_allow() {
+        let allower = role("reader");
+        let denier = role("embargoed");
+        let mut grants = HashMap::new();
+        grants.insert(
+            allower.id,
+            vec![grant("read:orders", PermissionEffect::Allow)],
+        );
+        grants.insert(
+            denier.id,
+            vec![grant("read:orders", PermissionEffect::Deny)],
+        );
+
+        let a = authority(
+            vec![
+                RoleAssignment {
+                    role: allower,
+                    resource_id: None,
+                },
+                RoleAssignment {
+                    role: denier,
+                    // Scoped to one resource — and it still withholds the
+                    // whole scope. That is the conservative reading, argued on
+                    // `RbacScopeAuthority`.
+                    resource_id: Some(Uuid::new_v4()),
+                },
+            ],
+            grants,
+        );
+
+        assert!(
+            a.held_scopes(Uuid::new_v4(), Uuid::new_v4(), &v(&["read:orders"]))
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// The port's contract: a filter, never a source. Whatever comes back was
+    /// in `candidates`.
+    #[tokio::test]
+    async fn the_result_is_always_a_subset_of_the_candidates() {
+        let r = role("wide");
+        let mut grants = HashMap::new();
+        grants.insert(
+            r.id,
+            vec![
+                grant("read:orders", PermissionEffect::Allow),
+                grant("admin", PermissionEffect::Allow),
+                grant("write:invoices", PermissionEffect::Allow),
+            ],
+        );
+        let a = authority(
+            vec![RoleAssignment {
+                role: r,
+                resource_id: None,
+            }],
+            grants,
+        );
+
+        let held = a
+            .held_scopes(Uuid::new_v4(), Uuid::new_v4(), &v(&["read:orders"]))
+            .await
+            .unwrap();
+        assert_eq!(
+            held,
+            v(&["read:orders"]),
+            "an action the user holds but nobody asked about must not appear"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_result_preserves_candidate_order_so_the_scope_string_is_stable() {
+        let r = role("wide");
+        let mut grants = HashMap::new();
+        grants.insert(
+            r.id,
+            vec![
+                grant("b", PermissionEffect::Allow),
+                grant("a", PermissionEffect::Allow),
+            ],
+        );
+        let a = authority(
+            vec![RoleAssignment {
+                role: r,
+                resource_id: None,
+            }],
+            grants,
+        );
+
+        assert_eq!(
+            a.held_scopes(Uuid::new_v4(), Uuid::new_v4(), &v(&["a", "b"]))
+                .await
+                .unwrap(),
+            v(&["a", "b"])
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_candidate_set_short_circuits_without_touching_the_datastore() {
+        // The stubs would panic on any other method; reaching the repositories
+        // at all with nothing to ask about would be wasted round-trips on a
+        // path that already failed.
+        let a = authority(vec![], HashMap::new());
+        assert!(
+            a.held_scopes(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+}

--- a/crates/axiam-api-rest/tests/external_token_exchange_test.rs
+++ b/crates/axiam-api-rest/tests/external_token_exchange_test.rs
@@ -1,0 +1,1054 @@
+//! X4 — external-IdP token exchange, end to end through the real token
+//! endpoint.
+//!
+//! What only exists once the grant is mounted: that a partner's token, signed
+//! by a *different* key than ours and verified against that IdP's JWKS, buys an
+//! AXIAM token — and that each invariant, violated in isolation, produces its
+//! own refusal. The scope arithmetic itself is proved exhaustively by
+//! `axiam-oauth2`'s unit tests; the claim/signature checks by
+//! `axiam-federation`'s. This file is about the seam.
+//!
+//! # The mock IdP
+//!
+//! RSA-2048, RS256, real JWKS served over loopback by wiremock — the same
+//! harness `federation_first_time_sso_test.rs` uses, for the same reason: the
+//! SSRF guard's `allow_private_networks` test seam (28-05) is what lets
+//! `discover()` and the JWKS fetch reach a loopback server. Production
+//! constructs `JwksCache::new()` and the guard stays fully enforced.
+//!
+//! # What this file deliberately does NOT prove
+//!
+//! X4's plan asks for fixtures minted by a **real Keycloak container** as
+//! cross-vendor proof. That belongs to the e2e compose suite, not here — a
+//! container is not available to a unit-test harness, and a hand-rolled
+//! "Keycloak-shaped" token would prove only that this file and this file's
+//! author agree. What *is* covered here is every claim shape those vendors
+//! emit (`scope`, `scp` as string and array, `roles`, `groups`), each with its
+//! own test.
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use actix_web::{App, test, web};
+use axiam_api_rest::RateLimitConfig;
+use axiam_api_rest::authz::{AllowAllAuthzChecker, AuthzChecker};
+use axiam_api_rest::register_api_v1_routes;
+use axiam_api_rest::state::AppState;
+use axiam_auth::config::AuthConfig;
+use axiam_core::models::federation::{
+    CreateFederationConfig, FederationProtocol, SubjectMapping, TokenExchangeTrust,
+};
+use axiam_core::models::oauth2_client::CreateOAuth2Client;
+use axiam_core::models::organization::CreateOrganization;
+use axiam_core::models::permission::CreatePermission;
+use axiam_core::models::role::CreateRole;
+use axiam_core::models::tenant::CreateTenant;
+use axiam_core::models::user::{CreateUser, UpdateUser, UserStatus};
+use axiam_core::repository::{
+    FederationConfigRepository, FederationLinkRepository, OAuth2ClientRepository,
+    OrganizationRepository, PermissionRepository, RoleRepository, TenantRepository, UserRepository,
+};
+use axiam_db::repository::{
+    SurrealFederationConfigRepository, SurrealOAuth2ClientRepository,
+    SurrealOrganizationRepository, SurrealPermissionRepository, SurrealRoleRepository,
+    SurrealTenantRepository, SurrealUserRepository,
+};
+use axiam_federation::jwks_cache::JwksCache;
+use axiam_federation::oidc::OidcFederationService;
+use axiam_oauth2::token_exchange::{
+    ISSUER_NOT_TRUSTED, TOKEN_EXCHANGE_GRANT_TYPE, TOKEN_TYPE_ACCESS_TOKEN, TOKEN_TYPE_ID_TOKEN,
+    TOKEN_TYPE_JWT, TOKEN_TYPE_REFRESH_TOKEN,
+};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use rsa::RsaPrivateKey;
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::traits::PublicKeyParts;
+use serde_json::{Value, json};
+use std::time::{SystemTime, UNIX_EPOCH};
+use surrealdb::Surreal;
+use surrealdb::engine::local::Mem;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+type TestDb = surrealdb::engine::local::Db;
+
+const TEST_PEER: &str = "127.0.0.1:34599";
+const TEST_PASSWORD: &str = "test-only-placeholder-not-a-real-password"; // gitleaks:allow
+/// Test-only AES-256-GCM key (32 bytes of 0x2a) — not a secret. gitleaks:allow
+const TEST_FED_ENC_KEY: [u8; 32] = [0x2a; 32];
+const KID: &str = "partner-key-1";
+const AXIAM_AUDIENCE: &str = "https://api.axiam.test";
+const EXTERNAL_SUBJECT: &str = "partner-user-42";
+
+// ---------------------------------------------------------------------------
+// Mock IdP
+// ---------------------------------------------------------------------------
+
+struct IdpKeys {
+    private_key_pem: String,
+    jwk: Value,
+}
+
+impl IdpKeys {
+    fn generate() -> Self {
+        let mut rng = rand_core::OsRng;
+        let key = RsaPrivateKey::new(&mut rng, 2048).expect("RSA key");
+        let private_key_pem = key
+            .to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)
+            .expect("PEM")
+            .to_string();
+        Self {
+            jwk: json!({
+                "kty": "RSA", "use": "sig", "alg": "RS256", "kid": KID,
+                "n": URL_SAFE_NO_PAD.encode(key.n().to_bytes_be()),
+                "e": URL_SAFE_NO_PAD.encode(key.e().to_bytes_be()),
+            }),
+            private_key_pem,
+        }
+    }
+
+    fn encoding_key(&self) -> EncodingKey {
+        EncodingKey::from_rsa_pem(self.private_key_pem.as_bytes()).expect("encoding key")
+    }
+}
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+fn test_auth_config() -> AuthConfig {
+    let kp = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).expect("ed25519");
+    AuthConfig {
+        jwt_private_key_pem: kp.serialize_pem(),
+        jwt_public_key_pem: kp.public_key_pem(),
+        access_token_lifetime_secs: 900,
+        jwt_issuer: "axiam-test".into(),
+        oauth2_issuer_url: "https://id.axiam.test".into(),
+        federation_encryption_key: Some(TEST_FED_ENC_KEY),
+        ..AuthConfig::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+struct Fixture {
+    db: Surreal<TestDb>,
+    auth: AuthConfig,
+    tenant_id: Uuid,
+    user_id: Uuid,
+    client_id: String,
+    client_secret: String,
+    keys: IdpKeys,
+    issuer: String,
+    /// Kept alive for the duration of the test — dropping it stops the server.
+    _idp: MockServer,
+}
+
+/// How the provider's trust block should be configured for a given test.
+struct TrustSpec {
+    enabled: bool,
+    accepted_audiences: Vec<String>,
+    subject_mapping: SubjectMapping,
+    scope_map: BTreeMap<String, Vec<String>>,
+    max_token_age_secs: i64,
+    max_lifetime_secs: Option<i64>,
+    /// Whether to write a `federation_link` for [`EXTERNAL_SUBJECT`].
+    link_subject: bool,
+    /// AXIAM actions granted to the seeded user, as `(action, deny)`.
+    grants: Vec<(&'static str, bool)>,
+}
+
+impl Default for TrustSpec {
+    fn default() -> Self {
+        let mut scope_map = BTreeMap::new();
+        scope_map.insert(
+            "partner.orders.read".to_string(),
+            vec!["read:orders".to_string()],
+        );
+        Self {
+            enabled: true,
+            accepted_audiences: vec![AXIAM_AUDIENCE.to_string()],
+            subject_mapping: SubjectMapping::LinkedOnly,
+            scope_map,
+            max_token_age_secs: 300,
+            max_lifetime_secs: None,
+            link_subject: true,
+            grants: vec![("read:orders", false)],
+        }
+    }
+}
+
+async fn setup(spec: TrustSpec) -> Fixture {
+    let db = Surreal::new::<Mem>(()).await.unwrap();
+    db.use_ns("test").use_db("test").await.unwrap();
+    axiam_db::run_migrations(&db).await.unwrap();
+
+    // --- the mock IdP ---------------------------------------------------
+    let keys = IdpKeys::generate();
+    let idp = MockServer::start().await;
+    let issuer = idp.uri();
+    Mock::given(method("GET"))
+        .and(path("/.well-known/openid-configuration"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "issuer": issuer,
+            "authorization_endpoint": format!("{issuer}/authorize"),
+            "token_endpoint": format!("{issuer}/token"),
+            "jwks_uri": format!("{issuer}/jwks"),
+        })))
+        .mount(&idp)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/jwks"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "keys": [keys.jwk.clone()] })),
+        )
+        .mount(&idp)
+        .await;
+
+    // --- tenant, user, client -------------------------------------------
+    let org = SurrealOrganizationRepository::new(db.clone())
+        .create(CreateOrganization {
+            name: "X4 Org".into(),
+            slug: "org-x4".into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    let tenant = SurrealTenantRepository::new(db.clone())
+        .create(CreateTenant {
+            organization_id: org.id,
+            name: "X4 Tenant".into(),
+            slug: "tenant-x4".into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let user_repo = SurrealUserRepository::new(db.clone());
+    let user = user_repo
+        .create(CreateUser {
+            tenant_id: tenant.id,
+            username: "partner-linked-user".into(),
+            email: "partner@example.com".into(),
+            password: TEST_PASSWORD.into(),
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    user_repo
+        .update(
+            tenant.id,
+            user.id,
+            UpdateUser {
+                status: Some(UserStatus::Active),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let (client, secret) = SurrealOAuth2ClientRepository::new(db.clone())
+        .create(CreateOAuth2Client {
+            tenant_id: tenant.id,
+            name: "edge-gateway".into(),
+            redirect_uris: vec!["https://orders.internal".into()],
+            grant_types: vec![TOKEN_EXCHANGE_GRANT_TYPE.into()],
+            scopes: vec!["read:orders".into(), "write:orders".into()],
+            post_logout_redirect_uris: Vec::new(),
+            backchannel_logout_uri: None,
+            require_par: false,
+        })
+        .await
+        .unwrap();
+
+    // --- RBAC: what the user actually holds ------------------------------
+    if !spec.grants.is_empty() {
+        let role_repo = SurrealRoleRepository::new(db.clone());
+        let perm_repo = SurrealPermissionRepository::new(db.clone());
+        let role = role_repo
+            .create(CreateRole {
+                tenant_id: tenant.id,
+                name: "partner-role".into(),
+                description: String::new(),
+                is_global: true,
+            })
+            .await
+            .unwrap();
+        role_repo
+            .assign_to_user(tenant.id, user.id, role.id, None)
+            .await
+            .unwrap();
+        for (action, deny) in &spec.grants {
+            let perm = perm_repo
+                .create(CreatePermission {
+                    tenant_id: tenant.id,
+                    action: (*action).into(),
+                    description: String::new(),
+                })
+                .await
+                .unwrap();
+            perm_repo
+                .grant_to_role_with_effect(
+                    tenant.id,
+                    role.id,
+                    perm.id,
+                    Vec::new(),
+                    if *deny {
+                        axiam_core::models::permission::PermissionEffect::Deny
+                    } else {
+                        axiam_core::models::permission::PermissionEffect::Allow
+                    },
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    // --- the federation provider, with its X4 trust block ----------------
+    let fed_repo = SurrealFederationConfigRepository::new(db.clone());
+    let config = fed_repo
+        .create(CreateFederationConfig {
+            tenant_id: tenant.id,
+            provider: "PartnerIdP".into(),
+            protocol: FederationProtocol::OidcConnect,
+            metadata_url: Some(format!("{issuer}/.well-known/openid-configuration")),
+            client_id: "axiam-at-partner".into(),
+            client_secret: "unused-for-exchange".into(),
+            attribute_map: None,
+            idp_signing_cert_pem: None,
+            allowed_algorithms: Some(vec!["RS256".into()]),
+            token_exchange: Some(TokenExchangeTrust {
+                enabled: spec.enabled,
+                accepted_audiences: spec.accepted_audiences,
+                subject_mapping: spec.subject_mapping,
+                scope_map: spec.scope_map,
+                max_token_age_secs: spec.max_token_age_secs,
+                max_lifetime_secs: spec.max_lifetime_secs,
+            }),
+        })
+        .await
+        .unwrap();
+
+    if spec.link_subject {
+        SurrealFederationLinkRepository::new(db.clone())
+            .create(axiam_core::models::federation::CreateFederationLink {
+                tenant_id: tenant.id,
+                user_id: user.id,
+                federation_config_id: config.id,
+                external_subject: EXTERNAL_SUBJECT.into(),
+                external_email: Some("partner@example.com".into()),
+            })
+            .await
+            .unwrap();
+    }
+
+    Fixture {
+        db,
+        auth: test_auth_config(),
+        tenant_id: tenant.id,
+        user_id: user.id,
+        client_id: client.client_id,
+        client_secret: secret,
+        keys,
+        issuer,
+        _idp: idp,
+    }
+}
+
+use axiam_db::repository::SurrealFederationLinkRepository;
+
+/// Build the app with X4 switched on, exactly as production does.
+macro_rules! test_app {
+    ($f:expr) => {{
+        let jwks_cache = Arc::new(JwksCache::new_allow_private_networks());
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new($f.auth.clone()))
+                .app_data(web::Data::new({
+                    let mut state = AppState::for_test($f.db.clone(), $f.auth.clone());
+                    // The loopback seam: without it the SSRF guard refuses the
+                    // wiremock IdP and every test here fails identically for
+                    // the wrong reason.
+                    state.http_client = reqwest::Client::builder()
+                        .redirect(reqwest::redirect::Policy::none())
+                        .timeout(std::time::Duration::from_secs(10))
+                        .build()
+                        .unwrap();
+                    state.jwks_cache = Arc::clone(&jwks_cache);
+                    state.oidc_federation_service = Some(OidcFederationService::new(
+                        state.federation_config_repo.clone(),
+                        state.federation_link_repo.clone(),
+                        state.user_repo.clone(),
+                        state.http_client.clone(),
+                        Arc::clone(&state.jwks_cache),
+                        TEST_FED_ENC_KEY,
+                    ));
+                    assert!(
+                        state.enable_external_token_exchange(),
+                        "the federation service is installed, so X4 must switch on"
+                    );
+                    state
+                }))
+                .app_data(web::Data::new(
+                    Arc::new(AllowAllAuthzChecker) as Arc<dyn AuthzChecker>
+                ))
+                .configure(|cfg| {
+                    register_api_v1_routes::<TestDb>(cfg, &RateLimitConfig::default())
+                }),
+        )
+        .await
+    }};
+}
+
+fn enc(s: &str) -> String {
+    s.replace(':', "%3A").replace('/', "%2F")
+}
+
+macro_rules! exchange {
+    ($app:expr, $f:expr, $extra:expr) => {{
+        let body = format!(
+            "grant_type={}&client_id={}&client_secret={}{}",
+            enc(TOKEN_EXCHANGE_GRANT_TYPE),
+            $f.client_id,
+            $f.client_secret,
+            $extra
+        );
+        let req = test::TestRequest::post()
+            .peer_addr(TEST_PEER.parse::<SocketAddr>().unwrap())
+            .uri(&format!("/oauth2/token?tenant_id={}", $f.tenant_id))
+            .insert_header(("content-type", "application/x-www-form-urlencoded"))
+            .set_payload(body)
+            .to_request();
+        let resp = test::call_service(&$app, req).await;
+        let status = resp.status().as_u16();
+        let json: Value = test::read_body_json(resp).await;
+        (status, json)
+    }};
+}
+
+/// A partner token, with per-test overrides applied to the claims.
+fn partner_token(f: &Fixture, mutate: impl FnOnce(&mut serde_json::Map<String, Value>)) -> String {
+    let mut claims = serde_json::Map::new();
+    claims.insert("iss".into(), json!(f.issuer));
+    claims.insert("sub".into(), json!(EXTERNAL_SUBJECT));
+    claims.insert("aud".into(), json!(AXIAM_AUDIENCE));
+    claims.insert("iat".into(), json!(now()));
+    claims.insert("exp".into(), json!(now() + 600));
+    claims.insert("scope".into(), json!("partner.orders.read"));
+    mutate(&mut claims);
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(KID.into());
+    header.typ = Some("at+jwt".into());
+    encode(&header, &Value::Object(claims), &f.keys.encoding_key()).expect("sign")
+}
+
+fn subject_param(token: &str, ty: &str) -> String {
+    format!("&subject_token={token}&subject_token_type={}", enc(ty))
+}
+
+fn claims_of(token: &str) -> Value {
+    let payload = token.split('.').nth(1).expect("three parts");
+    serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).expect("b64")).expect("json")
+}
+
+// ===========================================================================
+// The happy path
+// ===========================================================================
+
+#[actix_web::test]
+async fn a_trusted_partners_token_buys_a_scoped_axiam_token() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+
+    assert_eq!(status, 200, "{body:?}");
+    assert_eq!(body["token_type"], "Bearer");
+    assert_eq!(body["issued_token_type"], TOKEN_TYPE_ACCESS_TOKEN);
+    assert_eq!(body["scope"], "read:orders");
+    assert!(
+        body.get("refresh_token").is_none(),
+        "an exchange never issues a refresh token"
+    );
+
+    let claims = claims_of(body["access_token"].as_str().unwrap());
+    assert_eq!(
+        claims["sub"],
+        f.user_id.to_string(),
+        "the subject is the LINKED AXIAM user, not the partner's identifier"
+    );
+    assert_eq!(
+        claims["ext_exchange"]["iss"], f.issuer,
+        "provenance must be stamped into the token"
+    );
+    assert_eq!(claims["aud"], "axiam:user");
+    assert!(claims.get("act").is_none());
+}
+
+/// Every claim shape the target IdPs actually emit reaches the scope map.
+#[actix_web::test]
+async fn each_vendor_claim_shape_feeds_the_scope_map() {
+    for (name, apply) in [
+        (
+            "scope (Okta/Keycloak/RFC 9068)",
+            json!({ "scope": "partner.orders.read other" }),
+        ),
+        (
+            "scp string (Entra)",
+            json!({ "scp": "partner.orders.read" }),
+        ),
+        (
+            "scp array (Okta)",
+            json!({ "scp": ["partner.orders.read"] }),
+        ),
+        (
+            "roles (Entra app roles)",
+            json!({ "roles": ["partner.orders.read"] }),
+        ),
+        ("groups", json!({ "groups": ["partner.orders.read"] })),
+    ] {
+        let f = setup(TrustSpec::default()).await;
+        let app = test_app!(f);
+        let token = partner_token(&f, |c| {
+            c.remove("scope");
+            for (k, v) in apply.as_object().unwrap() {
+                c.insert(k.clone(), v.clone());
+            }
+        });
+        let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+        assert_eq!(status, 200, "{name}: {body:?}");
+        assert_eq!(body["scope"], "read:orders", "{name}");
+    }
+}
+
+#[actix_web::test]
+async fn an_access_token_type_is_accepted_for_an_external_issuer_too() {
+    // A caller who knows the partner calls it an access token should not have
+    // to learn RFC 8693's generic `…:jwt` type to be understood.
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_ACCESS_TOKEN));
+    assert_eq!(status, 200, "{body:?}");
+}
+
+// ===========================================================================
+// The validation matrix — each invariant violated in isolation
+// ===========================================================================
+
+#[actix_web::test]
+async fn a_provider_with_token_exchange_disabled_does_not_trust_its_own_issuer() {
+    let f = setup(TrustSpec {
+        enabled: false,
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+
+    assert_eq!(status, 400);
+    assert_eq!(body["error"], "invalid_grant");
+    assert_eq!(
+        body["error_description"], ISSUER_NOT_TRUSTED,
+        "configuring a provider for LOGIN is not agreement to accept its \
+         tokens as API credentials"
+    );
+}
+
+#[actix_web::test]
+async fn an_issuer_nobody_configured_is_named_as_such() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert("iss".into(), json!("https://stranger.example"));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+
+    assert_eq!(status, 400);
+    assert_eq!(body["error_description"], ISSUER_NOT_TRUSTED);
+}
+
+#[actix_web::test]
+async fn a_token_signed_by_the_wrong_key_is_refused_generically() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+
+    // Correct issuer, correct claims, a key the IdP's JWKS does not publish.
+    let impostor = IdpKeys::generate();
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(KID.into());
+    let token = encode(
+        &header,
+        &json!({
+            "iss": f.issuer, "sub": EXTERNAL_SUBJECT, "aud": AXIAM_AUDIENCE,
+            "iat": now(), "exp": now() + 600, "scope": "partner.orders.read",
+        }),
+        &impostor.encoding_key(),
+    )
+    .unwrap();
+
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400);
+    assert_eq!(body["error"], "invalid_grant");
+    assert_eq!(
+        body["error_description"], "subject token is not valid",
+        "which check refused is a map of our validation order; it stays off the wire"
+    );
+}
+
+#[actix_web::test]
+async fn a_token_addressed_to_someone_else_is_refused() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert("aud".into(), json!("https://someone-elses-api.example"));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400);
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+#[actix_web::test]
+async fn a_multi_valued_audience_needs_only_one_match() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert(
+            "aud".into(),
+            json!(["https://elsewhere.example", AXIAM_AUDIENCE]),
+        );
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 200, "{body:?}");
+}
+
+#[actix_web::test]
+async fn a_token_older_than_the_provider_allows_is_refused() {
+    let f = setup(TrustSpec {
+        max_token_age_secs: 60,
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    // Still valid by `exp` — 10 minutes of life left — but issued 5 minutes
+    // ago, which this provider does not accept. The two bounds are separate
+    // policies and this proves the age one bites on its own.
+    let token = partner_token(&f, |c| {
+        c.insert("iat".into(), json!(now() - 300));
+        c.insert("exp".into(), json!(now() + 600));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+#[actix_web::test]
+async fn an_expired_partner_token_is_refused() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert("iat".into(), json!(now() - 1000));
+        c.insert("exp".into(), json!(now() - 500));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400);
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+/// An ID token is an assertion to a client about a login, not a credential for
+/// an API — and OIDC gives it a longer, more widely distributed life for
+/// exactly that reason. Correctly signed, correctly addressed, still refused.
+#[actix_web::test]
+async fn a_correctly_signed_id_token_is_still_refused() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert("nonce".into(), json!("n-0S6_WzA2Mj"));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+#[actix_web::test]
+async fn refresh_and_id_token_types_are_refused_by_name() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+
+    for ty in [TOKEN_TYPE_REFRESH_TOKEN, TOKEN_TYPE_ID_TOKEN] {
+        let (status, body) = exchange!(app, f, subject_param(&token, ty));
+        assert_eq!(status, 400, "{ty}");
+        assert_eq!(body["error"], "invalid_request", "{ty}");
+        assert_ne!(
+            body["error_description"], "subject token is not valid",
+            "{ty} deserves an actionable message, not a generic refusal"
+        );
+    }
+}
+
+#[actix_web::test]
+async fn an_unlinked_subject_is_refused_under_linked_only() {
+    let f = setup(TrustSpec {
+        link_subject: false,
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+#[actix_web::test]
+async fn jit_provisioning_creates_the_user_when_the_provider_says_so() {
+    let f = setup(TrustSpec {
+        link_subject: false,
+        subject_mapping: SubjectMapping::JitProvision,
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+
+    // The JIT-provisioned user is brand new and therefore holds no roles, so
+    // the engine gate refuses it — which is itself the point worth pinning:
+    // provisioning an identity is not granting it anything.
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(
+        body["error"], "invalid_scope",
+        "a freshly provisioned user holds no permissions, so there is nothing \
+         to put in a token — but the failure is about SCOPES, not about the \
+         subject being unknown"
+    );
+}
+
+#[actix_web::test]
+async fn a_suspended_user_is_not_resurrected_by_a_partner_token() {
+    let f = setup(TrustSpec::default()).await;
+    SurrealUserRepository::new(f.db.clone())
+        .update(
+            f.tenant_id,
+            f.user_id,
+            UpdateUser {
+                status: Some(UserStatus::Inactive),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+// ===========================================================================
+// Scopes
+// ===========================================================================
+
+#[actix_web::test]
+async fn an_unmapped_partner_scope_contributes_nothing() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        // The partner says "admin". Nobody mapped it. It buys nothing, and
+        // there is no passthrough mode that would let it.
+        c.insert("scope".into(), json!("partner.admin"));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_scope");
+}
+
+/// The engine is the authority, not the admin's map. Same map, same token —
+/// the user simply does not hold the action.
+#[actix_web::test]
+async fn a_mapped_scope_the_user_does_not_hold_is_not_issued() {
+    let f = setup(TrustSpec {
+        grants: vec![],
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_scope");
+}
+
+/// B1 deny-override, on the cross-domain path.
+#[actix_web::test]
+async fn a_deny_rule_vetoes_a_scope_a_partner_token_would_otherwise_get() {
+    let f = setup(TrustSpec {
+        grants: vec![("read:orders", true)],
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_scope");
+}
+
+#[actix_web::test]
+async fn an_explicitly_requested_unmapped_scope_is_refused_by_name() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(
+        app,
+        f,
+        format!(
+            "{}&scope=write%3Aorders",
+            subject_param(&token, TOKEN_TYPE_JWT)
+        )
+    );
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_scope");
+    assert!(
+        body["error_description"]
+            .as_str()
+            .unwrap()
+            .contains("write:orders"),
+        "a refusal must name the scope: {body:?}"
+    );
+}
+
+// ===========================================================================
+// Transitivity
+// ===========================================================================
+
+/// The invariant that stops trust composing silently: A trusts B, B trusts C,
+/// therefore A trusts C — which nobody configured and nobody can see.
+#[actix_web::test]
+async fn a_token_minted_from_a_partner_token_cannot_be_exchanged_again() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+
+    let partner = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&partner, TOKEN_TYPE_JWT));
+    assert_eq!(status, 200, "{body:?}");
+    let minted = body["access_token"].as_str().unwrap().to_string();
+
+    // The minted token is ours, cryptographically valid, and carries the
+    // scope. It still cannot buy another one.
+    let (status, body) = exchange!(app, f, subject_param(&minted, TOKEN_TYPE_ACCESS_TOKEN));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_request");
+    assert!(
+        body["error_description"]
+            .as_str()
+            .unwrap()
+            .contains("do not compose"),
+        "{body:?}"
+    );
+}
+
+/// …and the other direction: a *foreign* token that carries the claim, because
+/// the partner also runs AXIAM or copied the convention.
+#[actix_web::test]
+async fn a_partner_token_that_is_itself_an_exchange_product_is_refused() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert(
+            "ext_exchange".into(),
+            json!({ "iss": "https://someone-upstream.example" }),
+        );
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_grant");
+}
+
+// ===========================================================================
+// Lifetime and actor
+// ===========================================================================
+
+#[actix_web::test]
+async fn the_issued_token_never_outlives_the_partners_token() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |c| {
+        c.insert("exp".into(), json!(now() + 45));
+    });
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 200, "{body:?}");
+    assert!(
+        body["expires_in"].as_u64().unwrap() <= 45,
+        "expires_in was {}",
+        body["expires_in"]
+    );
+}
+
+#[actix_web::test]
+async fn a_per_provider_lifetime_ceiling_is_honoured() {
+    let f = setup(TrustSpec {
+        max_lifetime_secs: Some(30),
+        ..Default::default()
+    })
+    .await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 200, "{body:?}");
+    assert!(body["expires_in"].as_u64().unwrap() <= 30);
+}
+
+#[actix_web::test]
+async fn an_actor_token_is_refused_across_the_trust_boundary() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let token = partner_token(&f, |_| {});
+    let (status, body) = exchange!(
+        app,
+        f,
+        format!(
+            "{}&actor_token=anything&actor_token_type={}",
+            subject_param(&token, TOKEN_TYPE_JWT),
+            enc(TOKEN_TYPE_ACCESS_TOKEN)
+        )
+    );
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(body["error"], "invalid_request");
+}
+
+// ===========================================================================
+// JWKS rollover
+// ===========================================================================
+
+/// The partner rotates its signing key between two exchanges. The first call
+/// warms the cache with the old JWKS; the second presents a token signed by a
+/// key that is only in the new one, and must succeed via the forced refetch.
+#[actix_web::test]
+async fn a_key_rotation_mid_flight_is_recovered_by_the_forced_refetch() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+
+    // Warm the JWKS cache with the original key.
+    let first = partner_token(&f, |_| {});
+    let (status, _) = exchange!(app, f, subject_param(&first, TOKEN_TYPE_JWT));
+    assert_eq!(status, 200);
+
+    // The IdP rotates: a new key under a new kid, served from the same URI.
+    //
+    // `reset()` rather than mounting a second `/jwks` mock — wiremock picks
+    // the *first* matching mock, so a shadowing registration would silently
+    // keep serving the old key and this test would prove nothing. Discovery is
+    // re-mounted alongside it; the discovery cache is already warm, so it is
+    // belt-and-braces rather than load-bearing.
+    let rotated = IdpKeys::generate();
+    let mut rotated_jwk = rotated.jwk.clone();
+    rotated_jwk["kid"] = json!("partner-key-2");
+    f._idp.reset().await;
+    let issuer = f.issuer.clone();
+    Mock::given(method("GET"))
+        .and(path("/.well-known/openid-configuration"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "issuer": issuer,
+            "authorization_endpoint": format!("{issuer}/authorize"),
+            "token_endpoint": format!("{issuer}/token"),
+            "jwks_uri": format!("{issuer}/jwks"),
+        })))
+        .mount(&f._idp)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/jwks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "keys": [rotated_jwk] })))
+        .mount(&f._idp)
+        .await;
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some("partner-key-2".into());
+    header.typ = Some("at+jwt".into());
+    let token = encode(
+        &header,
+        &json!({
+            "iss": f.issuer, "sub": EXTERNAL_SUBJECT, "aud": AXIAM_AUDIENCE,
+            "iat": now(), "exp": now() + 600, "scope": "partner.orders.read",
+        }),
+        &rotated.encoding_key(),
+    )
+    .unwrap();
+
+    let (status, body) = exchange!(app, f, subject_param(&token, TOKEN_TYPE_JWT));
+    assert_eq!(status, 200, "rollover must recover: {body:?}");
+}
+
+// ===========================================================================
+// Regression: the internal path is untouched
+// ===========================================================================
+
+/// X4 widens which subject tokens are admissible and nothing else. An ordinary
+/// AXIAM-issued token still exchanges exactly as B3 says it does.
+#[actix_web::test]
+async fn an_ordinary_axiam_subject_token_still_exchanges_unchanged() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+
+    let subject = axiam_auth::token::issue_access_token(
+        f.user_id,
+        f.tenant_id,
+        Uuid::new_v4(),
+        &["read:orders".to_string()],
+        &f.auth,
+        Uuid::new_v4().to_string(),
+        axiam_auth::token::AUD_USER,
+    )
+    .unwrap();
+
+    // No actor token and no `may_impersonate` grant ⇒ B3 refuses, as it always
+    // has. The value of the assertion is the error CODE: the token reached the
+    // internal path rather than being sent to the external resolver.
+    let (status, body) = exchange!(app, f, subject_param(&subject, TOKEN_TYPE_ACCESS_TOKEN));
+    assert_eq!(status, 400, "{body:?}");
+    assert_eq!(
+        body["error"], "unauthorized_client",
+        "an AXIAM-issued token must take the B3 path: {body:?}"
+    );
+}
+
+#[actix_web::test]
+async fn an_axiam_token_presented_as_the_generic_jwt_type_is_told_so() {
+    let f = setup(TrustSpec::default()).await;
+    let app = test_app!(f);
+    let subject = axiam_auth::token::issue_access_token(
+        f.user_id,
+        f.tenant_id,
+        Uuid::new_v4(),
+        &["read:orders".to_string()],
+        &f.auth,
+        Uuid::new_v4().to_string(),
+        axiam_auth::token::AUD_USER,
+    )
+    .unwrap();
+
+    let (status, body) = exchange!(app, f, subject_param(&subject, TOKEN_TYPE_JWT));
+    assert_eq!(status, 400);
+    assert_eq!(body["error"], "invalid_request");
+    assert!(
+        body["error_description"]
+            .as_str()
+            .unwrap()
+            .contains("external issuers"),
+        "{body:?}"
+    );
+}

--- a/crates/axiam-auth/src/password_reset.rs
+++ b/crates/axiam-auth/src/password_reset.rs
@@ -573,6 +573,7 @@ mod tests {
                 attribute_map: None,
                 idp_signing_cert_pem: None,
                 allowed_algorithms: None,
+                token_exchange: None,
             })
             .await
             .unwrap();
@@ -1250,6 +1251,7 @@ mod tests {
                 attribute_map: None,
                 idp_signing_cert_pem: None,
                 allowed_algorithms: None,
+                token_exchange: None,
             })
             .await
             .unwrap();
@@ -1413,6 +1415,7 @@ mod tests {
                 attribute_map: None,
                 idp_signing_cert_pem: None,
                 allowed_algorithms: None,
+                token_exchange: None,
             })
             .await
             .unwrap();

--- a/crates/axiam-auth/src/token.rs
+++ b/crates/axiam-auth/src/token.rs
@@ -113,6 +113,33 @@ pub struct AccessTokenClaims {
     /// subject token's remaining life, the configured maximum, and 300 s.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permissions: Option<Vec<RptPermission>>,
+    /// Provenance of a cross-domain exchange (X4) — present **only** on a
+    /// token minted from an *external* IdP's subject token.
+    ///
+    /// Two jobs, and the second is the reason it is inside the signed token
+    /// rather than only in the audit log:
+    ///
+    /// 1. A resource server can tell a cross-domain token from a
+    ///    locally-issued one without asking us anything.
+    /// 2. **It makes the exchange non-transitive.** Both exchange paths refuse
+    ///    a subject token carrying this claim, so a token minted from a
+    ///    partner's token can never be exchanged again — ours or theirs.
+    ///    Without it, trust composes silently: A trusts B, B trusts C,
+    ///    therefore A trusts C, which nobody configured and nobody can see.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ext_exchange: Option<ExtExchangeClaim>,
+}
+
+/// X4 provenance claim: which foreign issuer's token this one came from.
+///
+/// Deliberately just the issuer. The external `sub` is in the audit record,
+/// not here — a downstream service has no use for a partner-local identifier
+/// and every reason not to key anything on it, whereas the issuer is what a
+/// policy would actually branch on.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtExchangeClaim {
+    /// The external IdP's `iss`, exactly as it appeared in the subject token.
+    pub iss: String,
 }
 
 /// RFC 8693 §4.1 `act` claim: who is acting on the subject's behalf.
@@ -180,6 +207,7 @@ pub fn issue_access_token(
         sub_kind: SubjectKind::User,
         act: None,
         permissions: None,
+        ext_exchange: None,
     };
 
     // CQ-B14: Use pre-parsed key cache when available; fall back to PEM parsing.
@@ -197,6 +225,34 @@ pub fn issue_access_token(
         .map_err(|e| AuthError::Crypto(format!("JWT encode: {e}")))
 }
 
+/// Read the `iss` claim of a JWT **without verifying anything** (X4).
+///
+/// This is a routing primitive, not a validation one. It answers "which key
+/// should this token be checked against" — never "is this token good". Both
+/// destinations verify: a token claiming AXIAM's issuer is checked against
+/// AXIAM's signing key, and a token claiming a partner's issuer is checked
+/// against that partner's JWKS. A forged `iss` therefore selects the branch in
+/// which it fails, which is why reading it unverified is safe here and would
+/// not be anywhere that acts on the answer.
+///
+/// Returns `None` for anything that is not a three-part JWT with a
+/// base64url-decodable JSON payload carrying a string `iss`.
+pub fn unverified_issuer_of(token: &str) -> Option<String> {
+    let mut parts = token.split('.');
+    let (_header, payload, signature) = (parts.next()?, parts.next()?, parts.next()?);
+    // A two-part token is an unsigned JWT; there is no branch that would
+    // accept one, so refuse to route it at all rather than let it reach a
+    // signature check that reports a less specific failure.
+    if signature.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("iss")?.as_str().map(str::to_owned)
+}
+
 /// Issue an access token for an RFC 8693 token exchange (B3).
 ///
 /// Distinct from [`issue_access_token`] in exactly the two ways the exchange
@@ -208,6 +264,9 @@ pub fn issue_access_token(
 ///   seconds, exchange it, hold the result for fifteen minutes. The caller
 ///   computes `min(subject remaining, configured max)` and passes it here.
 /// * **`act` may be set**, naming the delegating party (§4.1).
+/// * **`ext_exchange` may be set** (X4), naming the foreign issuer whose token
+///   bought this one. Both exchange paths refuse a subject token that carries
+///   it, which is what makes the exchange non-transitive.
 ///
 /// Everything else — issuer, algorithm, key handling — is identical, so an
 /// exchanged token validates through exactly the same path as any other.
@@ -223,6 +282,7 @@ pub fn issue_exchanged_token(
     aud: &str,
     expires_at: i64,
     act: Option<ActClaim>,
+    ext_exchange: Option<ExtExchangeClaim>,
 ) -> Result<String, AuthError> {
     let now = Utc::now().timestamp();
     if expires_at <= now {
@@ -253,6 +313,7 @@ pub fn issue_exchanged_token(
         // through an exchange would carry a decision past the ticket that
         // authorised it.
         permissions: None,
+        ext_exchange,
     };
 
     let owned;
@@ -305,6 +366,7 @@ pub fn issue_client_credentials_token(
         sub_kind: SubjectKind::OAuth2Client,
         act: None,
         permissions: None,
+        ext_exchange: None,
     };
 
     // CQ-B14: Use pre-parsed key cache when available; fall back to PEM parsing.
@@ -366,6 +428,11 @@ pub fn issue_rpt(
         sub_kind: SubjectKind::User,
         act: None,
         permissions: Some(permissions),
+        // An RPT is minted from a ticket, never from an exchange. If the
+        // subject token that bought the ticket was itself cross-domain, that
+        // fact belongs to *that* token and its audit record; re-stamping it
+        // here would attribute this decision to a provenance it does not have.
+        ext_exchange: None,
     };
 
     let owned;
@@ -433,6 +500,7 @@ pub fn issue_service_account_token(
         sub_kind: SubjectKind::ServiceAccount,
         act: None,
         permissions: None,
+        ext_exchange: None,
     };
 
     // CQ-B14: Use pre-parsed key cache when available; fall back to PEM parsing.
@@ -503,6 +571,7 @@ pub fn issue_service_account_client_credentials_token(
         sub_kind: SubjectKind::ServiceAccount,
         act: None,
         permissions: None,
+        ext_exchange: None,
     };
 
     let owned;
@@ -1208,5 +1277,76 @@ MCowBQYDK2VwAyEAcweT2rPwpUxadO56wIhW1XBoMF63aWOE2UMAVsRudhs=
 
         let validated = validate_access_token(&token, &config).unwrap();
         assert_eq!(validated.0.sub_kind, SubjectKind::ServiceAccount);
+    }
+
+    // -----------------------------------------------------------------
+    // X4 — the ext_exchange provenance claim
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn an_ordinary_exchanged_token_carries_no_provenance_claim() {
+        let config = test_config();
+        let token = issue_exchanged_token(
+            &Uuid::new_v4().to_string(),
+            SubjectKind::User,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &["read".to_string()],
+            &config,
+            Uuid::new_v4().to_string(),
+            AUD_USER,
+            Utc::now().timestamp() + 60,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let claims = decode_access_token(&token, &config).unwrap();
+        assert!(
+            claims.ext_exchange.is_none(),
+            "a same-domain B3 exchange must not claim a foreign provenance"
+        );
+        // And the key must be absent from the wire, not present-and-null: a
+        // resource server testing `\"ext_exchange\" in claims` is doing the
+        // documented thing.
+        let payload = token.split('.').nth(1).unwrap();
+        let json = String::from_utf8(
+            base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .decode(payload)
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(!json.contains("ext_exchange"), "wire payload: {json}");
+    }
+
+    #[test]
+    fn a_cross_domain_exchange_stamps_the_foreign_issuer_and_it_survives_a_round_trip() {
+        let config = test_config();
+        let token = issue_exchanged_token(
+            &Uuid::new_v4().to_string(),
+            SubjectKind::User,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            &["read".to_string()],
+            &config,
+            Uuid::new_v4().to_string(),
+            AUD_USER,
+            Utc::now().timestamp() + 60,
+            None,
+            Some(ExtExchangeClaim {
+                iss: "https://partner.example/".into(),
+            }),
+        )
+        .unwrap();
+
+        let claims = decode_access_token(&token, &config).unwrap();
+        assert_eq!(
+            claims.ext_exchange,
+            Some(ExtExchangeClaim {
+                iss: "https://partner.example/".into()
+            }),
+            "the provenance claim is what makes the exchange non-transitive; \
+             a decode that loses it silently restores transitivity"
+        );
     }
 }

--- a/crates/axiam-auth/tests/auth_service_test.rs
+++ b/crates/axiam-auth/tests/auth_service_test.rs
@@ -1277,6 +1277,7 @@ async fn login_mfa_enforced_federated_user_skips_enforcement() {
             attribute_map: None,
             idp_signing_cert_pem: None,
             allowed_algorithms: None,
+            token_exchange: None,
         })
         .await
         .unwrap();

--- a/crates/axiam-core/src/models/federation.rs
+++ b/crates/axiam-core/src/models/federation.rs
@@ -3,6 +3,8 @@
 //! Supports external OIDC identity providers (including social login)
 //! and SAML service provider integration.
 
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -11,6 +13,258 @@ use uuid::Uuid;
 pub enum FederationProtocol {
     OidcConnect,
     Saml,
+}
+
+// ---------------------------------------------------------------------------
+// X4 — external-IdP token exchange trust
+// ---------------------------------------------------------------------------
+
+/// How an external subject with no existing federation link is handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectMapping {
+    /// Refuse. The user must already have logged in through this provider (or
+    /// been linked by an admin) before their partner token buys anything.
+    #[default]
+    LinkedOnly,
+    /// Provision an AXIAM user on first sight, via the existing federation JIT
+    /// path. Audited as such — it is the only record that a partner's IdP
+    /// created a local user.
+    JitProvision,
+}
+
+impl SubjectMapping {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LinkedOnly => "linked_only",
+            Self::JitProvision => "jit_provision",
+        }
+    }
+
+    /// Parse a wire value. Unknown values yield `None` so a caller can refuse
+    /// them: a typo'd `"jit_provsion"` must not silently become the default,
+    /// and the default is the *stricter* of the two, so a silent fallback
+    /// would fail closed here and open in the next revision that flips it.
+    pub fn from_wire(raw: &str) -> Option<Self> {
+        match raw.trim() {
+            "linked_only" => Some(Self::LinkedOnly),
+            "jit_provision" => Some(Self::JitProvision),
+            _ => None,
+        }
+    }
+}
+
+/// Default bound on `now - iat` for an accepted external subject token.
+pub const DEFAULT_MAX_TOKEN_AGE_SECS: i64 = 300;
+
+/// Hard ceiling on `max_token_age_secs`. An hour is already generous for a
+/// token being replayed at a trust boundary; beyond that the operator is
+/// asking for a bearer credential with a day's replay window.
+pub const MAX_TOKEN_AGE_CEILING_SECS: i64 = 3600;
+
+/// Bound on how many audiences and map entries a provider may carry.
+///
+/// Not tidiness: both are read on every external exchange and the map is
+/// walked once per asserted value, so an unbounded config is an unbounded
+/// per-request cost an admin can set.
+pub const MAX_ACCEPTED_AUDIENCES: usize = 64;
+pub const MAX_SCOPE_MAP_ENTRIES: usize = 256;
+
+/// Per-provider trust configuration for RFC 8693 exchange of that provider's
+/// tokens (X4).
+///
+/// See `claude_dev/external-token-exchange-design.md`. The one sentence that
+/// governs every field: **an external subject token is evidence of
+/// authentication, never a grant of authorization.** Nothing here can widen
+/// what the resolved user may do; every field can only narrow it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TokenExchangeTrust {
+    /// Off unless an operator says otherwise, per provider.
+    ///
+    /// An operator who configured Okta for *login* did not thereby agree to
+    /// accept Okta tokens as API credentials. Those are different trust
+    /// statements, so they get different switches.
+    pub enabled: bool,
+    /// Audiences an incoming subject token may name. **Non-empty when
+    /// `enabled`** — there is deliberately no "any audience" value.
+    ///
+    /// A token that was not addressed to us is a token we captured, not a
+    /// token we were given.
+    pub accepted_audiences: Vec<String>,
+    pub subject_mapping: SubjectMapping,
+    /// External asserted value → AXIAM scopes. Deny-by-default: a value with
+    /// no entry contributes nothing, and there is no passthrough mode.
+    ///
+    /// `BTreeMap` rather than `HashMap` so serialization is stable — this is
+    /// admin config that shows up in diffs and audit records.
+    pub scope_map: BTreeMap<String, Vec<String>>,
+    /// Bound on `now - iat`, independent of the token's own `exp`.
+    pub max_token_age_secs: i64,
+    /// Optional per-provider ceiling on the *issued* AXIAM token's lifetime,
+    /// applied on top of "never outlives its subject" and the server-wide
+    /// exchange maximum.
+    pub max_lifetime_secs: Option<i64>,
+}
+
+impl Default for TokenExchangeTrust {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            accepted_audiences: Vec::new(),
+            subject_mapping: SubjectMapping::LinkedOnly,
+            scope_map: BTreeMap::new(),
+            max_token_age_secs: DEFAULT_MAX_TOKEN_AGE_SECS,
+            max_lifetime_secs: None,
+        }
+    }
+}
+
+/// Why a submitted [`TokenExchangeTrust`] was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustConfigError {
+    NoAcceptedAudiences,
+    BlankAudience,
+    TooManyAudiences(usize),
+    TokenAgeOutOfRange(i64),
+    NonPositiveLifetime(i64),
+    TooManyScopeMapEntries(usize),
+    BlankScopeMapKey,
+    EmptyScopeMapValue(String),
+    BlankScopeName(String),
+}
+
+impl std::fmt::Display for TrustConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoAcceptedAudiences => write!(
+                f,
+                "token_exchange.accepted_audiences must name at least one audience \
+                 when token exchange is enabled; there is no accept-all value"
+            ),
+            Self::BlankAudience => {
+                write!(
+                    f,
+                    "token_exchange.accepted_audiences contains a blank entry"
+                )
+            }
+            Self::TooManyAudiences(n) => write!(
+                f,
+                "token_exchange.accepted_audiences has {n} entries; \
+                 the maximum is {MAX_ACCEPTED_AUDIENCES}"
+            ),
+            Self::TokenAgeOutOfRange(v) => write!(
+                f,
+                "token_exchange.max_token_age_secs is {v}; \
+                 it must be between 1 and {MAX_TOKEN_AGE_CEILING_SECS}"
+            ),
+            Self::NonPositiveLifetime(v) => write!(
+                f,
+                "token_exchange.max_lifetime_secs is {v}; it must be positive"
+            ),
+            Self::TooManyScopeMapEntries(n) => write!(
+                f,
+                "token_exchange.scope_map has {n} entries; \
+                 the maximum is {MAX_SCOPE_MAP_ENTRIES}"
+            ),
+            Self::BlankScopeMapKey => write!(f, "token_exchange.scope_map has a blank key"),
+            Self::EmptyScopeMapValue(k) => write!(
+                f,
+                "token_exchange.scope_map entry '{k}' maps to no AXIAM scopes; \
+                 remove the entry instead — an empty mapping is not a grant of nothing, \
+                 it is a mapping nobody can read"
+            ),
+            Self::BlankScopeName(k) => write!(
+                f,
+                "token_exchange.scope_map entry '{k}' maps to a blank scope name"
+            ),
+        }
+    }
+}
+
+impl TokenExchangeTrust {
+    /// Reject a configuration that cannot be enforced safely.
+    ///
+    /// Validation runs **whether or not `enabled` is set**, except for the
+    /// non-empty-audience rule: a disabled block with nonsense in it becomes
+    /// an enabled block with nonsense in it the moment someone flips a
+    /// checkbox, and that flip is not where an operator expects to be told
+    /// their `scope_map` was malformed.
+    pub fn validate(&self) -> Result<(), TrustConfigError> {
+        if self.enabled && self.accepted_audiences.is_empty() {
+            return Err(TrustConfigError::NoAcceptedAudiences);
+        }
+        if self.accepted_audiences.len() > MAX_ACCEPTED_AUDIENCES {
+            return Err(TrustConfigError::TooManyAudiences(
+                self.accepted_audiences.len(),
+            ));
+        }
+        if self.accepted_audiences.iter().any(|a| a.trim().is_empty()) {
+            return Err(TrustConfigError::BlankAudience);
+        }
+        if self.max_token_age_secs < 1 || self.max_token_age_secs > MAX_TOKEN_AGE_CEILING_SECS {
+            return Err(TrustConfigError::TokenAgeOutOfRange(
+                self.max_token_age_secs,
+            ));
+        }
+        if let Some(l) = self.max_lifetime_secs
+            && l < 1
+        {
+            return Err(TrustConfigError::NonPositiveLifetime(l));
+        }
+        if self.scope_map.len() > MAX_SCOPE_MAP_ENTRIES {
+            return Err(TrustConfigError::TooManyScopeMapEntries(
+                self.scope_map.len(),
+            ));
+        }
+        for (key, scopes) in &self.scope_map {
+            if key.trim().is_empty() {
+                return Err(TrustConfigError::BlankScopeMapKey);
+            }
+            if scopes.is_empty() {
+                return Err(TrustConfigError::EmptyScopeMapValue(key.clone()));
+            }
+            if scopes.iter().any(|s| s.trim().is_empty()) {
+                return Err(TrustConfigError::BlankScopeName(key.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether `aud` (already flattened to a list) names an accepted audience.
+    ///
+    /// Exact string equality, both directions. No normalisation: a trailing
+    /// slash is a different URI as far as this check is concerned, because
+    /// "close enough" comparisons at a trust boundary are how a token minted
+    /// for `https://api.partner.example.evil.com` gets accepted as
+    /// `https://api.partner.example`.
+    pub fn audience_accepted(&self, token_audiences: &[String]) -> bool {
+        token_audiences
+            .iter()
+            .any(|a| self.accepted_audiences.iter().any(|acc| acc == a))
+    }
+
+    /// Map what the external token asserted onto AXIAM scope names.
+    ///
+    /// Deny-by-default in the literal sense: an asserted value with no entry
+    /// contributes nothing and is not reported as an error — the partner's
+    /// token legitimately carries scopes that mean nothing here.
+    ///
+    /// Order follows `asserted`, then the map's own order, with duplicates
+    /// collapsed, so the result is deterministic and diffable.
+    pub fn map_scopes(&self, asserted: &[String]) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for value in asserted {
+            let Some(mapped) = self.scope_map.get(value) else {
+                continue;
+            };
+            for scope in mapped {
+                if !out.contains(scope) {
+                    out.push(scope.clone());
+                }
+            }
+        }
+        out
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -50,6 +304,17 @@ pub struct FederationConfig {
     /// Enables key rotation without re-encrypting all secrets at once.
     #[serde(skip_serializing)]
     pub client_secret_key_version: Option<i64>,
+    // ------------------------------------------------------------------
+    // X4 addition
+    // ------------------------------------------------------------------
+    /// RFC 8693 trust for tokens *issued by this provider* (X4).
+    ///
+    /// Meaningful only for [`FederationProtocol::OidcConnect`] rows. Absent in
+    /// the datastore for every pre-X4 row, which reads back as
+    /// [`TokenExchangeTrust::default()`] — `enabled: false`, i.e. exactly
+    /// today's behaviour.
+    #[serde(default)]
+    pub token_exchange: TokenExchangeTrust,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -74,6 +339,7 @@ impl std::fmt::Debug for FederationConfig {
             .field("client_secret_ciphertext", &"[REDACTED]")
             .field("client_secret_nonce", &"[REDACTED]")
             .field("client_secret_key_version", &"[REDACTED]")
+            .field("token_exchange", &self.token_exchange)
             .field("created_at", &self.created_at)
             .field("updated_at", &self.updated_at)
             .finish()
@@ -93,6 +359,8 @@ pub struct CreateFederationConfig {
     pub idp_signing_cert_pem: Option<String>,
     /// JWT signing algorithms accepted from this IdP (CQ-B40/REQ-14 AC-5).
     pub allowed_algorithms: Option<Vec<String>>,
+    /// X4 trust for exchanging this provider's tokens. Omitted ⇒ disabled.
+    pub token_exchange: Option<TokenExchangeTrust>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -107,6 +375,10 @@ pub struct UpdateFederationConfig {
     pub idp_signing_cert_pem: Option<Option<String>>,
     /// JWT signing algorithms accepted from this IdP (CQ-B40/REQ-14 AC-5).
     pub allowed_algorithms: Option<Vec<String>>,
+    /// X4 trust block. Replaced wholesale when present — a partial merge of a
+    /// trust configuration is how an operator ends up with an
+    /// `accepted_audiences` they did not intend to keep.
+    pub token_exchange: Option<TokenExchangeTrust>,
 }
 
 /// Tracks the link between an AXIAM user and their external IdP identity.
@@ -167,6 +439,7 @@ mod tests {
             client_secret_ciphertext: Some(CIPHERTEXT.to_string()),
             client_secret_nonce: Some(NONCE.to_string()),
             client_secret_key_version: Some(1),
+            token_exchange: TokenExchangeTrust::default(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -231,5 +504,163 @@ mod tests {
             debug_output.contains("[REDACTED]"),
             "Debug output must show a redaction marker for encrypted_private_key"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // X4 — TokenExchangeTrust
+    // -----------------------------------------------------------------
+
+    fn trust() -> TokenExchangeTrust {
+        TokenExchangeTrust {
+            enabled: true,
+            accepted_audiences: vec!["https://api.axiam.example".into()],
+            ..TokenExchangeTrust::default()
+        }
+    }
+
+    /// The headline default: X4 is off, and a config nobody touched behaves
+    /// exactly as it did before X4 existed.
+    #[test]
+    fn the_default_trust_block_is_disabled_and_trusts_nothing() {
+        let d = TokenExchangeTrust::default();
+        assert!(!d.enabled);
+        assert!(d.accepted_audiences.is_empty());
+        assert_eq!(d.subject_mapping, SubjectMapping::LinkedOnly);
+        assert!(d.scope_map.is_empty());
+        assert_eq!(d.max_token_age_secs, DEFAULT_MAX_TOKEN_AGE_SECS);
+        assert!(d.validate().is_ok(), "the default must be a valid config");
+    }
+
+    /// There is no accept-all audience, so enabling without one is refused.
+    #[test]
+    fn enabling_without_an_accepted_audience_is_refused() {
+        let t = TokenExchangeTrust {
+            enabled: true,
+            ..TokenExchangeTrust::default()
+        };
+        assert_eq!(t.validate(), Err(TrustConfigError::NoAcceptedAudiences));
+    }
+
+    /// …but a *disabled* block with no audiences is fine — that is the
+    /// default, and refusing it would make every pre-X4 row invalid.
+    #[test]
+    fn a_disabled_block_needs_no_audiences() {
+        assert!(TokenExchangeTrust::default().validate().is_ok());
+    }
+
+    #[test]
+    fn a_malformed_scope_map_is_refused_even_while_disabled() {
+        let mut t = TokenExchangeTrust::default();
+        t.scope_map.insert("partner.read".into(), vec![]);
+        assert_eq!(
+            t.validate(),
+            Err(TrustConfigError::EmptyScopeMapValue("partner.read".into())),
+            "a malformed map must be caught at write time, not at the checkbox flip"
+        );
+    }
+
+    #[test]
+    fn token_age_is_bounded_at_both_ends() {
+        for bad in [0, -1, MAX_TOKEN_AGE_CEILING_SECS + 1] {
+            let t = TokenExchangeTrust {
+                max_token_age_secs: bad,
+                ..trust()
+            };
+            assert_eq!(t.validate(), Err(TrustConfigError::TokenAgeOutOfRange(bad)));
+        }
+        for good in [1, DEFAULT_MAX_TOKEN_AGE_SECS, MAX_TOKEN_AGE_CEILING_SECS] {
+            let t = TokenExchangeTrust {
+                max_token_age_secs: good,
+                ..trust()
+            };
+            assert!(t.validate().is_ok(), "{good} should be accepted");
+        }
+    }
+
+    #[test]
+    fn audience_matching_is_exact_in_both_directions() {
+        let t = trust();
+        assert!(t.audience_accepted(&["https://api.axiam.example".to_string()]));
+        // A trailing slash is a different URI. "Close enough" here is how a
+        // token minted for a lookalike host gets accepted.
+        assert!(!t.audience_accepted(&["https://api.axiam.example/".to_string()]));
+        assert!(!t.audience_accepted(&["https://api.axiam.example.evil.test".to_string()]));
+        assert!(!t.audience_accepted(&[]));
+        // Multi-valued `aud`: one match is enough, which is what the spec says.
+        assert!(t.audience_accepted(&[
+            "https://other.example".to_string(),
+            "https://api.axiam.example".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn unmapped_external_values_contribute_nothing() {
+        let mut t = trust();
+        t.scope_map
+            .insert("partner.orders.read".into(), vec!["read:orders".into()]);
+
+        assert_eq!(
+            t.map_scopes(&[
+                "partner.orders.read".into(),
+                "partner.admin".into(), // no entry — silently contributes nothing
+            ]),
+            vec!["read:orders".to_string()],
+        );
+        // An entirely unmapped token maps to nothing at all, rather than to
+        // "everything the partner asked for".
+        assert!(t.map_scopes(&["partner.admin".into()]).is_empty());
+    }
+
+    #[test]
+    fn mapping_collapses_duplicates_and_keeps_a_deterministic_order() {
+        let mut t = trust();
+        t.scope_map.insert(
+            "a".into(),
+            vec!["read:orders".into(), "read:invoices".into()],
+        );
+        t.scope_map.insert("b".into(), vec!["read:orders".into()]);
+
+        assert_eq!(
+            t.map_scopes(&["a".into(), "b".into(), "a".into()]),
+            vec!["read:orders".to_string(), "read:invoices".to_string()],
+        );
+    }
+
+    /// The property the map exists to have: whatever comes out was named by
+    /// the map, never by the partner's token.
+    #[test]
+    fn mapped_output_is_always_a_subset_of_the_maps_own_range() {
+        let mut t = trust();
+        t.scope_map.insert("x".into(), vec!["read".into()]);
+        t.scope_map.insert("y".into(), vec!["write".into()]);
+        let range: Vec<String> = t.scope_map.values().flatten().cloned().collect();
+
+        for asserted in [
+            vec![],
+            vec!["x".to_string()],
+            vec!["y".to_string()],
+            vec!["x".to_string(), "y".to_string()],
+            // Values the partner invented, including ones that *look* like
+            // AXIAM scope names.
+            vec!["read".to_string(), "admin".to_string(), "z".to_string()],
+        ] {
+            for got in t.map_scopes(&asserted) {
+                assert!(range.contains(&got), "{got} escaped the map's range");
+            }
+        }
+    }
+
+    #[test]
+    fn an_unknown_subject_mapping_is_refused_rather_than_defaulted() {
+        assert_eq!(
+            SubjectMapping::from_wire("linked_only"),
+            Some(SubjectMapping::LinkedOnly)
+        );
+        assert_eq!(
+            SubjectMapping::from_wire("jit_provision"),
+            Some(SubjectMapping::JitProvision)
+        );
+        assert_eq!(SubjectMapping::from_wire("jit_provsion"), None);
+        assert_eq!(SubjectMapping::from_wire(""), None);
     }
 }

--- a/crates/axiam-core/src/repository.rs
+++ b/crates/axiam-core/src/repository.rs
@@ -1125,6 +1125,20 @@ pub trait FederationConfigRepository: Send + Sync {
         pagination: Pagination,
     ) -> impl Future<Output = AxiamResult<PaginatedResult<FederationConfig>>> + Send;
 
+    /// Every enabled OIDC provider of this tenant that has X4 external token
+    /// exchange switched on.
+    ///
+    /// A dedicated method rather than a filtered `list()` because it runs on
+    /// the exchange path: it is index-backed
+    /// (`idx_federation_config_tenant_tx`), it never hydrates the encrypted
+    /// secret columns, and — the part that matters for review — the "enabled
+    /// AND token-exchange-enabled" predicate lives in exactly one place
+    /// instead of being restated by every caller that could get it wrong.
+    fn list_token_exchange_enabled(
+        &self,
+        tenant_id: Uuid,
+    ) -> impl Future<Output = AxiamResult<Vec<FederationConfig>>> + Send;
+
     /// Return all `federation_config` rows where the legacy plaintext
     /// `client_secret` is present and the encrypted columns are absent.
     ///

--- a/crates/axiam-db/src/repository/federation_config.rs
+++ b/crates/axiam-db/src/repository/federation_config.rs
@@ -3,7 +3,8 @@
 use axiam_core::error::AxiamResult;
 use axiam_core::id::new_id;
 use axiam_core::models::federation::{
-    CreateFederationConfig, FederationConfig, FederationProtocol, UpdateFederationConfig,
+    CreateFederationConfig, DEFAULT_MAX_TOKEN_AGE_SECS, FederationConfig, FederationProtocol,
+    SubjectMapping, TokenExchangeTrust, UpdateFederationConfig,
 };
 use axiam_core::repository::{FederationConfigRepository, PaginatedResult, Pagination};
 use chrono::{DateTime, Utc};
@@ -35,6 +36,14 @@ struct FederationConfigRow {
     client_secret_ciphertext: Option<String>,
     client_secret_nonce: Option<String>,
     client_secret_key_version: Option<i64>,
+    // X4 token-exchange trust (schema v36) — every column is optional or
+    // DEFAULT-ed, so a pre-X4 row hydrates to `TokenExchangeTrust::default()`.
+    token_exchange_enabled: Option<bool>,
+    token_exchange_accepted_audiences: Option<Vec<String>>,
+    token_exchange_subject_mapping: Option<String>,
+    token_exchange_scope_map_json: Option<String>,
+    token_exchange_max_token_age_secs: Option<i64>,
+    token_exchange_max_lifetime_secs: Option<i64>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -56,6 +65,14 @@ struct FederationConfigRowWithId {
     client_secret_ciphertext: Option<String>,
     client_secret_nonce: Option<String>,
     client_secret_key_version: Option<i64>,
+    // X4 token-exchange trust (schema v36) — every column is optional or
+    // DEFAULT-ed, so a pre-X4 row hydrates to `TokenExchangeTrust::default()`.
+    token_exchange_enabled: Option<bool>,
+    token_exchange_accepted_audiences: Option<Vec<String>>,
+    token_exchange_subject_mapping: Option<String>,
+    token_exchange_scope_map_json: Option<String>,
+    token_exchange_max_token_age_secs: Option<i64>,
+    token_exchange_max_lifetime_secs: Option<i64>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -77,6 +94,14 @@ struct FederationConfigListRow {
     enabled: bool,
     allowed_algorithms: Vec<String>,
     idp_signing_cert_pem: Option<String>,
+    // X4 token-exchange trust (schema v36) — every column is optional or
+    // DEFAULT-ed, so a pre-X4 row hydrates to `TokenExchangeTrust::default()`.
+    token_exchange_enabled: Option<bool>,
+    token_exchange_accepted_audiences: Option<Vec<String>>,
+    token_exchange_subject_mapping: Option<String>,
+    token_exchange_scope_map_json: Option<String>,
+    token_exchange_max_token_age_secs: Option<i64>,
+    token_exchange_max_lifetime_secs: Option<i64>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -102,6 +127,53 @@ fn protocol_to_string(p: &FederationProtocol) -> &'static str {
     }
 }
 
+/// The six X4 columns, as they were read back, in row order.
+type TrustColumns = (
+    Option<bool>,
+    Option<Vec<String>>,
+    Option<String>,
+    Option<String>,
+    Option<i64>,
+    Option<i64>,
+);
+
+/// Hydrate the X4 trust block from its columns.
+///
+/// Every failure mode here resolves **towards the default**, which is
+/// `enabled: false` — a row whose `scope_map_json` no longer parses, or whose
+/// `subject_mapping` holds a value this build does not know, must not become a
+/// row that trusts *more* than intended. The one thing that is never inferred
+/// is `enabled`: it is read straight from its own column, so a corrupt
+/// neighbouring column can never switch external exchange on.
+fn trust_from_columns(cols: TrustColumns) -> TokenExchangeTrust {
+    let (enabled, audiences, mapping, scope_map_json, max_age, max_lifetime) = cols;
+    let default = TokenExchangeTrust::default();
+    TokenExchangeTrust {
+        enabled: enabled.unwrap_or(false),
+        accepted_audiences: audiences.unwrap_or_default(),
+        subject_mapping: mapping
+            .as_deref()
+            .and_then(SubjectMapping::from_wire)
+            .unwrap_or(default.subject_mapping),
+        scope_map: scope_map_json
+            .as_deref()
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_default(),
+        max_token_age_secs: max_age.unwrap_or(DEFAULT_MAX_TOKEN_AGE_SECS),
+        max_lifetime_secs: max_lifetime,
+    }
+}
+
+/// Serialize the scope map for storage.
+///
+/// Infallible by construction — the map is `BTreeMap<String, Vec<String>>`,
+/// which has no un-serializable inhabitant — so a failure here would be a bug
+/// in serde_json rather than bad data, and `{}` (trust nothing) is the safe
+/// answer to a bug.
+fn scope_map_json(trust: &TokenExchangeTrust) -> String {
+    serde_json::to_string(&trust.scope_map).unwrap_or_else(|_| "{}".to_string())
+}
+
 impl FederationConfigRow {
     fn try_into_entry(self, id: Uuid) -> Result<FederationConfig, DbError> {
         Ok(FederationConfig {
@@ -120,6 +192,14 @@ impl FederationConfigRow {
             client_secret_ciphertext: self.client_secret_ciphertext,
             client_secret_nonce: self.client_secret_nonce,
             client_secret_key_version: self.client_secret_key_version,
+            token_exchange: trust_from_columns((
+                self.token_exchange_enabled,
+                self.token_exchange_accepted_audiences,
+                self.token_exchange_subject_mapping,
+                self.token_exchange_scope_map_json,
+                self.token_exchange_max_token_age_secs,
+                self.token_exchange_max_lifetime_secs,
+            )),
             created_at: self.created_at,
             updated_at: self.updated_at,
         })
@@ -149,6 +229,14 @@ impl FederationConfigListRow {
             client_secret_ciphertext: None,
             client_secret_nonce: None,
             client_secret_key_version: None,
+            token_exchange: trust_from_columns((
+                self.token_exchange_enabled,
+                self.token_exchange_accepted_audiences,
+                self.token_exchange_subject_mapping,
+                self.token_exchange_scope_map_json,
+                self.token_exchange_max_token_age_secs,
+                self.token_exchange_max_lifetime_secs,
+            )),
             created_at: self.created_at,
             updated_at: self.updated_at,
         })
@@ -174,6 +262,14 @@ impl FederationConfigRowWithId {
             client_secret_ciphertext: self.client_secret_ciphertext,
             client_secret_nonce: self.client_secret_nonce,
             client_secret_key_version: self.client_secret_key_version,
+            token_exchange: trust_from_columns((
+                self.token_exchange_enabled,
+                self.token_exchange_accepted_audiences,
+                self.token_exchange_subject_mapping,
+                self.token_exchange_scope_map_json,
+                self.token_exchange_max_token_age_secs,
+                self.token_exchange_max_lifetime_secs,
+            )),
             created_at: self.created_at,
             updated_at: self.updated_at,
         })
@@ -213,6 +309,12 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
             .allowed_algorithms
             .unwrap_or_else(|| vec!["RS256".to_string()]);
 
+        // X4: absent means "no external token exchange", which is also what
+        // `TokenExchangeTrust::default()` means. The caller (the REST handler)
+        // has already validated it; re-validating here would duplicate the
+        // rule in a place that cannot report it usefully.
+        let trust = input.token_exchange.unwrap_or_default();
+
         let result = self
             .db
             .current()
@@ -227,6 +329,12 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
                  attribute_map = $attribute_map, \
                  idp_signing_cert_pem = $idp_signing_cert_pem, \
                  allowed_algorithms = $allowed_algorithms, \
+                 token_exchange_enabled = $tx_enabled, \
+                 token_exchange_accepted_audiences = $tx_audiences, \
+                 token_exchange_subject_mapping = $tx_mapping, \
+                 token_exchange_scope_map_json = $tx_scope_map, \
+                 token_exchange_max_token_age_secs = $tx_max_age, \
+                 token_exchange_max_lifetime_secs = $tx_max_lifetime, \
                  enabled = true, \
                  created_at = time::now(), \
                  updated_at = time::now()",
@@ -243,6 +351,15 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
             .bind(("attribute_map", attribute_map))
             .bind(("idp_signing_cert_pem", input.idp_signing_cert_pem))
             .bind(("allowed_algorithms", allowed_algorithms))
+            .bind(("tx_enabled", trust.enabled))
+            .bind(("tx_audiences", trust.accepted_audiences.clone()))
+            .bind((
+                "tx_mapping",
+                trust.subject_mapping.as_str().to_string(),
+            ))
+            .bind(("tx_scope_map", scope_map_json(&trust)))
+            .bind(("tx_max_age", trust.max_token_age_secs))
+            .bind(("tx_max_lifetime", trust.max_lifetime_secs))
             .await
             .map_err(DbError::from)?;
 
@@ -323,6 +440,38 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
             binds.push((
                 "allowed_algorithms".into(),
                 serde_json::json!(allowed_algorithms),
+            ));
+        }
+        // Replaced wholesale, never merged field-by-field: a partial merge of
+        // a trust configuration is how an operator ends up keeping an
+        // `accepted_audiences` entry they believed they had removed.
+        if let Some(ref trust) = input.token_exchange {
+            set_clauses.push("token_exchange_enabled = $tx_enabled".into());
+            binds.push(("tx_enabled".into(), serde_json::json!(trust.enabled)));
+            set_clauses.push("token_exchange_accepted_audiences = $tx_audiences".into());
+            binds.push((
+                "tx_audiences".into(),
+                serde_json::json!(trust.accepted_audiences),
+            ));
+            set_clauses.push("token_exchange_subject_mapping = $tx_mapping".into());
+            binds.push((
+                "tx_mapping".into(),
+                serde_json::json!(trust.subject_mapping.as_str()),
+            ));
+            set_clauses.push("token_exchange_scope_map_json = $tx_scope_map".into());
+            binds.push((
+                "tx_scope_map".into(),
+                serde_json::json!(scope_map_json(trust)),
+            ));
+            set_clauses.push("token_exchange_max_token_age_secs = $tx_max_age".into());
+            binds.push((
+                "tx_max_age".into(),
+                serde_json::json!(trust.max_token_age_secs),
+            ));
+            set_clauses.push("token_exchange_max_lifetime_secs = $tx_max_lifetime".into());
+            binds.push((
+                "tx_max_lifetime".into(),
+                serde_json::json!(trust.max_lifetime_secs),
             ));
         }
 
@@ -410,7 +559,10 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
             .query(
                 "SELECT meta::id(id) AS record_id, tenant_id, provider, protocol, \
                  metadata_url, client_id, attribute_map, enabled, allowed_algorithms, \
-                 idp_signing_cert_pem, created_at, updated_at \
+                 idp_signing_cert_pem, token_exchange_enabled, \
+                 token_exchange_accepted_audiences, token_exchange_subject_mapping, \
+                 token_exchange_scope_map_json, token_exchange_max_token_age_secs, \
+                 token_exchange_max_lifetime_secs, created_at, updated_at \
                  FROM federation_config \
                  WHERE tenant_id = $tenant_id \
                  ORDER BY created_at DESC \
@@ -432,6 +584,45 @@ impl<C: Connection> FederationConfigRepository for SurrealFederationConfigReposi
             .collect::<Result<_, _>>()?;
 
         Ok(paginate(items, count_rows, &pagination))
+    }
+
+    async fn list_token_exchange_enabled(
+        &self,
+        tenant_id: Uuid,
+    ) -> AxiamResult<Vec<FederationConfig>> {
+        // Both `enabled` flags are required, and they are different
+        // statements: `enabled` is "this provider is live at all",
+        // `token_exchange_enabled` is "…and its tokens may be exchanged".
+        // Protocol is filtered too — a SAML row has no issuer to match and no
+        // JWKS to verify against, so it can never be the answer here.
+        let result = self
+            .db
+            .current()
+            .query(
+                "SELECT meta::id(id) AS record_id, tenant_id, provider, protocol, \
+                 metadata_url, client_id, attribute_map, enabled, allowed_algorithms, \
+                 idp_signing_cert_pem, token_exchange_enabled, \
+                 token_exchange_accepted_audiences, token_exchange_subject_mapping, \
+                 token_exchange_scope_map_json, token_exchange_max_token_age_secs, \
+                 token_exchange_max_lifetime_secs, created_at, updated_at \
+                 FROM federation_config \
+                 WHERE tenant_id = $tenant_id \
+                 AND token_exchange_enabled = true \
+                 AND enabled = true \
+                 AND protocol = 'OidcConnect' \
+                 ORDER BY created_at ASC",
+            )
+            .bind(("tenant_id", tenant_id.to_string()))
+            .await
+            .map_err(DbError::from)?;
+
+        let mut result = result
+            .check()
+            .map_err(|e| DbError::Migration(e.to_string()))?;
+        let rows: Vec<FederationConfigListRow> = result.take(0).map_err(DbError::from)?;
+        rows.into_iter()
+            .map(|r| r.try_into_entry().map_err(Into::into))
+            .collect()
     }
 
     async fn list_with_legacy_plaintext_secret(&self) -> AxiamResult<Vec<FederationConfig>> {

--- a/crates/axiam-db/src/schema.rs
+++ b/crates/axiam-db/src/schema.rs
@@ -217,6 +217,11 @@ static MIGRATIONS: &[Migration] = &[
         name: "webauthn_attestation_policy_and_mds",
         sql: SCHEMA_V35,
     },
+    Migration {
+        version: 36,
+        name: "federation_external_token_exchange_trust",
+        sql: SCHEMA_V36,
+    },
 ];
 
 // -----------------------------------------------------------------------
@@ -1867,6 +1872,48 @@ DEFINE FIELD IF NOT EXISTS aaguid ON TABLE webauthn_credential TYPE option<strin
 DEFINE FIELD IF NOT EXISTS attestation_format ON TABLE webauthn_credential TYPE option<string>;
 DEFINE FIELD IF NOT EXISTS attested ON TABLE webauthn_credential TYPE bool DEFAULT false;
 DEFINE FIELD IF NOT EXISTS authenticator_name ON TABLE webauthn_credential TYPE option<string>;
+";
+
+// -----------------------------------------------------------------------
+// Schema v36 — external-IdP token-exchange trust on federation providers (X4)
+// -----------------------------------------------------------------------
+//
+// Purely additive columns on the existing `federation_config` table. Every
+// pre-X4 row reads back as `TokenExchangeTrust::default()` — the repository
+// maps a missing/NONE column to the default rather than relying on a DB
+// DEFAULT, so there is no backfill and no window in which a row is half-X4.
+//
+// `token_exchange_enabled` DEFAULTs to **false**, which is the whole safety
+// story of this migration: turning on X4 for a provider is an explicit act,
+// never a consequence of upgrading. An operator who configured Okta for login
+// did not thereby agree to accept Okta tokens as API credentials.
+//
+// `token_exchange_scope_map` is a JSON string rather than a nested SurrealDB
+// object, for the same reason `mds_entry.status_reports_json` is (v35): it is
+// read and written whole, never queried by sub-field, and modelling a
+// map-of-arrays in DDL a second time buys nothing. `accepted_audiences` IS a
+// native array — it is a list of scalars, and an operator reading the row
+// should be able to see at a glance which audiences a provider trusts.
+//
+// `subject_mapping` follows v25/v35's `option<string> ASSERT $value = NONE OR
+// $value IN [...]` pattern for an optional enum-like column; NONE means
+// `linked_only`, the stricter of the two.
+const SCHEMA_V36: &str = "\
+DEFINE FIELD IF NOT EXISTS token_exchange_enabled ON TABLE federation_config
+    TYPE bool DEFAULT false;
+DEFINE FIELD IF NOT EXISTS token_exchange_accepted_audiences ON TABLE federation_config
+    TYPE array<string> DEFAULT [];
+DEFINE FIELD IF NOT EXISTS token_exchange_subject_mapping ON TABLE federation_config
+    TYPE option<string>
+    ASSERT $value = NONE OR $value IN ['linked_only', 'jit_provision'];
+DEFINE FIELD IF NOT EXISTS token_exchange_scope_map_json ON TABLE federation_config
+    TYPE string DEFAULT '{}';
+DEFINE FIELD IF NOT EXISTS token_exchange_max_token_age_secs ON TABLE federation_config
+    TYPE option<int>;
+DEFINE FIELD IF NOT EXISTS token_exchange_max_lifetime_secs ON TABLE federation_config
+    TYPE option<int>;
+DEFINE INDEX IF NOT EXISTS idx_federation_config_tenant_tx ON TABLE federation_config
+    COLUMNS tenant_id, token_exchange_enabled;
 ";
 
 // -----------------------------------------------------------------------

--- a/crates/axiam-db/tests/uncovered_repos_test.rs
+++ b/crates/axiam-db/tests/uncovered_repos_test.rs
@@ -5,7 +5,8 @@
 
 use axiam_core::models::email_verification::CreateEmailVerificationToken;
 use axiam_core::models::federation::{
-    CreateFederationConfig, CreateFederationLink, FederationProtocol, UpdateFederationConfig,
+    CreateFederationConfig, CreateFederationLink, FederationProtocol, SubjectMapping,
+    TokenExchangeTrust, UpdateFederationConfig,
 };
 use axiam_core::models::oauth2_client::{CreateOAuth2Client, UpdateOAuth2Client};
 use axiam_core::models::organization::CreateOrganization;
@@ -248,6 +249,7 @@ async fn federation_config_crud_and_backfill() {
             attribute_map: None,
             idp_signing_cert_pem: None,
             allowed_algorithms: Some(vec!["RS256".into()]),
+            token_exchange: None,
         })
         .await
         .unwrap();
@@ -284,6 +286,222 @@ async fn federation_config_crud_and_backfill() {
 
     repo.delete(tenant_id, cfg.id).await.unwrap();
     assert!(repo.get_by_id(tenant_id, cfg.id).await.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// X4 — external token-exchange trust
+// ---------------------------------------------------------------------------
+
+/// A provider created without a trust block reads back as
+/// `TokenExchangeTrust::default()` — disabled, trusting nothing.
+///
+/// This is the "no backfill" claim of schema v36 stated as a test: the
+/// migration adds columns and nothing rewrites existing rows, so a pre-X4 row
+/// must hydrate to today's behaviour rather than to a partially-populated
+/// struct. `list_token_exchange_enabled` must also not see it.
+#[tokio::test]
+async fn a_provider_without_a_trust_block_reads_back_disabled() {
+    let (db, _org, tenant_id) = setup().await;
+    let repo = SurrealFederationConfigRepository::new(db);
+
+    let cfg = repo
+        .create(CreateFederationConfig {
+            tenant_id,
+            provider: "legacy-idp".into(),
+            protocol: FederationProtocol::OidcConnect,
+            metadata_url: Some("https://idp.example.com/.well-known".into()),
+            client_id: "cid".into(),
+            client_secret: String::new(),
+            attribute_map: None,
+            idp_signing_cert_pem: None,
+            allowed_algorithms: None,
+            token_exchange: None,
+        })
+        .await
+        .unwrap();
+
+    let got = repo.get_by_id(tenant_id, cfg.id).await.unwrap();
+    assert_eq!(got.token_exchange, TokenExchangeTrust::default());
+    assert!(!got.token_exchange.enabled);
+
+    assert!(
+        repo.list_token_exchange_enabled(tenant_id)
+            .await
+            .unwrap()
+            .is_empty(),
+        "a provider with no trust block must not be a candidate issuer"
+    );
+}
+
+/// Every field survives a write/read round trip, including the nested scope
+/// map — which is stored as a JSON string, so it is the one field a naive
+/// column mapping would quietly lose.
+#[tokio::test]
+async fn a_trust_block_round_trips_through_the_datastore() {
+    let (db, _org, tenant_id) = setup().await;
+    let repo = SurrealFederationConfigRepository::new(db);
+
+    let mut scope_map = std::collections::BTreeMap::new();
+    scope_map.insert(
+        "partner.orders.read".to_string(),
+        vec!["read:orders".to_string(), "list:orders".to_string()],
+    );
+    let trust = TokenExchangeTrust {
+        enabled: true,
+        accepted_audiences: vec!["https://api.example.com".into()],
+        subject_mapping: SubjectMapping::JitProvision,
+        scope_map,
+        max_token_age_secs: 120,
+        max_lifetime_secs: Some(600),
+    };
+
+    let cfg = repo
+        .create(CreateFederationConfig {
+            tenant_id,
+            provider: "partner".into(),
+            protocol: FederationProtocol::OidcConnect,
+            metadata_url: Some("https://partner.example/.well-known".into()),
+            client_id: "cid".into(),
+            client_secret: String::new(),
+            attribute_map: None,
+            idp_signing_cert_pem: None,
+            allowed_algorithms: Some(vec!["RS256".into()]),
+            token_exchange: Some(trust.clone()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        repo.get_by_id(tenant_id, cfg.id)
+            .await
+            .unwrap()
+            .token_exchange,
+        trust
+    );
+
+    // The exchange path's own query must find it, and hydrate it fully —
+    // that query uses the narrowed list projection, which is a second place
+    // the columns have to be named.
+    let candidates = repo.list_token_exchange_enabled(tenant_id).await.unwrap();
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].token_exchange, trust);
+
+    // Disabling removes it from the candidate set. Wholesale replacement, so
+    // the rest of the block travels with the flag.
+    repo.update(
+        tenant_id,
+        cfg.id,
+        UpdateFederationConfig {
+            token_exchange: Some(TokenExchangeTrust {
+                enabled: false,
+                ..trust.clone()
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        repo.list_token_exchange_enabled(tenant_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let after = repo.get_by_id(tenant_id, cfg.id).await.unwrap();
+    assert_eq!(
+        after.token_exchange.accepted_audiences,
+        trust.accepted_audiences
+    );
+    assert_eq!(after.token_exchange.scope_map, trust.scope_map);
+}
+
+/// A SAML row is never a candidate, whatever its columns say. It has no issuer
+/// to match and no JWKS to verify against, so the predicate lives in the query
+/// rather than in every caller.
+#[tokio::test]
+async fn a_saml_provider_is_never_a_token_exchange_candidate() {
+    let (db, _org, tenant_id) = setup().await;
+    let repo = SurrealFederationConfigRepository::new(db);
+
+    repo.create(CreateFederationConfig {
+        tenant_id,
+        provider: "saml-idp".into(),
+        protocol: FederationProtocol::Saml,
+        metadata_url: Some("https://saml.example/metadata".into()),
+        client_id: "cid".into(),
+        client_secret: String::new(),
+        attribute_map: None,
+        idp_signing_cert_pem: None,
+        allowed_algorithms: None,
+        token_exchange: Some(TokenExchangeTrust {
+            enabled: true,
+            accepted_audiences: vec!["https://api.example.com".into()],
+            ..TokenExchangeTrust::default()
+        }),
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        repo.list_token_exchange_enabled(tenant_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// A provider that is globally disabled is not a candidate either. `enabled`
+/// and `token_exchange.enabled` are different statements — "this provider is
+/// live at all" and "…and its tokens may be exchanged" — and both must hold.
+#[tokio::test]
+async fn a_globally_disabled_provider_is_not_a_candidate() {
+    let (db, _org, tenant_id) = setup().await;
+    let repo = SurrealFederationConfigRepository::new(db);
+
+    let cfg = repo
+        .create(CreateFederationConfig {
+            tenant_id,
+            provider: "paused".into(),
+            protocol: FederationProtocol::OidcConnect,
+            metadata_url: Some("https://paused.example/.well-known".into()),
+            client_id: "cid".into(),
+            client_secret: String::new(),
+            attribute_map: None,
+            idp_signing_cert_pem: None,
+            allowed_algorithms: None,
+            token_exchange: Some(TokenExchangeTrust {
+                enabled: true,
+                accepted_audiences: vec!["https://api.example.com".into()],
+                ..TokenExchangeTrust::default()
+            }),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        repo.list_token_exchange_enabled(tenant_id)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    repo.update(
+        tenant_id,
+        cfg.id,
+        UpdateFederationConfig {
+            enabled: Some(false),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        repo.list_token_exchange_enabled(tenant_id)
+            .await
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/crates/axiam-db/tests/uncovered_repos_test.rs
+++ b/crates/axiam-db/tests/uncovered_repos_test.rs
@@ -323,6 +323,7 @@ async fn federation_config_list_excludes_secret_columns() {
         attribute_map: None,
         idp_signing_cert_pem: None,
         allowed_algorithms: None,
+        token_exchange: None,
     })
     .await
     .unwrap();
@@ -352,6 +353,7 @@ async fn federation_config_legacy_plaintext_excludes_encrypted_rows() {
             attribute_map: None,
             idp_signing_cert_pem: None,
             allowed_algorithms: None,
+            token_exchange: None,
         })
         .await
         .unwrap();
@@ -367,6 +369,7 @@ async fn federation_config_legacy_plaintext_excludes_encrypted_rows() {
             attribute_map: None,
             idp_signing_cert_pem: None,
             allowed_algorithms: None,
+            token_exchange: None,
         })
         .await
         .unwrap();

--- a/crates/axiam-federation/src/lib.rs
+++ b/crates/axiam-federation/src/lib.rs
@@ -12,6 +12,8 @@ pub mod oidc;
 #[cfg(feature = "saml")]
 pub mod saml;
 pub mod secrets;
+/// X4 — verifying an external IdP's token as an RFC 8693 subject token.
+pub mod token_exchange;
 
 /// Shared SSRF guard (D2, X3): lifted verbatim to `axiam-pki` because it now
 /// backs the MDS BLOB fetch path too, and PKI is where trust-anchor/outbound

--- a/crates/axiam-federation/src/oidc.rs
+++ b/crates/axiam-federation/src/oidc.rs
@@ -23,7 +23,12 @@ use crate::discovery_cache::DiscoveryCache;
 use crate::error::FederationError;
 use crate::jwks_cache::JwksCache;
 use crate::secrets::decrypt_client_secret_or_legacy;
+// X4: the unverified-issuer reader is shared with `axiam-oauth2`'s exchange
+// grant, so it lives in `axiam-auth` (the crate both depend on) rather than
+// being written twice. Re-exported here so this crate's own call sites and
+// tests keep referring to it by the module they use.
 use crate::validate_metadata_url;
+pub use axiam_auth::token::unverified_issuer_of;
 
 /// Minimal OIDC Discovery document fields we care about.
 #[derive(Debug, Clone, Deserialize)]
@@ -141,6 +146,36 @@ where
             discovery_cache,
             encryption_key,
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Collaborator accessors (X4)
+    // ------------------------------------------------------------------
+    //
+    // The external token-exchange path lives in a sibling module and needs the
+    // same collaborators this one already owns. Exposing them `pub(crate)`
+    // beats a second service with its own copies: two JWKS caches would mean
+    // two rollover states, and two federation-link repositories would mean two
+    // answers to "which user is this".
+
+    pub(crate) fn jwks_cache(&self) -> &JwksCache {
+        &self.cache
+    }
+
+    pub(crate) fn http_client(&self) -> &reqwest::Client {
+        &self.http_client
+    }
+
+    pub(crate) fn federation_config_repo_ref(&self) -> &FC {
+        &self.federation_config_repo
+    }
+
+    pub(crate) fn federation_link_repo_ref(&self) -> &FL {
+        &self.federation_link_repo
+    }
+
+    pub(crate) fn user_repo_ref(&self) -> &UR {
+        &self.user_repo
     }
 
     /// Fetch and parse the OIDC discovery document from the provider.
@@ -496,7 +531,13 @@ where
 
     /// Provision a new user or link an existing one to the external IdP
     /// identity.
-    async fn provision_or_link_user(
+    ///
+    /// `pub(crate)` since X4: the external token-exchange path
+    /// ([`crate::token_exchange`]) resolves its subject through **this exact
+    /// function** rather than a parallel one, so a partner token and a browser
+    /// login can never disagree about which AXIAM user an `(issuer, sub)` pair
+    /// means, and the JIT provisioning rules are written down once.
+    pub(crate) async fn provision_or_link_user(
         &self,
         tenant_id: Uuid,
         config_id: Uuid,
@@ -1171,6 +1212,12 @@ MC4CAQAwBQYDK2VwBCIEINvQFIZqeI5OX7TDEFKcYhLxO5R75FOv/nC4+o+HHPfM\n\
         ) -> AxiamResult<PaginatedResult<FederationConfig>> {
             unimplemented!()
         }
+        async fn list_token_exchange_enabled(
+            &self,
+            _tenant_id: Uuid,
+        ) -> AxiamResult<Vec<FederationConfig>> {
+            Ok(Vec::new())
+        }
         async fn list_with_legacy_plaintext_secret(&self) -> AxiamResult<Vec<FederationConfig>> {
             unimplemented!()
         }
@@ -1761,6 +1808,12 @@ MC4CAQAwBQYDK2VwBCIEINvQFIZqeI5OX7TDEFKcYhLxO5R75FOv/nC4+o+HHPfM\n\
         ) -> AxiamResult<PaginatedResult<FederationConfig>> {
             unimplemented!()
         }
+        async fn list_token_exchange_enabled(
+            &self,
+            _tenant_id: Uuid,
+        ) -> AxiamResult<Vec<FederationConfig>> {
+            Ok(Vec::new())
+        }
         async fn list_with_legacy_plaintext_secret(&self) -> AxiamResult<Vec<FederationConfig>> {
             unimplemented!()
         }
@@ -1806,6 +1859,7 @@ MC4CAQAwBQYDK2VwBCIEINvQFIZqeI5OX7TDEFKcYhLxO5R75FOv/nC4+o+HHPfM\n\
             client_secret_ciphertext: None,
             client_secret_nonce: None,
             client_secret_key_version: None,
+            token_exchange: Default::default(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }

--- a/crates/axiam-federation/src/saml.rs
+++ b/crates/axiam-federation/src/saml.rs
@@ -1004,6 +1004,7 @@ mod tests {
             client_secret_ciphertext: None,
             client_secret_nonce: None,
             client_secret_key_version: None,
+            token_exchange: Default::default(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -1083,6 +1084,12 @@ mod tests {
             _: Pagination,
         ) -> axiam_core::error::AxiamResult<PaginatedResult<FederationConfig>> {
             unimplemented!()
+        }
+        async fn list_token_exchange_enabled(
+            &self,
+            _tenant_id: Uuid,
+        ) -> axiam_core::error::AxiamResult<Vec<FederationConfig>> {
+            Ok(Vec::new())
         }
         async fn list_with_legacy_plaintext_secret(
             &self,
@@ -1358,6 +1365,12 @@ mod tests {
             _: Pagination,
         ) -> axiam_core::error::AxiamResult<PaginatedResult<FederationConfig>> {
             unimplemented!()
+        }
+        async fn list_token_exchange_enabled(
+            &self,
+            _tenant_id: Uuid,
+        ) -> axiam_core::error::AxiamResult<Vec<FederationConfig>> {
+            Ok(Vec::new())
         }
         async fn list_with_legacy_plaintext_secret(
             &self,

--- a/crates/axiam-federation/src/token_exchange.rs
+++ b/crates/axiam-federation/src/token_exchange.rs
@@ -1,0 +1,835 @@
+//! X4 — accepting an **external IdP's** token as an RFC 8693 subject token.
+//!
+//! Design: `claude_dev/external-token-exchange-design.md`. The sentence that
+//! governs every function here, because it is what makes this path different
+//! from B3's:
+//!
+//! > **An external subject token is evidence of authentication, never a grant
+//! > of authorization.**
+//!
+//! B3 narrows an AXIAM token against itself; there is a `subject_scopes` set
+//! to intersect with. A partner's token has no such set — its scopes are the
+//! partner's vocabulary and carry no authority in this tenant. So this module
+//! answers exactly one question — *which AXIAM user, if any, does this token
+//! prove authenticated, and which AXIAM scope names did the admin agree that
+//! provider's assertions may map onto* — and hands the answer to
+//! `axiam-oauth2`, which decides what may actually be issued.
+//!
+//! # Why this lives in `axiam-federation`
+//!
+//! Every input is already here: the provider rows, the discovery cache, the
+//! JWKS cache with its kid-rollover behaviour, the SSRF guard, and the JIT
+//! provisioning path. Re-implementing any of them next to the token endpoint
+//! would create a second place where "which user is this" can be answered, and
+//! the two would drift. The exchange path resolves subjects through the *same*
+//! [`OidcFederationService::provision_or_link_user`] a browser login uses.
+
+use axiam_core::error::AxiamError;
+use axiam_core::models::federation::{FederationConfig, SubjectMapping};
+use axiam_core::models::user::UserStatus;
+use axiam_core::repository::{
+    FederationConfigRepository, FederationLinkRepository, UserRepository,
+};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::Deserialize;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::error::FederationError;
+use crate::oidc::{
+    OidcFederationService, find_jwk, map_algorithm_strings, reject_alg_none_raw,
+    unverified_issuer_of,
+};
+
+/// Clock-skew tolerance, matching the OIDC login path (D-05 / REQ-5).
+const LEEWAY_SECS: u64 = 60;
+
+/// Claims read out of an external subject token.
+///
+/// Everything is `Option` **except `sub`**: this struct is deserialized after
+/// `jsonwebtoken` has already enforced the presence of `iss`/`aud`/`exp`/`iat`
+/// through `set_required_spec_claims`, and duplicating that as non-optional
+/// fields would turn a clear "claim rejected" into an opaque parse error.
+#[derive(Debug, Clone, Deserialize)]
+struct ExternalClaims {
+    sub: String,
+    iss: Option<String>,
+    aud: Option<serde_json::Value>,
+    exp: Option<i64>,
+    iat: Option<i64>,
+    // ---- scope-bearing claims (see `asserted_values`) -------------------
+    scope: Option<String>,
+    scp: Option<serde_json::Value>,
+    roles: Option<Vec<String>>,
+    groups: Option<Vec<String>>,
+    // ---- shape markers --------------------------------------------------
+    /// OIDC Core §3.1.3.7 — an ID-token-only claim.
+    nonce: Option<String>,
+    /// OIDC Core §3.3.2.11 / §3.2.2.9 — ID-token-only hashes.
+    at_hash: Option<String>,
+    c_hash: Option<String>,
+    s_hash: Option<String>,
+    /// X4's own provenance claim. Present ⇒ this token is already the product
+    /// of an exchange and must not buy another one.
+    ext_exchange: Option<serde_json::Value>,
+    /// Some IdPs (notably Keycloak) put the token kind in a `typ` *claim*
+    /// rather than only in the JOSE header.
+    typ: Option<String>,
+}
+
+/// What a successful external verification established.
+#[derive(Debug, Clone)]
+pub struct ExternalSubject {
+    /// The foreign issuer, exactly as the token spelled it. Stamped into the
+    /// issued token's `ext_exchange` claim and into the audit record.
+    pub issuer: String,
+    pub provider_id: Uuid,
+    pub provider_name: String,
+    /// The partner-local subject identifier (`sub`). Audit only — never a key
+    /// for anything downstream.
+    pub external_subject: String,
+    pub user_id: Uuid,
+    /// True when this call created the AXIAM user. The only record that a
+    /// partner's IdP provisioned a local identity.
+    pub newly_provisioned: bool,
+    /// AXIAM scope names the provider's `scope_map` produced. A **candidate**
+    /// set: the client registration and the RBAC engine still have to agree.
+    pub candidate_scopes: Vec<String>,
+    /// The external token's `exp`, so the issued token cannot outlive it.
+    pub subject_exp: i64,
+    /// Per-provider ceiling on the issued token's lifetime, if configured.
+    pub max_lifetime_secs: Option<i64>,
+}
+
+/// Why an external subject token was refused.
+///
+/// Split by *what the operator should do about it* rather than by which check
+/// failed: the token endpoint maps `IssuerNotTrusted` to a distinguishable
+/// description (fix your config) and everything else to a generic
+/// `invalid_grant` (fix your token).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalSubjectError {
+    /// No enabled, exchange-enabled provider in this tenant claims this
+    /// issuer — or the token has no readable `iss` at all.
+    IssuerNotTrusted,
+    /// Signature, claim, age, audience or shape check failed. The string is
+    /// for the audit record and the server log, **not** for the wire.
+    Rejected(String),
+    /// The `(provider, sub)` pair has no AXIAM user and the provider is
+    /// configured `linked_only`.
+    SubjectNotLinked,
+    /// A user exists but is not in a state that may hold a token.
+    UserNotActive,
+    Server(String),
+}
+
+impl std::fmt::Display for ExternalSubjectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::IssuerNotTrusted => {
+                write!(f, "issuer is not configured for token exchange")
+            }
+            Self::Rejected(why) => write!(f, "external subject token rejected: {why}"),
+            Self::SubjectNotLinked => write!(f, "external subject is not linked to an AXIAM user"),
+            Self::UserNotActive => write!(f, "the linked AXIAM user is not active"),
+            Self::Server(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl ExternalSubjectError {
+    fn rejected(why: impl Into<String>) -> Self {
+        Self::Rejected(why.into())
+    }
+
+    /// A stable, low-cardinality label for metrics and audit records.
+    pub const fn reason_code(&self) -> &'static str {
+        match self {
+            Self::IssuerNotTrusted => "issuer_not_trusted",
+            Self::Rejected(_) => "token_rejected",
+            Self::SubjectNotLinked => "subject_not_linked",
+            Self::UserNotActive => "user_not_active",
+            Self::Server(_) => "server_error",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — unit-testable without a datastore, a network or a clock
+// ---------------------------------------------------------------------------
+
+/// Flatten an OIDC `aud` claim, which the spec allows to be a string or an
+/// array of strings.
+///
+/// Anything else (a number, an object, an array containing non-strings)
+/// flattens to **nothing**, which fails the audience check. Coercing a number
+/// to its decimal spelling here would be inventing an audience the issuer did
+/// not write.
+pub(crate) fn flatten_audience(aud: Option<&serde_json::Value>) -> Vec<String> {
+    match aud {
+        Some(serde_json::Value::String(s)) => vec![s.clone()],
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The external values a `scope_map` may be keyed on.
+///
+/// Four claim shapes, because those are the four the IdPs this feature exists
+/// for actually emit:
+///
+/// | claim | who |
+/// |---|---|
+/// | `scope` (space-separated string) | Okta, Keycloak, Auth0, RFC 9068 |
+/// | `scp` (string **or** array) | Entra ID (string), some Okta configs (array) |
+/// | `roles` (array) | Entra ID app roles |
+/// | `groups` (array) | Okta, Entra group claims |
+///
+/// Anything else is invisible to the map. That is the conservative direction:
+/// a claim we do not read cannot grant anything, whereas a claim we read
+/// wrongly can. Nested shapes (Keycloak's `realm_access.roles`) are
+/// deliberately out of v1 — mapping a path expression is a feature, and a
+/// half-done one here would silently read the wrong node.
+fn asserted_values(claims: &ExternalClaims) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |v: &str| {
+        let v = v.trim();
+        if !v.is_empty() && !out.iter().any(|e| e == v) {
+            out.push(v.to_owned());
+        }
+    };
+
+    if let Some(scope) = claims.scope.as_deref() {
+        scope.split_whitespace().for_each(&mut push);
+    }
+    match claims.scp.as_ref() {
+        Some(serde_json::Value::String(s)) => s.split_whitespace().for_each(&mut push),
+        Some(serde_json::Value::Array(items)) => {
+            for item in items {
+                if let Some(s) = item.as_str() {
+                    push(s);
+                }
+            }
+        }
+        _ => {}
+    }
+    for list in [claims.roles.as_ref(), claims.groups.as_ref()] {
+        for value in list.into_iter().flatten() {
+            push(value);
+        }
+    }
+    out
+}
+
+/// Refuse a correctly-signed token that is nonetheless the wrong *kind* of
+/// token.
+///
+/// An ID token is an assertion to a **client** about a login; OIDC gives it a
+/// longer life and a wider distribution than an access token precisely because
+/// it is not meant to be presented to APIs. A refresh token is a
+/// re-authentication credential. Accepting either as a subject token would let
+/// an artefact the partner considers low-risk buy an AXIAM credential.
+///
+/// Detection is by the claims and header markers that are *only* legal on
+/// those token types — never by absence of an access-token marker, because
+/// plenty of legitimate access tokens carry no `typ` at all.
+fn reject_wrong_token_kind(
+    claims: &ExternalClaims,
+    header_typ: Option<&str>,
+) -> Result<(), ExternalSubjectError> {
+    for (name, present) in [
+        ("nonce", claims.nonce.is_some()),
+        ("at_hash", claims.at_hash.is_some()),
+        ("c_hash", claims.c_hash.is_some()),
+        ("s_hash", claims.s_hash.is_some()),
+    ] {
+        if present {
+            return Err(ExternalSubjectError::rejected(format!(
+                "the token carries '{name}', which is an ID-token claim; \
+                 present an access token"
+            )));
+        }
+    }
+
+    for typ in [header_typ, claims.typ.as_deref()].into_iter().flatten() {
+        let normalized = typ.trim().to_ascii_lowercase();
+        let normalized = normalized
+            .strip_prefix("application/")
+            .unwrap_or(&normalized);
+        if matches!(
+            normalized,
+            "id_token" | "id+jwt" | "refresh" | "refresh_token" | "offline" | "logout+jwt"
+        ) {
+            return Err(ExternalSubjectError::rejected(format!(
+                "token type '{typ}' is not usable as a subject token"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Time-based checks that `jsonwebtoken`'s own validation does not cover.
+///
+/// `exp` is enforced by the decoder; what is enforced here is **age**, which
+/// is a separate policy: a partner IdP issuing 24-hour access tokens should
+/// not thereby hand out a 24-hour replay window into AXIAM.
+fn check_age(iat: Option<i64>, now: i64, max_age_secs: i64) -> Result<(), ExternalSubjectError> {
+    let Some(iat) = iat else {
+        // Unreachable in practice — `iat` is in `set_required_spec_claims` —
+        // but the age rule is meaningless without it, and "meaningless" must
+        // not silently mean "unbounded".
+        return Err(ExternalSubjectError::rejected("token has no 'iat' claim"));
+    };
+    if iat > now + LEEWAY_SECS as i64 {
+        return Err(ExternalSubjectError::rejected(
+            "token is issued in the future beyond the permitted skew",
+        ));
+    }
+    let age = now - iat;
+    if age > max_age_secs {
+        return Err(ExternalSubjectError::rejected(format!(
+            "token is {age}s old; this provider accepts at most {max_age_secs}s"
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// The service method
+// ---------------------------------------------------------------------------
+
+impl<FC, FL, UR> OidcFederationService<FC, FL, UR>
+where
+    FC: FederationConfigRepository,
+    FL: FederationLinkRepository,
+    UR: UserRepository,
+{
+    /// Verify an external IdP's token and resolve it to an AXIAM subject.
+    ///
+    /// The pipeline order is normative and is reproduced in the design doc's
+    /// §"Validation pipeline". Two orderings in particular are load-bearing:
+    ///
+    /// * **The provider is resolved before anything else is believed.** The
+    ///   `iss` claim read at step 1 is *unverified* and is used only to select
+    ///   which key the token is then checked against — never to decide whether
+    ///   it is checked.
+    /// * **Scope mapping happens after subject resolution, not before.** A
+    ///   token that maps to no scopes and a token whose subject is unknown are
+    ///   different failures, and an operator reading the audit trail needs to
+    ///   see which one happened.
+    pub async fn verify_external_subject_token(
+        &self,
+        tenant_id: Uuid,
+        token: &str,
+        now: i64,
+    ) -> Result<ExternalSubject, ExternalSubjectError> {
+        // --- 1. Which provider claims this issuer? -------------------------
+        let claimed_issuer = unverified_issuer_of(token).ok_or_else(|| {
+            // No readable `iss` is indistinguishable, from the caller's side,
+            // from an issuer nobody trusts — and it is: neither can name a
+            // provider.
+            ExternalSubjectError::IssuerNotTrusted
+        })?;
+
+        let (config, discovery) = self
+            .resolve_trusted_provider(tenant_id, &claimed_issuer)
+            .await?;
+        let trust = &config.token_exchange;
+
+        // A misconfiguration this check exists to make impossible rather than
+        // merely unlikely: if a provider advertised AXIAM's own issuer, the
+        // internal and external branches would overlap and a foreign key could
+        // verify a token that claims to be ours.
+        if discovery.issuer != claimed_issuer {
+            return Err(ExternalSubjectError::IssuerNotTrusted);
+        }
+
+        // --- 2. Signature ---------------------------------------------------
+        reject_alg_none_raw(token)
+            .map_err(|_| ExternalSubjectError::rejected("'none' is not a signature algorithm"))?;
+        let header = decode_header(token)
+            .map_err(|_| ExternalSubjectError::rejected("unparseable JOSE header"))?;
+        let allowed: Vec<Algorithm> = map_algorithm_strings(&config.allowed_algorithms);
+        if allowed.is_empty() {
+            // An empty allow-list would make `Validation` accept the header's
+            // own choice. Refusing is the only safe reading of "the operator
+            // configured no algorithms".
+            return Err(ExternalSubjectError::rejected(
+                "the provider has no accepted signature algorithms configured",
+            ));
+        }
+        if !allowed.contains(&header.alg) {
+            return Err(ExternalSubjectError::rejected(format!(
+                "algorithm {:?} is not accepted from this provider",
+                header.alg
+            )));
+        }
+
+        let cache_key = (tenant_id, config.id);
+        let jwks = self
+            .jwks_cache()
+            .get_or_fetch(self.http_client(), cache_key, &discovery.jwks_uri)
+            .await
+            .map_err(|e| ExternalSubjectError::rejected(format!("JWKS unavailable: {e}")))?;
+        let jwk = match find_jwk(&jwks, header.kid.as_deref()) {
+            Some(j) => j,
+            None => {
+                // Unknown kid → the provider rotated. Same rate-limited forced
+                // refetch the login path uses; sharing it is the point of
+                // living in this crate.
+                let refreshed = self
+                    .jwks_cache()
+                    .force_refetch_if_allowed(self.http_client(), cache_key, &discovery.jwks_uri)
+                    .await
+                    .map_err(|e| {
+                        ExternalSubjectError::rejected(format!("JWKS refetch failed: {e}"))
+                    })?;
+                find_jwk(&refreshed, header.kid.as_deref()).ok_or_else(|| {
+                    ExternalSubjectError::rejected("no JWKS key matches the token's kid")
+                })?
+            }
+        };
+        let decoding_key = DecodingKey::from_jwk(&jwk)
+            .map_err(|_| ExternalSubjectError::rejected("unusable JWKS key"))?;
+
+        let mut validation = Validation::new(header.alg);
+        validation.algorithms = allowed;
+        validation.set_issuer(&[&discovery.issuer]);
+        // `aud` is checked against the provider's `accepted_audiences` below,
+        // not here: `jsonwebtoken` would treat a match against any one
+        // configured value as success, which is what we want — but it would
+        // also let an empty configured list mean "no audience validation",
+        // and an audience check that silently disappears when a list is empty
+        // is exactly the failure `accepted_audiences` is non-empty to prevent.
+        validation.validate_aud = false;
+        validation.set_required_spec_claims(&["iss", "aud", "exp", "iat"]);
+        validation.leeway = LEEWAY_SECS;
+
+        let claims = decode::<ExternalClaims>(token, &decoding_key, &validation)
+            .map_err(|e| {
+                use jsonwebtoken::errors::ErrorKind;
+                match e.kind() {
+                    ErrorKind::InvalidSignature => {
+                        ExternalSubjectError::rejected("signature is invalid")
+                    }
+                    other => ExternalSubjectError::rejected(format!("claim rejected: {other:?}")),
+                }
+            })?
+            .claims;
+
+        // --- 3. Claims the decoder does not police --------------------------
+        if claims.ext_exchange.is_some() {
+            return Err(ExternalSubjectError::rejected(
+                "the token is itself the product of a token exchange; \
+                 exchanges do not compose",
+            ));
+        }
+        reject_wrong_token_kind(&claims, header.typ.as_deref())?;
+        check_age(claims.iat, now, trust.max_token_age_secs)?;
+
+        let audiences = flatten_audience(claims.aud.as_ref());
+        if !trust.audience_accepted(&audiences) {
+            return Err(ExternalSubjectError::rejected(
+                "the token's audience is not accepted by this provider's configuration",
+            ));
+        }
+
+        let subject_exp = claims
+            .exp
+            .ok_or_else(|| ExternalSubjectError::rejected("token has no 'exp' claim"))?;
+        if subject_exp <= now {
+            return Err(ExternalSubjectError::rejected("token has expired"));
+        }
+        if claims.sub.trim().is_empty() {
+            return Err(ExternalSubjectError::rejected("token has an empty 'sub'"));
+        }
+
+        // --- 4. Which AXIAM user? -------------------------------------------
+        let user_id;
+        let newly_provisioned;
+        match trust.subject_mapping {
+            SubjectMapping::LinkedOnly => {
+                let link = self
+                    .federation_link_repo_ref()
+                    .get_by_external_subject(tenant_id, config.id, &claims.sub)
+                    .await
+                    .map_err(|e| match e {
+                        AxiamError::NotFound { .. } => ExternalSubjectError::SubjectNotLinked,
+                        other => ExternalSubjectError::Server(other.to_string()),
+                    })?;
+                user_id = link.user_id;
+                newly_provisioned = false;
+            }
+            SubjectMapping::JitProvision => {
+                // Deliberately the *same* function a browser login uses, so a
+                // partner token and an interactive login can never disagree
+                // about which AXIAM user an `(issuer, sub)` pair means.
+                let resolved = self
+                    .provision_or_link_user(
+                        tenant_id,
+                        config.id,
+                        &crate::oidc::IdTokenClaims {
+                            sub: claims.sub.clone(),
+                            iss: claims.iss.clone(),
+                            aud: claims.aud.clone(),
+                            exp: claims.exp.map(|v| v as u64),
+                            iat: claims.iat.map(|v| v as u64),
+                            email: None,
+                            email_verified: None,
+                            name: None,
+                            nonce: None,
+                        },
+                    )
+                    .await
+                    .map_err(|e| ExternalSubjectError::Server(e.to_string()))?;
+                user_id = resolved.user.id;
+                newly_provisioned = resolved.newly_provisioned;
+                if newly_provisioned {
+                    info!(
+                        target: "axiam::audit",
+                        event = "federation.jit_provision",
+                        tenant_id = %tenant_id,
+                        provider = %config.provider,
+                        user_id = %user_id,
+                        source = "token_exchange",
+                        "JIT-provisioned an AXIAM user from an external subject token"
+                    );
+                }
+            }
+        }
+
+        // A suspended, locked or anonymized user is not resurrected by a
+        // partner's token. Checked after resolution rather than folded into it
+        // so a JIT-provisioned user goes through the identical gate.
+        //
+        // **`PendingVerification` is allowed here, and that is not laxity.**
+        // `UserRepository::create` writes that status for every new row, and
+        // the federation provisioning path (`provision_new_user`) never moves
+        // a federated user off it — there is nothing for AXIAM to verify,
+        // since a federated user has no usable password and a synthetic email
+        // address. Every user who logged in through this provider's browser
+        // flow is therefore `PendingVerification` for life. Requiring `Active`
+        // would refuse exactly the population X4 exists to serve, while
+        // stopping nobody: the states that mean "this account must not be
+        // used" are the three refused below.
+        let user = self
+            .user_repo_ref()
+            .get_by_id(tenant_id, user_id)
+            .await
+            .map_err(|e| match e {
+                AxiamError::NotFound { .. } => ExternalSubjectError::SubjectNotLinked,
+                other => ExternalSubjectError::Server(other.to_string()),
+            })?;
+        match user.status {
+            UserStatus::Active | UserStatus::PendingVerification => {}
+            UserStatus::Locked | UserStatus::Inactive | UserStatus::Anonymized => {
+                return Err(ExternalSubjectError::UserNotActive);
+            }
+        }
+
+        // --- 5. What may the provider's assertions map onto? ----------------
+        let candidate_scopes = trust.map_scopes(&asserted_values(&claims));
+
+        Ok(ExternalSubject {
+            issuer: claimed_issuer,
+            provider_id: config.id,
+            provider_name: config.provider.clone(),
+            external_subject: claims.sub,
+            user_id,
+            newly_provisioned,
+            candidate_scopes,
+            subject_exp,
+            max_lifetime_secs: trust.max_lifetime_secs,
+        })
+    }
+
+    /// Find the enabled, exchange-enabled provider whose **discovery
+    /// document** advertises `claimed_issuer`.
+    ///
+    /// The issuer is taken from the provider's discovery document rather than
+    /// from an admin-typed field, so trust follows the same source of truth
+    /// the login path verifies against. Matching is exact — no trailing-slash
+    /// forgiveness, no case folding, no normalisation.
+    async fn resolve_trusted_provider(
+        &self,
+        tenant_id: Uuid,
+        claimed_issuer: &str,
+    ) -> Result<(FederationConfig, crate::oidc::OidcDiscoveryDocument), ExternalSubjectError> {
+        let candidates = self
+            .federation_config_repo_ref()
+            .list_token_exchange_enabled(tenant_id)
+            .await
+            .map_err(|e| ExternalSubjectError::Server(e.to_string()))?;
+
+        for config in candidates {
+            // A row can be enabled and still be unusable; a misconfigured
+            // provider must not take the whole exchange path down with it, so
+            // each failure is logged and skipped rather than returned.
+            if config.token_exchange.validate().is_err() {
+                warn!(
+                    tenant_id = %tenant_id,
+                    provider = %config.provider,
+                    "skipping token-exchange provider with an invalid trust configuration"
+                );
+                continue;
+            }
+            let Some(metadata_url) = config.metadata_url.as_deref() else {
+                continue;
+            };
+            let discovery = match self.discover(metadata_url).await {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!(
+                        tenant_id = %tenant_id,
+                        provider = %config.provider,
+                        error = %e,
+                        "token-exchange provider discovery failed; skipping"
+                    );
+                    continue;
+                }
+            };
+            if discovery.issuer == claimed_issuer {
+                return Ok((config, discovery));
+            }
+        }
+        Err(ExternalSubjectError::IssuerNotTrusted)
+    }
+}
+
+impl From<FederationError> for ExternalSubjectError {
+    fn from(e: FederationError) -> Self {
+        Self::Server(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn claims() -> ExternalClaims {
+        ExternalClaims {
+            sub: "partner-user-1".into(),
+            iss: Some("https://partner.example".into()),
+            aud: Some(json!("https://api.axiam.example")),
+            exp: Some(0),
+            iat: Some(0),
+            scope: None,
+            scp: None,
+            roles: None,
+            groups: None,
+            nonce: None,
+            at_hash: None,
+            c_hash: None,
+            s_hash: None,
+            ext_exchange: None,
+            typ: None,
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Audience flattening
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn audience_accepts_both_spec_shapes() {
+        assert_eq!(flatten_audience(Some(&json!("a"))), vec!["a".to_string()]);
+        assert_eq!(
+            flatten_audience(Some(&json!(["a", "b"]))),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        assert!(flatten_audience(None).is_empty());
+    }
+
+    /// A non-string audience flattens to nothing rather than to its decimal
+    /// spelling: coercing here would invent an audience the issuer never
+    /// wrote, and the audience check is the one that decides whether this
+    /// token was addressed to us at all.
+    #[test]
+    fn a_non_string_audience_flattens_to_nothing() {
+        assert!(flatten_audience(Some(&json!(42))).is_empty());
+        assert!(flatten_audience(Some(&json!({ "aud": "a" }))).is_empty());
+        assert_eq!(
+            flatten_audience(Some(&json!(["a", 42, null]))),
+            vec!["a".to_string()],
+            "non-string members drop out; the string ones survive"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Asserted values
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn every_supported_claim_shape_contributes() {
+        let c = ExternalClaims {
+            scope: Some("read  write".into()),
+            scp: Some(json!("admin")),
+            roles: Some(vec!["Orders.Read".into()]),
+            groups: Some(vec!["finance".into()]),
+            ..claims()
+        };
+        let mut got = asserted_values(&c);
+        got.sort();
+        assert_eq!(
+            got,
+            vec!["Orders.Read", "admin", "finance", "read", "write"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn scp_is_read_as_both_a_string_and_an_array() {
+        let as_array = ExternalClaims {
+            scp: Some(json!(["a", "b"])),
+            ..claims()
+        };
+        assert_eq!(asserted_values(&as_array), vec!["a", "b"]);
+
+        let as_string = ExternalClaims {
+            scp: Some(json!("a b")),
+            ..claims()
+        };
+        assert_eq!(asserted_values(&as_string), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn duplicates_across_claims_collapse() {
+        let c = ExternalClaims {
+            scope: Some("read".into()),
+            scp: Some(json!("read")),
+            roles: Some(vec!["read".into()]),
+            ..claims()
+        };
+        assert_eq!(asserted_values(&c), vec!["read".to_string()]);
+    }
+
+    #[test]
+    fn unreadable_claim_shapes_contribute_nothing_rather_than_guessing() {
+        let c = ExternalClaims {
+            // Keycloak's nested realm_access.roles arrives as an object; v1
+            // does not read it, and must not half-read it.
+            scp: Some(json!({ "roles": ["admin"] })),
+            ..claims()
+        };
+        assert!(asserted_values(&c).is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Token kind
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn an_access_token_shape_passes() {
+        assert!(reject_wrong_token_kind(&claims(), Some("at+jwt")).is_ok());
+        assert!(reject_wrong_token_kind(&claims(), Some("JWT")).is_ok());
+        assert!(reject_wrong_token_kind(&claims(), None).is_ok());
+    }
+
+    #[test]
+    fn every_id_token_marker_is_refused() {
+        for c in [
+            ExternalClaims {
+                nonce: Some("n".into()),
+                ..claims()
+            },
+            ExternalClaims {
+                at_hash: Some("h".into()),
+                ..claims()
+            },
+            ExternalClaims {
+                c_hash: Some("h".into()),
+                ..claims()
+            },
+            ExternalClaims {
+                s_hash: Some("h".into()),
+                ..claims()
+            },
+        ] {
+            assert!(
+                reject_wrong_token_kind(&c, None).is_err(),
+                "an ID token must not be usable as a subject token"
+            );
+        }
+    }
+
+    #[test]
+    fn refresh_and_id_token_types_are_refused_from_either_header_or_claim() {
+        for typ in ["Refresh", "refresh_token", "ID_TOKEN", "application/id+jwt"] {
+            assert!(
+                reject_wrong_token_kind(&claims(), Some(typ)).is_err(),
+                "header typ {typ} must be refused"
+            );
+            let c = ExternalClaims {
+                typ: Some(typ.into()),
+                ..claims()
+            };
+            assert!(
+                reject_wrong_token_kind(&c, None).is_err(),
+                "claim typ {typ} must be refused"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Age
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_token_older_than_the_provider_allows_is_refused() {
+        assert!(check_age(Some(1_000), 1_200, 300).is_ok());
+        assert!(check_age(Some(1_000), 1_301, 300).is_err());
+        // Exactly at the bound is still inside it.
+        assert!(check_age(Some(1_000), 1_300, 300).is_ok());
+    }
+
+    #[test]
+    fn an_iat_in_the_future_is_refused_beyond_skew_and_tolerated_inside_it() {
+        assert!(check_age(Some(1_030), 1_000, 300).is_ok(), "30s of skew");
+        assert!(check_age(Some(1_200), 1_000, 300).is_err(), "200s of skew");
+    }
+
+    #[test]
+    fn a_missing_iat_is_refused_rather_than_treated_as_unbounded() {
+        assert!(check_age(None, 1_000, 300).is_err());
+    }
+
+    // -----------------------------------------------------------------
+    // Error surface
+    // -----------------------------------------------------------------
+
+    /// The reason codes are what the audit trail and the metrics key on, so
+    /// they are pinned rather than left to follow the variant names around.
+    #[test]
+    fn reason_codes_are_stable() {
+        assert_eq!(
+            ExternalSubjectError::IssuerNotTrusted.reason_code(),
+            "issuer_not_trusted"
+        );
+        assert_eq!(
+            ExternalSubjectError::rejected("x").reason_code(),
+            "token_rejected"
+        );
+        assert_eq!(
+            ExternalSubjectError::SubjectNotLinked.reason_code(),
+            "subject_not_linked"
+        );
+        assert_eq!(
+            ExternalSubjectError::UserNotActive.reason_code(),
+            "user_not_active"
+        );
+    }
+
+    /// The rejection *reason* is for the log, never for the wire — but it
+    /// still must not smuggle the token into either.
+    #[test]
+    fn a_rejection_reason_never_contains_the_token() {
+        let e = ExternalSubjectError::rejected("signature is invalid");
+        assert!(!e.to_string().contains('.'), "{e}");
+    }
+}

--- a/crates/axiam-federation/src/token_exchange.rs
+++ b/crates/axiam-federation/src/token_exchange.rs
@@ -327,12 +327,10 @@ where
         now: i64,
     ) -> Result<ExternalSubject, ExternalSubjectError> {
         // --- 1. Which provider claims this issuer? -------------------------
-        let claimed_issuer = unverified_issuer_of(token).ok_or_else(|| {
-            // No readable `iss` is indistinguishable, from the caller's side,
-            // from an issuer nobody trusts — and it is: neither can name a
-            // provider.
-            ExternalSubjectError::IssuerNotTrusted
-        })?;
+        // No readable `iss` is indistinguishable, from the caller's side, from
+        // an issuer nobody trusts — and rightly so: neither can name a provider.
+        let claimed_issuer =
+            unverified_issuer_of(token).ok_or(ExternalSubjectError::IssuerNotTrusted)?;
 
         let (config, discovery) = self
             .resolve_trusted_provider(tenant_id, &claimed_issuer)

--- a/crates/axiam-federation/tests/secrets_and_errors.rs
+++ b/crates/axiam-federation/tests/secrets_and_errors.rs
@@ -180,6 +180,7 @@ fn make_config(plaintext: &str) -> FederationConfig {
         client_secret_ciphertext: None,
         client_secret_nonce: None,
         client_secret_key_version: None,
+        token_exchange: Default::default(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
     }
@@ -215,6 +216,12 @@ impl FederationConfigRepository for MockFedRepo {
         _p: Pagination,
     ) -> AxiamResult<PaginatedResult<FederationConfig>> {
         unimplemented!()
+    }
+    async fn list_token_exchange_enabled(
+        &self,
+        _tenant_id: Uuid,
+    ) -> AxiamResult<Vec<FederationConfig>> {
+        Ok(Vec::new())
     }
     async fn list_with_legacy_plaintext_secret(&self) -> AxiamResult<Vec<FederationConfig>> {
         Ok(self.rows.clone())

--- a/crates/axiam-oauth2/Cargo.toml
+++ b/crates/axiam-oauth2/Cargo.toml
@@ -25,3 +25,8 @@ base64 = { workspace = true }
 hex = { workspace = true }
 utoipa = { workspace = true }
 subtle = { workspace = true }
+
+[dev-dependencies]
+# X4 external-exchange unit tests mint an Ed25519 keypair for the AuthConfig
+# under test, the same way every other crate's token tests do.
+rcgen = { workspace = true }

--- a/crates/axiam-oauth2/src/token_exchange.rs
+++ b/crates/axiam-oauth2/src/token_exchange.rs
@@ -15,9 +15,13 @@
 //! arm of [`crate::token::TokenService`]: it needs different collaborators,
 //! and the REST layer keeps the seam at one `match` on `grant_type`.
 
+use std::future::Future;
+use std::pin::Pin;
+
 use axiam_auth::config::AuthConfig;
 use axiam_auth::token::{
-    AUD_M2M, AUD_USER, ActClaim, MAX_ACT_CHAIN_DEPTH, decode_access_token, issue_exchanged_token,
+    AUD_M2M, AUD_USER, ActClaim, ExtExchangeClaim, MAX_ACT_CHAIN_DEPTH, SubjectKind,
+    decode_access_token, issue_exchanged_token, unverified_issuer_of,
 };
 use axiam_core::models::oauth2_client::OAuth2Client;
 use axiam_core::repository::TenantRepository;
@@ -30,13 +34,33 @@ use crate::error::OAuth2Error;
 /// The grant type this service handles.
 pub const TOKEN_EXCHANGE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
 
-/// The only subject/actor token type accepted in v1.
+/// The subject/actor token type for an AXIAM-issued access token.
 ///
-/// Refusing everything else is deliberate rather than unfinished: accepting a
-/// token means accepting whatever its issuer asserts about the subject, and
-/// the trust configuration that makes an *external* issuer safe is a feature
-/// of its own (X4). Hard-wiring "us" keeps this grant small enough to review.
+/// Since X4 this is no longer the *only* admissible subject token type — see
+/// [`TOKEN_TYPE_JWT`] — but it remains the only type an exchange **issues**,
+/// and the only type an `actor_token` may be.
 pub const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
+
+/// RFC 8693 §3 generic JWT subject-token type (X4).
+///
+/// Accepted only on the external path: a caller presenting a partner's token
+/// rarely knows whether that IdP would call it an "access token" in AXIAM's
+/// sense, and RFC 8693 provides this type for exactly that case. The token is
+/// still shape-checked — an ID token labelled `…:jwt` is refused just as
+/// firmly as one labelled `…:id_token`.
+pub const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
+
+/// Token types a caller sometimes reaches for and never gets (X4).
+///
+/// Named individually rather than lumped into "unsupported" because a caller
+/// who sent one has made a *specific* mistake, and "unsupported
+/// subject_token_type" sends them looking for a config switch that does not
+/// exist. Refusing these is a security property, not a gap: a refresh token is
+/// a re-authentication credential and an ID token is an assertion to a client
+/// about a login — neither is a bearer credential for an API, and both are
+/// treated as lower-risk artefacts by the IdPs that issue them.
+pub const TOKEN_TYPE_REFRESH_TOKEN: &str = "urn:ietf:params:oauth:token-type:refresh_token";
+pub const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
 
 /// Grant-list entry that permits impersonation.
 ///
@@ -82,6 +106,94 @@ pub struct TokenExchangeResponse {
     pub scope: Option<String>,
 }
 
+// ---------------------------------------------------------------------------
+// X4 ports
+// ---------------------------------------------------------------------------
+
+/// What verifying an external IdP's subject token established.
+///
+/// Mirrors `axiam_federation::token_exchange::ExternalSubject` without
+/// importing it — `axiam-oauth2` does not depend on `axiam-federation`, and
+/// `axiam-api-rest` is the composition root that owns both. Same seam UMA's
+/// [`crate::uma::PermissionEvaluator`] uses, for the same reason.
+#[derive(Debug, Clone)]
+pub struct ResolvedExternalSubject {
+    /// The foreign issuer, verbatim. Stamped into the issued token.
+    pub issuer: String,
+    pub provider_id: Uuid,
+    pub provider_name: String,
+    /// The partner-local `sub`. Audit only.
+    pub external_subject: String,
+    pub user_id: Uuid,
+    pub newly_provisioned: bool,
+    /// AXIAM scope names the provider's `scope_map` produced.
+    ///
+    /// A **candidate** set and nothing more. Names in here have been agreed by
+    /// an AXIAM admin as things this provider's assertions *may* map onto —
+    /// not as things this user holds. The client registration and the RBAC
+    /// engine still have to agree, below.
+    pub candidate_scopes: Vec<String>,
+    /// The external token's `exp`, so the issued token cannot outlive it.
+    pub subject_exp: i64,
+    pub max_lifetime_secs: Option<i64>,
+}
+
+/// Why an external subject token was refused, in the shape this crate answers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalSubjectRejection {
+    /// No trusted, exchange-enabled provider claims the token's issuer.
+    IssuerNotTrusted,
+    /// Anything else about the token. The payload is for the audit record.
+    Rejected(String),
+    Server(String),
+}
+
+impl ExternalSubjectRejection {
+    /// Stable label for the audit record and metrics.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::IssuerNotTrusted => "issuer_not_trusted",
+            Self::Rejected(_) => "token_rejected",
+            Self::Server(_) => "server_error",
+        }
+    }
+}
+
+/// Resolves an external IdP's token to an AXIAM subject (X4).
+pub trait ExternalSubjectResolver: Send + Sync {
+    fn resolve<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        subject_token: &'a str,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<ResolvedExternalSubject, ExternalSubjectRejection>>
+                + Send
+                + 'a,
+        >,
+    >;
+}
+
+/// Answers "which of these scope names does this subject actually hold" (X4).
+///
+/// The port exists because a partner's token proves *authentication* and
+/// nothing else: what the resolved user may do is a question only the RBAC
+/// engine can answer, and `axiam-oauth2` cannot see the engine. Implemented in
+/// the composition root over `axiam-authz`.
+///
+/// The contract is one-directional and that is the whole point: an
+/// implementation may return **fewer** names than it was given, never more and
+/// never different ones. A caller treats the result as a filter, not as a
+/// source of scopes.
+pub trait SubjectScopeAuthority: Send + Sync {
+    fn held_scopes<'a>(
+        &'a self,
+        tenant_id: Uuid,
+        subject_id: Uuid,
+        candidates: &'a [String],
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, String>> + Send + 'a>>;
+}
+
 /// What an exchange did, for the audit record.
 ///
 /// Impersonation is the reason this type exists. A delegated token carries an
@@ -92,6 +204,17 @@ pub struct TokenExchangeResponse {
 pub enum ExchangeKind {
     Delegation,
     Impersonation,
+    /// X4 — the subject token came from a trusted external IdP.
+    ///
+    /// A third kind rather than a flavour of impersonation, even though the
+    /// issued token also carries no `act` claim. The distinction is what the
+    /// acting party's authority rests on: an impersonating client asserts on
+    /// *its own* authority that it may be the user, while an external exchange
+    /// presents a trusted IdP's signed assertion that the user authenticated,
+    /// addressed to us. Different evidence, different gate (the per-provider
+    /// trust block, not `may_impersonate`), and an audit reader must be able
+    /// to tell them apart at a glance.
+    External,
 }
 
 impl ExchangeKind {
@@ -99,11 +222,27 @@ impl ExchangeKind {
         match self {
             Self::Delegation => "delegation",
             Self::Impersonation => "impersonation",
+            Self::External => "external",
         }
     }
 }
 
+/// Provenance of an [`ExchangeKind::External`] exchange, for the audit record.
+#[derive(Debug, Clone)]
+pub struct ExternalProvenance {
+    pub issuer: String,
+    pub provider_id: Uuid,
+    pub provider_name: String,
+    pub external_subject: String,
+    pub newly_provisioned: bool,
+}
+
 /// The outcome the caller audits and returns.
+///
+/// `Debug` is hand-written rather than derived: it would otherwise print the
+/// freshly-minted access token into whatever log line touched it, which is the
+/// one thing in this struct that must never be logged. Same reasoning, and the
+/// same `[REDACTED]` marker, as `FederationConfig`'s secret columns.
 pub struct ExchangeOutcome {
     pub response: TokenExchangeResponse,
     pub kind: ExchangeKind,
@@ -111,6 +250,24 @@ pub struct ExchangeOutcome {
     pub actor: Option<String>,
     pub granted_scopes: Vec<String>,
     pub audience: String,
+    /// Present exactly when `kind == External` (X4).
+    pub external: Option<ExternalProvenance>,
+}
+
+impl std::fmt::Debug for ExchangeOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExchangeOutcome")
+            .field("access_token", &"[REDACTED]")
+            .field("issued_token_type", &self.response.issued_token_type)
+            .field("expires_in", &self.response.expires_in)
+            .field("kind", &self.kind)
+            .field("subject", &self.subject)
+            .field("actor", &self.actor)
+            .field("granted_scopes", &self.granted_scopes)
+            .field("audience", &self.audience)
+            .field("external", &self.external)
+            .finish()
+    }
 }
 
 /// Intersect the three scope sets, preserving the caller's requested order.
@@ -184,6 +341,18 @@ pub struct TokenExchangeService<TR> {
     /// Independent ceiling on an exchanged token's lifetime, applied on top of
     /// "never outlives its subject".
     max_lifetime_secs: i64,
+    /// X4 — resolves external subject tokens. `None` disables the external
+    /// path entirely: a deployment that never wires this in cannot accept a
+    /// foreign token no matter how a provider row is configured, which is the
+    /// behaviour every pre-X4 test asserts and must keep asserting.
+    external_resolver: Option<std::sync::Arc<dyn ExternalSubjectResolver>>,
+    /// X4 — the RBAC engine's answer for the resolved user.
+    ///
+    /// Paired with `external_resolver` and checked as a pair: an external
+    /// exchange with no way to consult the engine would have to either fail or
+    /// skip the check, and skipping it is how `scope_map` output becomes an
+    /// authority in its own right.
+    scope_authority: Option<std::sync::Arc<dyn SubjectScopeAuthority>>,
 }
 
 impl<TR> TokenExchangeService<TR>
@@ -195,7 +364,25 @@ where
             tenant_repo,
             auth_config,
             max_lifetime_secs,
+            external_resolver: None,
+            scope_authority: None,
         }
+    }
+
+    /// Enable the X4 external path (both collaborators, together).
+    ///
+    /// Taken as a pair on purpose. There is no useful configuration in which
+    /// external subject tokens are accepted but the engine is not consulted,
+    /// and a builder that let the two be set independently would make that
+    /// configuration expressible.
+    pub fn with_external_subjects(
+        mut self,
+        resolver: std::sync::Arc<dyn ExternalSubjectResolver>,
+        authority: std::sync::Arc<dyn SubjectScopeAuthority>,
+    ) -> Self {
+        self.external_resolver = Some(resolver);
+        self.scope_authority = Some(authority);
+        self
     }
 
     /// Perform an exchange.
@@ -232,16 +419,81 @@ where
             )));
         }
 
-        if req.subject_token_type != TOKEN_TYPE_ACCESS_TOKEN {
+        // Named refusals first (X4). A caller who sent a refresh or ID token
+        // type has made a specific mistake, and "unsupported
+        // subject_token_type" would send them hunting for a config switch that
+        // does not and will not exist.
+        match req.subject_token_type.as_str() {
+            TOKEN_TYPE_REFRESH_TOKEN => {
+                return Err(OAuth2Error::InvalidRequest(
+                    "a refresh token is a re-authentication credential, not a subject \
+                     token; present an access token"
+                        .into(),
+                ));
+            }
+            TOKEN_TYPE_ID_TOKEN => {
+                return Err(OAuth2Error::InvalidRequest(
+                    "an ID token asserts a login to a client, not authority at an API; \
+                     present an access token"
+                        .into(),
+                ));
+            }
+            TOKEN_TYPE_ACCESS_TOKEN | TOKEN_TYPE_JWT => {}
+            other => {
+                return Err(OAuth2Error::InvalidRequest(format!(
+                    "unsupported subject_token_type '{other}'; \
+                     accepted types are {TOKEN_TYPE_ACCESS_TOKEN} and {TOKEN_TYPE_JWT}"
+                )));
+            }
+        }
+
+        // --- internal or external? (X4) --------------------------------------
+        //
+        // Routed on the subject token's UNVERIFIED `iss`, which is safe
+        // precisely because neither destination trusts it: a token claiming to
+        // be ours is checked against our signing key, and a token claiming a
+        // partner's issuer is checked against that partner's JWKS. The claim
+        // chooses which key the token faces, never whether it faces one.
+        //
+        // A token with no readable `iss` takes the internal path, where
+        // `decode_access_token` refuses it — that is the same answer this grant
+        // gave before X4 existed, and it keeps "malformed" a single failure
+        // rather than two that differ by which branch noticed.
+        let claimed_issuer = unverified_issuer_of(&req.subject_token);
+        let is_external = match claimed_issuer.as_deref() {
+            Some(iss) => iss != self.auth_config.effective_issuer(),
+            None => false,
+        };
+
+        if is_external {
+            return self.exchange_external(tenant_id, client, req).await;
+        }
+
+        // From here down is B3, unchanged except for the transitivity check.
+        if req.subject_token_type == TOKEN_TYPE_JWT {
             return Err(OAuth2Error::InvalidRequest(format!(
-                "unsupported subject_token_type '{}'; v1 accepts only {TOKEN_TYPE_ACCESS_TOKEN}",
-                req.subject_token_type
+                "subject_token_type {TOKEN_TYPE_JWT} is for tokens from external \
+                 issuers; an AXIAM-issued token must be presented as \
+                 {TOKEN_TYPE_ACCESS_TOKEN}"
             )));
         }
 
         // --- the subject ---------------------------------------------------
         let subject = decode_access_token(&req.subject_token, &self.auth_config)
             .map_err(|_| OAuth2Error::InvalidGrant("subject token is not valid".into()))?;
+
+        // No re-exchange of a cross-domain token (X4), on this path too. The
+        // external path refuses the claim on the way in; this refuses it on
+        // the way back round. Without both, trust composes silently: a
+        // partner's token buys an AXIAM token, and that token buys another one
+        // whose provenance nobody can see.
+        if subject.ext_exchange.is_some() {
+            return Err(OAuth2Error::InvalidRequest(
+                "the subject token is already the product of a cross-domain exchange; \
+                 exchanges do not compose"
+                    .into(),
+            ));
+        }
 
         // Cross-tenant is `invalid_grant`, not a distinct error: a caller
         // learning that their token is valid SOMEWHERE ELSE is a
@@ -394,6 +646,8 @@ where
             &audience,
             expires_at,
             act,
+            // Same-domain: no foreign provenance to record.
+            None,
         )
         .map_err(|e| OAuth2Error::ServerError(e.to_string()))?;
 
@@ -413,9 +667,241 @@ where
             actor: actor_sub,
             granted_scopes: granted,
             audience,
+            external: None,
+        })
+    }
+
+    /// X4 — the external branch of [`Self::exchange`].
+    ///
+    /// Separate function, not a `match` arm, because it shares almost nothing
+    /// with the internal path: the subject is resolved by a different
+    /// authority, the scopes come from a different source, and the answer to
+    /// "what may this token do" is decided by the RBAC engine rather than by
+    /// another token. Splicing the two would produce a function where every
+    /// line needs a "…but not on the external path" qualifier, which is the
+    /// shape mistakes hide in.
+    ///
+    /// The **order** of the checks below is the design doc's §"Validation
+    /// pipeline" and is normative.
+    async fn exchange_external(
+        &self,
+        tenant_id: Uuid,
+        client: &OAuth2Client,
+        req: TokenExchangeRequest,
+    ) -> Result<ExchangeOutcome, OAuth2Error> {
+        // Not configured ⇒ the external path does not exist. Deliberately the
+        // same answer as "no provider trusts this issuer": whether a
+        // deployment has X4 wired in at all is not something an authenticated
+        // client needs to distinguish from a provider it did not configure.
+        let (Some(resolver), Some(authority)) = (
+            self.external_resolver.as_ref(),
+            self.scope_authority.as_ref(),
+        ) else {
+            return Err(OAuth2Error::InvalidGrant(ISSUER_NOT_TRUSTED.into()));
+        };
+
+        // Delegation across a trust boundary needs a second trust decision —
+        // "may this actor act for a subject *this IdP* vouched for" — that X4
+        // does not make. Refused before the token is verified so the answer
+        // does not depend on whether the subject token happened to be good.
+        if req.actor_token.is_some() || req.actor_token_type.is_some() {
+            return Err(OAuth2Error::InvalidRequest(
+                "actor_token is not supported for subject tokens from external \
+                 issuers in v1"
+                    .into(),
+            ));
+        }
+
+        let external = resolver
+            .resolve(tenant_id, &req.subject_token)
+            .await
+            .map_err(|e| match e {
+                ExternalSubjectRejection::IssuerNotTrusted => {
+                    OAuth2Error::InvalidGrant(ISSUER_NOT_TRUSTED.into())
+                }
+                // The precise reason goes to the audit record, not to the
+                // wire: which of a dozen checks refused a token is a map of
+                // our validation order, drawn one request at a time.
+                ExternalSubjectRejection::Rejected(_) => {
+                    OAuth2Error::InvalidGrant("subject token is not valid".into())
+                }
+                ExternalSubjectRejection::Server(m) => OAuth2Error::ServerError(m),
+            })?;
+
+        // --- scopes: four gates, and the partner's token is not one of them --
+        //
+        // `candidate_scopes` is what an AXIAM admin agreed this provider's
+        // assertions may map onto. It is not what the user holds, and it is
+        // certainly not what the partner said — deny-by-default mapping has
+        // already dropped everything unmapped.
+        let requested_explicitly = req.scope.is_some();
+        let requested =
+            parse_scopes(req.scope.as_deref()).unwrap_or_else(|| external.candidate_scopes.clone());
+
+        // Gate 1 + 2: the map's output and the exchanging client's ceiling.
+        // Reusing `narrow_scopes` is deliberate — the client-ceiling rule that
+        // stops a low-privilege service minting an admin token is exactly the
+        // same rule here, and a second implementation of it would be a second
+        // thing to keep correct.
+        let mapped_and_registered = if requested_explicitly {
+            narrow_scopes(&requested, &external.candidate_scopes, &client.scopes)?
+        } else {
+            // The default drops rather than refuses — see the design doc. A
+            // provider's `scope_map` is written for a provider, not a user, so
+            // a no-`scope` call that refused on the first name the caller
+            // could not have would fail for everyone but the most privileged
+            // user in the tenant.
+            let kept: Vec<String> = requested
+                .into_iter()
+                .filter(|s| external.candidate_scopes.contains(s) && client.scopes.contains(s))
+                .collect();
+            if kept.is_empty() {
+                return Err(OAuth2Error::InvalidScope(
+                    "no scope this provider maps to is registered for this client".into(),
+                ));
+            }
+            kept
+        };
+
+        // Gate 3: the RBAC engine, at mint time. Deny-override (B1) applies —
+        // see the authority's implementation. This is the check that makes an
+        // external token evidence of authentication rather than a grant of
+        // authorization: without it, an admin's `scope_map` would be an
+        // authority in its own right and every user the provider vouches for
+        // would hold the same scopes.
+        let held = authority
+            .held_scopes(tenant_id, external.user_id, &mapped_and_registered)
+            .await
+            .map_err(OAuth2Error::ServerError)?;
+
+        let granted: Vec<String> = if requested_explicitly {
+            if let Some(missing) = mapped_and_registered.iter().find(|s| !held.contains(s)) {
+                return Err(OAuth2Error::InvalidScope(format!(
+                    "the resolved user does not hold scope '{missing}'"
+                )));
+            }
+            mapped_and_registered
+        } else {
+            mapped_and_registered
+                .into_iter()
+                .filter(|s| held.contains(s))
+                .collect()
+        };
+        if granted.is_empty() {
+            return Err(OAuth2Error::InvalidScope(
+                "the exchange would grant no scopes at all".into(),
+            ));
+        }
+
+        // --- audience --------------------------------------------------------
+        //
+        // B3's rule, with one change that matters: when the request names no
+        // target the issued token gets AXIAM's own user audience. It never
+        // inherits the external token's `aud`, which names the *partner's*
+        // resource server and would be meaningless here — or, worse,
+        // coincidentally meaningful.
+        let target = match (req.audience.as_deref(), req.resource.as_deref()) {
+            (Some(a), Some(r)) if a != r => {
+                return Err(OAuth2Error::InvalidRequest(
+                    "audience and resource disagree; supply one or make them equal".into(),
+                ));
+            }
+            (Some(a), _) => Some(a),
+            (None, Some(r)) => Some(r),
+            (None, None) => None,
+        };
+        let audience = match target {
+            Some(t) => {
+                if !is_builtin_audience(t) && !client.redirect_uris.iter().any(|u| u == t) {
+                    return Err(OAuth2Error::InvalidTarget(format!(
+                        "'{t}' is not a registered target for this client"
+                    )));
+                }
+                t.to_owned()
+            }
+            None => AUD_USER.to_string(),
+        };
+
+        // --- lifetime ---------------------------------------------------------
+        let now = Utc::now().timestamp();
+        let subject_remaining = external.subject_exp - now;
+        if subject_remaining <= 0 {
+            return Err(OAuth2Error::InvalidGrant(
+                "subject token has expired".into(),
+            ));
+        }
+        let mut lifetime = subject_remaining.min(self.max_lifetime_secs);
+        if let Some(provider_max) = external.max_lifetime_secs {
+            lifetime = lifetime.min(provider_max);
+        }
+        if lifetime <= 0 {
+            return Err(OAuth2Error::InvalidGrant(
+                "subject token has expired".into(),
+            ));
+        }
+
+        // --- issue --------------------------------------------------------------
+        let tenant = self
+            .tenant_repo
+            .get_by_id(tenant_id)
+            .await
+            .map_err(|e| OAuth2Error::ServerError(e.to_string()))?;
+
+        let access_token = issue_exchanged_token(
+            &external.user_id.to_string(),
+            // The subject is an AXIAM user — resolved through the federation
+            // link, which is what a federated login resolves through too.
+            SubjectKind::User,
+            tenant_id,
+            tenant.organization_id,
+            &granted,
+            &self.auth_config,
+            Uuid::new_v4().to_string(),
+            &audience,
+            now + lifetime,
+            // No `act`: nobody acted *for* the user. The IdP asserted that the
+            // user authenticated, which is a different statement, and the one
+            // `ext_exchange` records.
+            None,
+            Some(ExtExchangeClaim {
+                iss: external.issuer.clone(),
+            }),
+        )
+        .map_err(|e| OAuth2Error::ServerError(e.to_string()))?;
+
+        Ok(ExchangeOutcome {
+            response: TokenExchangeResponse {
+                access_token,
+                issued_token_type: TOKEN_TYPE_ACCESS_TOKEN.to_string(),
+                token_type: "Bearer".into(),
+                expires_in: lifetime as u64,
+                scope: Some(granted.join(" ")),
+            },
+            kind: ExchangeKind::External,
+            subject: external.user_id.to_string(),
+            actor: None,
+            granted_scopes: granted,
+            audience,
+            external: Some(ExternalProvenance {
+                issuer: external.issuer,
+                provider_id: external.provider_id,
+                provider_name: external.provider_name,
+                external_subject: external.external_subject,
+                newly_provisioned: external.newly_provisioned,
+            }),
         })
     }
 }
+
+/// The one X4 refusal given a distinguishable description.
+///
+/// The exchanging client is an authenticated confidential client of this
+/// tenant, not an anonymous prober: telling it that an issuer it named is not
+/// configured leaks nothing it could not get by asking the admin, and without
+/// it an SDK cannot tell "fix your trust configuration" from "fix your token".
+/// Pinned as a constant because the SDK contract's §15 addendum quotes it.
+pub const ISSUER_NOT_TRUSTED: &str =
+    "the subject token's issuer is not configured for token exchange";
 
 #[cfg(test)]
 mod tests {
@@ -551,5 +1037,751 @@ mod tests {
         );
         client.grant_types.push(MAY_IMPERSONATE_GRANT.into());
         assert!(client_may_impersonate(&client));
+    }
+
+    // =================================================================
+    // X4 — the external branch
+    // =================================================================
+
+    mod external {
+        use super::*;
+        use axiam_core::error::AxiamResult;
+        use axiam_core::models::tenant::{CreateTenant, Tenant, TenantStatus, UpdateTenant};
+        use axiam_core::repository::{PaginatedResult, Pagination};
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        // ---- collaborators ------------------------------------------
+
+        #[derive(Clone)]
+        struct StubTenantRepo {
+            org_id: Uuid,
+        }
+
+        impl TenantRepository for StubTenantRepo {
+            async fn create(&self, _input: CreateTenant) -> AxiamResult<Tenant> {
+                unimplemented!()
+            }
+            async fn get_by_id(&self, id: Uuid) -> AxiamResult<Tenant> {
+                Ok(Tenant {
+                    id,
+                    organization_id: self.org_id,
+                    name: "t".into(),
+                    slug: "t".into(),
+                    status: TenantStatus::Active,
+                    metadata: serde_json::json!({}),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                })
+            }
+            async fn get_by_slug(&self, _o: Uuid, _s: &str) -> AxiamResult<Tenant> {
+                unimplemented!()
+            }
+            async fn update(&self, _id: Uuid, _i: UpdateTenant) -> AxiamResult<Tenant> {
+                unimplemented!()
+            }
+            async fn delete(&self, _id: Uuid) -> AxiamResult<()> {
+                unimplemented!()
+            }
+            async fn list_by_organization(
+                &self,
+                _o: Uuid,
+                _p: Pagination,
+            ) -> AxiamResult<PaginatedResult<Tenant>> {
+                unimplemented!()
+            }
+        }
+
+        struct StubResolver {
+            outcome: Result<ResolvedExternalSubject, ExternalSubjectRejection>,
+            called: AtomicBool,
+        }
+
+        impl StubResolver {
+            fn ok(subject: ResolvedExternalSubject) -> Arc<Self> {
+                Arc::new(Self {
+                    outcome: Ok(subject),
+                    called: AtomicBool::new(false),
+                })
+            }
+            fn err(e: ExternalSubjectRejection) -> Arc<Self> {
+                Arc::new(Self {
+                    outcome: Err(e),
+                    called: AtomicBool::new(false),
+                })
+            }
+        }
+
+        impl ExternalSubjectResolver for StubResolver {
+            fn resolve<'a>(
+                &'a self,
+                _tenant_id: Uuid,
+                _subject_token: &'a str,
+            ) -> Pin<
+                Box<
+                    dyn Future<Output = Result<ResolvedExternalSubject, ExternalSubjectRejection>>
+                        + Send
+                        + 'a,
+                >,
+            > {
+                self.called.store(true, Ordering::SeqCst);
+                let outcome = self.outcome.clone();
+                Box::pin(async move { outcome })
+            }
+        }
+
+        /// An authority that holds exactly the scopes it was told to.
+        ///
+        /// Mirrors the real contract deliberately — a **filter**, never a
+        /// source. A stub that could return a name it was not given would let
+        /// a test pass that the real port makes impossible.
+        struct StubAuthority(Vec<String>);
+
+        impl SubjectScopeAuthority for StubAuthority {
+            fn held_scopes<'a>(
+                &'a self,
+                _tenant_id: Uuid,
+                _subject_id: Uuid,
+                candidates: &'a [String],
+            ) -> Pin<Box<dyn Future<Output = Result<Vec<String>, String>> + Send + 'a>>
+            {
+                let held: Vec<String> = candidates
+                    .iter()
+                    .filter(|c| self.0.contains(c))
+                    .cloned()
+                    .collect();
+                Box::pin(async move { Ok(held) })
+            }
+        }
+
+        // ---- fixtures ------------------------------------------------
+
+        const EXT_ISS: &str = "https://partner.example";
+
+        fn auth_config() -> AuthConfig {
+            let kp = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519).unwrap();
+            AuthConfig {
+                jwt_private_key_pem: kp.serialize_pem(),
+                jwt_public_key_pem: kp.public_key_pem(),
+                access_token_lifetime_secs: 900,
+                jwt_issuer: "axiam-test".into(),
+                oauth2_issuer_url: "https://id.axiam.test".into(),
+                ..AuthConfig::default()
+            }
+        }
+
+        fn subject(candidates: &[&str]) -> ResolvedExternalSubject {
+            ResolvedExternalSubject {
+                issuer: EXT_ISS.into(),
+                provider_id: Uuid::new_v4(),
+                provider_name: "PartnerIdP".into(),
+                external_subject: "partner-user-1".into(),
+                user_id: Uuid::new_v4(),
+                newly_provisioned: false,
+                candidate_scopes: candidates.iter().map(|s| (*s).to_string()).collect(),
+                subject_exp: Utc::now().timestamp() + 600,
+                max_lifetime_secs: None,
+            }
+        }
+
+        fn client(scopes: &[&str]) -> OAuth2Client {
+            OAuth2Client {
+                id: Uuid::new_v4(),
+                tenant_id: Uuid::new_v4(),
+                client_id: "oa_gateway".into(),
+                client_secret_hash: String::new(),
+                name: "gateway".into(),
+                redirect_uris: vec![],
+                grant_types: vec![TOKEN_EXCHANGE_GRANT_TYPE.into()],
+                scopes: scopes.iter().map(|s| (*s).to_string()).collect(),
+                post_logout_redirect_uris: Vec::new(),
+                backchannel_logout_uri: None,
+                require_par: false,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }
+        }
+
+        /// A syntactically well-formed JWT whose payload names `iss`.
+        ///
+        /// Never verified by anything in these tests — the resolver is stubbed
+        /// — so the signature segment is a placeholder. What it exercises is
+        /// the *routing* decision, which is the only thing the unverified
+        /// payload is allowed to influence.
+        fn foreign_token(iss: &str) -> String {
+            use base64::Engine;
+            let b64 = |v: &serde_json::Value| {
+                base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(serde_json::to_vec(v).unwrap())
+            };
+            format!(
+                "{}.{}.{}",
+                b64(&serde_json::json!({ "alg": "RS256", "typ": "at+jwt" })),
+                b64(&serde_json::json!({ "iss": iss, "sub": "partner-user-1" })),
+                "c2ln"
+            )
+        }
+
+        fn service(
+            cfg: &AuthConfig,
+            resolver: Arc<dyn ExternalSubjectResolver>,
+            authority: Arc<dyn SubjectScopeAuthority>,
+        ) -> TokenExchangeService<StubTenantRepo> {
+            TokenExchangeService::new(
+                StubTenantRepo {
+                    org_id: Uuid::new_v4(),
+                },
+                cfg.clone(),
+                900,
+            )
+            .with_external_subjects(resolver, authority)
+        }
+
+        fn request(token: String, scope: Option<&str>) -> TokenExchangeRequest {
+            TokenExchangeRequest {
+                subject_token: token,
+                subject_token_type: TOKEN_TYPE_JWT.into(),
+                requested_token_type: None,
+                actor_token: None,
+                actor_token_type: None,
+                scope: scope.map(str::to_owned),
+                audience: None,
+                resource: None,
+            }
+        }
+
+        // ---- the happy path, and what it proves ----------------------
+
+        #[tokio::test]
+        async fn a_trusted_partner_token_mints_a_narrowed_axiam_token() {
+            let cfg = auth_config();
+            let subj = subject(&["read:orders"]);
+            let user_id = subj.user_id;
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subj),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let outcome = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders", "write:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .expect("a fully-permitted exchange must succeed");
+
+            assert_eq!(outcome.kind, ExchangeKind::External);
+            assert_eq!(outcome.granted_scopes, vec!["read:orders".to_string()]);
+            assert_eq!(outcome.subject, user_id.to_string());
+            assert_eq!(
+                outcome.external.as_ref().unwrap().issuer,
+                EXT_ISS,
+                "the audit record must name the foreign issuer"
+            );
+
+            let claims = decode_access_token(&outcome.response.access_token, &cfg).unwrap();
+            assert_eq!(
+                claims.ext_exchange.map(|e| e.iss),
+                Some(EXT_ISS.to_string()),
+                "the issued token must carry its provenance"
+            );
+            assert!(
+                claims.act.is_none(),
+                "nobody acted FOR the user; the IdP asserted the user authenticated"
+            );
+            assert_eq!(claims.sub, user_id.to_string());
+        }
+
+        /// The headline invariant: the partner's token never widens anything.
+        /// A scope the map produces but the engine refuses does not come out.
+        #[tokio::test]
+        async fn the_engine_bounds_the_result_even_when_the_map_is_generous() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders", "admin"])),
+                // The user holds `read:orders` and nothing else.
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let outcome = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders", "admin"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(
+                outcome.granted_scopes,
+                vec!["read:orders".to_string()],
+                "an admin-configured scope_map is not an authority; the engine is"
+            );
+        }
+
+        #[tokio::test]
+        async fn an_explicitly_requested_scope_the_user_lacks_is_refused_not_dropped() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders", "admin"])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders", "admin"]),
+                    request(foreign_token(EXT_ISS), Some("read:orders admin")),
+                )
+                .await
+                .unwrap_err();
+
+            assert_eq!(err.error_code(), "invalid_scope");
+            assert!(
+                err.error_description().contains("admin"),
+                "the error must name the offending scope: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn the_exchanging_clients_own_ceiling_still_applies() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["admin"])),
+                Arc::new(StubAuthority(vec!["admin".into()])),
+            );
+
+            // Everything else says yes; the client is not registered for it.
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), Some("admin")),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_scope");
+        }
+
+        #[tokio::test]
+        async fn an_unmapped_partner_token_yields_no_token_at_all() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&[])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_scope");
+        }
+
+        // ---- routing --------------------------------------------------
+
+        /// A deployment that never wired X4 in cannot accept a foreign token,
+        /// whatever a provider row says — and answers the same way as "no
+        /// provider trusts this issuer".
+        #[tokio::test]
+        async fn without_the_external_collaborators_a_foreign_token_is_untrusted() {
+            let cfg = auth_config();
+            let svc = TokenExchangeService::new(
+                StubTenantRepo {
+                    org_id: Uuid::new_v4(),
+                },
+                cfg.clone(),
+                900,
+            );
+
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_grant");
+            assert_eq!(err.error_description(), ISSUER_NOT_TRUSTED);
+        }
+
+        #[tokio::test]
+        async fn an_untrusted_issuer_says_so_distinguishably() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::err(ExternalSubjectRejection::IssuerNotTrusted),
+                Arc::new(StubAuthority(vec![])),
+            );
+
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token("https://nobody.example"), None),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_description(), ISSUER_NOT_TRUSTED);
+        }
+
+        /// Every *other* refusal is generic: which of a dozen checks refused a
+        /// token is a map of our validation order, drawn one request at a time.
+        #[tokio::test]
+        async fn every_other_rejection_reason_stays_off_the_wire() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::err(ExternalSubjectRejection::Rejected(
+                    "signature is invalid".into(),
+                )),
+                Arc::new(StubAuthority(vec![])),
+            );
+
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_grant");
+            assert_eq!(err.error_description(), "subject token is not valid");
+            assert!(!err.error_description().contains("signature"));
+        }
+
+        /// A token claiming AXIAM's own issuer takes the internal path, where
+        /// it faces AXIAM's signing key — the routing claim is unverified, and
+        /// choosing a branch is all it can do.
+        #[tokio::test]
+        async fn a_token_claiming_our_issuer_is_verified_against_our_key() {
+            let cfg = auth_config();
+            let resolver = StubResolver::ok(subject(&["read:orders"]));
+            let svc = service(
+                &cfg,
+                resolver.clone(),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let mut req = request(foreign_token(cfg.effective_issuer()), None);
+            req.subject_token_type = TOKEN_TYPE_ACCESS_TOKEN.into();
+            let err = svc
+                .exchange(Uuid::new_v4(), &client(&["read:orders"]), req)
+                .await
+                .unwrap_err();
+
+            assert_eq!(err.error_code(), "invalid_grant");
+            assert!(
+                !resolver.called.load(Ordering::SeqCst),
+                "a token claiming our issuer must never reach the external resolver"
+            );
+        }
+
+        // ---- the invariants X4 exists to hold ------------------------
+
+        #[tokio::test]
+        async fn an_actor_token_is_refused_across_a_trust_boundary() {
+            let cfg = auth_config();
+            let resolver = StubResolver::ok(subject(&["read:orders"]));
+            let svc = service(
+                &cfg,
+                resolver.clone(),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let mut req = request(foreign_token(EXT_ISS), None);
+            req.actor_token = Some("whatever".into());
+            req.actor_token_type = Some(TOKEN_TYPE_ACCESS_TOKEN.into());
+
+            let err = svc
+                .exchange(Uuid::new_v4(), &client(&["read:orders"]), req)
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_request");
+            assert!(
+                !resolver.called.load(Ordering::SeqCst),
+                "refused before the token is verified, so the answer cannot \
+                 depend on whether the subject token happened to be good"
+            );
+        }
+
+        #[tokio::test]
+        async fn refresh_and_id_subject_token_types_are_refused_by_name() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders"])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            for (ty, needle) in [
+                (TOKEN_TYPE_REFRESH_TOKEN, "re-authentication"),
+                (TOKEN_TYPE_ID_TOKEN, "asserts a login"),
+            ] {
+                let mut req = request(foreign_token(EXT_ISS), None);
+                req.subject_token_type = ty.into();
+                let err = svc
+                    .exchange(Uuid::new_v4(), &client(&["read:orders"]), req)
+                    .await
+                    .unwrap_err();
+                assert_eq!(err.error_code(), "invalid_request");
+                assert!(
+                    err.error_description().contains(needle),
+                    "{ty} should be refused by name, got: {err}"
+                );
+            }
+        }
+
+        /// The transitivity ban, in the direction only this crate can test:
+        /// an AXIAM token that itself came from a cross-domain exchange cannot
+        /// buy another one.
+        #[tokio::test]
+        async fn a_token_minted_by_an_external_exchange_cannot_be_exchanged_again() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders"])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let first = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap();
+
+            // Present the result back as a subject token — same issuer as us,
+            // so it takes the internal path and is cryptographically valid.
+            let mut req = request(first.response.access_token, None);
+            req.subject_token_type = TOKEN_TYPE_ACCESS_TOKEN.into();
+            let err = svc
+                .exchange(Uuid::new_v4(), &client(&["read:orders"]), req)
+                .await
+                .unwrap_err();
+
+            assert_eq!(err.error_code(), "invalid_request");
+            assert!(
+                err.error_description().contains("do not compose"),
+                "got: {err}"
+            );
+        }
+
+        #[tokio::test]
+        async fn the_issued_token_never_outlives_the_partners_token() {
+            let cfg = auth_config();
+            let mut subj = subject(&["read:orders"]);
+            // The partner's token has 30 seconds left; the server-wide cap is
+            // 900. Without the min(), an exchange would launder lifetime.
+            subj.subject_exp = Utc::now().timestamp() + 30;
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subj),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let outcome = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap();
+            assert!(
+                outcome.response.expires_in <= 30,
+                "expires_in was {}",
+                outcome.response.expires_in
+            );
+        }
+
+        #[tokio::test]
+        async fn a_per_provider_lifetime_ceiling_is_honoured() {
+            let cfg = auth_config();
+            let mut subj = subject(&["read:orders"]);
+            subj.max_lifetime_secs = Some(60);
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subj),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let outcome = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap();
+            assert!(outcome.response.expires_in <= 60);
+        }
+
+        #[tokio::test]
+        async fn an_expired_partner_token_buys_nothing() {
+            let cfg = auth_config();
+            let mut subj = subject(&["read:orders"]);
+            subj.subject_exp = Utc::now().timestamp() - 1;
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subj),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let err = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_grant");
+        }
+
+        /// The issued `aud` is AXIAM's, never the partner's — the external
+        /// token's audience names *their* resource server.
+        #[tokio::test]
+        async fn the_partners_audience_is_never_inherited() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders"])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let outcome = svc
+                .exchange(
+                    Uuid::new_v4(),
+                    &client(&["read:orders"]),
+                    request(foreign_token(EXT_ISS), None),
+                )
+                .await
+                .unwrap();
+            assert_eq!(outcome.audience, AUD_USER);
+        }
+
+        #[tokio::test]
+        async fn an_unregistered_audience_is_invalid_target() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders"])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let mut req = request(foreign_token(EXT_ISS), None);
+            req.audience = Some("https://not-registered.example".into());
+            let err = svc
+                .exchange(Uuid::new_v4(), &client(&["read:orders"]), req)
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "invalid_target");
+        }
+
+        #[tokio::test]
+        async fn a_client_without_the_exchange_grant_gets_nowhere_near_the_resolver() {
+            let cfg = auth_config();
+            let resolver = StubResolver::ok(subject(&["read:orders"]));
+            let svc = service(
+                &cfg,
+                resolver.clone(),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let mut c = client(&["read:orders"]);
+            c.grant_types.clear();
+            let err = svc
+                .exchange(Uuid::new_v4(), &c, request(foreign_token(EXT_ISS), None))
+                .await
+                .unwrap_err();
+            assert_eq!(err.error_code(), "unauthorized_client");
+            assert!(!resolver.called.load(Ordering::SeqCst));
+        }
+
+        /// `may_impersonate` is deliberately NOT the gate here — the evidence
+        /// is a trusted IdP's signed assertion, not the client's own say-so.
+        #[tokio::test]
+        async fn the_external_path_does_not_require_the_impersonation_grant() {
+            let cfg = auth_config();
+            let svc = service(
+                &cfg,
+                StubResolver::ok(subject(&["read:orders"])),
+                Arc::new(StubAuthority(vec!["read:orders".into()])),
+            );
+
+            let c = client(&["read:orders"]);
+            assert!(!client_may_impersonate(&c));
+            assert!(
+                svc.exchange(Uuid::new_v4(), &c, request(foreign_token(EXT_ISS), None))
+                    .await
+                    .is_ok()
+            );
+        }
+
+        /// Exhaustive over the three gates the request itself does not set:
+        /// whatever comes out is a subset of every one of them. The single
+        /// most valuable test in the feature, mirroring B3's own property test
+        /// one layer up.
+        #[tokio::test]
+        async fn granted_is_always_a_subset_of_map_client_and_engine() {
+            let universe = ["a", "b", "c"];
+            let subsets: Vec<Vec<String>> = (0u8..8)
+                .map(|mask| {
+                    universe
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| mask & (1 << i) != 0)
+                        .map(|(_, s)| (*s).to_string())
+                        .collect()
+                })
+                .collect();
+            let cfg = auth_config();
+
+            for candidates in &subsets {
+                for client_scopes in &subsets {
+                    for held in &subsets {
+                        let mut subj = subject(&[]);
+                        subj.candidate_scopes = candidates.clone();
+                        let svc = service(
+                            &cfg,
+                            StubResolver::ok(subj),
+                            Arc::new(StubAuthority(held.clone())),
+                        );
+                        let mut c = client(&[]);
+                        c.scopes = client_scopes.clone();
+
+                        match svc
+                            .exchange(Uuid::new_v4(), &c, request(foreign_token(EXT_ISS), None))
+                            .await
+                        {
+                            Ok(outcome) => {
+                                assert!(!outcome.granted_scopes.is_empty());
+                                for s in &outcome.granted_scopes {
+                                    assert!(candidates.contains(s), "escaped the scope map");
+                                    assert!(client_scopes.contains(s), "escaped the client");
+                                    assert!(held.contains(s), "escaped the engine");
+                                }
+                            }
+                            Err(e) => assert_eq!(e.error_code(), "invalid_scope"),
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/axiam-server/src/main.rs
+++ b/crates/axiam-server/src/main.rs
@@ -1711,6 +1711,27 @@ async fn main() -> std::io::Result<()> {
         saml_federation_service: saml_federation_service.clone(),
     };
 
+    // X4 — accept subject tokens from trusted external IdPs.
+    //
+    // Enabled here rather than at construction because it needs the OIDC
+    // federation service, which is itself conditional on the federation
+    // encryption key. Nothing changes for a deployment that has not switched
+    // `token_exchange.enabled` on for any provider: the path exists, and every
+    // issuer fails to resolve.
+    let mut app_state = app_state;
+    if app_state.enable_external_token_exchange() {
+        tracing::info!(
+            "X4: external-IdP token exchange is available (per-provider trust \
+             still decides whether any issuer is accepted)"
+        );
+    } else {
+        tracing::info!(
+            "X4: external-IdP token exchange is OFF — no OIDC federation service \
+             (AXIAM__AUTH__FEDERATION_ENCRYPTION_KEY is unset)"
+        );
+    }
+    let app_state = app_state;
+
     let http_server = HttpServer::new(move || {
         let rl = rate_limit_cfg.clone();
         App::new()

--- a/docs/api/federated-token-exchange.md
+++ b/docs/api/federated-token-exchange.md
@@ -1,0 +1,289 @@
+# Federated token exchange — accepting a partner IdP's token
+
+A partner, or a sibling business unit, runs their own identity provider —
+Microsoft Entra ID, Okta, Keycloak. Their service calls yours, carrying *their*
+token. You need an AXIAM token to do anything with it.
+
+X4 is how you get one: present the partner's token at the ordinary
+[token-exchange](token-exchange.md) endpoint and receive an AXIAM access token
+scoped to what the resolved AXIAM user may actually do.
+
+This extends [`token-exchange.md`](token-exchange.md); **every rule there still
+applies.** What is new is which subject tokens are admissible, and the trust
+configuration that decides.
+
+> **The rule this page exists to make concrete.**
+> An external subject token is **evidence of authentication, never a grant of
+> authorization.** The partner's IdP stays the authority on *who
+> authenticated*. AXIAM stays the authority on *what they may do here*. Nothing
+> in a partner's token can widen what the resulting AXIAM token permits.
+
+Design rationale, including the alternatives rejected and the threat each check
+answers:
+[`claude_dev/external-token-exchange-design.md`](../../claude_dev/external-token-exchange-design.md).
+
+---
+
+## Before you start: it is off
+
+External token exchange is **disabled by default, per federation provider.**
+Configuring Okta for *login* is not agreement to accept Okta tokens as API
+credentials — those are different trust statements, so they get different
+switches. Upgrading AXIAM never turns this on.
+
+You need, in order:
+
+1. An **OIDC** federation provider (SAML providers cannot do this — there is no
+   issuer to match and no JWKS to verify against; AXIAM refuses the
+   configuration outright).
+2. A `token_exchange` block on that provider with `enabled: true` and at least
+   one `accepted_audiences` entry.
+3. A `scope_map` saying which of the partner's assertions may map onto which
+   AXIAM scopes.
+4. An AXIAM user each partner subject resolves to — either pre-linked, or
+   JIT-provisioned if you opt in.
+5. That user actually holding the permissions, in AXIAM's own RBAC.
+
+Miss any one and the exchange is refused. That is the design.
+
+---
+
+## Trust configuration
+
+`PATCH /api/v1/federation/configs/{id}` (admin, `federation:update`):
+
+```json
+{
+  "token_exchange": {
+    "enabled": true,
+    "accepted_audiences": ["https://api.example.com"],
+    "subject_mapping": "linked_only",
+    "scope_map": {
+      "partner.orders.read":  ["read:orders"],
+      "Orders.ReadWrite.All": ["read:orders", "write:orders"]
+    },
+    "max_token_age_secs": 300,
+    "max_lifetime_secs": 600
+  }
+}
+```
+
+The block is **replaced wholesale**, never merged field by field — a partial
+merge of a trust configuration is how you end up keeping an
+`accepted_audiences` entry you believed you had removed.
+
+| Field | Default | What it does |
+|---|---|---|
+| `enabled` | `false` | Master switch for this provider. |
+| `accepted_audiences` | — | Audiences an incoming token may name. **Required, non-empty, when enabled.** |
+| `subject_mapping` | `linked_only` | `linked_only` or `jit_provision` — see below. |
+| `scope_map` | `{}` | Partner assertion → AXIAM scopes. Deny-by-default. |
+| `max_token_age_secs` | `300` | Bound on `now - iat`, independent of `exp`. 1…3600. |
+| `max_lifetime_secs` | unset | Per-provider ceiling on the *issued* token's life. |
+
+### Why there is no "accept any audience"
+
+A token that was not addressed to you is a token you **captured**, not a token
+you were **given**. Accepting any audience turns every token the partner mints
+anywhere in their estate into an AXIAM credential — including ones minted for a
+third party who is not you, and including ones a different relying party could
+replay at your door.
+
+So `accepted_audiences` must name at least one value, and matching is **exact
+string equality**: no trailing-slash forgiveness, no case folding, no
+normalisation. "Close enough" comparisons at a trust boundary are how a token
+minted for `https://api.example.com.attacker.test` gets accepted as
+`https://api.example.com`.
+
+Put your own API's audience identifier here — the value the partner configures
+on their side when they mint a token *for you*.
+
+### The scope map is deny-by-default
+
+An assertion with no entry in `scope_map` contributes **nothing**. There is no
+passthrough mode and no identity mapping, because an identity mapping would let
+the *partner's* administrator name AXIAM scopes.
+
+AXIAM reads four claim shapes — the ones the target IdPs actually emit:
+
+| Claim | Shape | Emitted by |
+|---|---|---|
+| `scope` | space-separated string | Okta, Keycloak, Auth0, RFC 9068 |
+| `scp` | string **or** array | Entra ID (string), some Okta configs (array) |
+| `roles` | array | Entra ID app roles |
+| `groups` | array | Okta, Entra group claims |
+
+Nested shapes (Keycloak's `realm_access.roles`) are **not** read in v1. If your
+partner's authority lives there, add a protocol mapper on their side that
+projects it into `scope` or `roles` — a claim AXIAM does not read cannot grant
+anything, which is the safe direction, but it also means it silently grants
+nothing.
+
+### `linked_only` vs `jit_provision`
+
+`linked_only` (the default): the partner subject must already resolve to an
+AXIAM user — because they logged in through this provider's browser flow at
+least once, or because an admin created the link. Unknown subject ⇒ refused.
+
+`jit_provision`: AXIAM creates the user on first sight, through the same
+provisioning path a browser SSO login uses, audited as such.
+
+**A JIT-provisioned user holds no roles, so their first exchange still yields
+nothing.** Provisioning an identity is not granting it anything — the user
+appears in AXIAM so an admin can grant them something, and until that happens
+every exchange for them fails with `invalid_scope`. This is worth knowing
+before you conclude the feature is broken.
+
+---
+
+## Making a request
+
+```http
+POST /oauth2/token?tenant_id=<uuid>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token=<the partner's JWT>
+&subject_token_type=urn:ietf:params:oauth:token-type:jwt
+&scope=read:orders                  # optional
+&audience=https://orders.internal   # optional
+&client_id=oa_...&client_secret=...
+```
+
+`subject_token_type` may be `…:jwt` or `…:access_token`; both are accepted for
+an external issuer. `…:refresh_token` and `…:id_token` are refused **by name**.
+
+**`actor_token` is not supported.** Delegation across a trust boundary needs a
+second trust decision — "may this actor act for a subject *that IdP* vouched
+for" — which v1 does not make. Sending one is `invalid_request`.
+
+The exchanging client authenticates normally and must be registered for the
+token-exchange grant. It does **not** need `may_impersonate`: the evidence here
+is a trusted IdP's signed assertion that the user authenticated, not the
+client's own say-so that it may be them.
+
+### What comes back
+
+An ordinary AXIAM access token, plus one claim:
+
+```json
+{
+  "sub": "<the AXIAM user's id>",
+  "scope": "read:orders",
+  "aud": "axiam:user",
+  "ext_exchange": { "iss": "https://partner.example/" }
+}
+```
+
+`ext_exchange` is the token's provenance. A resource server can read it to tell
+a cross-domain token from a locally-issued one without asking AXIAM anything.
+
+Note what is **not** there: the partner's `aud` is never inherited (it names
+*their* resource server), there is no `act` claim (nobody acted *for* the user),
+and there is no refresh token (re-run the exchange).
+
+---
+
+## How a scope is decided
+
+```
+candidate = ⋃ scope_map[v]   for each assertion v in the partner's token
+granted   = requested ∩ candidate ∩ client registration ∩ RBAC engine
+```
+
+Four gates, and the partner's token is only the first. In particular the **RBAC
+engine is consulted at mint time**: a scope survives only if the resolved user
+holds an `allow` grant for that action and **no `deny` grant for it anywhere**
+in their applicable roles.
+
+That last clause is deliberately broader than a live access check. A deny scoped
+to one resource withholds the *scope* entirely, even though the same deny would
+only veto that one resource in a live check. A bearer scope cannot express
+"except on resource X" — it travels in a token with no resource attached — so
+the only two honest answers are "grant it everywhere" or "do not grant it", and
+on a cross-domain path AXIAM takes the narrower one. The live check still
+governs every actual request.
+
+**Explicit requests refuse; the default drops.** If you name `scope`, a value
+you cannot have is `invalid_scope` naming the offender. If you name nothing, you
+get whatever survives all four gates. (This differs from a same-domain exchange,
+where the default also refuses — there the default is the subject token's own
+scopes, which pass by construction, whereas a `scope_map` is written for a
+provider and routinely exceeds what any individual user holds.)
+
+---
+
+## No transitive trust
+
+Every token minted from an external subject token carries `ext_exchange`, and
+**both exchange paths refuse a subject token that carries it.** So:
+
+- a token you got from an external exchange cannot be exchanged again, and
+- a partner token that itself carries the claim cannot be exchanged here.
+
+Without this, trust composes silently: A trusts B, B trusts C, therefore A
+trusts C — which nobody configured, and which nobody can see by reading either
+configuration.
+
+---
+
+## Refusals
+
+| Condition | `error` | Description |
+|---|---|---|
+| Issuer matches no exchange-enabled provider | `invalid_grant` | **`the subject token's issuer is not configured for token exchange`** |
+| Signature, claims, age, audience, token shape, unlinked subject, inactive user | `invalid_grant` | `subject token is not valid` |
+| `subject_token_type` is a refresh or ID token type | `invalid_request` | names the type |
+| `actor_token` supplied | `invalid_request` | v1 unsupported |
+| Subject token already the product of an exchange | `invalid_request` | "exchanges do not compose" |
+| Requested scope outside the map / client / engine | `invalid_scope` | names the scope |
+| Nothing survives the four gates | `invalid_scope` | generic |
+| `audience`/`resource` not registered to the client | `invalid_target` | names the target |
+
+**Untrusted-issuer is the one failure given a distinguishable message.** The
+exchanging client is an authenticated confidential client of your tenant, not an
+anonymous prober, so telling it that an issuer is not configured leaks nothing
+it could not learn by asking you — and without it, an integrator cannot tell
+"fix the AXIAM trust configuration" from "fix your token". Everything else is
+generic on purpose: which of a dozen checks refused a token is a map of the
+validation order, drawn one request at a time.
+
+The precise reason is always in the audit record.
+
+---
+
+## Audit
+
+Every external exchange — successful or refused — records the exchanging
+client, the external issuer, the external subject, the federation provider, the
+resolved AXIAM user, whether that user was JIT-provisioned, the granted scopes,
+the audience, and the outcome. All in one entry: a reader correlating two lines
+by timestamp is a reader who can be made to correlate the wrong two.
+
+For a JIT provision this is the **only** record that a partner's IdP created an
+AXIAM user.
+
+---
+
+## Operational notes
+
+- **JWKS and discovery reuse the login path's caches.** Key rotation is handled
+  by the same unknown-`kid` forced refetch (rate-limited to one per minute per
+  provider) that federated login uses. There are no new outbound fetch paths and
+  no new SSRF surface.
+- **Rate limiting**: the exchange's existing per-client bucket
+  (`AXIAM__RATE_LIMIT__TOKEN_EXCHANGE_PER_MIN`) covers this path too.
+- **Requires `AXIAM__AUTH__FEDERATION_ENCRYPTION_KEY`.** Without it AXIAM has no
+  OIDC federation service, so there is nothing to read provider trust *with*,
+  and every external issuer resolves to "not configured". The startup log says
+  which posture is live.
+- **`max_token_age_secs` is not `exp`.** A partner IdP issuing 24-hour access
+  tokens should not thereby hand out a 24-hour replay window into AXIAM. Set it
+  to the shortest value your integration tolerates; the default of 5 minutes
+  suits a gateway that exchanges on receipt.
+
+## See also
+
+- [`token-exchange.md`](token-exchange.md) — the same-domain grant this extends
+- [SDK contract §15.7](../../sdks/CONTRACT.md) — what SDKs must and must not do
+- [`claude_dev/external-token-exchange-design.md`](../../claude_dev/external-token-exchange-design.md) — the rationale

--- a/frontend/src/pages/federation/FederationPage.test.tsx
+++ b/frontend/src/pages/federation/FederationPage.test.tsx
@@ -6,6 +6,7 @@ import { apiMock, res } from "@/test/apiMock";
 vi.mock("@/lib/api", () => ({ default: apiMock }));
 
 import { FederationPage } from "./FederationPage";
+import { DEFAULT_TOKEN_EXCHANGE_TRUST } from "@/services/federation";
 import { renderWithProviders } from "@/test/renderWithProviders";
 import { setToastDispatch } from "@/hooks/useToast";
 
@@ -316,6 +317,11 @@ describe("FederationPage", () => {
         metadata_url: "https://okta.example.com/.well-known/openid-configuration",
         attribute_map: { email: "mail" },
         enabled: true,
+        // X4: an OIDC provider always carries its complete trust block. The
+        // server replaces it wholesale, so sending a patch — or omitting it —
+        // is how an operator keeps a setting they believed they had changed.
+        // This fixture has none configured, so it is the disabled default.
+        token_exchange: DEFAULT_TOKEN_EXCHANGE_TRUST,
       }),
     );
   });

--- a/frontend/src/pages/federation/FederationPage.tsx
+++ b/frontend/src/pages/federation/FederationPage.tsx
@@ -11,12 +11,12 @@ import {
   type UpdateFederationConfigRequest,
   type TokenExchangeTrust,
 } from "@/services/federation";
+import { TokenExchangeTrustEditor } from "./TokenExchangeTrustEditor";
 import {
-  TokenExchangeTrustEditor,
   parseScopeMap,
   stringifyAudiences,
   stringifyScopeMap,
-} from "./TokenExchangeTrustEditor";
+} from "./tokenExchangeTrustFormat";
 import { PageHeader } from "@/components/PageHeader";
 import { DataTable, type Column } from "@/components/DataTable";
 import { FormDialog } from "@/components/FormDialog";

--- a/frontend/src/pages/federation/FederationPage.tsx
+++ b/frontend/src/pages/federation/FederationPage.tsx
@@ -3,11 +3,20 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Pencil, Trash2 } from "lucide-react";
 import {
   federationService,
+  validateTokenExchangeTrust,
+  DEFAULT_TOKEN_EXCHANGE_TRUST,
   type FederationConfig,
   type FederationProtocol,
   type CreateFederationConfigRequest,
   type UpdateFederationConfigRequest,
+  type TokenExchangeTrust,
 } from "@/services/federation";
+import {
+  TokenExchangeTrustEditor,
+  parseScopeMap,
+  stringifyAudiences,
+  stringifyScopeMap,
+} from "./TokenExchangeTrustEditor";
 import { PageHeader } from "@/components/PageHeader";
 import { DataTable, type Column } from "@/components/DataTable";
 import { FormDialog } from "@/components/FormDialog";
@@ -309,6 +318,14 @@ function useConfigFormState() {
   const [attributeMap, setAttributeMap] = useState("");
   const [enabled, setEnabled] = useState(true);
   const [error, setError] = useState("");
+  // X4 — the trust block, plus the two textareas' raw text kept beside it so a
+  // half-typed scope map survives a re-render instead of being swallowed by the
+  // parse.
+  const [tokenExchange, setTokenExchange] = useState<TokenExchangeTrust>(
+    DEFAULT_TOKEN_EXCHANGE_TRUST,
+  );
+  const [audiencesText, setAudiencesText] = useState("");
+  const [scopeMapText, setScopeMapText] = useState("");
 
   function reset() {
     setProvider("");
@@ -321,6 +338,9 @@ function useConfigFormState() {
     setAttributeMap("");
     setEnabled(true);
     setError("");
+    setTokenExchange(DEFAULT_TOKEN_EXCHANGE_TRUST);
+    setAudiencesText("");
+    setScopeMapText("");
   }
 
   function load(config: FederationConfig) {
@@ -335,6 +355,10 @@ function useConfigFormState() {
     setAttributeMap(stringifyAttributeMap(config.attribute_map));
     setEnabled(config.enabled);
     setError("");
+    const trust = config.token_exchange ?? DEFAULT_TOKEN_EXCHANGE_TRUST;
+    setTokenExchange(trust);
+    setAudiencesText(stringifyAudiences(trust.accepted_audiences));
+    setScopeMapText(stringifyScopeMap(trust.scope_map));
   }
 
   return {
@@ -358,6 +382,12 @@ function useConfigFormState() {
     setEnabled,
     error,
     setError,
+    tokenExchange,
+    setTokenExchange,
+    audiencesText,
+    setAudiencesText,
+    scopeMapText,
+    setScopeMapText,
     reset,
     load,
   };
@@ -521,6 +551,25 @@ export function FederationPage() {
       if (cert) payload.idp_signing_cert_pem = cert;
       const algos = parseAlgorithms(editForm.allowedAlgorithms);
       if (algos.length > 0) payload.allowed_algorithms = algos;
+    } else {
+      // X4. Sent as a complete block, never a patch — the server replaces it
+      // wholesale, and a partial send is how an operator keeps an accepted
+      // audience they believed they had removed.
+      const scopeMapResult = parseScopeMap(editForm.scopeMapText);
+      if ("error" in scopeMapResult) {
+        editForm.setError(scopeMapResult.error);
+        return;
+      }
+      const trust: TokenExchangeTrust = {
+        ...editForm.tokenExchange,
+        scope_map: scopeMapResult.value,
+      };
+      const trustError = validateTokenExchangeTrust(trust);
+      if (trustError) {
+        editForm.setError(trustError);
+        return;
+      }
+      payload.token_exchange = trust;
     }
 
     editMutation.mutate({ id: editConfig.id, payload });
@@ -713,6 +762,19 @@ export function FederationPage() {
           label="Enabled"
           checked={editForm.enabled}
           onChange={editForm.setEnabled}
+        />
+        {/* X4 — external token-exchange trust. Edit-only: you configure what a
+            provider's tokens are worth after the provider exists, and the
+            create form is already long. */}
+        <TokenExchangeTrustEditor
+          value={editForm.tokenExchange}
+          onChange={editForm.setTokenExchange}
+          audiencesText={editForm.audiencesText}
+          onAudiencesTextChange={editForm.setAudiencesText}
+          scopeMapText={editForm.scopeMapText}
+          onScopeMapTextChange={editForm.setScopeMapText}
+          isOidc={editConfig?.protocol !== "Saml"}
+          idPrefix="edit"
         />
       </FormDialog>
 

--- a/frontend/src/pages/federation/TokenExchangeTrustEditor.test.tsx
+++ b/frontend/src/pages/federation/TokenExchangeTrustEditor.test.tsx
@@ -4,7 +4,7 @@ import {
   parseScopeMap,
   stringifyAudiences,
   stringifyScopeMap,
-} from "./TokenExchangeTrustEditor";
+} from "./tokenExchangeTrustFormat";
 import {
   DEFAULT_TOKEN_EXCHANGE_TRUST,
   validateTokenExchangeTrust,

--- a/frontend/src/pages/federation/TokenExchangeTrustEditor.test.tsx
+++ b/frontend/src/pages/federation/TokenExchangeTrustEditor.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseAudiences,
+  parseScopeMap,
+  stringifyAudiences,
+  stringifyScopeMap,
+} from "./TokenExchangeTrustEditor";
+import {
+  DEFAULT_TOKEN_EXCHANGE_TRUST,
+  validateTokenExchangeTrust,
+  type TokenExchangeTrust,
+} from "@/services/federation";
+
+describe("parseAudiences", () => {
+  it("takes one audience per line and drops blanks", () => {
+    expect(parseAudiences("https://a.example\n\n  https://b.example  \n")).toEqual([
+      "https://a.example",
+      "https://b.example",
+    ]);
+  });
+
+  it("round-trips through stringifyAudiences", () => {
+    const audiences = ["https://a.example", "https://b.example"];
+    expect(parseAudiences(stringifyAudiences(audiences))).toEqual(audiences);
+  });
+
+  it("yields nothing for an empty box, which the validator then refuses", () => {
+    expect(parseAudiences("   \n\n")).toEqual([]);
+  });
+});
+
+describe("parseScopeMap", () => {
+  it("reads one mapping per line", () => {
+    const result = parseScopeMap(
+      "partner.orders.read = read:orders\nOrders.ReadWrite.All = read:orders write:orders",
+    );
+    expect(result).toEqual({
+      value: {
+        "partner.orders.read": ["read:orders"],
+        "Orders.ReadWrite.All": ["read:orders", "write:orders"],
+      },
+    });
+  });
+
+  it("accepts commas as well as spaces between scopes", () => {
+    expect(parseScopeMap("a = x, y")).toEqual({ value: { a: ["x", "y"] } });
+  });
+
+  it("ignores blank lines and comments", () => {
+    expect(parseScopeMap("# a comment\n\na = x\n")).toEqual({
+      value: { a: ["x"] },
+    });
+  });
+
+  it("names the line when a mapping has no equals sign", () => {
+    const result = parseScopeMap("a = x\nthis is not a mapping");
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("Line 2");
+  });
+
+  /**
+   * An empty mapping is refused rather than accepted-as-nothing: it reads, to
+   * the next person, as if it grants something.
+   */
+  it("refuses a key that maps to no scopes", () => {
+    const result = parseScopeMap("partner.admin =");
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("partner.admin");
+  });
+
+  it("refuses a blank key", () => {
+    expect(parseScopeMap(" = read:orders")).toHaveProperty("error");
+  });
+
+  /**
+   * Never a partial map: a half-parsed trust configuration submitted by
+   * accident is the failure this form exists to avoid.
+   */
+  it("returns no map at all when any line is bad", () => {
+    const result = parseScopeMap("good = x\nbad line\nalso.good = y");
+    expect(result).not.toHaveProperty("value");
+  });
+
+  it("round-trips through stringifyScopeMap", () => {
+    const map = { "partner.orders.read": ["read:orders", "write:orders"] };
+    expect(parseScopeMap(stringifyScopeMap(map))).toEqual({ value: map });
+  });
+});
+
+describe("validateTokenExchangeTrust", () => {
+  const enabled = (over: Partial<TokenExchangeTrust> = {}): TokenExchangeTrust => ({
+    ...DEFAULT_TOKEN_EXCHANGE_TRUST,
+    enabled: true,
+    accepted_audiences: ["https://api.example.com"],
+    ...over,
+  });
+
+  it("accepts the server default", () => {
+    expect(validateTokenExchangeTrust(DEFAULT_TOKEN_EXCHANGE_TRUST)).toBeNull();
+  });
+
+  it("refuses enabling with no accepted audience", () => {
+    const msg = validateTokenExchangeTrust(enabled({ accepted_audiences: [] }));
+    expect(msg).toContain("accept-all");
+  });
+
+  it("allows a disabled block with no audiences — that is the default", () => {
+    expect(
+      validateTokenExchangeTrust({
+        ...DEFAULT_TOKEN_EXCHANGE_TRUST,
+        enabled: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("bounds the token age at both ends", () => {
+    expect(validateTokenExchangeTrust(enabled({ max_token_age_secs: 0 }))).not.toBeNull();
+    expect(
+      validateTokenExchangeTrust(enabled({ max_token_age_secs: 3601 })),
+    ).not.toBeNull();
+    expect(validateTokenExchangeTrust(enabled({ max_token_age_secs: 3600 }))).toBeNull();
+  });
+
+  it("refuses a non-positive issued lifetime but allows it unset", () => {
+    expect(validateTokenExchangeTrust(enabled({ max_lifetime_secs: 0 }))).not.toBeNull();
+    expect(validateTokenExchangeTrust(enabled({ max_lifetime_secs: null }))).toBeNull();
+  });
+
+  it("refuses a scope-map entry that grants nothing", () => {
+    const msg = validateTokenExchangeTrust(
+      enabled({ scope_map: { "partner.admin": [] } }),
+    );
+    expect(msg).toContain("partner.admin");
+  });
+
+  it("refuses a blank audience entry", () => {
+    expect(
+      validateTokenExchangeTrust(
+        enabled({ accepted_audiences: ["https://api.example.com", "  "] }),
+      ),
+    ).not.toBeNull();
+  });
+});

--- a/frontend/src/pages/federation/TokenExchangeTrustEditor.tsx
+++ b/frontend/src/pages/federation/TokenExchangeTrustEditor.tsx
@@ -1,0 +1,266 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { ToggleField } from "@/components/shared";
+import {
+  DEFAULT_TOKEN_EXCHANGE_TRUST,
+  MAX_TOKEN_AGE_CEILING_SECS,
+  type SubjectMapping,
+  type TokenExchangeTrust,
+} from "@/services/federation";
+
+/**
+ * X4 — editor for a federation provider's external token-exchange trust.
+ *
+ * Operator guide: `docs/api/federated-token-exchange.md`. This form configures
+ * a **trust boundary**: switching it on means AXIAM will accept tokens minted
+ * by someone else's identity provider as proof that a user authenticated. The
+ * copy below is deliberately explicit about that, because the two fields that
+ * decide the blast radius (`accepted_audiences` and `scope_map`) both look like
+ * ordinary optional settings and are neither.
+ *
+ * OIDC only — the server refuses an enabled block on a SAML provider, which has
+ * no issuer to match and no JWKS to verify against.
+ */
+
+/** Parse the audience textarea: one per line, blanks dropped. */
+export function parseAudiences(raw: string): string[] {
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+}
+
+export function stringifyAudiences(audiences: string[]): string {
+  return audiences.join("\n");
+}
+
+/**
+ * Parse the scope map from `partner.value = axiam:scope another:scope` lines.
+ *
+ * A line-oriented format rather than raw JSON: this is a mapping an operator
+ * reads and edits far more often than they write, and `{"a": ["b"]}` obscures
+ * the one thing they are checking — which partner claim buys which scope.
+ *
+ * Returns the parsed map, or an error naming the offending line. Never returns
+ * a partial map: a half-parsed trust configuration submitted by accident is
+ * exactly the failure this whole form is careful about.
+ */
+export function parseScopeMap(
+  raw: string,
+): { value: Record<string, string[]> } | { error: string } {
+  const map: Record<string, string[]> = {};
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) {
+      return {
+        error: `Line ${i + 1}: expected "partner.value = axiam:scope [more:scopes]".`,
+      };
+    }
+    const key = line.slice(0, eq).trim();
+    const scopes = line
+      .slice(eq + 1)
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
+    if (key === "") {
+      return { error: `Line ${i + 1}: the partner value is blank.` };
+    }
+    if (scopes.length === 0) {
+      return {
+        error: `Line ${i + 1}: "${key}" maps to no AXIAM scopes. Remove the line instead — an empty mapping grants nothing and reads as if it grants something.`,
+      };
+    }
+    map[key] = scopes;
+  }
+  return { value: map };
+}
+
+export function stringifyScopeMap(map: Record<string, string[]>): string {
+  return Object.entries(map)
+    .map(([key, scopes]) => `${key} = ${scopes.join(" ")}`)
+    .join("\n");
+}
+
+export interface TokenExchangeTrustEditorProps {
+  /** The live trust block. */
+  value: TokenExchangeTrust;
+  onChange: (next: TokenExchangeTrust) => void;
+  /** Raw textarea state, kept outside `value` so a half-typed map survives. */
+  audiencesText: string;
+  onAudiencesTextChange: (raw: string) => void;
+  scopeMapText: string;
+  onScopeMapTextChange: (raw: string) => void;
+  /** Disabled with an explanation on non-OIDC providers. */
+  isOidc: boolean;
+  idPrefix: string;
+}
+
+export function TokenExchangeTrustEditor({
+  value,
+  onChange,
+  audiencesText,
+  onAudiencesTextChange,
+  scopeMapText,
+  onScopeMapTextChange,
+  isOidc,
+  idPrefix,
+}: TokenExchangeTrustEditorProps) {
+  if (!isOidc) {
+    return (
+      <div className="border-t border-border pt-4 mt-4">
+        <h3 className="text-sm font-semibold mb-1">External Token Exchange</h3>
+        <p className="text-xs text-muted-foreground">
+          Available for OIDC providers only. A SAML provider has no issuer to
+          match and no JWKS to verify tokens against, so there is nothing an
+          exchange could check.
+        </p>
+      </div>
+    );
+  }
+
+  const set = (patch: Partial<TokenExchangeTrust>) =>
+    onChange({ ...value, ...patch });
+
+  return (
+    <div className="border-t border-border pt-4 mt-4 space-y-4">
+      <div>
+        <h3 className="text-sm font-semibold">External Token Exchange (X4)</h3>
+        <p className="text-xs text-muted-foreground mt-1">
+          Accept access tokens issued by <em>this</em> provider as proof that a
+          user authenticated, and exchange them for AXIAM tokens. Configuring a
+          provider for login does not enable this — it is a separate trust
+          decision.
+        </p>
+      </div>
+
+      <ToggleField
+        id={`${idPrefix}-tx-enabled`}
+        label="Accept this provider's tokens for exchange"
+        checked={value.enabled}
+        onChange={(enabled) => set({ enabled })}
+      />
+
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-tx-audiences`}>
+          Accepted audiences (one per line)
+        </Label>
+        <Textarea
+          id={`${idPrefix}-tx-audiences`}
+          rows={3}
+          value={audiencesText}
+          onChange={(e) => {
+            onAudiencesTextChange(e.target.value);
+            set({ accepted_audiences: parseAudiences(e.target.value) });
+          }}
+          placeholder={"https://api.example.com"}
+        />
+        <p className="text-xs text-muted-foreground">
+          Required when enabled, and matched exactly — a trailing slash is a
+          different audience. There is deliberately no accept-all value: a token
+          that was not addressed to you is one you captured, not one you were
+          given.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-tx-scope-map`}>Scope map</Label>
+        <Textarea
+          id={`${idPrefix}-tx-scope-map`}
+          rows={4}
+          className="font-mono text-xs"
+          value={scopeMapText}
+          onChange={(e) => {
+            onScopeMapTextChange(e.target.value);
+            const parsed = parseScopeMap(e.target.value);
+            if ("value" in parsed) set({ scope_map: parsed.value });
+          }}
+          placeholder={"partner.orders.read = read:orders\nOrders.ReadWrite.All = read:orders write:orders"}
+        />
+        <p className="text-xs text-muted-foreground">
+          One mapping per line. Deny-by-default: a partner assertion with no
+          entry grants nothing, and there is no passthrough mode. AXIAM reads the
+          partner's <code>scope</code>, <code>scp</code>, <code>roles</code> and{" "}
+          <code>groups</code> claims. A mapped scope is still only issued if the
+          resolved user actually holds it in AXIAM's RBAC.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-tx-subject-mapping`}>
+          Unknown subjects
+        </Label>
+        <select
+          id={`${idPrefix}-tx-subject-mapping`}
+          className="w-full h-9 rounded-md border border-input bg-background px-3 text-sm"
+          value={value.subject_mapping}
+          onChange={(e) =>
+            set({ subject_mapping: e.target.value as SubjectMapping })
+          }
+        >
+          <option value="linked_only">
+            Refuse — the user must already be linked
+          </option>
+          <option value="jit_provision">
+            Provision an AXIAM user on first sight
+          </option>
+        </select>
+        <p className="text-xs text-muted-foreground">
+          A just-provisioned user holds no roles, so their first exchange still
+          yields nothing. Provisioning an identity is not granting it anything.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor={`${idPrefix}-tx-max-age`}>
+            Max token age (seconds)
+          </Label>
+          <Input
+            id={`${idPrefix}-tx-max-age`}
+            type="number"
+            min={1}
+            max={MAX_TOKEN_AGE_CEILING_SECS}
+            value={value.max_token_age_secs}
+            onChange={(e) =>
+              set({
+                max_token_age_secs:
+                  Number(e.target.value) ||
+                  DEFAULT_TOKEN_EXCHANGE_TRUST.max_token_age_secs,
+              })
+            }
+          />
+          <p className="text-xs text-muted-foreground">
+            Bounds how old a presented token may be, independently of its own
+            expiry. A partner issuing 24-hour tokens should not thereby hand out
+            a 24-hour replay window.
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor={`${idPrefix}-tx-max-lifetime`}>
+            Max issued lifetime (seconds, optional)
+          </Label>
+          <Input
+            id={`${idPrefix}-tx-max-lifetime`}
+            type="number"
+            min={1}
+            value={value.max_lifetime_secs ?? ""}
+            onChange={(e) =>
+              set({
+                max_lifetime_secs:
+                  e.target.value === "" ? null : Number(e.target.value),
+              })
+            }
+          />
+          <p className="text-xs text-muted-foreground">
+            Applied on top of &ldquo;never outlives the partner&apos;s
+            token&rdquo;. Leave blank for no extra ceiling.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/federation/TokenExchangeTrustEditor.tsx
+++ b/frontend/src/pages/federation/TokenExchangeTrustEditor.tsx
@@ -8,6 +8,7 @@ import {
   type SubjectMapping,
   type TokenExchangeTrust,
 } from "@/services/federation";
+import { parseAudiences, parseScopeMap } from "./tokenExchangeTrustFormat";
 
 /**
  * X4 — editor for a federation provider's external token-exchange trust.
@@ -22,68 +23,6 @@ import {
  * OIDC only — the server refuses an enabled block on a SAML provider, which has
  * no issuer to match and no JWKS to verify against.
  */
-
-/** Parse the audience textarea: one per line, blanks dropped. */
-export function parseAudiences(raw: string): string[] {
-  return raw
-    .split("\n")
-    .map((s) => s.trim())
-    .filter((s) => s !== "");
-}
-
-export function stringifyAudiences(audiences: string[]): string {
-  return audiences.join("\n");
-}
-
-/**
- * Parse the scope map from `partner.value = axiam:scope another:scope` lines.
- *
- * A line-oriented format rather than raw JSON: this is a mapping an operator
- * reads and edits far more often than they write, and `{"a": ["b"]}` obscures
- * the one thing they are checking — which partner claim buys which scope.
- *
- * Returns the parsed map, or an error naming the offending line. Never returns
- * a partial map: a half-parsed trust configuration submitted by accident is
- * exactly the failure this whole form is careful about.
- */
-export function parseScopeMap(
-  raw: string,
-): { value: Record<string, string[]> } | { error: string } {
-  const map: Record<string, string[]> = {};
-  const lines = raw.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (line === "" || line.startsWith("#")) continue;
-    const eq = line.indexOf("=");
-    if (eq === -1) {
-      return {
-        error: `Line ${i + 1}: expected "partner.value = axiam:scope [more:scopes]".`,
-      };
-    }
-    const key = line.slice(0, eq).trim();
-    const scopes = line
-      .slice(eq + 1)
-      .split(/[\s,]+/)
-      .map((s) => s.trim())
-      .filter((s) => s !== "");
-    if (key === "") {
-      return { error: `Line ${i + 1}: the partner value is blank.` };
-    }
-    if (scopes.length === 0) {
-      return {
-        error: `Line ${i + 1}: "${key}" maps to no AXIAM scopes. Remove the line instead — an empty mapping grants nothing and reads as if it grants something.`,
-      };
-    }
-    map[key] = scopes;
-  }
-  return { value: map };
-}
-
-export function stringifyScopeMap(map: Record<string, string[]>): string {
-  return Object.entries(map)
-    .map(([key, scopes]) => `${key} = ${scopes.join(" ")}`)
-    .join("\n");
-}
 
 export interface TokenExchangeTrustEditorProps {
   /** The live trust block. */

--- a/frontend/src/pages/federation/tokenExchangeTrustFormat.ts
+++ b/frontend/src/pages/federation/tokenExchangeTrustFormat.ts
@@ -1,0 +1,69 @@
+/**
+ * X4 — text formats for the token-exchange trust editor.
+ *
+ * Separate from the component because these are pure functions with their own
+ * tests, and the lint rule that keeps fast-refresh working requires a component
+ * file to export only components. Both reasons point the same way.
+ */
+
+/** Parse the audience textarea: one per line, blanks dropped. */
+export function parseAudiences(raw: string): string[] {
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+}
+
+export function stringifyAudiences(audiences: string[]): string {
+  return audiences.join("\n");
+}
+
+/**
+ * Parse the scope map from `partner.value = axiam:scope another:scope` lines.
+ *
+ * A line-oriented format rather than raw JSON: this is a mapping an operator
+ * reads and edits far more often than they write, and `{"a": ["b"]}` obscures
+ * the one thing they are checking — which partner claim buys which scope.
+ *
+ * Returns the parsed map, or an error naming the offending line. Never returns
+ * a partial map: a half-parsed trust configuration submitted by accident is
+ * exactly the failure this whole form is careful about.
+ */
+export function parseScopeMap(
+  raw: string,
+): { value: Record<string, string[]> } | { error: string } {
+  const map: Record<string, string[]> = {};
+  const lines = raw.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) {
+      return {
+        error: `Line ${i + 1}: expected "partner.value = axiam:scope [more:scopes]".`,
+      };
+    }
+    const key = line.slice(0, eq).trim();
+    const scopes = line
+      .slice(eq + 1)
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
+    if (key === "") {
+      return { error: `Line ${i + 1}: the partner value is blank.` };
+    }
+    if (scopes.length === 0) {
+      return {
+        error: `Line ${i + 1}: "${key}" maps to no AXIAM scopes. Remove the line instead — an empty mapping grants nothing and reads as if it grants something.`,
+      };
+    }
+    map[key] = scopes;
+  }
+  return { value: map };
+}
+
+export function stringifyScopeMap(map: Record<string, string[]>): string {
+  return Object.entries(map)
+    .map(([key, scopes]) => `${key} = ${scopes.join(" ")}`)
+    .join("\n");
+}

--- a/frontend/src/services/federation.ts
+++ b/frontend/src/services/federation.ts
@@ -6,6 +6,85 @@ import { unwrapList } from "@/services/_pagination";
 /** Backend protocol discriminator (exact strings from `protocol_to_string`). */
 export type FederationProtocol = "OidcConnect" | "Saml";
 
+/** How an unlinked external subject is handled (X4). */
+export type SubjectMapping = "linked_only" | "jit_provision";
+
+/**
+ * X4 — trust for exchanging this provider's tokens (RFC 8693, external issuer).
+ *
+ * Read the server's own guide before changing any of it:
+ * `docs/api/federated-token-exchange.md`. Two fields decide the blast radius:
+ * `accepted_audiences` (a token not addressed to us is one we captured, not one
+ * we were given) and `scope_map` (deny-by-default — an unmapped partner
+ * assertion grants nothing, and there is no passthrough).
+ */
+export interface TokenExchangeTrust {
+  enabled: boolean;
+  accepted_audiences: string[];
+  subject_mapping: SubjectMapping;
+  /** Partner assertion → AXIAM scopes. */
+  scope_map: Record<string, string[]>;
+  max_token_age_secs: number;
+  max_lifetime_secs?: number | null;
+}
+
+/** Server default: off, trusting nothing. Mirrors `TokenExchangeTrust::default()`. */
+export const DEFAULT_TOKEN_EXCHANGE_TRUST: TokenExchangeTrust = {
+  enabled: false,
+  accepted_audiences: [],
+  subject_mapping: "linked_only",
+  scope_map: {},
+  max_token_age_secs: 300,
+  max_lifetime_secs: null,
+};
+
+/** Server-side bounds on `max_token_age_secs` (`axiam_core::models::federation`). */
+export const MAX_TOKEN_AGE_CEILING_SECS = 3600;
+
+/**
+ * Client-side mirror of `TokenExchangeTrust::validate`.
+ *
+ * The server is the authority and rejects the same cases; this exists so an
+ * operator finds out before they submit, not so the server can skip checking.
+ * Returns a human-readable reason, or `null` when the block is acceptable.
+ */
+export function validateTokenExchangeTrust(
+  t: TokenExchangeTrust,
+): string | null {
+  if (t.enabled && t.accepted_audiences.length === 0) {
+    return "At least one accepted audience is required to enable token exchange — there is deliberately no accept-all value.";
+  }
+  if (t.accepted_audiences.some((a) => a.trim() === "")) {
+    return "Accepted audiences must not contain blank entries.";
+  }
+  if (
+    !Number.isInteger(t.max_token_age_secs) ||
+    t.max_token_age_secs < 1 ||
+    t.max_token_age_secs > MAX_TOKEN_AGE_CEILING_SECS
+  ) {
+    return `Maximum token age must be a whole number between 1 and ${MAX_TOKEN_AGE_CEILING_SECS} seconds.`;
+  }
+  if (
+    t.max_lifetime_secs !== null &&
+    t.max_lifetime_secs !== undefined &&
+    t.max_lifetime_secs < 1
+  ) {
+    return "Maximum issued-token lifetime must be positive.";
+  }
+  for (const [key, scopes] of Object.entries(t.scope_map)) {
+    if (key.trim() === "") {
+      return "Scope-map keys must not be blank.";
+    }
+    if (scopes.length === 0) {
+      return `Scope-map entry "${key}" maps to no AXIAM scopes — remove the entry instead.`;
+    }
+    if (scopes.some((s) => s.trim() === "")) {
+      return `Scope-map entry "${key}" maps to a blank scope name.`;
+    }
+  }
+  return null;
+}
+
 /**
  * Server → client representation of a federation config.
  * Note: `client_secret` is write-only and is NEVER returned by the backend.
@@ -19,6 +98,8 @@ export interface FederationConfig {
   client_id: string;
   attribute_map: unknown;
   enabled: boolean;
+  /** X4. Always present on responses; absent on pre-X4 servers. */
+  token_exchange?: TokenExchangeTrust;
   created_at: string;
   updated_at: string;
 }
@@ -33,6 +114,7 @@ export interface CreateFederationConfigRequest {
   attribute_map?: unknown;
   idp_signing_cert_pem?: string | null;
   allowed_algorithms?: string[];
+  token_exchange?: TokenExchangeTrust;
 }
 
 /** Client → server payload for updating a federation config (all fields optional). */
@@ -45,6 +127,13 @@ export interface UpdateFederationConfigRequest {
   enabled?: boolean;
   idp_signing_cert_pem?: string | null;
   allowed_algorithms?: string[];
+  /**
+   * Replaced **wholesale** by the server when present — never merged field by
+   * field. Send the complete block, not a patch: a partial merge of a trust
+   * configuration is how an operator ends up keeping an accepted audience they
+   * believed they had removed.
+   */
+  token_exchange?: TokenExchangeTrust;
 }
 
 // ─── Service ──────────────────────────────────────────────────────────────────

--- a/sdks/CONTRACT.md
+++ b/sdks/CONTRACT.md
@@ -1998,6 +1998,77 @@ the response carries no refresh token and the client's own session is unchanged 
 call; `issued_token_type` is surfaced; a cross-tenant subject token surfaces `invalid_grant`
 with no attempt to refine it.
 
+### §15.7 External-IdP subject tokens (X4)
+
+**No new per-language surface.** `token_exchange`'s existing parameters already carry
+everything an external exchange needs; what changes is *which* subject tokens the server
+will accept and *what the refusals mean*. Server documentation:
+[`docs/api/federated-token-exchange.md`](../docs/api/federated-token-exchange.md).
+
+**The use case:** a partner runs their own IdP (Entra, Okta, Keycloak). Their service calls
+yours carrying *their* token. You present it here and get back an AXIAM token scoped to what
+the resolved AXIAM user may actually do.
+
+#### What to pass
+
+| Parameter | External exchange |
+|---|---|
+| `subject_token` | the **partner's** access token (a JWT) |
+| `subject_token_type` | `urn:ietf:params:oauth:token-type:jwt` — or `…:access_token`; both are accepted for an external issuer |
+| `actor_token` | **MUST be omitted.** Delegation across a trust boundary is not supported in v1 and is refused with `invalid_request` |
+| `scope` | as always: omit to get everything the trust configuration and the user's permissions allow, or name scopes to be told about any you cannot have |
+
+An SDK MUST NOT inspect the subject token to decide which `subject_token_type` to send, and
+MUST NOT default `subject_token_type` on the caller's behalf. Which kind of token the caller
+holds is something only the caller knows, and a wrong guess here is the difference between a
+request that is refused and one that is silently reinterpreted.
+
+#### Which errors mean what
+
+`error` codes are unchanged (§15.3). One `error_description` is normative and an SDK MAY
+match on it:
+
+> `the subject token's issuer is not configured for token exchange`
+
+carried on `invalid_grant`. It is the **only** external failure that is distinguishable, and
+it means *fix the AXIAM trust configuration* (an operator must enable token exchange for
+that federation provider and list your audience) rather than *fix your token*. Every other
+external failure — bad signature, expired, too old, audience not accepted, wrong token kind,
+subject not linked — answers `invalid_grant` with a generic description, deliberately:
+which of a dozen checks refused a token is a map of the server's validation order, drawn one
+request at a time.
+
+Two refusals worth surfacing with their own guidance:
+
+- `invalid_request` naming a **refresh or ID token type**. A refresh token is a
+  re-authentication credential and an ID token is an assertion to a client about a login;
+  neither is a bearer credential for an API. An SDK MUST NOT retry as a different type.
+- `invalid_request` saying the subject token is **already the product of an exchange**.
+  Exchanges do not compose. An SDK MUST NOT attempt to re-exchange a token it obtained from
+  a previous `token_exchange` call, in either direction.
+
+#### The issued token
+
+Identical in shape to a same-domain exchange, with one additional claim:
+
+```json
+{ "ext_exchange": { "iss": "https://partner.example/" } }
+```
+
+A resource server MAY read it to tell a cross-domain token from a locally-issued one. An SDK
+MUST NOT treat its presence or absence as an authorization input — the `scope` claim and the
+server's own checks remain the authority — and MUST NOT strip it when forwarding.
+
+`§15.2` rules 4–7 apply verbatim: no refresh token, never adopted as the client's session,
+`issued_token_type` surfaced, and `scope` read as the granted set.
+
+#### Required tests (extends §15.6)
+
+An exchange with an external subject token and `subject_token_type=…:jwt` surfaces the
+result unchanged; passing an `actor_token` alongside an external subject token surfaces
+`invalid_request` with no retry and no rewriting; the `issuer is not configured` description
+reaches the caller intact; a token carrying `ext_exchange` is not re-exchanged by any helper.
+
 ---
 
 ## §16 Retry Policy (D5)

--- a/sdks/openapi.json
+++ b/sdks/openapi.json
@@ -1571,6 +1571,7 @@
                           "client_id",
                           "attribute_map",
                           "enabled",
+                          "token_exchange",
                           "created_at",
                           "updated_at"
                         ],
@@ -1605,6 +1606,10 @@
                           "tenant_id": {
                             "type": "string",
                             "format": "uuid"
+                          },
+                          "token_exchange": {
+                            "$ref": "#/components/schemas/TokenExchangeTrustResponse",
+                            "description": "X4 external token-exchange trust."
                           },
                           "updated_at": {
                             "type": "string",
@@ -9289,6 +9294,17 @@
           "provider": {
             "type": "string",
             "description": "Display name for the identity provider (e.g., \"Google\", \"Okta\")."
+          },
+          "token_exchange": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TokenExchangeTrustRequest",
+                "description": "X4 external token-exchange trust. Omitted means disabled."
+              }
+            ]
           }
         }
       },
@@ -10205,6 +10221,7 @@
           "client_id",
           "attribute_map",
           "enabled",
+          "token_exchange",
           "created_at",
           "updated_at"
         ],
@@ -10239,6 +10256,10 @@
           "tenant_id": {
             "type": "string",
             "format": "uuid"
+          },
+          "token_exchange": {
+            "$ref": "#/components/schemas/TokenExchangeTrustResponse",
+            "description": "X4 external token-exchange trust."
           },
           "updated_at": {
             "type": "string",
@@ -13392,6 +13413,107 @@
           }
         }
       },
+      "TokenExchangeTrustRequest": {
+        "type": "object",
+        "description": "X4 trust for exchanging this provider's tokens (RFC 8693, external issuer).\n\nMirrors [`TokenExchangeTrust`] on the wire rather than reusing it directly\nso the API surface can carry its own defaults: an admin PUTting a partial\nblock gets the documented default for anything they omitted, instead of a\ndeserialization error listing fields they have never heard of.",
+        "properties": {
+          "accepted_audiences": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Audiences an incoming subject token may name. Required (non-empty)\nwhen `enabled`; there is deliberately no accept-all value."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Off unless explicitly enabled. Configuring a provider for *login* is\nnot agreement to accept its tokens as API credentials."
+          },
+          "max_lifetime_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Per-provider ceiling on the issued AXIAM token's lifetime."
+          },
+          "max_token_age_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Bound on `now - iat`, independent of the token's own `exp`."
+          },
+          "scope_map": {
+            "type": "object",
+            "description": "External asserted value -> AXIAM scopes. Deny-by-default: an external\nvalue with no entry contributes nothing.",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "subject_mapping": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`linked_only` (default) or `jit_provision`."
+          }
+        }
+      },
+      "TokenExchangeTrustResponse": {
+        "type": "object",
+        "description": "X4 trust as returned. Same shape as the request; nothing here is secret —\nan operator reading a provider needs to see exactly what it trusts.",
+        "required": [
+          "enabled",
+          "accepted_audiences",
+          "subject_mapping",
+          "scope_map",
+          "max_token_age_secs"
+        ],
+        "properties": {
+          "accepted_audiences": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "max_lifetime_secs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "max_token_age_secs": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "scope_map": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "subject_mapping": {
+            "type": "string"
+          }
+        }
+      },
       "TokenPolicy": {
         "type": "object",
         "description": "Token lifetime configuration.",
@@ -13685,6 +13807,17 @@
             "type": [
               "string",
               "null"
+            ]
+          },
+          "token_exchange": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TokenExchangeTrustRequest",
+                "description": "X4 external token-exchange trust. Replaced **wholesale** when present:\na partial merge of a trust configuration is how an operator ends up\nkeeping an `accepted_audiences` entry they believed they had removed."
+              }
             ]
           }
         }

--- a/website/src/threatModel.ts
+++ b/website/src/threatModel.ts
@@ -15,11 +15,11 @@ export const THREAT_MODEL: ThreatModel = {
  "title": "Axiam",
  "owner": "ilpanich",
  "description": "Complete IAM SW written in Rust using SurrealDB to store data and relationships. STRIDE threat model covering the system context, authentication and session management, the OAuth2/OIDC provider, inbound federation, the RBAC authorization engine, PKI and IoT device identity, audit/webhooks/email, and the Kubernetes deployment.",
- "version": "2.5.0",
+ "version": "2.6.0",
  "diagramCount": 9,
- "total": 154,
- "open": 22,
- "mitigated": 132,
+ "total": 162,
+ "open": 23,
+ "mitigated": 139,
  "diagrams": [
   {
    "id": 0,
@@ -2535,6 +2535,51 @@ export const THREAT_MODEL: ThreatModel = {
        "status": "Mitigated",
        "description": "Without nonce binding, an id_token obtained elsewhere can be injected into a victim's session.",
        "mitigation": "state and nonce are both required, generated with a CSPRNG, stored server-side against the pending flow, and verified before any identity is established."
+      },
+      {
+       "number": 155,
+       "title": "A partner's token is accepted as an AXIAM credential (X4)",
+       "type": "Elevation of privilege",
+       "severity": "Critical",
+       "status": "Mitigated",
+       "description": "External-IdP token exchange (RFC 8693, X4) lets a client present a token minted by a partner's IdP and receive an AXIAM token. If the partner's assertions were trusted as authorization, the partner's administrator would be able to name AXIAM scopes and grant their own users authority in this tenant.",
+       "mitigation": "An external subject token is treated as evidence of authentication only. The issued token's scopes are the intersection of an AXIAM-admin-authored deny-by-default scope_map, the exchanging client's registration, and the RBAC engine's answer for the resolved user at mint time (deny-override applied at its broadest reading). Trust is off by default per provider, and enabling it requires a non-empty accepted_audiences list."
+      },
+      {
+       "number": 156,
+       "title": "A token not addressed to AXIAM is replayed at the exchange (X4)",
+       "type": "Spoofing",
+       "severity": "High",
+       "status": "Mitigated",
+       "description": "A token the partner minted for a third party — or for their own internal service — is captured and presented to AXIAM's token endpoint. Without an audience check, any token from the partner's estate becomes an AXIAM credential.",
+       "mitigation": "accepted_audiences is required and non-empty whenever token exchange is enabled; there is deliberately no accept-all value. Matching is exact string equality in both directions (no trailing-slash forgiveness, no case folding), and aud may be a string or an array, of which at least one member must match."
+      },
+      {
+       "number": 157,
+       "title": "Trust composes transitively across three domains (X4)",
+       "type": "Elevation of privilege",
+       "severity": "High",
+       "status": "Mitigated",
+       "description": "AXIAM trusts partner B; B trusts partner C. Without a barrier, a token C minted can be exchanged at B and the result exchanged at AXIAM, giving C authority nobody configured and neither configuration reveals.",
+       "mitigation": "Every token minted from an external subject token carries an ext_exchange provenance claim naming the foreign issuer, and BOTH exchange paths refuse a subject token that carries it. An exchanged token can never be re-exchanged, ours or theirs."
+      },
+      {
+       "number": 158,
+       "title": "A long-lived partner token becomes a long replay window (X4)",
+       "type": "Elevation of privilege",
+       "severity": "Medium",
+       "status": "Mitigated",
+       "description": "A partner IdP that issues 24-hour access tokens would, without an independent bound, hand a captured token a 24-hour window in which it can be turned into AXIAM credentials.",
+       "mitigation": "max_token_age_secs bounds the token's age independently of its own exp (default 300 s, hard ceiling 3600 s), and an iat in the future beyond 60 s of skew is refused. The issued token's lifetime is the minimum of the partner token's remaining life, the per-provider ceiling, and the server-wide exchange maximum."
+      },
+      {
+       "number": 159,
+       "title": "An ID token or refresh token is presented as a subject token (X4)",
+       "type": "Spoofing",
+       "severity": "Medium",
+       "status": "Mitigated",
+       "description": "An ID token is an assertion to a client about a login, which an OIDC deployment distributes more widely and gives a longer life than an access token; a refresh token is a re-authentication credential. Either accepted as a subject token would let an artefact the partner considers low-risk buy an AXIAM credential.",
+       "mitigation": "Both are refused by name at the subject_token_type check, and — since a caller can mislabel a token — again by shape: the ID-token-only claims nonce, at_hash, c_hash and s_hash, and typ headers or claims naming an ID or refresh token, are rejected even when the signature verifies."
       }
      ],
      "open": 0
@@ -2656,9 +2701,27 @@ export const THREAT_MODEL: ThreatModel = {
        "status": "Mitigated",
        "description": "Unbounded just-in-time user creation from a federated IdP lets a hostile IdP create arbitrarily many tenant users.",
        "mitigation": "JIT provisioning is opt-in per federation config and the created users hold no roles beyond those the mapping allow-list grants."
+      },
+      {
+       "number": 160,
+       "title": "A suspended user is revived through the exchange path (X4)",
+       "type": "Elevation of privilege",
+       "severity": "Medium",
+       "status": "Mitigated",
+       "description": "An AXIAM user who has been locked, deactivated or anonymized would, if the exchange path skipped the status gate, still be able to obtain tokens for as long as their partner IdP kept authenticating them.",
+       "mitigation": "The resolved user's status is checked after subject resolution and before any token is minted; Locked, Inactive and Anonymized are refused. PendingVerification is allowed deliberately: federation provisioning never moves a federated user off it, so requiring Active would refuse the whole population the feature serves while stopping nobody."
+      },
+      {
+       "number": 161,
+       "title": "A partner's IdP silently populates the AXIAM user table (X4)",
+       "type": "Denial of service",
+       "severity": "Low",
+       "status": "Open",
+       "description": "With subject_mapping set to jit_provision, every previously-unseen subject the partner vouches for creates an AXIAM user row. A partner with a large or hostile user population can grow the table without an AXIAM administrator acting.",
+       "mitigation": "Off by default (linked_only refuses unknown subjects). Every JIT provision is audited with the provider and the external subject, and a provisioned user holds no roles, so the exchange that created them still yields no token. Residual risk accepted: the same exposure the browser SSO JIT path already carries, bounded by the same per-client exchange rate limit."
       }
      ],
-     "open": 0
+     "open": 1
     },
     {
      "id": "24bff414-a751-52a6-bb4e-b0b187da2873",
@@ -2683,6 +2746,15 @@ export const THREAT_MODEL: ThreatModel = {
        "status": "Mitigated",
        "description": "The OIDC client secret configured for an IdP is a credential against that IdP; leaking it in a trace line is a real third-party compromise.",
        "mitigation": "SECHRD-09: the federation secret type carries a manual Debug impl that redacts the value, and the secret is encrypted at rest. The same treatment was applied to webhook secrets under SEC-067."
+      },
+      {
+       "number": 162,
+       "title": "A malformed trust block is enabled without review (X4)",
+       "type": "Tampering",
+       "severity": "Medium",
+       "status": "Mitigated",
+       "description": "A scope_map entry mapping to no scopes, an out-of-range token age, or an unknown subject_mapping value stored while token exchange is disabled becomes live the moment an administrator ticks the enable box — which is not where they expect to be told their configuration was wrong.",
+       "mitigation": "The trust block is validated at the API edge on every write, whether or not it is enabled (only the non-empty-audience rule is conditional). On read, every hydration failure resolves towards the default, and enabled is read from its own column so a corrupt neighbouring column can never switch exchange on. A provider whose stored trust block fails validation is skipped at resolution time with a warning rather than being used."
       }
      ],
      "open": 0
@@ -2972,13 +3044,13 @@ export const THREAT_MODEL: ThreatModel = {
      "open": 0
     }
    ],
-   "total": 15,
-   "open": 0,
+   "total": 23,
+   "open": 1,
    "bySeverity": {
-    "High": 5,
-    "Medium": 6,
-    "Critical": 3,
-    "Low": 1
+    "High": 7,
+    "Medium": 10,
+    "Critical": 4,
+    "Low": 2
    }
   },
   {

--- a/website/src/threatModelSummary.ts
+++ b/website/src/threatModelSummary.ts
@@ -23,11 +23,11 @@ export interface ThreatModelSummary {
 }
 
 export const THREAT_MODEL_SUMMARY: ThreatModelSummary = {
- "version": "2.5.0",
+ "version": "2.6.0",
  "diagramCount": 9,
- "total": 154,
- "open": 22,
- "mitigated": 132,
+ "total": 162,
+ "open": 23,
+ "mitigated": 139,
  "areas": [
   {
    "id": 0,
@@ -50,8 +50,8 @@ export const THREAT_MODEL_SUMMARY: ThreatModelSummary = {
   {
    "id": 3,
    "title": "Federation — SAML SP & OIDC relying party",
-   "total": 15,
-   "open": 0
+   "total": 23,
+   "open": 1
   },
   {
    "id": 4,


### PR DESCRIPTION
Implements **X4** of [`claude_dev/extra-B-track-features.md`](https://github.com/ilpanich/axiam/blob/main/claude_dev/extra-B-track-features.md) — external-IdP token exchange. Gated on B3, which is merged.

## What it does

A partner runs their own IdP (Entra, Okta, Keycloak). Their service calls ours carrying *their* token. X4 lets a gateway present that token at the ordinary token endpoint and receive an AXIAM token scoped to what the resolved AXIAM user may actually do.

## The rule everything serves

> **An external subject token is evidence of *authentication*, never a grant of *authorization*.**

This is what makes X4 more than "B3 with a wider issuer check". B3 narrows an AXIAM token against itself — there is a `subject_scopes` set to intersect with. A partner's token has no such set: its scopes are the partner's vocabulary and carry no authority in this tenant. So the issued token's contents are decided **entirely by AXIAM state** — an admin-authored deny-by-default scope map, the exchanging client's registration, and the RBAC engine's answer for the resolved user at mint time. The partner's token can only ever *reduce* that set.

- Design: [`claude_dev/external-token-exchange-design.md`](claude_dev/external-token-exchange-design.md)
- Operator guide: [`docs/api/federated-token-exchange.md`](docs/api/federated-token-exchange.md)

## Trust configuration

New `token_exchange` block per **OIDC** federation provider (schema v36, purely additive — every pre-X4 row reads back as disabled, no backfill):

```
enabled              default FALSE
accepted_audiences   non-empty REQUIRED when enabled
subject_mapping      linked_only (default) | jit_provision
scope_map            external assertion → AXIAM scopes, deny-by-default
max_token_age_secs   default 300, ceiling 3600
max_lifetime_secs    optional per-provider ceiling
```

Two defaults are decisions, not conveniences:

- **`enabled` is false.** An operator who configured Okta for *login* did not thereby agree to accept Okta tokens as API credentials. Different trust statements, different switches — and upgrading never turns it on.
- **There is no accept-all audience.** A token that was not addressed to us is one we *captured*, not one we were *given*. Matching is exact string equality — no trailing-slash forgiveness, no case folding.

## How routing works, and why it is safe

The grant reads the subject token's **unverified `iss`** to pick a branch. That is safe precisely because neither destination trusts it: a token claiming AXIAM's issuer lands in the branch that verifies against AXIAM's signing key; one claiming a partner's issuer lands in the branch that verifies against that partner's JWKS. The claim selects *which key the token faces*, never *whether* it faces one. A provider advertising AXIAM's own issuer is refused at resolution, so the branches cannot overlap.

## Invariants, each with a test named after what it stops

| Invariant | How |
|---|---|
| **No transitive exchange** | Minted tokens carry `ext_exchange: {iss}`; **both** paths refuse a subject token bearing it — ours or theirs. Without it, A→B→C trust composes silently and neither config reveals it. |
| **Never widen** | `granted = requested ∩ scope_map ∩ client registration ∩ engine`. Proved exhaustively over all subset triples. |
| **Never inherit the partner's `aud`** | It names *their* resource server. Issued tokens get `axiam:user` unless a registered target is named. |
| **Never outlive the subject** | `min(partner remaining, provider ceiling, server maximum)`. |
| **Age bounded independently of `exp`** | A partner issuing 24-hour tokens must not hand out a 24-hour replay window. |
| **Wrong token kinds refused** | ID and refresh tokens, by name *and* by shape (`nonce`/`at_hash`/`c_hash`/`s_hash`, `typ`), even when correctly signed. |
| **`actor_token` refused** | Delegation across a trust boundary needs a second trust decision v1 does not make. |

`may_impersonate` is deliberately **not** the gate: the evidence is a trusted IdP's signed assertion that the user authenticated, not the client's own say-so that it may *be* them.

## Three decisions worth a reviewer's attention

1. **Deny-override at its broadest reading.** A `deny` grant *anywhere* in the user's applicable roles withholds the scope entirely, even though the same deny would only veto one resource in a live check. A bearer scope cannot express "except on resource X" — it travels in a token with no resource attached — so the only honest answers are "everywhere" or "not at all", and on a cross-domain path we take the narrower one. Argued in full on `RbacScopeAuthority`.

2. **`PendingVerification` users are accepted.** Caught by a test, not by review: `UserRepository::create` writes that status for every row and federation provisioning never moves a federated user off it. Requiring `Active` would have refused exactly the population this feature serves while stopping nobody. `Locked`, `Inactive` and `Anonymized` are refused.

3. **One distinguishable refusal.** "Issuer is not configured for token exchange" gets its own description, because the exchanging client is an authenticated confidential client of the tenant and without it an integrator cannot tell "fix your config" from "fix your token". Everything else is generic: which of a dozen checks refused a token is a map of our validation order, drawn one request at a time. The precise reason always reaches the audit record.

## Structure

`axiam-oauth2` defines two narrow ports (`ExternalSubjectResolver`, `SubjectScopeAuthority`) rather than depending on `axiam-federation`/`axiam-authz` — the same seam X2's UMA grant uses, so every branch is unit-testable without a datastore or a network. Verification lives in `axiam-federation`, beside the login path that answers the same "which user is this" question through the *same* `provision_or_link_user`. `axiam-api-rest` is the composition root.

No new outbound fetch paths: discovery, JWKS (with unknown-`kid` rollover) and the SSRF guard are the existing ones.

## Tests — 55 new, all green

- **27 e2e** (`external_token_exchange_test.rs`): a wiremock IdP with a real RSA key and JWKS. Happy path; each vendor claim shape (`scope`, `scp` as string *and* array, `roles`, `groups`); every invariant violated in isolation; JIT on/off; JWKS rotation mid-flight recovered by forced refetch; transitivity refused in both directions; and two regression tests that the B3 path is untouched.
- **20 unit** in `axiam-oauth2` including the exhaustive subset property.
- **17 unit** in `axiam-federation` (audience flattening, claim shapes, token-kind detection, age).
- **12** in `axiam-core` (trust validation, deny-by-default mapping), **6** in `axiam-api-rest` (the RBAC authority), **26** frontend.

Regression: `axiam-core` 132, `axiam-auth` 154, `axiam-oauth2` 108, `axiam-federation` 111, `axiam-db` 144, `axiam-api-rest` lib 156, B3's own suite 21 — all green.

### Honest gap

X4's plan asks for fixtures minted by a **real Keycloak container** as cross-vendor proof. That belongs to the e2e compose suite and is **not** in this PR — a container is not available to the unit-test harness, and a hand-rolled "Keycloak-shaped" token would only prove the test and its author agree. Every claim shape those vendors emit *is* covered, each with its own test. This is stated in the test file's header too.

## Also in this PR

- SDK contract **§15.7** — no new per-language surface; what to pass, and which errors mean "issuer not trusted". The downstream `axiam-*-sdk` repos need a `CONTRACT.md`/`openapi.json` re-sync plus the TypeScript + Go examples the plan names; that is a follow-up PR per repo.
- Frontend trust editor on the federation page (line-oriented scope-map format, client-side mirror of the server's validation).
- OpenAPI regenerated; threat model 2.6.0 with 8 new STRIDE threats (7 mitigated, 1 open + accepted: JIT provisioning inflating the user population, the same exposure the browser SSO path already carries).

## Notes

- No issue to close — X4 has none; the plan document is the reference.
- Commits are unsigned: `commit.gpgsign` is set in the container but the configured key file is empty, matching the previously-merged agent commits on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT515YSzu2xfC3qutsudhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT515YSzu2xfC3qutsudhe)_